### PR TITLE
test: quality & test coverage expansion (#3)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -61,6 +61,7 @@
     "@types/pg": "^8.18.0",
     "@types/turndown": "^5.0.5",
     "@types/uuid": "^11.0.0",
+    "@vitest/coverage-v8": "^4.1.2",
     "eslint": "^9.27.0",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-boundaries": "^5.4.0",

--- a/backend/src/routes/foundation/auth-routes.test.ts
+++ b/backend/src/routes/foundation/auth-routes.test.ts
@@ -1,0 +1,551 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+import cookie from '@fastify/cookie';
+import { ZodError } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared BEFORE the route import so vi.mock hoisting works
+// ---------------------------------------------------------------------------
+
+const mockQuery = vi.fn();
+vi.mock('../../core/db/postgres.js', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+const mockBcryptHash = vi.fn();
+const mockBcryptCompare = vi.fn();
+vi.mock('bcrypt', () => ({
+  default: {
+    hash: (...a: unknown[]) => mockBcryptHash(...a),
+    compare: (...a: unknown[]) => mockBcryptCompare(...a),
+  },
+}));
+
+const mockGenerateAccessToken = vi.fn().mockResolvedValue('mock-access-token');
+const mockGenerateRefreshToken = vi.fn().mockResolvedValue({ token: 'mock-refresh-token', jti: 'mock-jti' });
+const mockVerifyRefreshToken = vi.fn();
+const mockRevokeToken = vi.fn();
+const mockRevokeAllUserTokens = vi.fn();
+const mockCleanupExpiredTokens = vi.fn();
+const mockVerifyToken = vi.fn();
+vi.mock('../../core/plugins/auth.js', () => ({
+  generateAccessToken: (...a: unknown[]) => mockGenerateAccessToken(...a),
+  generateRefreshToken: (...a: unknown[]) => mockGenerateRefreshToken(...a),
+  verifyRefreshToken: (...a: unknown[]) => mockVerifyRefreshToken(...a),
+  revokeToken: (...a: unknown[]) => mockRevokeToken(...a),
+  revokeAllUserTokens: (...a: unknown[]) => mockRevokeAllUserTokens(...a),
+  cleanupExpiredTokens: (...a: unknown[]) => mockCleanupExpiredTokens(...a),
+  verifyToken: (...a: unknown[]) => mockVerifyToken(...a),
+}));
+
+vi.mock('../../core/services/audit-service.js', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
+vi.mock('../../core/utils/logger.js', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('../../core/services/rate-limit-service.js', () => ({
+  getRateLimits: vi.fn().mockResolvedValue({ auth: { max: 100 }, admin: { max: 100 }, global: { max: 1000 } }),
+}));
+
+import { authRoutes } from './auth.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_USER = {
+  id: 'user-uuid-1',
+  username: 'testuser',
+  role: 'user',
+  password_hash: '$2b$12$hashedpassword',
+};
+
+function buildApp() {
+  const app = Fastify({ logger: false });
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Auth routes', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = buildApp();
+    await app.register(sensible);
+    await app.register(cookie);
+
+    // Zod validation → 400 (matches production error handler)
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof ZodError) {
+        reply.status(400).send({
+          error: 'ValidationError',
+          message: error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join('; '),
+          statusCode: 400,
+        });
+        return;
+      }
+      reply.status(error.statusCode ?? 500).send({
+        error: error.message,
+        statusCode: error.statusCode ?? 500,
+      });
+    });
+
+    // Decorators used by auth routes (authenticate, requireAdmin)
+    app.decorate('authenticate', async (request: { userId: string; username: string; userRole: string }) => {
+      request.userId = 'admin-user-id';
+      request.username = 'admin';
+      request.userRole = 'admin';
+    });
+    app.decorate('requireAdmin', async (request: { userId: string; username: string; userRole: string }) => {
+      request.userId = 'admin-user-id';
+      request.username = 'admin';
+      request.userRole = 'admin';
+    });
+
+    await app.register(authRoutes, { prefix: '/api/auth' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Restore default happy-path mocks
+    mockGenerateAccessToken.mockResolvedValue('mock-access-token');
+    mockGenerateRefreshToken.mockResolvedValue({ token: 'mock-refresh-token', jti: 'mock-jti' });
+  });
+
+  // ==========================================================================
+  // POST /register
+  // ==========================================================================
+
+  describe('POST /api/auth/register', () => {
+    it('should create a user and return 201 with accessToken and user', async () => {
+      mockBcryptHash.mockResolvedValue('hashed-password');
+      // First query: INSERT user RETURNING id, username, role
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: TEST_USER.id, username: TEST_USER.username, role: TEST_USER.role }],
+      });
+      // Second query: INSERT user_settings
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/register',
+        payload: { username: 'testuser', password: 'securepassword' },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = JSON.parse(response.body);
+      expect(body.accessToken).toBe('mock-access-token');
+      expect(body.user).toEqual({
+        id: TEST_USER.id,
+        username: TEST_USER.username,
+        role: TEST_USER.role,
+      });
+
+      // Verify bcrypt was called with password and salt rounds
+      expect(mockBcryptHash).toHaveBeenCalledWith('securepassword', 12);
+
+      // Verify refresh cookie was set
+      const setCookieHeader = response.headers['set-cookie'];
+      expect(setCookieHeader).toBeDefined();
+      const cookieStr = Array.isArray(setCookieHeader) ? setCookieHeader[0] : setCookieHeader;
+      expect(cookieStr).toContain('kb_refresh=mock-refresh-token');
+      expect(cookieStr).toContain('HttpOnly');
+    });
+
+    it('should return 409 when username is already taken', async () => {
+      mockBcryptHash.mockResolvedValue('hashed-password');
+      // Simulate PostgreSQL unique constraint violation (code 23505)
+      const duplicateError = new Error('duplicate key value violates unique constraint') as Error & { code: string };
+      duplicateError.code = '23505';
+      mockQuery.mockRejectedValueOnce(duplicateError);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/register',
+        payload: { username: 'existinguser', password: 'securepassword' },
+      });
+
+      expect(response.statusCode).toBe(409);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('Username already taken');
+    });
+
+    it('should return 400 when username is too short', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/register',
+        payload: { username: 'ab', password: 'securepassword' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 when password is too short', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/register',
+        payload: { username: 'testuser', password: 'short' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 when username or password is missing', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/register',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  // ==========================================================================
+  // POST /login
+  // ==========================================================================
+
+  describe('POST /api/auth/login', () => {
+    it('should return 200 with accessToken and user and set refresh cookie', async () => {
+      // SELECT user by username
+      mockQuery.mockResolvedValueOnce({
+        rows: [{
+          id: TEST_USER.id,
+          username: TEST_USER.username,
+          password_hash: TEST_USER.password_hash,
+          role: TEST_USER.role,
+        }],
+      });
+      mockBcryptCompare.mockResolvedValue(true);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/login',
+        payload: { username: 'testuser', password: 'securepassword' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.accessToken).toBe('mock-access-token');
+      expect(body.user).toEqual({
+        id: TEST_USER.id,
+        username: TEST_USER.username,
+        role: TEST_USER.role,
+      });
+
+      // Verify refresh cookie was set
+      const setCookieHeader = response.headers['set-cookie'];
+      expect(setCookieHeader).toBeDefined();
+      const cookieStr = Array.isArray(setCookieHeader) ? setCookieHeader[0] : setCookieHeader;
+      expect(cookieStr).toContain('kb_refresh=mock-refresh-token');
+      expect(cookieStr).toContain('HttpOnly');
+
+      // Verify bcrypt.compare was called
+      expect(mockBcryptCompare).toHaveBeenCalledWith('securepassword', TEST_USER.password_hash);
+    });
+
+    it('should return 401 when user is not found', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/login',
+        payload: { username: 'nonexistent', password: 'somepassword' },
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('Invalid username or password');
+    });
+
+    it('should return 401 when password is wrong', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{
+          id: TEST_USER.id,
+          username: TEST_USER.username,
+          password_hash: TEST_USER.password_hash,
+          role: TEST_USER.role,
+        }],
+      });
+      mockBcryptCompare.mockResolvedValue(false);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/login',
+        payload: { username: 'testuser', password: 'wrongpassword' },
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('Invalid username or password');
+    });
+  });
+
+  // ==========================================================================
+  // POST /refresh
+  // ==========================================================================
+
+  describe('POST /api/auth/refresh', () => {
+    it('should rotate tokens and return a new accessToken', async () => {
+      mockVerifyRefreshToken.mockResolvedValue({
+        sub: TEST_USER.id,
+        username: TEST_USER.username,
+        role: TEST_USER.role,
+        jti: 'old-jti',
+        family: 'token-family-1',
+      });
+      // SELECT user by id
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: TEST_USER.id, username: TEST_USER.username, role: TEST_USER.role }],
+      });
+      mockRevokeToken.mockResolvedValue(undefined);
+      mockGenerateAccessToken.mockResolvedValue('new-access-token');
+      mockGenerateRefreshToken.mockResolvedValue({ token: 'new-refresh-token', jti: 'new-jti' });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/refresh',
+        cookies: { kb_refresh: 'valid-refresh-token' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.accessToken).toBe('new-access-token');
+      expect(body.user).toEqual({
+        id: TEST_USER.id,
+        username: TEST_USER.username,
+        role: TEST_USER.role,
+      });
+
+      // Verify old token was revoked
+      expect(mockRevokeToken).toHaveBeenCalledWith('old-jti');
+
+      // Verify new refresh cookie was set
+      const setCookieHeader = response.headers['set-cookie'];
+      expect(setCookieHeader).toBeDefined();
+      const cookieStr = Array.isArray(setCookieHeader) ? setCookieHeader[0] : setCookieHeader;
+      expect(cookieStr).toContain('kb_refresh=new-refresh-token');
+
+      // Verify family was passed for rotation tracking
+      expect(mockGenerateRefreshToken).toHaveBeenCalledWith(
+        expect.objectContaining({ sub: TEST_USER.id }),
+        'token-family-1',
+      );
+    });
+
+    it('should return 401 when no refresh cookie is present', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/refresh',
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('No refresh token');
+    });
+
+    it('should return 401 when refresh token is invalid or expired', async () => {
+      mockVerifyRefreshToken.mockRejectedValue(new Error('Token expired'));
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/refresh',
+        cookies: { kb_refresh: 'expired-token' },
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('Invalid refresh token');
+    });
+
+    it('should return 401 when user no longer exists', async () => {
+      mockVerifyRefreshToken.mockResolvedValue({
+        sub: 'deleted-user-id',
+        username: 'deleted',
+        role: 'user',
+        jti: 'some-jti',
+        family: 'some-family',
+      });
+      // User lookup returns empty
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/refresh',
+        cookies: { kb_refresh: 'valid-token-deleted-user' },
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('Invalid refresh token');
+    });
+  });
+
+  // ==========================================================================
+  // POST /logout
+  // ==========================================================================
+
+  describe('POST /api/auth/logout', () => {
+    it('should clear the refresh cookie and return a message when bearer token is valid', async () => {
+      mockVerifyToken.mockResolvedValue({ sub: TEST_USER.id });
+      mockRevokeAllUserTokens.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/logout',
+        headers: { authorization: 'Bearer valid-access-token' },
+        cookies: { kb_refresh: 'some-refresh-token' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.message).toBe('Logged out');
+
+      // Verify all user tokens were revoked
+      expect(mockRevokeAllUserTokens).toHaveBeenCalledWith(TEST_USER.id);
+
+      // Verify refresh cookie was cleared
+      const setCookieHeader = response.headers['set-cookie'];
+      expect(setCookieHeader).toBeDefined();
+      const cookieStr = Array.isArray(setCookieHeader) ? setCookieHeader[0] : setCookieHeader;
+      expect(cookieStr).toContain('kb_refresh=');
+    });
+
+    it('should fall back to refresh cookie when bearer token is invalid', async () => {
+      // Bearer token verification fails
+      mockVerifyToken.mockRejectedValue(new Error('Token expired'));
+      // Refresh cookie succeeds
+      mockVerifyRefreshToken.mockResolvedValue({ sub: TEST_USER.id, jti: 'refresh-jti' });
+      mockRevokeToken.mockResolvedValue(undefined);
+      mockRevokeAllUserTokens.mockResolvedValue(undefined);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/logout',
+        headers: { authorization: 'Bearer expired-access-token' },
+        cookies: { kb_refresh: 'valid-refresh-token' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.message).toBe('Logged out');
+
+      // Verify specific refresh JTI was revoked
+      expect(mockRevokeToken).toHaveBeenCalledWith('refresh-jti');
+      // Verify all user tokens were revoked
+      expect(mockRevokeAllUserTokens).toHaveBeenCalledWith(TEST_USER.id);
+    });
+
+    it('should succeed gracefully even when no valid token is available', async () => {
+      // Both bearer and refresh cookie fail
+      mockVerifyToken.mockRejectedValue(new Error('Invalid'));
+      mockVerifyRefreshToken.mockRejectedValue(new Error('Invalid'));
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/logout',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.message).toBe('Logged out');
+
+      // No tokens to revoke — should NOT have been called
+      expect(mockRevokeAllUserTokens).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // POST /cleanup-tokens
+  // ==========================================================================
+
+  describe('POST /api/auth/cleanup-tokens', () => {
+    it('should return the deleted token count for admin users', async () => {
+      mockCleanupExpiredTokens.mockResolvedValue(42);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/cleanup-tokens',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.message).toBe('Cleaned up 42 expired tokens');
+      expect(mockCleanupExpiredTokens).toHaveBeenCalled();
+    });
+  });
+});
+
+// =============================================================================
+// Non-admin access guard for cleanup-tokens
+// =============================================================================
+
+describe('Auth routes - non-admin access guard', () => {
+  let nonAdminApp: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    nonAdminApp = Fastify({ logger: false });
+    await nonAdminApp.register(sensible);
+    await nonAdminApp.register(cookie);
+
+    nonAdminApp.setErrorHandler((error, _request, reply) => {
+      reply.status(error.statusCode ?? 500).send({
+        error: error.message,
+        statusCode: error.statusCode ?? 500,
+      });
+    });
+
+    // Simulate non-admin: authenticate passes, requireAdmin rejects
+    nonAdminApp.decorate('authenticate', async (request: { userId: string; username: string; userRole: string }) => {
+      request.userId = 'regular-user-id';
+      request.username = 'regular';
+      request.userRole = 'user';
+    });
+    nonAdminApp.decorate(
+      'requireAdmin',
+      async (
+        request: { userId: string; username: string; userRole: string },
+        reply: { code: (n: number) => { send: (body: unknown) => void } },
+      ) => {
+        request.userId = 'regular-user-id';
+        request.username = 'regular';
+        request.userRole = 'user';
+        reply.code(403).send({ error: 'Admin access required', statusCode: 403 });
+      },
+    );
+
+    await nonAdminApp.register(authRoutes, { prefix: '/api/auth' });
+    await nonAdminApp.ready();
+  });
+
+  afterAll(async () => {
+    await nonAdminApp.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should reject non-admin users on POST /api/auth/cleanup-tokens with 403', async () => {
+    const response = await nonAdminApp.inject({
+      method: 'POST',
+      url: '/api/auth/cleanup-tokens',
+    });
+
+    expect(response.statusCode).toBe(403);
+    const body = JSON.parse(response.body);
+    expect(body.error).toBe('Admin access required');
+  });
+});

--- a/backend/src/routes/knowledge/analytics-routes.test.ts
+++ b/backend/src/routes/knowledge/analytics-routes.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+
+// --- Mock: postgres query ---
+const mockQuery = vi.fn();
+vi.mock('../../core/db/postgres.js', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+import { analyticsRoutes } from './analytics.js';
+
+const ADMIN_USER_ID = 'admin-user-id';
+
+// =============================================================================
+// Auth + admin required
+// =============================================================================
+
+describe('Search analytics routes - auth required', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.decorate('authenticate', async () => {
+      throw app.httpErrors.unauthorized('Missing token');
+    });
+    app.decorate('requireAdmin', async () => {
+      throw app.httpErrors.forbidden('Admin required');
+    });
+    app.decorateRequest('userId', '');
+    app.decorateRequest('userRole', '');
+
+    await app.register(analyticsRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should return 403 for GET /api/analytics/knowledge-gaps without admin', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/knowledge-gaps' });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('should return 403 for GET /api/analytics/search-trends without admin', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/search-trends' });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+// =============================================================================
+// Happy-path tests (admin user)
+// =============================================================================
+
+describe('Search analytics routes - admin', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.decorate('authenticate', async (request: { userId: string; userRole: string }) => {
+      request.userId = ADMIN_USER_ID;
+      request.userRole = 'admin';
+    });
+    app.decorate('requireAdmin', async (request: { userId: string; userRole: string }) => {
+      request.userId = ADMIN_USER_ID;
+      request.userRole = 'admin';
+    });
+    app.decorateRequest('userId', '');
+    app.decorateRequest('userRole', '');
+
+    await app.register(analyticsRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── GET /api/analytics/knowledge-gaps ─────────────────────────────
+
+  it('should return knowledge gaps', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          query_text: 'kubernetes deployment',
+          occurrence_count: '5',
+          last_searched: new Date('2025-06-01'),
+          avg_max_score: 0.1,
+        },
+      ],
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/knowledge-gaps' });
+    expect(res.statusCode).toBe(200);
+
+    const body = res.json();
+    expect(body.gaps).toHaveLength(1);
+    expect(body.gaps[0].query).toBe('kubernetes deployment');
+    expect(body.gaps[0].occurrences).toBe(5);
+    expect(body.total).toBe(1);
+    expect(body.periodDays).toBe(30); // default
+  });
+
+  it('should accept custom days and minOccurrences', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/analytics/knowledge-gaps?days=7&minOccurrences=3',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().periodDays).toBe(7);
+  });
+
+  it('should return empty gaps when no data', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/knowledge-gaps' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().gaps).toHaveLength(0);
+    expect(res.json().total).toBe(0);
+  });
+
+  // ── GET /api/analytics/search-trends ──────────────────────────────
+
+  it('should return search trends', async () => {
+    // Top queries
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          query_text: 'docker setup',
+          search_count: '15',
+          avg_results: '3.5',
+          avg_score: 0.7,
+        },
+      ],
+    });
+    // Daily volume
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          day: '2025-06-01',
+          total_searches: '42',
+          zero_result_searches: '5',
+        },
+      ],
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/search-trends' });
+    expect(res.statusCode).toBe(200);
+
+    const body = res.json();
+    expect(body.topQueries).toHaveLength(1);
+    expect(body.topQueries[0].query).toBe('docker setup');
+    expect(body.topQueries[0].searchCount).toBe(15);
+    expect(body.dailyVolume).toHaveLength(1);
+    expect(body.dailyVolume[0].totalSearches).toBe(42);
+    expect(body.periodDays).toBe(30);
+  });
+
+  it('should accept custom days param for trends', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/analytics/search-trends?days=14',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().periodDays).toBe(14);
+  });
+});

--- a/backend/src/routes/knowledge/content-analytics-routes.test.ts
+++ b/backend/src/routes/knowledge/content-analytics-routes.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+
+// --- Mock: postgres query ---
+const mockQuery = vi.fn();
+vi.mock('../../core/db/postgres.js', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+import { contentAnalyticsRoutes } from './content-analytics.js';
+
+const TEST_USER_ID = 'user-abc';
+
+// =============================================================================
+// Auth-required tests
+// =============================================================================
+
+describe('Content analytics routes - auth required', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.decorate('authenticate', async () => {
+      throw app.httpErrors.unauthorized('Missing token');
+    });
+    app.decorateRequest('userId', '');
+
+    await app.register(contentAnalyticsRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should return 401 for POST /api/pages/:id/feedback without auth', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/pages/1/feedback',
+      payload: { isHelpful: true },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('should return 401 for GET /api/analytics/trending without auth', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/trending' });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// =============================================================================
+// Happy-path tests
+// =============================================================================
+
+describe('Content analytics routes - authenticated', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.decorate('authenticate', async (request: { userId: string }) => {
+      request.userId = TEST_USER_ID;
+    });
+    app.decorateRequest('userId', '');
+
+    await app.register(contentAnalyticsRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── POST /api/pages/:id/feedback ──────────────────────────────────
+
+  it('should submit feedback', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/feedback',
+      payload: { isHelpful: true, comment: 'Great article!' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json().id).toBe(1);
+    expect(mockQuery).toHaveBeenCalledOnce();
+    // Verify the upsert SQL
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('ON CONFLICT');
+  });
+
+  it('should submit negative feedback without comment', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 2 }] });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/feedback',
+      payload: { isHelpful: false },
+    });
+
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('should reject feedback with invalid pageId', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/pages/-1/feedback',
+      payload: { isHelpful: true },
+    });
+
+    // Zod validation error — 500 without custom app error handler
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+  });
+
+  it('should reject feedback without isHelpful field', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/pages/1/feedback',
+      payload: {},
+    });
+
+    // Zod validation error — 500 without custom app error handler
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+  });
+
+  // ── GET /api/pages/:id/feedback ───────────────────────────────────
+
+  it('should get feedback summary for a page', async () => {
+    // Summary query
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ helpful_count: '5', not_helpful_count: '2', total_count: '7' }],
+    });
+    // User vote query
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ is_helpful: true, comment: 'Nice' }],
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/pages/42/feedback' });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.helpful).toBe(5);
+    expect(body.notHelpful).toBe(2);
+    expect(body.total).toBe(7);
+    expect(body.userVote).toEqual({ isHelpful: true, comment: 'Nice' });
+  });
+
+  it('should return null userVote when user has not voted', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ helpful_count: '0', not_helpful_count: '0', total_count: '0' }],
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({ method: 'GET', url: '/api/pages/42/feedback' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().userVote).toBeNull();
+  });
+
+  // ── POST /api/pages/:id/view ──────────────────────────────────────
+
+  it('should record a page view', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/view',
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json().recorded).toBe(true);
+  });
+
+  it('should deduplicate views within 30 minutes', async () => {
+    // Recent view found
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/view',
+      payload: { sessionId: 'session-1' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().recorded).toBe(false);
+    expect(res.json().reason).toBe('duplicate');
+  });
+
+  it('should record new view with session when no recent duplicate', async () => {
+    // No recent view found
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // Insert view
+    mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/view',
+      payload: { sessionId: 'session-new' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json().recorded).toBe(true);
+  });
+
+  // ── GET /api/analytics/trending ───────────────────────────────────
+
+  it('should return trending articles', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          page_id: 1,
+          view_count: '42',
+          unique_viewers: '10',
+          title: 'Popular Article',
+          space_key: 'DEV',
+          confluence_id: 'page-1',
+        },
+      ],
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/trending' });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.articles).toHaveLength(1);
+    expect(body.articles[0].viewCount).toBe(42);
+    expect(body.articles[0].uniqueViewers).toBe(10);
+    expect(body.periodDays).toBe(7); // default
+  });
+
+  it('should accept custom days and limit params', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/trending?days=30&limit=5' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().periodDays).toBe(30);
+  });
+
+  // ── GET /api/analytics/content-quality ─────────────────────────────
+
+  it('should return content quality report', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          page_id: 1,
+          confluence_id: 'page-1',
+          title: 'Needs Work',
+          space_key: 'DEV',
+          last_modified_at: new Date('2024-01-01'),
+          helpful_count: '1',
+          not_helpful_count: '5',
+          total_feedback: '6',
+          view_count: '3',
+        },
+      ],
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/content-quality' });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.pages).toHaveLength(1);
+    expect(body.pages[0].notHelpful).toBe(5);
+    expect(body.pages[0].viewCount).toBe(3);
+  });
+
+  // ── GET /api/analytics/content-gaps ────────────────────────────────
+
+  it('should return content gaps', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          query_text: 'kubernetes deployment',
+          occurrence_count: '5',
+          last_searched: new Date('2025-06-01'),
+          avg_max_score: 0.15,
+        },
+      ],
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/content-gaps' });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.gaps).toHaveLength(1);
+    expect(body.gaps[0].query).toBe('kubernetes deployment');
+    expect(body.gaps[0].occurrences).toBe(5);
+    expect(body.total).toBe(1);
+    expect(body.periodDays).toBe(30); // default
+  });
+
+  it('should accept custom days and minOccurrences', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/analytics/content-gaps?days=7&minOccurrences=5',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().periodDays).toBe(7);
+  });
+});

--- a/backend/src/routes/knowledge/templates-routes.test.ts
+++ b/backend/src/routes/knowledge/templates-routes.test.ts
@@ -1,0 +1,468 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+
+// --- Mock: postgres query ---
+const mockQuery = vi.fn();
+vi.mock('../../core/db/postgres.js', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+// --- Mock: logger ---
+vi.mock('../../core/utils/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { templateRoutes } from './templates.js';
+
+// =============================================================================
+// Auth-required tests
+// =============================================================================
+
+describe('Template routes - auth required', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.decorate('authenticate', async () => {
+      throw app.httpErrors.unauthorized('Missing or invalid token');
+    });
+    app.decorateRequest('userId', '');
+    app.decorateRequest('userRole', '');
+
+    await app.register(templateRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should return 401 for GET /api/templates without auth', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/templates' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('should return 401 for POST /api/templates without auth', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/templates',
+      payload: { title: 'test', bodyJson: '{}', bodyHtml: '<p></p>' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// =============================================================================
+// Happy-path tests (authenticated user)
+// =============================================================================
+
+describe('Template routes - authenticated', () => {
+  let app: ReturnType<typeof Fastify>;
+  const TEST_USER_ID = 'user-123';
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.decorate('authenticate', async (request: { userId: string; userRole: string }) => {
+      request.userId = TEST_USER_ID;
+      request.userRole = 'user';
+    });
+    app.decorateRequest('userId', '');
+    app.decorateRequest('userRole', '');
+
+    await app.register(templateRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── GET /api/templates ────────────────────────────────────────────────
+
+  it('should list templates for user', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          title: 'My Template',
+          description: 'A template',
+          category: 'docs',
+          icon: '📄',
+          is_global: false,
+          use_count: 3,
+          created_by: TEST_USER_ID,
+          created_at: new Date('2025-01-01'),
+        },
+      ],
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/templates' });
+    expect(res.statusCode).toBe(200);
+
+    const body = res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].title).toBe('My Template');
+    expect(body[0].isGlobal).toBe(false);
+    expect(body[0].useCount).toBe(3);
+  });
+
+  it('should filter templates by scope=global', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({ method: 'GET', url: '/api/templates?scope=global' });
+    expect(res.statusCode).toBe(200);
+
+    // Verify query includes is_global filter
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('is_global = TRUE');
+  });
+
+  it('should filter templates by scope=mine', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({ method: 'GET', url: '/api/templates?scope=mine' });
+    expect(res.statusCode).toBe(200);
+
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('created_by');
+  });
+
+  it('should filter templates by category', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({ method: 'GET', url: '/api/templates?category=engineering' });
+    expect(res.statusCode).toBe(200);
+
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('category');
+  });
+
+  // ── GET /api/templates/:id ──────────────────────────────────────────
+
+  it('should get a single template by id', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        id: 1,
+        title: 'Test',
+        description: null,
+        category: null,
+        icon: null,
+        body_json: '{"type":"doc"}',
+        body_html: '<p>test</p>',
+        variables: [],
+        created_by: TEST_USER_ID,
+        is_global: false,
+        space_key: null,
+        use_count: 0,
+        created_at: new Date(),
+        updated_at: new Date(),
+      }],
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/templates/1' });
+    expect(res.statusCode).toBe(200);
+
+    const body = res.json();
+    expect(body.title).toBe('Test');
+    expect(body.bodyJson).toBe('{"type":"doc"}');
+  });
+
+  it('should return 404 for non-existent template', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({ method: 'GET', url: '/api/templates/999' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should reject invalid id param', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/templates/-1' });
+    // Zod validation error — 500 without the custom app error handler
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+  });
+
+  // ── POST /api/templates ─────────────────────────────────────────────
+
+  it('should create a template', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 10, created_at: new Date('2025-06-01') }],
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/templates',
+      payload: {
+        title: 'New Template',
+        bodyJson: '{"type":"doc","content":[]}',
+        bodyHtml: '<p>content</p>',
+        category: 'engineering',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.id).toBe(10);
+  });
+
+  it('should reject creating global template as non-admin', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/templates',
+      payload: {
+        title: 'Global Attempt',
+        bodyJson: '{}',
+        bodyHtml: '<p></p>',
+        isGlobal: true,
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('should reject template with empty title', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/templates',
+      payload: {
+        title: '',
+        bodyJson: '{}',
+        bodyHtml: '<p></p>',
+      },
+    });
+
+    // Zod validation error — 500 without custom app error handler
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+  });
+
+  // ── POST /api/templates/:id/use ─────────────────────────────────────
+
+  it('should use a template and increment count', async () => {
+    // First call: find the template
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        id: 1,
+        title: 'My Template',
+        body_json: '{"type":"doc"}',
+        body_html: '<p>hello</p>',
+        is_global: false,
+        created_by: TEST_USER_ID,
+      }],
+    });
+    // Second call: increment use_count
+    mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/templates/1/use',
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.title).toBe('My Template');
+    expect(body.bodyJson).toBe('{"type":"doc"}');
+  });
+
+  it('should return 404 when using non-existent template', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/templates/999/use',
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  // ── PATCH /api/templates/:id ────────────────────────────────────────
+
+  it('should update a template', async () => {
+    // First call: check ownership
+    mockQuery.mockResolvedValueOnce({ rows: [{ created_by: TEST_USER_ID }] });
+    // Second call: actual update
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, updated_at: new Date() }] });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/templates/1',
+      payload: { title: 'Updated Title' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.id).toBe(1);
+  });
+
+  it('should reject update by non-owner non-admin', async () => {
+    // Template owned by someone else
+    mockQuery.mockResolvedValueOnce({ rows: [{ created_by: 'other-user' }] });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/templates/1',
+      payload: { title: 'Hijack' },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('should return 404 when updating non-existent template', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/templates/999',
+      payload: { title: 'Ghost' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should reject update with no fields', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ created_by: TEST_USER_ID }] });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/templates/1',
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should reject setting isGlobal as non-admin', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ created_by: TEST_USER_ID }] });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/templates/1',
+      payload: { isGlobal: true },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  // ── DELETE /api/templates/:id ───────────────────────────────────────
+
+  it('should delete own template', async () => {
+    // Check ownership
+    mockQuery.mockResolvedValueOnce({ rows: [{ created_by: TEST_USER_ID }] });
+    // Actual delete
+    mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/templates/1' });
+    expect(res.statusCode).toBe(200);
+
+    const body = res.json();
+    expect(body.message).toBe('Template deleted');
+  });
+
+  it('should reject delete by non-owner non-admin', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ created_by: 'other-user' }] });
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/templates/1' });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('should return 404 when deleting non-existent template', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/templates/999' });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// =============================================================================
+// Admin user tests
+// =============================================================================
+
+describe('Template routes - admin user', () => {
+  let app: ReturnType<typeof Fastify>;
+  const ADMIN_USER_ID = 'admin-123';
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.decorate('authenticate', async (request: { userId: string; userRole: string }) => {
+      request.userId = ADMIN_USER_ID;
+      request.userRole = 'admin';
+    });
+    app.decorateRequest('userId', '');
+    app.decorateRequest('userRole', '');
+
+    await app.register(templateRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should allow admin to create global template', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 20, created_at: new Date() }],
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/templates',
+      payload: {
+        title: 'Global Template',
+        bodyJson: '{}',
+        bodyHtml: '<p></p>',
+        isGlobal: true,
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('should allow admin to update any template', async () => {
+    // Template owned by someone else
+    mockQuery.mockResolvedValueOnce({ rows: [{ created_by: 'other-user' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, updated_at: new Date() }] });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/templates/1',
+      payload: { title: 'Admin Updated' },
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('should allow admin to delete any template', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ created_by: 'other-user' }] });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/templates/1' });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('should allow admin to set isGlobal flag on update', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ created_by: ADMIN_USER_ID }] });
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, updated_at: new Date() }] });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/templates/1',
+      payload: { isGlobal: true },
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/backend/src/routes/knowledge/verification-routes.test.ts
+++ b/backend/src/routes/knowledge/verification-routes.test.ts
@@ -1,0 +1,444 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+import { ZodError } from 'zod';
+
+// Hoisted mocks
+const mockQuery = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+
+vi.mock('../../core/db/postgres.js', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+  getPool: vi.fn().mockReturnValue({}),
+  runMigrations: vi.fn(),
+  closePool: vi.fn(),
+}));
+
+const mockGetUserAccessibleSpaces = vi.fn().mockResolvedValue(['TEST', 'DEV']);
+vi.mock('../../core/services/rbac-service.js', () => ({
+  getUserAccessibleSpaces: (...args: unknown[]) => mockGetUserAccessibleSpaces(...args),
+}));
+
+vi.mock('../../core/utils/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { verificationRoutes } from './verification.js';
+
+const TEST_USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const VALID_OWNER_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+function buildApp(opts?: { rejectAuth?: boolean }) {
+  const app = Fastify({ logger: false });
+  app.register(sensible);
+
+  app.setErrorHandler((error, _request, reply) => {
+    if (error instanceof ZodError) {
+      reply.status(400).send({
+        error: 'ValidationError',
+        message: error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join('; '),
+        statusCode: 400,
+      });
+      return;
+    }
+    reply.status(error.statusCode ?? 500).send({ error: error.message, statusCode: error.statusCode ?? 500 });
+  });
+
+  if (opts?.rejectAuth) {
+    app.decorate('authenticate', async (_request: unknown, reply: { code: (n: number) => { send: (b: unknown) => void } }) => {
+      reply.code(401).send({ error: 'Unauthorized', statusCode: 401 });
+    });
+  } else {
+    app.decorate('authenticate', async (request: { userId: string; userRole: string }) => {
+      request.userId = TEST_USER_ID;
+      request.userRole = 'admin';
+    });
+  }
+
+  app.register(verificationRoutes, { prefix: '/api' });
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Main test suite (authenticated)
+// ---------------------------------------------------------------------------
+describe('Verification routes', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = buildApp();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockGetUserAccessibleSpaces.mockReset();
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    mockGetUserAccessibleSpaces.mockResolvedValue(['TEST', 'DEV']);
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /api/pages/:id/verify
+  // -------------------------------------------------------------------------
+  describe('POST /api/pages/:id/verify', () => {
+    it('should return 200 and { success: true } when page exists and user has access', async () => {
+      // assertPageAccess query — page found
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 42 }] });
+      // UPDATE pages ... RETURNING id
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 42 }], rowCount: 1 });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/42/verify',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+
+      // assertPageAccess should call getUserAccessibleSpaces
+      expect(mockGetUserAccessibleSpaces).toHaveBeenCalledWith(TEST_USER_ID);
+
+      // Verify the UPDATE was called with userId and pageId
+      const updateCall = mockQuery.mock.calls[1];
+      expect(updateCall[0]).toContain('UPDATE pages SET');
+      expect(updateCall[0]).toContain('verified_by');
+      expect(updateCall[1]).toEqual([TEST_USER_ID, 42]);
+    });
+
+    it('should return 404 when page is not found', async () => {
+      // assertPageAccess query — no rows
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/999/verify',
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should accept confluence_id (non-numeric) as page identifier', async () => {
+      // assertPageAccess with non-numeric id uses confluence_id column
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 7 }] });
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 7 }], rowCount: 1 });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/conf-abc-123/verify',
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      // The assertPageAccess query should use confluence_id for non-numeric ids
+      const accessQuery = mockQuery.mock.calls[0][0] as string;
+      expect(accessQuery).toContain('p.confluence_id = $2');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // PUT /api/pages/:id/owner
+  // -------------------------------------------------------------------------
+  describe('PUT /api/pages/:id/owner', () => {
+    it('should return 200 and { success: true } when assigning a valid owner', async () => {
+      // assertPageAccess — page found
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 42 }] });
+      // Owner user exists check
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: VALID_OWNER_ID }] });
+      // UPDATE pages SET owner_id
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 42 }], rowCount: 1 });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/42/owner',
+        payload: { ownerId: VALID_OWNER_ID },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+
+      // Verify the owner update query
+      const updateCall = mockQuery.mock.calls[2];
+      expect(updateCall[0]).toContain('UPDATE pages SET owner_id');
+      expect(updateCall[1]).toEqual([VALID_OWNER_ID, 42]);
+    });
+
+    it('should return 400 for invalid ownerId (not a UUID)', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/42/owner',
+        payload: { ownerId: 'not-a-uuid' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 when owner user is not found', async () => {
+      // assertPageAccess — page found
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 42 }] });
+      // Owner user check — no rows
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/42/owner',
+        payload: { ownerId: VALID_OWNER_ID },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body);
+      expect(body.message || body.error).toContain('Owner user not found');
+    });
+
+    it('should return 404 when page is not found', async () => {
+      // assertPageAccess — no rows
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/999/owner',
+        payload: { ownerId: VALID_OWNER_ID },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // PUT /api/pages/:id/review-interval
+  // -------------------------------------------------------------------------
+  describe('PUT /api/pages/:id/review-interval', () => {
+    it('should return 200 and { success: true } with valid days', async () => {
+      // assertPageAccess — page found
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 42 }] });
+      // UPDATE pages SET review_interval_days
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 42 }], rowCount: 1 });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/42/review-interval',
+        payload: { days: 30 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+
+      // Verify the update query received the correct days value
+      const updateCall = mockQuery.mock.calls[1];
+      expect(updateCall[0]).toContain('review_interval_days');
+      expect(updateCall[1]).toEqual([30, 42]);
+    });
+
+    it('should return 400 for days = 0 (below minimum)', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/42/review-interval',
+        payload: { days: 0 },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 for days > 365 (above maximum)', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/42/review-interval',
+        payload: { days: 366 },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 for non-integer days', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/42/review-interval',
+        payload: { days: 30.5 },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should accept boundary values (1 and 365)', async () => {
+      // days = 1
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 42 }] });
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 42 }], rowCount: 1 });
+
+      const response1 = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/42/review-interval',
+        payload: { days: 1 },
+      });
+      expect(response1.statusCode).toBe(200);
+
+      mockQuery.mockReset();
+      mockGetUserAccessibleSpaces.mockReset();
+      mockGetUserAccessibleSpaces.mockResolvedValue(['TEST', 'DEV']);
+
+      // days = 365
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 42 }] });
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 42 }], rowCount: 1 });
+
+      const response365 = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/42/review-interval',
+        payload: { days: 365 },
+      });
+      expect(response365.statusCode).toBe(200);
+    });
+
+    it('should return 404 when page is not found', async () => {
+      // assertPageAccess — no rows
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/999/review-interval',
+        payload: { days: 30 },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/analytics/verification-health
+  // -------------------------------------------------------------------------
+  describe('GET /api/analytics/verification-health', () => {
+    it('should return health stats with correct shape', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{
+          fresh: '10',
+          aging: '5',
+          overdue: '3',
+          unverified: '12',
+          total: '30',
+        }],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/analytics/verification-health',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toEqual({
+        fresh: 10,
+        aging: 5,
+        overdue: 3,
+        unverified: 12,
+        total: 30,
+      });
+    });
+
+    it('should return all zeros when no pages exist', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{
+          fresh: '0',
+          aging: '0',
+          overdue: '0',
+          unverified: '0',
+          total: '0',
+        }],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/analytics/verification-health',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.fresh).toBe(0);
+      expect(body.aging).toBe(0);
+      expect(body.overdue).toBe(0);
+      expect(body.unverified).toBe(0);
+      expect(body.total).toBe(0);
+    });
+
+    it('should parse string counts from PostgreSQL into integers', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{
+          fresh: '999',
+          aging: '0',
+          overdue: '1',
+          unverified: '50',
+          total: '1050',
+        }],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/analytics/verification-health',
+      });
+
+      const body = JSON.parse(response.body);
+      // All values should be numbers, not strings
+      expect(typeof body.fresh).toBe('number');
+      expect(typeof body.aging).toBe('number');
+      expect(typeof body.overdue).toBe('number');
+      expect(typeof body.unverified).toBe('number');
+      expect(typeof body.total).toBe('number');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth rejection suite (unauthenticated)
+// ---------------------------------------------------------------------------
+describe('Verification routes — unauthenticated', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = buildApp({ rejectAuth: true });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /api/pages/:id/verify returns 401 without auth', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/verify',
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('PUT /api/pages/:id/owner returns 401 without auth', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/pages/42/owner',
+      payload: { ownerId: VALID_OWNER_ID },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('PUT /api/pages/:id/review-interval returns 401 without auth', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/pages/42/review-interval',
+      payload: { days: 30 },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('GET /api/analytics/verification-health returns 401 without auth', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/analytics/verification-health',
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+});

--- a/backend/src/routes/llm/llm-summarize.test.ts
+++ b/backend/src/routes/llm/llm-summarize.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+
+// --- Mock: llm-provider (providerStreamChat) ---
+const mockProviderStreamChat = vi.fn();
+
+vi.mock('../../domains/llm/services/llm-provider.js', () => ({
+  providerStreamChat: (...args: unknown[]) => mockProviderStreamChat(...args),
+}));
+
+// --- Mock: llm-cache ---
+const mockGetCachedResponse = vi.fn().mockResolvedValue(null);
+const mockReleaseLock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../domains/llm/services/llm-cache.js', () => {
+  class MockLlmCache {
+    getCachedResponse = mockGetCachedResponse;
+    setCachedResponse = vi.fn().mockResolvedValue(undefined);
+    acquireLock = vi.fn().mockResolvedValue(true);
+    releaseLock = mockReleaseLock;
+    waitForCachedResponse = vi.fn().mockResolvedValue(null);
+    clearAll = vi.fn();
+  }
+  return {
+    LlmCache: MockLlmCache,
+    buildLlmCacheKey: vi.fn().mockReturnValue('test-cache-key'),
+  };
+});
+
+// --- Mock: _web-search-helper ---
+const mockFetchWebSources = vi.fn().mockResolvedValue([]);
+const mockFormatWebContext = vi.fn().mockReturnValue('');
+
+vi.mock('./_web-search-helper.js', () => ({
+  fetchWebSources: (...args: unknown[]) => mockFetchWebSources(...args),
+  formatWebContext: (...args: unknown[]) => mockFormatWebContext(...args),
+}));
+
+// --- Mock: audit-service ---
+const mockLogAuditEvent = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../core/services/audit-service.js', () => ({
+  logAuditEvent: (...args: unknown[]) => mockLogAuditEvent(...args),
+}));
+
+// --- Mock: _helpers ---
+const mockAssembleContextIfNeeded = vi.fn().mockResolvedValue({ markdown: 'test content', multiPageSuffix: '' });
+const mockResolveSystemPrompt = vi.fn().mockResolvedValue('You are a summarizer');
+const mockCheckCacheWithLock = vi.fn().mockResolvedValue({ cached: null, lockAcquired: true });
+const mockSendCachedSSE = vi.fn();
+const mockStreamSSE = vi.fn().mockResolvedValue(undefined);
+const mockSanitizeLlmInput = vi.fn((input: string) => ({ sanitized: input, warnings: [] }));
+const mockBuildOutputPostProcessor = vi.fn().mockResolvedValue((text: string) => text);
+
+vi.mock('./_helpers.js', () => ({
+  assembleContextIfNeeded: (...args: unknown[]) => mockAssembleContextIfNeeded(...args),
+  resolveSystemPrompt: (...args: unknown[]) => mockResolveSystemPrompt(...args),
+  checkCacheWithLock: (...args: unknown[]) => mockCheckCacheWithLock(...args),
+  sendCachedSSE: (...args: unknown[]) => mockSendCachedSSE(...args),
+  streamSSE: (...args: unknown[]) => mockStreamSSE(...args),
+  sanitizeLlmInput: (...args: unknown[]) => mockSanitizeLlmInput(...args),
+  buildOutputPostProcessor: (...args: unknown[]) => mockBuildOutputPostProcessor(...args),
+  LLM_STREAM_RATE_LIMIT: {},
+  MAX_INPUT_LENGTH: 100_000,
+}));
+
+import { llmSummarizeRoutes } from './llm-summarize.js';
+
+// =============================================================================
+// Test Suite 1: Auth-required tests
+// =============================================================================
+
+describe('POST /api/llm/summarize - auth required', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.decorate('authenticate', async () => {
+      throw app.httpErrors.unauthorized('Missing or invalid token');
+    });
+    app.decorate('requireAdmin', async () => {});
+    app.decorate('redis', {});
+    app.decorateRequest('userId', '');
+
+    await app.register(llmSummarizeRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should return 401 when no auth token is provided', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: { content: 'Some article text', model: 'llama3' },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+});
+
+// =============================================================================
+// Test Suite 2: Validation, caching, streaming, and business logic
+// =============================================================================
+
+describe('POST /api/llm/summarize - functionality', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.decorate('authenticate', async () => {});
+    app.decorate('requireAdmin', async () => {});
+    app.decorate('redis', {});
+    app.decorateRequest('userId', '');
+    app.addHook('onRequest', async (request) => {
+      request.userId = 'test-user-123';
+    });
+
+    await app.register(llmSummarizeRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset defaults
+    mockAssembleContextIfNeeded.mockResolvedValue({ markdown: 'test content', multiPageSuffix: '' });
+    mockResolveSystemPrompt.mockResolvedValue('You are a summarizer');
+    mockCheckCacheWithLock.mockResolvedValue({ cached: null, lockAcquired: true });
+    mockSanitizeLlmInput.mockImplementation((input: string) => ({ sanitized: input, warnings: [] }));
+    mockBuildOutputPostProcessor.mockResolvedValue((text: string) => text);
+    mockStreamSSE.mockResolvedValue(undefined);
+    mockFetchWebSources.mockResolvedValue([]);
+    mockProviderStreamChat.mockReturnValue((async function* () {
+      yield { content: 'Summary text', done: true };
+    })());
+  });
+
+  // ---------------------------------------------------------------------------
+  // Validation
+  // ---------------------------------------------------------------------------
+
+  it('should return 400 when content is missing', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: { model: 'llama3' },
+    });
+
+    expect(response.statusCode).toBeGreaterThanOrEqual(400);
+  });
+
+  it('should return 400 when model is missing', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: { content: 'Some text to summarize' },
+    });
+
+    expect(response.statusCode).toBeGreaterThanOrEqual(400);
+  });
+
+  it('should return 400 when content exceeds MAX_INPUT_LENGTH', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: {
+        content: 'x'.repeat(100_001),
+        model: 'llama3',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.message).toContain('Content too large');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cache hit
+  // ---------------------------------------------------------------------------
+
+  it('should return cached SSE response when cache has a hit', async () => {
+    mockCheckCacheWithLock.mockResolvedValue({
+      cached: { content: 'Cached summary result' },
+      lockAcquired: false,
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: { content: 'Some text', model: 'llama3' },
+    });
+
+    expect(mockSendCachedSSE).toHaveBeenCalledOnce();
+    expect(mockSendCachedSSE).toHaveBeenCalledWith(
+      expect.anything(),
+      'Cached summary result',
+    );
+    // streamSSE should NOT be called on cache hit
+    expect(mockStreamSSE).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Successful stream
+  // ---------------------------------------------------------------------------
+
+  it('should return 200 with SSE stream for valid request', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: { content: 'Some article text to summarize', model: 'llama3' },
+    });
+
+    // streamSSE was called (it handles writing the response)
+    expect(mockStreamSSE).toHaveBeenCalledOnce();
+    expect(mockProviderStreamChat).toHaveBeenCalledOnce();
+
+    // Verify providerStreamChat was called with correct messages
+    const [userId, model, messages] = mockProviderStreamChat.mock.calls[0] as [string, string, Array<{ role: string; content: string }>];
+    expect(userId).toBe('test-user-123');
+    expect(model).toBe('llama3');
+    expect(messages).toHaveLength(2);
+    expect(messages[0].role).toBe('system');
+    expect(messages[1].role).toBe('user');
+  });
+
+  it('should release lock in finally block after streaming', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: { content: 'Some text', model: 'llama3' },
+    });
+
+    expect(mockReleaseLock).toHaveBeenCalledWith('test-cache-key');
+  });
+
+  it('should not release lock when lockAcquired is false (cache hit)', async () => {
+    mockCheckCacheWithLock.mockResolvedValue({
+      cached: { content: 'Cached' },
+      lockAcquired: false,
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: { content: 'Some text', model: 'llama3' },
+    });
+
+    expect(mockReleaseLock).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Length parameter
+  // ---------------------------------------------------------------------------
+
+  it('should use "short" length instruction in system prompt', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: { content: 'Some text', model: 'llama3', length: 'short' },
+    });
+
+    const [, , messages] = mockProviderStreamChat.mock.calls[0] as [string, string, Array<{ role: string; content: string }>];
+    expect(messages[0].content).toContain('brief 2-3 sentence');
+  });
+
+  it('should use "medium" length instruction by default', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: { content: 'Some text', model: 'llama3' },
+    });
+
+    const [, , messages] = mockProviderStreamChat.mock.calls[0] as [string, string, Array<{ role: string; content: string }>];
+    expect(messages[0].content).toContain('1-2 paragraphs');
+  });
+
+  it('should use "detailed" length instruction in system prompt', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: { content: 'Some text', model: 'llama3', length: 'detailed' },
+    });
+
+    const [, , messages] = mockProviderStreamChat.mock.calls[0] as [string, string, Array<{ role: string; content: string }>];
+    expect(messages[0].content).toContain('detailed summary covering all important points');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Sanitization warnings trigger audit event
+  // ---------------------------------------------------------------------------
+
+  it('should log audit event when sanitization finds warnings', async () => {
+    mockSanitizeLlmInput.mockImplementation((input: string) => ({
+      sanitized: input,
+      warnings: ['Suspicious pattern detected'],
+    }));
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: { content: 'Some suspicious text', model: 'llama3' },
+    });
+
+    expect(mockLogAuditEvent).toHaveBeenCalledOnce();
+    expect(mockLogAuditEvent).toHaveBeenCalledWith(
+      'test-user-123',
+      'PROMPT_INJECTION_DETECTED',
+      'llm',
+      undefined,
+      { warnings: ['Suspicious pattern detected'], route: '/llm/summarize' },
+      expect.anything(), // request object
+    );
+  });
+
+  it('should not log audit event when sanitization has no warnings', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: { content: 'Normal text', model: 'llama3' },
+    });
+
+    expect(mockLogAuditEvent).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Web search integration
+  // ---------------------------------------------------------------------------
+
+  it('should fetch web sources when searchWeb is true', async () => {
+    mockFetchWebSources.mockResolvedValue([
+      { title: 'Web Result', url: 'https://example.com', snippet: 'Some info' },
+    ]);
+    mockFormatWebContext.mockReturnValue('\n\n---\nReference: Web Result\n');
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: {
+        content: 'Some text',
+        model: 'llama3',
+        searchWeb: true,
+        searchQuery: 'test query',
+      },
+    });
+
+    expect(mockFetchWebSources).toHaveBeenCalledWith('test query', 'test-user-123');
+    expect(mockFormatWebContext).toHaveBeenCalledOnce();
+
+    // streamSSE should receive extras with sources
+    const streamCall = mockStreamSSE.mock.calls[0] as unknown[];
+    const extras = streamCall[3] as { sources: Array<Record<string, unknown>> };
+    expect(extras).toBeDefined();
+    expect(extras.sources).toHaveLength(1);
+    expect(extras.sources[0].spaceKey).toBe('Web');
+    expect(extras.sources[0].confluenceId).toBe('https://example.com');
+  });
+
+  it('should not fetch web sources when searchWeb is not set', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: { content: 'Some text', model: 'llama3' },
+    });
+
+    expect(mockFetchWebSources).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // assembleContextIfNeeded integration
+  // ---------------------------------------------------------------------------
+
+  it('should pass includeSubPages to assembleContextIfNeeded', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: {
+        content: 'Some text',
+        model: 'llama3',
+        pageId: 'page-123',
+        includeSubPages: true,
+      },
+    });
+
+    expect(mockAssembleContextIfNeeded).toHaveBeenCalledWith(
+      'test-user-123',
+      'page-123',
+      'Some text',
+      true,
+    );
+  });
+
+  it('should include multiPageSuffix in system prompt', async () => {
+    mockAssembleContextIfNeeded.mockResolvedValue({
+      markdown: 'multi-page content',
+      multiPageSuffix: ' (includes 3 sub-pages)',
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/llm/summarize',
+      payload: {
+        content: 'Some text',
+        model: 'llama3',
+        pageId: 'page-123',
+        includeSubPages: true,
+      },
+    });
+
+    const [, , messages] = mockProviderStreamChat.mock.calls[0] as [string, string, Array<{ role: string; content: string }>];
+    expect(messages[0].content).toContain('(includes 3 sub-pages)');
+  });
+});

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -95,10 +95,10 @@ Performance is measured at three layers:
    npm run dev
    ```
 
-2. Seed test data (if needed):
+2. Seed 1,000 test pages for benchmarking:
    ```bash
-   # Create test pages via the API
-   node scripts/seed-test-data.js  # (if available)
+   POSTGRES_URL=postgresql://kb_user:changeme-postgres@localhost:5432/kb_creator \
+     npx tsx scripts/seed-perf-data.ts
    ```
 
 ### API Latency Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "@types/pg": "^8.18.0",
         "@types/turndown": "^5.0.5",
         "@types/uuid": "^11.0.0",
+        "@vitest/coverage-v8": "^4.1.2",
         "eslint": "^9.27.0",
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-boundaries": "^5.4.0",
@@ -85,6 +86,130 @@
         "typescript-eslint": "^8.56.1",
         "vitest": "^4.0.18"
       }
+    },
+    "backend/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "backend/node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "backend/node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "backend/node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "backend/node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "backend/node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "backend/node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "backend/node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "backend/node_modules/eslint": {
       "version": "9.39.3",
@@ -192,6 +317,145 @@
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      }
+    },
+    "backend/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "backend/node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "backend/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "backend/node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "backend/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "frontend": {
@@ -733,6 +997,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@boundaries/elements": {
@@ -8427,6 +8701,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -12265,6 +12558,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -12996,6 +13296,87 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jerrypick": {
@@ -13929,6 +14310,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-dir": {

--- a/scripts/seed-perf-data.ts
+++ b/scripts/seed-perf-data.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env npx tsx
+/**
+ * Seed script for performance baseline testing.
+ *
+ * Creates 1,000 test pages with realistic content lengths for measuring:
+ * - Pages list query latency
+ * - Full-text search performance
+ * - Hybrid search (vector + keyword) when embeddings are generated
+ *
+ * Usage:
+ *   npx tsx scripts/seed-perf-data.ts
+ *
+ * Prerequisites:
+ *   - PostgreSQL running (docker compose up -d)
+ *   - Migrations applied (npm run dev starts the backend which runs migrations)
+ *   - POSTGRES_URL env var set (default: postgresql://kb_user:changeme-postgres@localhost:5432/kb_creator)
+ *
+ * This script is idempotent — it checks for existing perf-test pages before inserting.
+ */
+
+import pg from 'pg';
+
+const POSTGRES_URL = process.env.POSTGRES_URL;
+if (!POSTGRES_URL) {
+  console.error('Error: POSTGRES_URL environment variable is required.');
+  console.error('Example: POSTGRES_URL=postgresql://kb_user:pass@localhost:5432/kb_creator npx tsx scripts/seed-perf-data.ts');
+  process.exit(1);
+}
+
+const TOTAL_PAGES = 1000;
+const BATCH_SIZE = 100;
+
+// Sample content building blocks for realistic pages
+const TOPICS = [
+  'Kubernetes', 'Docker', 'PostgreSQL', 'Redis', 'Nginx',
+  'React', 'TypeScript', 'Node.js', 'GraphQL', 'REST API',
+  'CI/CD Pipeline', 'Monitoring', 'Logging', 'Security', 'Authentication',
+  'Microservices', 'Load Balancing', 'Caching', 'Database Migration', 'Testing',
+];
+
+const SECTIONS = [
+  'Overview', 'Getting Started', 'Configuration', 'Deployment',
+  'Troubleshooting', 'Best Practices', 'Architecture', 'FAQ',
+];
+
+function generateContent(index: number): { title: string; body: string; spaceKey: string } {
+  const topic = TOPICS[index % TOPICS.length];
+  const section = SECTIONS[index % SECTIONS.length];
+  const spaceKey = `PERF${Math.floor(index / 200)}`;
+
+  const title = `${topic} — ${section} (Page ${index + 1})`;
+
+  // Generate 200-2000 word paragraphs
+  const paragraphCount = 3 + (index % 5);
+  const paragraphs: string[] = [];
+  for (let p = 0; p < paragraphCount; p++) {
+    const sentences = 5 + (index * p) % 10;
+    const lines: string[] = [];
+    for (let s = 0; s < sentences; s++) {
+      lines.push(
+        `This section covers ${topic.toLowerCase()} ${section.toLowerCase()} concepts including setup, configuration, and operational best practices for production environments.`,
+      );
+    }
+    paragraphs.push(lines.join(' '));
+  }
+
+  const body = `<h1>${title}</h1>\n${paragraphs.map((p) => `<p>${p}</p>`).join('\n')}`;
+  return { title, body, spaceKey };
+}
+
+async function main() {
+  const pool = new pg.Pool({ connectionString: POSTGRES_URL });
+
+  try {
+    // Check if perf-test pages already exist
+    const existing = await pool.query(
+      "SELECT COUNT(*)::int AS count FROM pages WHERE confluence_id LIKE 'perf-test-%'",
+    );
+
+    if (existing.rows[0].count >= TOTAL_PAGES) {
+      console.log(`Already have ${existing.rows[0].count} perf-test pages. Skipping seed.`);
+      return;
+    }
+
+    if (existing.rows[0].count > 0) {
+      console.log(`Cleaning up ${existing.rows[0].count} existing perf-test pages...`);
+      await pool.query("DELETE FROM pages WHERE confluence_id LIKE 'perf-test-%'");
+    }
+
+    console.log(`Seeding ${TOTAL_PAGES} test pages in batches of ${BATCH_SIZE}...`);
+
+    const startTime = Date.now();
+    let inserted = 0;
+
+    for (let batch = 0; batch < TOTAL_PAGES / BATCH_SIZE; batch++) {
+      const values: unknown[] = [];
+      const placeholders: string[] = [];
+      let paramIdx = 1;
+
+      for (let i = 0; i < BATCH_SIZE; i++) {
+        const pageIndex = batch * BATCH_SIZE + i;
+        const { title, body, spaceKey } = generateContent(pageIndex);
+        const confluenceId = `perf-test-${pageIndex.toString().padStart(4, '0')}`;
+
+        placeholders.push(
+          `($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++})`,
+        );
+        values.push(
+          confluenceId,
+          spaceKey,
+          title,
+          body,       // body_storage (XHTML)
+          body,       // body_html
+          title,      // body_text (plain)
+          1,          // version
+          'confluence', // source
+        );
+      }
+
+      await pool.query(
+        `INSERT INTO pages (confluence_id, space_key, title, body_storage, body_html, body_text, version, source)
+         VALUES ${placeholders.join(',\n')}
+         ON CONFLICT (confluence_id) DO NOTHING`,
+        values,
+      );
+
+      inserted += BATCH_SIZE;
+      process.stdout.write(`\r  Inserted ${inserted}/${TOTAL_PAGES} pages...`);
+    }
+
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    console.log(`\nDone! Seeded ${TOTAL_PAGES} pages in ${elapsed}s.`);
+
+    // Verify count
+    const count = await pool.query(
+      "SELECT COUNT(*)::int AS count FROM pages WHERE confluence_id LIKE 'perf-test-%'",
+    );
+    console.log(`Verified: ${count.rows[0].count} perf-test pages in database.`);
+
+    // Run basic query benchmarks
+    console.log('\nRunning quick latency checks...\n');
+
+    // 1. Pages list query
+    const t1 = Date.now();
+    await pool.query(
+      `SELECT id, title, space_key, updated_at FROM pages WHERE deleted_at IS NULL ORDER BY updated_at DESC LIMIT 50`,
+    );
+    console.log(`  Pages list (LIMIT 50):          ${Date.now() - t1}ms`);
+
+    // 2. Full-text search (if search_vector is populated)
+    const t2 = Date.now();
+    await pool.query(
+      `SELECT id, title FROM pages WHERE deleted_at IS NULL AND body_text ILIKE '%kubernetes%' ORDER BY updated_at DESC LIMIT 20`,
+    );
+    console.log(`  Keyword search (ILIKE):          ${Date.now() - t2}ms`);
+
+    // 3. Count query
+    const t3 = Date.now();
+    await pool.query(`SELECT COUNT(*) FROM pages WHERE deleted_at IS NULL`);
+    console.log(`  Count all pages:                 ${Date.now() - t3}ms`);
+
+    console.log('\nTo run the full hybrid search benchmark, generate embeddings first:');
+    console.log('  1. Start the backend: npm run dev');
+    console.log('  2. Trigger embedding: POST /api/llm/embeddings/generate');
+    console.log('  3. Run: autocannon -c 5 -d 10 -H "Authorization=Bearer $TOKEN" "http://localhost:3051/api/pages?search=kubernetes"');
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add **103 new route-level tests** across 6 new test files for low-coverage backend routes
- Add **performance baseline seed script** (`scripts/seed-perf-data.ts`) for 1,000-page benchmarking
- Update `docs/PERFORMANCE.md` to reference the seed script
- Add `@vitest/coverage-v8` devDependency for coverage reporting

## Coverage Impact

| Route File | Before | After |
|-----------|--------|-------|
| `llm-summarize.ts` | 8.8% | ~80% |
| `foundation/auth.ts` (routes) | 5.5% | ~70% |
| `knowledge/templates.ts` | 5.2% | ~75% |
| `knowledge/verification.ts` | 6.1% | ~70% |
| `knowledge/content-analytics.ts` | 13.0% | ~70% |
| `knowledge/analytics.ts` | 13.3% | ~70% |

Backend total: 1551 tests passing (up from 1448, +103 new tests)

## Progress on #3

Covers tasks 7.1 (backend coverage audit + route tests) and 7.4 (performance baseline seed script + docs).

Tasks 7.2 (E2E Playwright tests) and 7.3 (frontend component tests) were already completed in earlier commits on `dev`.

## Test plan
- [x] All 1551 backend tests pass
- [x] All 1628 frontend tests pass
- [x] TypeScript clean (both workspaces)
- [x] ESLint clean (both workspaces)
- [x] New test files cover all route endpoints with auth, validation, and happy-path tests
- [x] Seed script documented in PERFORMANCE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)