### PR TITLE
fix(enterprise): guard CE license route to prevent duplicate-route error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ AtlasMind uses an open-core model. The CE (Community Edition) is this repo. The 
 - CE defines types, loader, noop stub, and feature constants only. No enterprise logic.
 - The noop plugin must be completely inert (zero dependencies, zero side effects).
 - `app.ts` calls `loadEnterprisePlugin()` during bootstrap and decorates Fastify with `license` and `enterprise`.
-- `GET /api/admin/license` always returns `{ edition: 'community', tier: 'community', features: [] }` in CE mode.
+- `GET /api/admin/license` returns `{ edition: 'community', tier: 'community', features: [] }` in CE mode. The fallback route is only registered when `enterprise.version === 'community'` (noop plugin) to avoid duplicate-route errors when the EE plugin registers its own version via `registerRoutes()`.
 - OIDC routes are conditionally registered only when the enterprise plugin enables `ENTERPRISE_FEATURES.OIDC_SSO`.
 - Frontend `loadEnterpriseUI()` uses `@vite-ignore` to prevent Vite from resolving the missing package at build time.
 - License format: `ATM-{tier}-{seats}-{expiryYYYYMMDD}.{ed25519SignatureBase64url}` via `ATLASMIND_LICENSE_KEY` env var.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -183,13 +183,14 @@ export async function buildApp() {
   await app.register(rbacRoutes, { prefix: '/api' });
 
   // Community-mode license endpoint fallback.
-  // The enterprise plugin may register a richer version via registerRoutes().
-  // This ensures GET /api/admin/license always returns something.
-  app.get('/api/admin/license', { onRequest: [app.requireAdmin] }, async () => ({
-    edition: 'community',
-    tier: 'community',
-    features: [],
-  }));
+  // Skip if the enterprise plugin registered its own richer version via registerRoutes().
+  if (enterprise.version === 'community') {
+    app.get('/api/admin/license', { onRequest: [app.requireAdmin] }, async () => ({
+      edition: 'community',
+      tier: 'community',
+      features: [],
+    }));
+  }
 
   // ── Conditional Enterprise Route Registration ────────────────────
   // OIDC routes would be registered here when the enterprise plugin


### PR DESCRIPTION
## Summary
- Wrap the CE fallback `GET /api/admin/license` route in `if (enterprise.version === 'community')` guard
- Prevents `FastifyError: Method 'GET' already declared for route '/api/admin/license'` when the EE plugin registers its own version via `registerRoutes()`
- Update CLAUDE.md to document the guard condition

## Context
Discovered during EE Docker build — the EE plugin's `registerRoutes()` registers `GET /api/admin/license` with richer license info. The CE fallback for the same route caused a duplicate-route crash at startup.

## Test plan
- [x] `app.test.ts` passes (CE mode — noop plugin, route still registered)
- [x] `app-integration.test.ts` passes (enterprise plugin integration)
- [x] TypeScript clean
- [x] ESLint clean
- [x] Verified EE container starts without duplicate-route error

🤖 Generated with [Claude Code](https://claude.com/claude-code)