### PR TITLE
ci: rename Docker images from atlasmind to compendiq-ce

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,7 +27,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: diinlu/atlasmind-backend
+          images: diinlu/compendiq-ce-backend
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -50,8 +50,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=registry,ref=diinlu/atlasmind-backend:buildcache
-          cache-to: type=registry,ref=diinlu/atlasmind-backend:buildcache,mode=max
+          cache-from: type=registry,ref=diinlu/compendiq-ce-backend:buildcache
+          cache-to: type=registry,ref=diinlu/compendiq-ce-backend:buildcache,mode=max
           sbom: true
           provenance: mode=max
 
@@ -75,7 +75,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: diinlu/atlasmind-frontend
+          images: diinlu/compendiq-ce-frontend
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -98,8 +98,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=registry,ref=diinlu/atlasmind-frontend:buildcache
-          cache-to: type=registry,ref=diinlu/atlasmind-frontend:buildcache,mode=max
+          cache-from: type=registry,ref=diinlu/compendiq-ce-frontend:buildcache
+          cache-to: type=registry,ref=diinlu/compendiq-ce-frontend:buildcache,mode=max
           sbom: true
           provenance: mode=max
 
@@ -123,7 +123,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: diinlu/atlasmind-searxng
+          images: diinlu/compendiq-ce-searxng
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -146,8 +146,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=registry,ref=diinlu/atlasmind-searxng:buildcache
-          cache-to: type=registry,ref=diinlu/atlasmind-searxng:buildcache,mode=max
+          cache-from: type=registry,ref=diinlu/compendiq-ce-searxng:buildcache
+          cache-to: type=registry,ref=diinlu/compendiq-ce-searxng:buildcache,mode=max
 
   docker-mcp-docs:
     name: MCP Docs Image
@@ -169,7 +169,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: diinlu/atlasmind-mcp-docs
+          images: diinlu/compendiq-ce-mcp-docs
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -192,7 +192,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=registry,ref=diinlu/atlasmind-mcp-docs:buildcache
-          cache-to: type=registry,ref=diinlu/atlasmind-mcp-docs:buildcache,mode=max
+          cache-from: type=registry,ref=diinlu/compendiq-ce-mcp-docs:buildcache
+          cache-to: type=registry,ref=diinlu/compendiq-ce-mcp-docs:buildcache,mode=max
           sbom: true
           provenance: mode=max

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,8 +1,8 @@
-name: atlasmind
+name: compendiq
 
 services:
   frontend:
-    image: diinlu/atlasmind-frontend:dev
+    image: diinlu/compendiq-ce-frontend:dev
     build:
       context: ..
       dockerfile: frontend/Dockerfile
@@ -15,7 +15,7 @@ services:
     networks: [frontend-net, backend-net]
 
   backend:
-    image: diinlu/atlasmind-backend:dev
+    image: diinlu/compendiq-ce-backend:dev
     build:
       context: ..
       dockerfile: backend/Dockerfile
@@ -91,7 +91,7 @@ services:
     networks: [data-net]
 
   mcp-docs:
-    image: diinlu/atlasmind-mcp-docs:dev
+    image: diinlu/compendiq-ce-mcp-docs:dev
     build:
       context: ..
       dockerfile: mcp-docs/Dockerfile
@@ -117,7 +117,7 @@ services:
     networks: [backend-net]
 
   searxng:
-    image: diinlu/atlasmind-searxng:dev
+    image: diinlu/compendiq-ce-searxng:dev
     build:
       context: ./searxng
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
Rename all Docker Hub image references from `diinlu/atlasmind-*` to `diinlu/compendiq-ce-*`:

| Old | New |
|-----|-----|
| `diinlu/atlasmind-backend` | `diinlu/compendiq-ce-backend` |
| `diinlu/atlasmind-frontend` | `diinlu/compendiq-ce-frontend` |
| `diinlu/atlasmind-mcp-docs` | `diinlu/compendiq-ce-mcp-docs` |
| `diinlu/atlasmind-searxng` | `diinlu/compendiq-ce-searxng` |

Also update compose project name from `atlasmind` to `compendiq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)