### PR TITLE
fix(sync): use soft-delete for Confluence page deletion detection

### DIFF
--- a/backend/src/domains/confluence/services/sync-service.test.ts
+++ b/backend/src/domains/confluence/services/sync-service.test.ts
@@ -4,6 +4,7 @@
  * Mocks Redis, database, and external services to isolate the lock/status logic.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { QueryResult } from 'pg';
 import type { RedisClientType } from 'redis';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
@@ -37,7 +38,7 @@ const mockConfluenceClientInstance: Record<string, ReturnType<typeof vi.fn>> = {
 };
 
 vi.mock('./confluence-client.js', () => ({
-  ConfluenceClient: vi.fn(function (this: any) {
+  ConfluenceClient: vi.fn(function (this: Record<string, ReturnType<typeof vi.fn>>) {
     Object.assign(this, mockConfluenceClientInstance);
   }),
 }));
@@ -362,7 +363,7 @@ describe('sync-service', () => {
       vi.mocked(getUserAccessibleSpaces).mockResolvedValue(['TEST']);
 
       // Track query calls and provide responses
-      vi.mocked(query).mockImplementation(async (sql: string, params?: unknown[]) => {
+      vi.mocked(query).mockImplementation(async (sql: string, _params?: unknown[]) => {
         const sqlStr = typeof sql === 'string' ? sql : '';
         const emptyResult = { rows: [], rowCount: 0, command: '', oid: 0, fields: [] };
 
@@ -371,27 +372,27 @@ describe('sync-service', () => {
           return {
             rows: [{ confluence_url: 'https://confluence.test', confluence_pat: 'encrypted-pat' }],
             rowCount: 1, command: '', oid: 0, fields: [],
-          } as any;
+          } as QueryResult;
         }
 
         // syncSpace: upsert space metadata
         if (sqlStr.includes('INSERT INTO spaces')) {
-          return emptyResult as any;
+          return emptyResult as QueryResult;
         }
 
         // syncSpace: check last sync time (return null to force full sync)
         if (sqlStr.includes('last_synced') && sqlStr.includes('FROM spaces')) {
-          return { rows: [{ last_synced: null }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+          return { rows: [{ last_synced: null }], rowCount: 1, command: '', oid: 0, fields: [] } as QueryResult;
         }
 
         // syncPage: check existing page
         if (sqlStr.includes('SELECT version') && sqlStr.includes('FROM pages')) {
-          return emptyResult as any;
+          return emptyResult as QueryResult;
         }
 
         // syncPage: upsert page
         if (sqlStr.includes('INSERT INTO pages')) {
-          return emptyResult as any;
+          return emptyResult as QueryResult;
         }
 
         // detectDeletedPages: RBAC user count
@@ -399,7 +400,7 @@ describe('sync-service', () => {
           return {
             rows: [{ count: String(rbacUserCount) }],
             rowCount: 1, command: '', oid: 0, fields: [],
-          } as any;
+          } as QueryResult;
         }
 
         // detectDeletedPages: existing pages in DB
@@ -407,26 +408,26 @@ describe('sync-service', () => {
           return {
             rows: dbPageIds.map((id) => ({ confluence_id: id })),
             rowCount: dbPageIds.length, command: '', oid: 0, fields: [],
-          } as any;
+          } as QueryResult;
         }
 
         // detectDeletedPages: soft-delete UPDATE
         if (sqlStr.includes('UPDATE pages SET deleted_at = NOW()')) {
-          return { rows: [], rowCount: 1, command: 'UPDATE', oid: 0, fields: [] } as any;
+          return { rows: [], rowCount: 1, command: 'UPDATE', oid: 0, fields: [] } as QueryResult;
         }
 
         // purgeDeletedPages: DELETE old soft-deleted
         if (sqlStr.includes('DELETE FROM pages') && sqlStr.includes('deleted_at <')) {
-          return { rows: [], rowCount: 0, command: 'DELETE', oid: 0, fields: [] } as any;
+          return { rows: [], rowCount: 0, command: 'DELETE', oid: 0, fields: [] } as QueryResult;
         }
 
         // syncSpace: update space timestamp
         if (sqlStr.includes('UPDATE spaces SET last_synced')) {
-          return emptyResult as any;
+          return emptyResult as QueryResult;
         }
 
         // processDirtyPages status updates (setSyncStatus via Redis, not query)
-        return emptyResult as any;
+        return emptyResult as QueryResult;
       });
     }
 
@@ -509,23 +510,23 @@ describe('sync-service', () => {
           return {
             rows: [{ confluence_url: 'https://confluence.test', confluence_pat: 'encrypted-pat' }],
             rowCount: 1, command: '', oid: 0, fields: [],
-          } as any;
+          } as QueryResult;
         }
-        if (sqlStr.includes('INSERT INTO spaces')) return emptyResult as any;
+        if (sqlStr.includes('INSERT INTO spaces')) return emptyResult as QueryResult;
         if (sqlStr.includes('last_synced') && sqlStr.includes('FROM spaces')) {
-          return { rows: [{ last_synced: null }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+          return { rows: [{ last_synced: null }], rowCount: 1, command: '', oid: 0, fields: [] } as QueryResult;
         }
         if (sqlStr.includes('COUNT(DISTINCT principal_id)')) {
-          return { rows: [{ count: '1' }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+          return { rows: [{ count: '1' }], rowCount: 1, command: '', oid: 0, fields: [] } as QueryResult;
         }
         if (sqlStr.includes('SELECT confluence_id FROM pages')) {
-          return emptyResult as any;
+          return emptyResult as QueryResult;
         }
         if (sqlStr.includes('DELETE FROM pages') && sqlStr.includes('deleted_at <')) {
-          return { rows: [], rowCount: 0, command: 'DELETE', oid: 0, fields: [] } as any;
+          return { rows: [], rowCount: 0, command: 'DELETE', oid: 0, fields: [] } as QueryResult;
         }
-        if (sqlStr.includes('UPDATE spaces SET last_synced')) return emptyResult as any;
-        return emptyResult as any;
+        if (sqlStr.includes('UPDATE spaces SET last_synced')) return emptyResult as QueryResult;
+        return emptyResult as QueryResult;
       });
 
       await syncUser('user-1');
@@ -557,26 +558,26 @@ describe('sync-service', () => {
           return {
             rows: [{ confluence_url: 'https://confluence.test', confluence_pat: 'encrypted-pat' }],
             rowCount: 1, command: '', oid: 0, fields: [],
-          } as any;
+          } as QueryResult;
         }
-        if (sqlStr.includes('INSERT INTO spaces')) return emptyResult as any;
+        if (sqlStr.includes('INSERT INTO spaces')) return emptyResult as QueryResult;
         if (sqlStr.includes('last_synced') && sqlStr.includes('FROM spaces')) {
-          return { rows: [{ last_synced: null }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+          return { rows: [{ last_synced: null }], rowCount: 1, command: '', oid: 0, fields: [] } as QueryResult;
         }
         if (sqlStr.includes('COUNT(DISTINCT principal_id)')) {
-          return { rows: [{ count: '1' }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+          return { rows: [{ count: '1' }], rowCount: 1, command: '', oid: 0, fields: [] } as QueryResult;
         }
         if (sqlStr.includes('SELECT confluence_id FROM pages')) {
-          return emptyResult as any;
+          return emptyResult as QueryResult;
         }
         if (sqlStr.includes('DELETE FROM pages') && sqlStr.includes('deleted_at <')) {
           return {
             rows: [{ confluence_id: 'purged-1' }, { confluence_id: 'purged-2' }],
             rowCount: 2, command: 'DELETE', oid: 0, fields: [],
-          } as any;
+          } as QueryResult;
         }
-        if (sqlStr.includes('UPDATE spaces SET last_synced')) return emptyResult as any;
-        return emptyResult as any;
+        if (sqlStr.includes('UPDATE spaces SET last_synced')) return emptyResult as QueryResult;
+        return emptyResult as QueryResult;
       });
 
       await syncUser('user-1');
@@ -618,31 +619,31 @@ describe('sync-service', () => {
           return {
             rows: [{ confluence_url: 'https://confluence.test', confluence_pat: 'encrypted-pat' }],
             rowCount: 1, command: '', oid: 0, fields: [],
-          } as any;
+          } as QueryResult;
         }
-        if (sqlStr.includes('INSERT INTO spaces')) return emptyResult as any;
+        if (sqlStr.includes('INSERT INTO spaces')) return emptyResult as QueryResult;
         if (sqlStr.includes('last_synced') && sqlStr.includes('FROM spaces')) {
-          return { rows: [{ last_synced: null }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+          return { rows: [{ last_synced: null }], rowCount: 1, command: '', oid: 0, fields: [] } as QueryResult;
         }
         // syncPage: existing page check — return no existing page so upsert is used
         if (sqlStr.includes('SELECT version') && sqlStr.includes('FROM pages')) {
-          return emptyResult as any;
+          return emptyResult as QueryResult;
         }
         // syncPage: upsert with deleted_at = NULL
         if (sqlStr.includes('INSERT INTO pages')) {
-          return emptyResult as any;
+          return emptyResult as QueryResult;
         }
         if (sqlStr.includes('COUNT(DISTINCT principal_id)')) {
-          return { rows: [{ count: '1' }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+          return { rows: [{ count: '1' }], rowCount: 1, command: '', oid: 0, fields: [] } as QueryResult;
         }
         if (sqlStr.includes('SELECT confluence_id FROM pages') && sqlStr.includes('deleted_at IS NULL')) {
-          return emptyResult as any;
+          return emptyResult as QueryResult;
         }
         if (sqlStr.includes('DELETE FROM pages') && sqlStr.includes('deleted_at <')) {
-          return { rows: [], rowCount: 0, command: 'DELETE', oid: 0, fields: [] } as any;
+          return { rows: [], rowCount: 0, command: 'DELETE', oid: 0, fields: [] } as QueryResult;
         }
-        if (sqlStr.includes('UPDATE spaces SET last_synced')) return emptyResult as any;
-        return emptyResult as any;
+        if (sqlStr.includes('UPDATE spaces SET last_synced')) return emptyResult as QueryResult;
+        return emptyResult as QueryResult;
       });
 
       await syncUser('user-1');

--- a/backend/src/domains/confluence/services/sync-service.test.ts
+++ b/backend/src/domains/confluence/services/sync-service.test.ts
@@ -102,6 +102,7 @@ import { getSyncStatus, setSyncStatus, startSyncWorker, stopSyncWorker, syncUser
 import { query } from '../../../core/db/postgres.js';
 import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
 import { cleanPageAttachments } from './attachment-handler.js';
+import { clearAttachmentFailures } from '../../../core/services/redis-cache.js';
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
@@ -521,7 +522,7 @@ describe('sync-service', () => {
           return emptyResult as any;
         }
         if (sqlStr.includes('DELETE FROM pages') && sqlStr.includes('deleted_at <')) {
-          return { rows: [], rowCount: 2, command: 'DELETE', oid: 0, fields: [] } as any;
+          return { rows: [], rowCount: 0, command: 'DELETE', oid: 0, fields: [] } as any;
         }
         if (sqlStr.includes('UPDATE spaces SET last_synced')) return emptyResult as any;
         return emptyResult as any;
@@ -537,6 +538,53 @@ describe('sync-service', () => {
       );
       expect(purgeCall).toBeDefined();
       expect(purgeCall![1]).toEqual(['TEST']);
+    });
+
+    it('calls cleanPageAttachments and clearPageFailures for each purged page', async () => {
+      mockConfluenceClientInstance.getAllSpaces.mockResolvedValue([{ key: 'TEST', name: 'Test Space', homepage: null }]);
+      mockConfluenceClientInstance.getAllPagesInSpace.mockResolvedValue([]);
+      mockConfluenceClientInstance.getModifiedPages.mockResolvedValue([]);
+
+      vi.mocked(getUserAccessibleSpaces).mockResolvedValue(['TEST']);
+      mockRedisSet.mockResolvedValue('OK');
+      mockRedisGet.mockResolvedValue(null);
+
+      vi.mocked(query).mockImplementation(async (sql: string) => {
+        const sqlStr = typeof sql === 'string' ? sql : '';
+        const emptyResult = { rows: [], rowCount: 0, command: '', oid: 0, fields: [] };
+
+        if (sqlStr.includes('confluence_url') && sqlStr.includes('user_settings')) {
+          return {
+            rows: [{ confluence_url: 'https://confluence.test', confluence_pat: 'encrypted-pat' }],
+            rowCount: 1, command: '', oid: 0, fields: [],
+          } as any;
+        }
+        if (sqlStr.includes('INSERT INTO spaces')) return emptyResult as any;
+        if (sqlStr.includes('last_synced') && sqlStr.includes('FROM spaces')) {
+          return { rows: [{ last_synced: null }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+        }
+        if (sqlStr.includes('COUNT(DISTINCT principal_id)')) {
+          return { rows: [{ count: '1' }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+        }
+        if (sqlStr.includes('SELECT confluence_id FROM pages')) {
+          return emptyResult as any;
+        }
+        if (sqlStr.includes('DELETE FROM pages') && sqlStr.includes('deleted_at <')) {
+          return {
+            rows: [{ confluence_id: 'purged-1' }, { confluence_id: 'purged-2' }],
+            rowCount: 2, command: 'DELETE', oid: 0, fields: [],
+          } as any;
+        }
+        if (sqlStr.includes('UPDATE spaces SET last_synced')) return emptyResult as any;
+        return emptyResult as any;
+      });
+
+      await syncUser('user-1');
+
+      expect(vi.mocked(cleanPageAttachments)).toHaveBeenCalledWith('', 'purged-1');
+      expect(vi.mocked(cleanPageAttachments)).toHaveBeenCalledWith('', 'purged-2');
+      expect(vi.mocked(clearAttachmentFailures)).toHaveBeenCalledWith(mockRedisClient, 'purged-1');
+      expect(vi.mocked(clearAttachmentFailures)).toHaveBeenCalledWith(mockRedisClient, 'purged-2');
     });
   });
 

--- a/backend/src/domains/confluence/services/sync-service.test.ts
+++ b/backend/src/domains/confluence/services/sync-service.test.ts
@@ -28,8 +28,18 @@ vi.mock('../../../core/utils/ssrf-guard.js', () => ({
   addAllowedBaseUrl: vi.fn(),
 }));
 
+const mockConfluenceClientInstance: Record<string, ReturnType<typeof vi.fn>> = {
+  getAllSpaces: vi.fn().mockResolvedValue([]),
+  getAllPagesInSpace: vi.fn().mockResolvedValue([]),
+  getModifiedPages: vi.fn().mockResolvedValue([]),
+  getPage: vi.fn().mockResolvedValue({ id: '', title: '', body: { storage: { value: '' } }, version: { number: 1 }, metadata: { labels: { results: [] } }, ancestors: [] }),
+  getPageAttachments: vi.fn().mockResolvedValue({ results: [] }),
+};
+
 vi.mock('./confluence-client.js', () => ({
-  ConfluenceClient: vi.fn(),
+  ConfluenceClient: vi.fn(function (this: any) {
+    Object.assign(this, mockConfluenceClientInstance);
+  }),
 }));
 
 vi.mock('../../../core/services/content-converter.js', () => ({
@@ -88,8 +98,10 @@ vi.mock('../../../core/services/redis-cache.js', () => ({
 }));
 
 // Now import the module under test
-import { getSyncStatus, setSyncStatus, startSyncWorker, stopSyncWorker } from './sync-service.js';
+import { getSyncStatus, setSyncStatus, startSyncWorker, stopSyncWorker, syncUser } from './sync-service.js';
 import { query } from '../../../core/db/postgres.js';
+import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
+import { cleanPageAttachments } from './attachment-handler.js';
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
@@ -310,6 +322,293 @@ describe('sync-service', () => {
       // Can restart
       startSyncWorker(15);
       expect(setIntervalSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── soft-delete and restore (issue #33) ────────────────────────────────
+
+  describe('detectDeletedPages (soft-delete)', () => {
+    /**
+     * Helper: set up mocks so syncUser flows through syncSpace → detectDeletedPages.
+     * Uses a full sync (no last_synced) so detectDeletedPages is called.
+     */
+    function setupSyncMocks(opts: {
+      confluencePageIds: string[];
+      dbPageIds: string[];
+      rbacUserCount?: number;
+    }) {
+      const { confluencePageIds, dbPageIds, rbacUserCount = 1 } = opts;
+
+      // Configure the shared mock client instance
+      mockConfluenceClientInstance.getAllSpaces.mockResolvedValue([{ key: 'TEST', name: 'Test Space', homepage: null }]);
+      mockConfluenceClientInstance.getAllPagesInSpace.mockResolvedValue(
+        confluencePageIds.map((id) => ({ id, title: `Page ${id}`, status: 'current' })),
+      );
+      mockConfluenceClientInstance.getModifiedPages.mockResolvedValue([]);
+      mockConfluenceClientInstance.getPage.mockImplementation((id: string) =>
+        Promise.resolve({
+          id,
+          title: `Page ${id}`,
+          body: { storage: { value: '<p>content</p>' } },
+          version: { number: 1, when: '2025-01-01T00:00:00Z', by: { displayName: 'Author' } },
+          metadata: { labels: { results: [] } },
+          ancestors: [],
+        }),
+      );
+      mockConfluenceClientInstance.getPageAttachments.mockResolvedValue({ results: [] });
+
+      // Mock RBAC spaces
+      vi.mocked(getUserAccessibleSpaces).mockResolvedValue(['TEST']);
+
+      // Track query calls and provide responses
+      vi.mocked(query).mockImplementation(async (sql: string, params?: unknown[]) => {
+        const sqlStr = typeof sql === 'string' ? sql : '';
+        const emptyResult = { rows: [], rowCount: 0, command: '', oid: 0, fields: [] };
+
+        // getClientForUser: user settings
+        if (sqlStr.includes('confluence_url') && sqlStr.includes('user_settings')) {
+          return {
+            rows: [{ confluence_url: 'https://confluence.test', confluence_pat: 'encrypted-pat' }],
+            rowCount: 1, command: '', oid: 0, fields: [],
+          } as any;
+        }
+
+        // syncSpace: upsert space metadata
+        if (sqlStr.includes('INSERT INTO spaces')) {
+          return emptyResult as any;
+        }
+
+        // syncSpace: check last sync time (return null to force full sync)
+        if (sqlStr.includes('last_synced') && sqlStr.includes('FROM spaces')) {
+          return { rows: [{ last_synced: null }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+        }
+
+        // syncPage: check existing page
+        if (sqlStr.includes('SELECT version') && sqlStr.includes('FROM pages')) {
+          return emptyResult as any;
+        }
+
+        // syncPage: upsert page
+        if (sqlStr.includes('INSERT INTO pages')) {
+          return emptyResult as any;
+        }
+
+        // detectDeletedPages: RBAC user count
+        if (sqlStr.includes('COUNT(DISTINCT principal_id)')) {
+          return {
+            rows: [{ count: String(rbacUserCount) }],
+            rowCount: 1, command: '', oid: 0, fields: [],
+          } as any;
+        }
+
+        // detectDeletedPages: existing pages in DB
+        if (sqlStr.includes('SELECT confluence_id FROM pages') && sqlStr.includes('deleted_at IS NULL')) {
+          return {
+            rows: dbPageIds.map((id) => ({ confluence_id: id })),
+            rowCount: dbPageIds.length, command: '', oid: 0, fields: [],
+          } as any;
+        }
+
+        // detectDeletedPages: soft-delete UPDATE
+        if (sqlStr.includes('UPDATE pages SET deleted_at = NOW()')) {
+          return { rows: [], rowCount: 1, command: 'UPDATE', oid: 0, fields: [] } as any;
+        }
+
+        // purgeDeletedPages: DELETE old soft-deleted
+        if (sqlStr.includes('DELETE FROM pages') && sqlStr.includes('deleted_at <')) {
+          return { rows: [], rowCount: 0, command: 'DELETE', oid: 0, fields: [] } as any;
+        }
+
+        // syncSpace: update space timestamp
+        if (sqlStr.includes('UPDATE spaces SET last_synced')) {
+          return emptyResult as any;
+        }
+
+        // processDirtyPages status updates (setSyncStatus via Redis, not query)
+        return emptyResult as any;
+      });
+    }
+
+    it('uses UPDATE SET deleted_at instead of DELETE for stale pages', async () => {
+      // DB has pages 'page-1' and 'page-2', but Confluence only returns 'page-1'
+      setupSyncMocks({
+        confluencePageIds: ['page-1'],
+        dbPageIds: ['page-1', 'page-2'],
+      });
+      mockRedisSet.mockResolvedValue('OK');
+      mockRedisGet.mockResolvedValue(null);
+
+      await syncUser('user-1');
+
+      // Verify soft-delete was called for page-2 (the missing page)
+      const queryCalls = vi.mocked(query).mock.calls;
+      const softDeleteCall = queryCalls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('UPDATE pages SET deleted_at = NOW()'),
+      );
+      expect(softDeleteCall).toBeDefined();
+      expect(softDeleteCall![1]).toEqual(['page-2']);
+
+      // Verify hard DELETE was NOT called for pages
+      const hardDeleteCall = queryCalls.find(
+        (call) => typeof call[0] === 'string'
+          && call[0].includes('DELETE FROM pages')
+          && !call[0].includes('deleted_at <'),
+      );
+      expect(hardDeleteCall).toBeUndefined();
+    });
+
+    it('does not soft-delete pages that still exist in Confluence', async () => {
+      // Both pages exist in Confluence and DB
+      setupSyncMocks({
+        confluencePageIds: ['page-1', 'page-2'],
+        dbPageIds: ['page-1', 'page-2'],
+      });
+      mockRedisSet.mockResolvedValue('OK');
+      mockRedisGet.mockResolvedValue(null);
+
+      await syncUser('user-1');
+
+      const queryCalls = vi.mocked(query).mock.calls;
+      const softDeleteCall = queryCalls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('UPDATE pages SET deleted_at = NOW()'),
+      );
+      expect(softDeleteCall).toBeUndefined();
+    });
+
+    it('calls cleanPageAttachments and clearPageFailures after soft-delete', async () => {
+      setupSyncMocks({
+        confluencePageIds: [],
+        dbPageIds: ['page-orphan'],
+      });
+      mockRedisSet.mockResolvedValue('OK');
+      mockRedisGet.mockResolvedValue(null);
+
+      await syncUser('user-1');
+
+      expect(vi.mocked(cleanPageAttachments)).toHaveBeenCalledWith('', 'page-orphan');
+    });
+  });
+
+  describe('purgeDeletedPages', () => {
+    it('runs DELETE for pages with deleted_at older than 30 days', async () => {
+      // Configure the shared mock client instance for a minimal sync
+      mockConfluenceClientInstance.getAllSpaces.mockResolvedValue([{ key: 'TEST', name: 'Test Space', homepage: null }]);
+      mockConfluenceClientInstance.getAllPagesInSpace.mockResolvedValue([]);
+      mockConfluenceClientInstance.getModifiedPages.mockResolvedValue([]);
+
+      vi.mocked(getUserAccessibleSpaces).mockResolvedValue(['TEST']);
+      mockRedisSet.mockResolvedValue('OK');
+      mockRedisGet.mockResolvedValue(null);
+
+      vi.mocked(query).mockImplementation(async (sql: string) => {
+        const sqlStr = typeof sql === 'string' ? sql : '';
+        const emptyResult = { rows: [], rowCount: 0, command: '', oid: 0, fields: [] };
+
+        if (sqlStr.includes('confluence_url') && sqlStr.includes('user_settings')) {
+          return {
+            rows: [{ confluence_url: 'https://confluence.test', confluence_pat: 'encrypted-pat' }],
+            rowCount: 1, command: '', oid: 0, fields: [],
+          } as any;
+        }
+        if (sqlStr.includes('INSERT INTO spaces')) return emptyResult as any;
+        if (sqlStr.includes('last_synced') && sqlStr.includes('FROM spaces')) {
+          return { rows: [{ last_synced: null }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+        }
+        if (sqlStr.includes('COUNT(DISTINCT principal_id)')) {
+          return { rows: [{ count: '1' }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+        }
+        if (sqlStr.includes('SELECT confluence_id FROM pages')) {
+          return emptyResult as any;
+        }
+        if (sqlStr.includes('DELETE FROM pages') && sqlStr.includes('deleted_at <')) {
+          return { rows: [], rowCount: 2, command: 'DELETE', oid: 0, fields: [] } as any;
+        }
+        if (sqlStr.includes('UPDATE spaces SET last_synced')) return emptyResult as any;
+        return emptyResult as any;
+      });
+
+      await syncUser('user-1');
+
+      const queryCalls = vi.mocked(query).mock.calls;
+      const purgeCall = queryCalls.find(
+        (call) => typeof call[0] === 'string'
+          && call[0].includes('DELETE FROM pages')
+          && call[0].includes("deleted_at < NOW() - INTERVAL '30 days'"),
+      );
+      expect(purgeCall).toBeDefined();
+      expect(purgeCall![1]).toEqual(['TEST']);
+    });
+  });
+
+  describe('syncPage restore (deleted_at = NULL)', () => {
+    it('sets deleted_at = NULL in the upsert ON CONFLICT clause when syncing a page', async () => {
+      // Configure the shared mock client instance
+      mockConfluenceClientInstance.getAllSpaces.mockResolvedValue([{ key: 'TEST', name: 'Test Space', homepage: null }]);
+      mockConfluenceClientInstance.getAllPagesInSpace.mockResolvedValue([
+        { id: 'restored-page', title: 'Restored', status: 'current' },
+      ]);
+      mockConfluenceClientInstance.getModifiedPages.mockResolvedValue([]);
+      mockConfluenceClientInstance.getPage.mockResolvedValue({
+        id: 'restored-page',
+        title: 'Restored Page',
+        body: { storage: { value: '<p>restored</p>' } },
+        version: { number: 2, when: '2025-06-01T00:00:00Z', by: { displayName: 'Author' } },
+        metadata: { labels: { results: [] } },
+        ancestors: [],
+      });
+      mockConfluenceClientInstance.getPageAttachments.mockResolvedValue({ results: [] });
+
+      vi.mocked(getUserAccessibleSpaces).mockResolvedValue(['TEST']);
+      mockRedisSet.mockResolvedValue('OK');
+      mockRedisGet.mockResolvedValue(null);
+
+      vi.mocked(query).mockImplementation(async (sql: string) => {
+        const sqlStr = typeof sql === 'string' ? sql : '';
+        const emptyResult = { rows: [], rowCount: 0, command: '', oid: 0, fields: [] };
+
+        if (sqlStr.includes('confluence_url') && sqlStr.includes('user_settings')) {
+          return {
+            rows: [{ confluence_url: 'https://confluence.test', confluence_pat: 'encrypted-pat' }],
+            rowCount: 1, command: '', oid: 0, fields: [],
+          } as any;
+        }
+        if (sqlStr.includes('INSERT INTO spaces')) return emptyResult as any;
+        if (sqlStr.includes('last_synced') && sqlStr.includes('FROM spaces')) {
+          return { rows: [{ last_synced: null }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+        }
+        // syncPage: existing page check — return no existing page so upsert is used
+        if (sqlStr.includes('SELECT version') && sqlStr.includes('FROM pages')) {
+          return emptyResult as any;
+        }
+        // syncPage: upsert with deleted_at = NULL
+        if (sqlStr.includes('INSERT INTO pages')) {
+          return emptyResult as any;
+        }
+        if (sqlStr.includes('COUNT(DISTINCT principal_id)')) {
+          return { rows: [{ count: '1' }], rowCount: 1, command: '', oid: 0, fields: [] } as any;
+        }
+        if (sqlStr.includes('SELECT confluence_id FROM pages') && sqlStr.includes('deleted_at IS NULL')) {
+          return emptyResult as any;
+        }
+        if (sqlStr.includes('DELETE FROM pages') && sqlStr.includes('deleted_at <')) {
+          return { rows: [], rowCount: 0, command: 'DELETE', oid: 0, fields: [] } as any;
+        }
+        if (sqlStr.includes('UPDATE spaces SET last_synced')) return emptyResult as any;
+        return emptyResult as any;
+      });
+
+      await syncUser('user-1');
+
+      // Find the upsert query and verify it includes deleted_at = NULL
+      const queryCalls = vi.mocked(query).mock.calls;
+      const upsertCall = queryCalls.find(
+        (call) => typeof call[0] === 'string'
+          && call[0].includes('INSERT INTO pages')
+          && call[0].includes('ON CONFLICT'),
+      );
+      expect(upsertCall).toBeDefined();
+      const upsertSql = upsertCall![0] as string;
+      expect(upsertSql).toContain('deleted_at = NULL');
     });
   });
 });

--- a/backend/src/domains/confluence/services/sync-service.ts
+++ b/backend/src/domains/confluence/services/sync-service.ts
@@ -215,6 +215,9 @@ async function syncSpace(client: ConfluenceClient, userId: string, spaceKey: str
     await detectDeletedPages(client, spaceKey, pages);
   }
 
+  // Purge pages that have been soft-deleted for more than 30 days
+  await purgeDeletedPages(spaceKey);
+
   // Update space sync timestamp (shared table)
   await query(
     'UPDATE spaces SET last_synced = NOW() WHERE space_key = $1',
@@ -317,7 +320,8 @@ async function syncPage(
              summary_status = CASE
                WHEN body_text IS DISTINCT FROM $5 THEN 'pending'
                ELSE summary_status
-             END
+             END,
+             deleted_at = NULL
          WHERE confluence_id = $1`,
         [page.id, page.title, bodyStorage, bodyHtml, bodyText, parentId, labels, author, lastModified],
       );
@@ -351,6 +355,8 @@ async function syncPage(
   }
 
   // Upsert page (shared table, no user_id)
+  // deleted_at = NULL restores pages that were previously soft-deleted
+  // (e.g. page was restored from Confluence trash)
   await query(
     `INSERT INTO pages
        (confluence_id, space_key, title, body_storage, body_html, body_text,
@@ -369,7 +375,8 @@ async function syncPage(
        last_modified_at = EXCLUDED.last_modified_at,
        last_synced = NOW(),
        embedding_dirty = TRUE,
-       summary_status = 'pending'`,
+       summary_status = 'pending',
+       deleted_at = NULL`,
     [page.id, spaceKey, page.title, bodyStorage, bodyHtml, bodyText,
      page.version.number, parentId, labels, author, lastModified],
   );
@@ -475,20 +482,36 @@ async function detectDeletedPages(
 
   const currentIds = new Set(currentPages.map((p) => p.id));
 
-  // Query shared table by space_key only
+  // Query shared table by space_key only (exclude already soft-deleted pages)
   const existingResult = await query<{ confluence_id: string }>(
-    'SELECT confluence_id FROM pages WHERE space_key = $1',
+    'SELECT confluence_id FROM pages WHERE space_key = $1 AND deleted_at IS NULL',
     [spaceKey],
   );
 
   for (const { confluence_id } of existingResult.rows) {
     if (!currentIds.has(confluence_id)) {
-      logger.info({ spaceKey, confluenceId: confluence_id }, 'Deleting stale page');
-      // page_embeddings are deleted by CASCADE on pages
-      await query('DELETE FROM pages WHERE confluence_id = $1', [confluence_id]);
+      logger.info({ spaceKey, confluenceId: confluence_id }, 'Soft-deleting stale page');
+      await query(
+        'UPDATE pages SET deleted_at = NOW() WHERE confluence_id = $1 AND deleted_at IS NULL',
+        [confluence_id],
+      );
       await cleanPageAttachments('', confluence_id);
       await clearPageFailures(confluence_id);
     }
+  }
+}
+
+/**
+ * Permanently remove pages that were soft-deleted more than 30 days ago.
+ * page_embeddings are removed by CASCADE on the pages table FK.
+ */
+async function purgeDeletedPages(spaceKey: string): Promise<void> {
+  const result = await query(
+    `DELETE FROM pages WHERE space_key = $1 AND deleted_at < NOW() - INTERVAL '30 days'`,
+    [spaceKey],
+  );
+  if (result.rowCount && result.rowCount > 0) {
+    logger.info({ spaceKey, purged: result.rowCount }, 'Purged expired soft-deleted pages');
   }
 }
 

--- a/backend/src/domains/confluence/services/sync-service.ts
+++ b/backend/src/domains/confluence/services/sync-service.ts
@@ -506,11 +506,15 @@ async function detectDeletedPages(
  * page_embeddings are removed by CASCADE on the pages table FK.
  */
 async function purgeDeletedPages(spaceKey: string): Promise<void> {
-  const result = await query(
-    `DELETE FROM pages WHERE space_key = $1 AND deleted_at < NOW() - INTERVAL '30 days'`,
+  const result = await query<{ confluence_id: string }>(
+    `DELETE FROM pages WHERE space_key = $1 AND deleted_at < NOW() - INTERVAL '30 days' RETURNING confluence_id`,
     [spaceKey],
   );
   if (result.rowCount && result.rowCount > 0) {
+    for (const { confluence_id } of result.rows) {
+      await cleanPageAttachments('', confluence_id);
+      await clearPageFailures(confluence_id);
+    }
     logger.info({ spaceKey, purged: result.rowCount }, 'Purged expired soft-deleted pages');
   }
 }


### PR DESCRIPTION
## Summary
- Changes `detectDeletedPages()` from hard `DELETE` to soft-delete (`UPDATE SET deleted_at = NOW()`)
- Adds `purgeDeletedPages()` to permanently remove pages soft-deleted > 30 days ago
- Adds restore logic: pages that reappear in Confluence sync get `deleted_at = NULL`
- The `deleted_at` column and `IS NULL` query filters already existed (migration 029, 89 queries) — this fix makes `detectDeletedPages` consistent with the rest of the codebase

Closes #33

## Test plan
- [x] `detectDeletedPages` uses UPDATE SET deleted_at instead of DELETE
- [x] Pages still in Confluence are not soft-deleted
- [x] cleanPageAttachments and clearPageFailures still called after soft-delete
- [x] purgeDeletedPages removes pages older than 30 days
- [x] Restored pages get deleted_at = NULL via upsert ON CONFLICT
- [ ] Manual: sync a space, delete a page in Confluence, re-sync, verify page is soft-deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)