### PR TITLE
feat(editor): add inline editing and styled badges for status labels

### DIFF
--- a/frontend/src/shared/components/article/StatusBadgeView.test.tsx
+++ b/frontend/src/shared/components/article/StatusBadgeView.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StatusBadgeView } from './StatusBadgeView';
+import type { NodeViewProps } from '@tiptap/react';
+
+function makeProps(overrides: Partial<NodeViewProps> = {}): NodeViewProps {
+  return {
+    node: {
+      attrs: {
+        color: 'blue',
+        label: 'IN PROGRESS',
+      },
+      ...overrides.node,
+    },
+    updateAttributes: vi.fn(),
+    deleteNode: vi.fn(),
+    editor: {
+      isEditable: true,
+      ...overrides.editor,
+    },
+    getPos: () => 0,
+    extension: {} as NodeViewProps['extension'],
+    HTMLAttributes: {},
+    decorations: [],
+    selected: false,
+    ...overrides,
+  } as unknown as NodeViewProps;
+}
+
+describe('StatusBadgeView', () => {
+  it('renders badge with correct color and label', () => {
+    render(<StatusBadgeView {...makeProps()} />);
+
+    const badge = screen.getByTestId('status-badge');
+    expect(badge).toBeTruthy();
+    expect(badge.textContent).toBe('IN PROGRESS');
+    expect(badge.getAttribute('data-color')).toBe('blue');
+  });
+
+  it('renders all 5 status colors correctly', () => {
+    const colors = ['grey', 'blue', 'green', 'yellow', 'red'] as const;
+
+    for (const color of colors) {
+      const props = makeProps({
+        node: {
+          attrs: { color, label: color.toUpperCase() },
+        } as NodeViewProps['node'],
+      });
+
+      const { unmount } = render(<StatusBadgeView {...props} />);
+      const badge = screen.getByTestId('status-badge');
+      expect(badge.getAttribute('data-color')).toBe(color);
+      expect(badge.textContent).toBe(color.toUpperCase());
+      unmount();
+    }
+  });
+
+  it('opens popover with text input and color picker on click', () => {
+    render(<StatusBadgeView {...makeProps()} />);
+
+    // Popover should not be visible initially
+    expect(screen.queryByTestId('status-badge-popover')).toBeNull();
+
+    // Click the badge
+    fireEvent.click(screen.getByTestId('status-badge'));
+
+    // Popover should now be visible with input, color picker, and apply button
+    expect(screen.getByTestId('status-badge-popover')).toBeTruthy();
+    expect(screen.getByTestId('status-label-input')).toBeTruthy();
+    expect(screen.getByTestId('status-color-picker')).toBeTruthy();
+    expect(screen.getByTestId('status-apply-btn')).toBeTruthy();
+  });
+
+  it('calls updateAttributes with new values when apply is clicked', () => {
+    const updateAttributes = vi.fn();
+    const props = makeProps({ updateAttributes });
+
+    render(<StatusBadgeView {...props} />);
+
+    // Open popover
+    fireEvent.click(screen.getByTestId('status-badge'));
+
+    // Change label text
+    const input = screen.getByTestId('status-label-input');
+    fireEvent.change(input, { target: { value: 'DONE' } });
+
+    // Change color to green
+    fireEvent.click(screen.getByTestId('status-color-green'));
+
+    // Click apply
+    fireEvent.click(screen.getByTestId('status-apply-btn'));
+
+    expect(updateAttributes).toHaveBeenCalledWith({
+      color: 'green',
+      label: 'DONE',
+    });
+  });
+
+  it('does not open popover when editor is not editable', () => {
+    const props = makeProps({
+      editor: { isEditable: false } as NodeViewProps['editor'],
+    });
+
+    render(<StatusBadgeView {...props} />);
+
+    fireEvent.click(screen.getByTestId('status-badge'));
+
+    // Popover should not appear
+    expect(screen.queryByTestId('status-badge-popover')).toBeNull();
+  });
+
+  it('uses default label "STATUS" when input is empty and apply is clicked', () => {
+    const updateAttributes = vi.fn();
+    const props = makeProps({
+      updateAttributes,
+      node: {
+        attrs: { color: 'grey', label: '' },
+      } as NodeViewProps['node'],
+    });
+
+    render(<StatusBadgeView {...props} />);
+
+    // Open popover
+    fireEvent.click(screen.getByTestId('status-badge'));
+
+    // Leave input empty and apply
+    const input = screen.getByTestId('status-label-input');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.click(screen.getByTestId('status-apply-btn'));
+
+    expect(updateAttributes).toHaveBeenCalledWith({
+      color: 'grey',
+      label: 'STATUS',
+    });
+  });
+
+  it('applies on Enter key in the input', () => {
+    const updateAttributes = vi.fn();
+    const props = makeProps({ updateAttributes });
+
+    render(<StatusBadgeView {...props} />);
+
+    fireEvent.click(screen.getByTestId('status-badge'));
+
+    const input = screen.getByTestId('status-label-input');
+    fireEvent.change(input, { target: { value: 'REVIEWED' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(updateAttributes).toHaveBeenCalledWith({
+      color: 'blue',
+      label: 'REVIEWED',
+    });
+  });
+
+  it('converts label input to uppercase', () => {
+    render(<StatusBadgeView {...makeProps()} />);
+
+    fireEvent.click(screen.getByTestId('status-badge'));
+
+    const input = screen.getByTestId('status-label-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'done' } });
+
+    expect(input.value).toBe('DONE');
+  });
+
+  it('shows all 5 color options in the picker', () => {
+    render(<StatusBadgeView {...makeProps()} />);
+
+    fireEvent.click(screen.getByTestId('status-badge'));
+
+    expect(screen.getByTestId('status-color-grey')).toBeTruthy();
+    expect(screen.getByTestId('status-color-blue')).toBeTruthy();
+    expect(screen.getByTestId('status-color-green')).toBeTruthy();
+    expect(screen.getByTestId('status-color-yellow')).toBeTruthy();
+    expect(screen.getByTestId('status-color-red')).toBeTruthy();
+  });
+});

--- a/frontend/src/shared/components/article/StatusBadgeView.tsx
+++ b/frontend/src/shared/components/article/StatusBadgeView.tsx
@@ -1,0 +1,136 @@
+import { useState, useCallback } from 'react';
+import { NodeViewWrapper } from '@tiptap/react';
+import * as Popover from '@radix-ui/react-popover';
+import type { NodeViewProps } from '@tiptap/react';
+
+const STATUS_COLORS = [
+  { label: 'Grey', value: 'grey' },
+  { label: 'Blue', value: 'blue' },
+  { label: 'Green', value: 'green' },
+  { label: 'Yellow', value: 'yellow' },
+  { label: 'Red', value: 'red' },
+] as const;
+
+/**
+ * React NodeView component for the ConfluenceStatus inline node.
+ *
+ * In edit mode, clicking the badge opens a Radix Popover with a text input
+ * and color picker to modify the status label inline.
+ *
+ * In read-only mode, renders as a static colored badge using the existing
+ * `.confluence-status` CSS classes from index.css.
+ */
+export function StatusBadgeView({ node, updateAttributes, editor }: NodeViewProps) {
+  const { color, label } = node.attrs;
+  const isEditable = editor.isEditable;
+
+  const [open, setOpen] = useState(false);
+  const [editLabel, setEditLabel] = useState(label);
+  const [editColor, setEditColor] = useState(color);
+
+  const handleOpen = useCallback(
+    (nextOpen: boolean) => {
+      if (!isEditable) return;
+      setOpen(nextOpen);
+      if (nextOpen) {
+        // Reset edit state to current node values when opening
+        setEditLabel(label);
+        setEditColor(color);
+      }
+    },
+    [isEditable, label, color],
+  );
+
+  const handleApply = useCallback(() => {
+    const newLabel = editLabel.trim() || 'STATUS';
+    updateAttributes({ color: editColor, label: newLabel });
+    setOpen(false);
+  }, [editLabel, editColor, updateAttributes]);
+
+  return (
+    <NodeViewWrapper as="span" className="status-badge-nodeview" style={{ display: 'inline' }}>
+      <Popover.Root open={open} onOpenChange={handleOpen}>
+        <Popover.Trigger asChild>
+          <span
+            role="button"
+            tabIndex={0}
+            className="confluence-status"
+            data-color={color}
+            data-testid="status-badge"
+            style={{ cursor: isEditable ? 'pointer' : 'default' }}
+            onKeyDown={(e) => {
+              if (isEditable && (e.key === 'Enter' || e.key === ' ')) {
+                e.preventDefault();
+                setOpen(true);
+              }
+            }}
+          >
+            {label || 'STATUS'}
+          </span>
+        </Popover.Trigger>
+
+        {isEditable && (
+          <Popover.Portal>
+            <Popover.Content
+              className="z-50 w-56 rounded-lg border border-border bg-card p-3 shadow-lg"
+              sideOffset={6}
+              align="start"
+              data-testid="status-badge-popover"
+              onOpenAutoFocus={(e) => e.preventDefault()}
+            >
+              {/* Color picker */}
+              <div className="mb-2 flex gap-1.5" data-testid="status-color-picker">
+                {STATUS_COLORS.map((c) => (
+                  <button
+                    key={c.value}
+                    type="button"
+                    title={c.label}
+                    data-testid={`status-color-${c.value}`}
+                    onClick={() => setEditColor(c.value)}
+                    className={`confluence-status h-6 min-w-[2.5rem] text-center transition-transform ${
+                      editColor === c.value ? 'ring-2 ring-primary ring-offset-1 ring-offset-card scale-105' : ''
+                    }`}
+                    data-color={c.value}
+                  >
+                    {c.label.charAt(0)}
+                  </button>
+                ))}
+              </div>
+
+              {/* Label input */}
+              <input
+                type="text"
+                value={editLabel}
+                onChange={(e) => setEditLabel(e.target.value.toUpperCase())}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleApply();
+                  }
+                  // Prevent TipTap from capturing keyboard events inside the popover
+                  e.stopPropagation();
+                }}
+                placeholder="STATUS"
+                className="mb-2 w-full rounded-md border border-border bg-background px-2 py-1 text-xs font-semibold uppercase tracking-wide"
+                data-testid="status-label-input"
+                autoFocus
+              />
+
+              {/* Apply button */}
+              <button
+                type="button"
+                onClick={handleApply}
+                className="w-full rounded-md bg-primary/20 px-2 py-1 text-xs font-medium text-primary hover:bg-primary/30 transition-colors"
+                data-testid="status-apply-btn"
+              >
+                Apply
+              </button>
+
+              <Popover.Arrow className="fill-card" />
+            </Popover.Content>
+          </Popover.Portal>
+        )}
+      </Popover.Root>
+    </NodeViewWrapper>
+  );
+}

--- a/frontend/src/shared/components/article/article-extensions.ts
+++ b/frontend/src/shared/components/article/article-extensions.ts
@@ -1,6 +1,7 @@
 import { Node, mergeAttributes, type Editor } from '@tiptap/core';
 import { ReactNodeViewRenderer } from '@tiptap/react';
 import { DrawioDiagramNodeView } from './DrawioDiagramNodeView';
+import { StatusBadgeView } from './StatusBadgeView';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -275,6 +276,10 @@ export const ConfluenceStatus = Node.create({
       },
       node.attrs.label,
     ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(StatusBadgeView);
   },
 });
 


### PR DESCRIPTION
## Summary
- Adds `StatusBadgeView` React NodeView for the `ConfluenceStatus` TipTap node
- Click-to-edit: opens a Radix Popover with text input + 5-color picker (Grey, Blue, Green, Yellow, Red)
- Colored pill badges with dark mode support (reuses existing CSS from index.css)
- Read-only mode: badges render as static elements, popover disabled
- Core round-trip conversion untouched (already working correctly)

Closes #35

## Test plan
- [x] Badge renders with correct color and data attributes for all 5 colors
- [x] Click opens popover with text input and color picker
- [x] Changing color/text and applying calls updateAttributes
- [x] Read-only mode blocks popover opening
- [x] Empty input defaults to "STATUS"
- [x] Enter key submits the form
- [x] 113 total tests passing, 0 regressions
- [ ] Manual: create status badges in editor, verify colors and inline editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)