### PR TITLE
feat: add interactive Confluence Children Pages macro rendering

### DIFF
--- a/backend/src/routes/knowledge/pages-children.test.ts
+++ b/backend/src/routes/knowledge/pages-children.test.ts
@@ -99,9 +99,9 @@ describe('GET /api/pages/:id/children', () => {
   });
 
   it('should return child pages for a given page', async () => {
-    // First query: resolve the page by id
+    // First query: resolve the page by id (now includes RBAC fields)
     mockQueryFn.mockResolvedValueOnce({
-      rows: [{ id: 10, confluence_id: 'parent-conf-id' }],
+      rows: [{ id: 10, confluence_id: 'parent-conf-id', space_key: 'DEV', source: 'confluence', visibility: 'private', created_by_user_id: null }],
     });
     // Second query: fetch children
     mockQueryFn.mockResolvedValueOnce({
@@ -136,7 +136,7 @@ describe('GET /api/pages/:id/children', () => {
   it('should return empty children array when page has no children', async () => {
     // Resolve page
     mockQueryFn.mockResolvedValueOnce({
-      rows: [{ id: 5, confluence_id: 'page-5' }],
+      rows: [{ id: 5, confluence_id: 'page-5', space_key: 'DEV', source: 'confluence', visibility: 'private', created_by_user_id: null }],
     });
     // No children
     mockQueryFn.mockResolvedValueOnce({ rows: [] });
@@ -165,7 +165,7 @@ describe('GET /api/pages/:id/children', () => {
   it('should respect depth parameter for recursive children', async () => {
     // Resolve page
     mockQueryFn.mockResolvedValueOnce({
-      rows: [{ id: 1, confluence_id: 'root' }],
+      rows: [{ id: 1, confluence_id: 'root', space_key: 'DEV', source: 'confluence', visibility: 'private', created_by_user_id: null }],
     });
     // Level 1 children
     mockQueryFn.mockResolvedValueOnce({
@@ -196,7 +196,7 @@ describe('GET /api/pages/:id/children', () => {
   it('should resolve confluence_id string parameter', async () => {
     // Resolve page by confluence_id
     mockQueryFn.mockResolvedValueOnce({
-      rows: [{ id: 10, confluence_id: 'my-conf-page' }],
+      rows: [{ id: 10, confluence_id: 'my-conf-page', space_key: 'DEV', source: 'confluence', visibility: 'private', created_by_user_id: null }],
     });
     // Children
     mockQueryFn.mockResolvedValueOnce({
@@ -232,7 +232,7 @@ describe('GET /api/pages/:id/children', () => {
   it('should use default sort and order when not specified', async () => {
     // Resolve page
     mockQueryFn.mockResolvedValueOnce({
-      rows: [{ id: 1, confluence_id: 'root' }],
+      rows: [{ id: 1, confluence_id: 'root', space_key: 'DEV', source: 'confluence', visibility: 'private', created_by_user_id: null }],
     });
     // Children
     mockQueryFn.mockResolvedValueOnce({ rows: [] });
@@ -245,5 +245,96 @@ describe('GET /api/pages/:id/children', () => {
     // Verify children query uses default sort (title ASC)
     const childrenQuerySql = mockQueryFn.mock.calls[1][0] as string;
     expect(childrenQuerySql).toContain('ORDER BY title ASC');
+  });
+
+  it('should return 404 when user lacks space access for confluence page', async () => {
+    // Resolve page in a space the user does NOT have access to
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 10, confluence_id: 'secret-page', space_key: 'SECRET', source: 'confluence', visibility: 'private', created_by_user_id: null }],
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages/10/children',
+    });
+
+    // getUserAccessibleSpaces mock returns ['DEV', 'OPS'] — 'SECRET' is not in the list
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('should return 404 for standalone page not owned by user and not shared', async () => {
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 10, confluence_id: null, space_key: null, source: 'standalone', visibility: 'private', created_by_user_id: 'other-user-id' }],
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages/10/children',
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('should allow access to shared standalone page owned by another user', async () => {
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 10, confluence_id: null, space_key: null, source: 'standalone', visibility: 'shared', created_by_user_id: 'other-user-id' }],
+    });
+    // Children query
+    mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages/10/children',
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('should cap total fetched nodes at MAX_TOTAL_NODES', async () => {
+    // Resolve page
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 1, confluence_id: 'root', space_key: 'DEV', source: 'confluence', visibility: 'private', created_by_user_id: null }],
+    });
+
+    // Generate 200 children at level 1 (the cap) — limit is 100 per request but cap is 200
+    // With limit=100, first fetch gets 100, second fetch (for depth=2 children of first child) would get capped
+    const level1Children = Array.from({ length: 100 }, (_, i) => ({
+      id: 100 + i,
+      confluence_id: `child-${i}`,
+      title: `Child ${i}`,
+      space_key: 'DEV',
+    }));
+    mockQueryFn.mockResolvedValueOnce({ rows: level1Children });
+
+    // For depth=2, each child will try to fetch sub-children.
+    // After 100 level-1 nodes, only 100 more are allowed (200 - 100 = 100).
+    // First child's sub-children fetch: allow up to 100
+    const level2Children = Array.from({ length: 100 }, (_, i) => ({
+      id: 1000 + i,
+      confluence_id: `grandchild-${i}`,
+      title: `Grandchild ${i}`,
+      space_key: 'DEV',
+    }));
+    mockQueryFn.mockResolvedValueOnce({ rows: level2Children });
+
+    // Second child onwards: totalFetched = 200 >= MAX_TOTAL_NODES, so fetchChildren returns []
+    // No more queries should be made
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages/1/children?depth=2&limit=100',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.payload);
+    expect(body.children).toHaveLength(100);
+    // Only the first child should have sub-children (the rest are capped)
+    expect(body.children[0].children).toHaveLength(100);
+    // Second child should have no children (cap reached)
+    expect(body.children[1].children).toBeUndefined();
+
+    // Verify: 1 page-resolve + 1 level-1 fetch + 1 level-2 fetch for first child = 3 queries total
+    // No further queries because totalFetched reached 200
+    expect(mockQueryFn).toHaveBeenCalledTimes(3);
   });
 });

--- a/backend/src/routes/knowledge/pages-children.test.ts
+++ b/backend/src/routes/knowledge/pages-children.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+import { ZodError } from 'zod';
+import { pagesCrudRoutes } from './pages-crud.js';
+
+vi.mock('../../core/services/redis-cache.js', () => ({
+  RedisCache: class MockRedisCache {
+    get = vi.fn().mockResolvedValue(null);
+    set = vi.fn().mockResolvedValue(undefined);
+    invalidate = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('../../core/services/audit-service.js', () => ({
+  logAuditEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../core/utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../domains/confluence/services/sync-service.js', () => ({
+  getClientForUser: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../core/services/content-converter.js', () => ({
+  htmlToConfluence: vi.fn((html: string) => html),
+  confluenceToHtml: vi.fn((html: string) => html),
+  htmlToText: vi.fn((html: string) => html.replace(/<[^>]*>/g, '')),
+}));
+
+vi.mock('../../domains/confluence/services/attachment-handler.js', () => ({
+  cleanPageAttachments: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../domains/llm/services/embedding-service.js', () => ({
+  processDirtyPages: vi.fn().mockResolvedValue(undefined),
+  isProcessingUser: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../core/services/rbac-service.js', () => ({
+  getUserAccessibleSpaces: vi.fn().mockResolvedValue(['DEV', 'OPS']),
+  invalidateRbacCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockQueryFn = vi.fn();
+vi.mock('../../core/db/postgres.js', () => ({
+  query: (...args: unknown[]) => mockQueryFn(...args),
+  getPool: vi.fn().mockReturnValue({}),
+  runMigrations: vi.fn(),
+  closePool: vi.fn(),
+}));
+
+describe('GET /api/pages/:id/children', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof ZodError) {
+        reply.status(400).send({
+          error: 'ValidationError',
+          message: error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join('; '),
+          statusCode: 400,
+        });
+        return;
+      }
+      reply.status(error.statusCode ?? 500).send({
+        error: error.message,
+        statusCode: error.statusCode ?? 500,
+      });
+    });
+
+    app.decorate('authenticate', async (request: { userId: string; username: string; userRole: string }) => {
+      request.userId = 'test-user-id';
+      request.username = 'testuser';
+      request.userRole = 'user';
+    });
+    app.decorate('requireAdmin', async (request: { userId: string; username: string; userRole: string }) => {
+      request.userId = 'test-user-id';
+      request.username = 'testuser';
+      request.userRole = 'admin';
+    });
+    app.decorate('redis', {});
+
+    await app.register(pagesCrudRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return child pages for a given page', async () => {
+    // First query: resolve the page by id
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 10, confluence_id: 'parent-conf-id' }],
+    });
+    // Second query: fetch children
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [
+        { id: 20, confluence_id: 'child-1', title: 'Child One', space_key: 'DEV' },
+        { id: 30, confluence_id: 'child-2', title: 'Child Two', space_key: 'DEV' },
+      ],
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages/10/children',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.payload);
+    expect(body.children).toHaveLength(2);
+    expect(body.children[0]).toEqual({
+      id: 20,
+      confluenceId: 'child-1',
+      title: 'Child One',
+      spaceKey: 'DEV',
+    });
+    expect(body.children[1]).toEqual({
+      id: 30,
+      confluenceId: 'child-2',
+      title: 'Child Two',
+      spaceKey: 'DEV',
+    });
+  });
+
+  it('should return empty children array when page has no children', async () => {
+    // Resolve page
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 5, confluence_id: 'page-5' }],
+    });
+    // No children
+    mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages/5/children',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.payload);
+    expect(body.children).toHaveLength(0);
+  });
+
+  it('should return 404 when page does not exist', async () => {
+    mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages/999/children',
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('should respect depth parameter for recursive children', async () => {
+    // Resolve page
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 1, confluence_id: 'root' }],
+    });
+    // Level 1 children
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [
+        { id: 2, confluence_id: 'child-1', title: 'Child 1', space_key: 'DEV' },
+      ],
+    });
+    // Level 2 children (of child-1)
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [
+        { id: 3, confluence_id: 'grandchild-1', title: 'Grandchild 1', space_key: 'DEV' },
+      ],
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages/1/children?depth=2',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.payload);
+    expect(body.children).toHaveLength(1);
+    expect(body.children[0].title).toBe('Child 1');
+    expect(body.children[0].children).toHaveLength(1);
+    expect(body.children[0].children[0].title).toBe('Grandchild 1');
+  });
+
+  it('should resolve confluence_id string parameter', async () => {
+    // Resolve page by confluence_id
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 10, confluence_id: 'my-conf-page' }],
+    });
+    // Children
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [
+        { id: 20, confluence_id: 'child-1', title: 'Child One', space_key: 'DEV' },
+      ],
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages/my-conf-page/children',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.payload);
+    expect(body.children).toHaveLength(1);
+
+    // Verify the first query used confluence_id (not numeric)
+    const firstCallSql = mockQueryFn.mock.calls[0][0] as string;
+    expect(firstCallSql).toContain('confluence_id');
+  });
+
+  it('should validate query parameters', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages/1/children?depth=5',
+    });
+
+    // depth > 3 should fail validation
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('should use default sort and order when not specified', async () => {
+    // Resolve page
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 1, confluence_id: 'root' }],
+    });
+    // Children
+    mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+    await app.inject({
+      method: 'GET',
+      url: '/api/pages/1/children',
+    });
+
+    // Verify children query uses default sort (title ASC)
+    const childrenQuerySql = mockQueryFn.mock.calls[1][0] as string;
+    expect(childrenQuerySql).toContain('ORDER BY title ASC');
+  });
+});

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -602,13 +602,14 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
 
   fastify.get('/pages/:id/children', async (request) => {
     const { id } = IdParamSchema.parse(request.params);
+    const userId = request.userId;
     const params = ChildrenQuerySchema.parse(request.query);
     const { sort, order, depth, limit } = params;
 
     // Resolve page: try confluence_id first, then integer id
     const isNumericId = /^\d+$/.test(id);
-    const pageResult = await query<{ id: number; confluence_id: string | null }>(
-      `SELECT id, confluence_id FROM pages
+    const pageResult = await query<{ id: number; confluence_id: string | null; space_key: string | null; source: string; visibility: string; created_by_user_id: string | null }>(
+      `SELECT id, confluence_id, space_key, source, visibility, created_by_user_id FROM pages
        WHERE ${isNumericId ? '(confluence_id = $1 OR id = $1::int)' : 'confluence_id = $1'}
          AND deleted_at IS NULL
        LIMIT 1`,
@@ -620,6 +621,19 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     }
 
     const page = pageResult.rows[0];
+
+    // Access control: same pattern as GET /pages/:id
+    if (page.source === 'confluence') {
+      const spaces = await getUserAccessibleSpaces(userId);
+      if (!page.space_key || !spaces.includes(page.space_key)) {
+        throw fastify.httpErrors.notFound('Page not found');
+      }
+    } else {
+      if (page.created_by_user_id !== userId && page.visibility !== 'shared') {
+        throw fastify.httpErrors.notFound('Page not found');
+      }
+    }
+
     // Children are linked via parent_id which stores the confluence_id string
     const parentLookupId = page.confluence_id ?? String(page.id);
 
@@ -627,17 +641,25 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     const sortColumn = sort === 'created_at' ? 'created_at' : 'title';
     const sortOrder = order === 'desc' ? 'DESC' : 'ASC';
 
+    // Cap total nodes to prevent unbounded recursive N+1 queries (DoS protection)
+    const MAX_TOTAL_NODES = 200;
+    let totalFetched = 0;
+
     type ChildRow = { id: number; confluence_id: string | null; title: string; space_key: string | null };
 
     async function fetchChildren(parentId: string, currentDepth: number): Promise<Array<{ id: number; confluenceId: string | null; title: string; spaceKey: string | null; children?: Array<unknown> }>> {
+      if (currentDepth > depth || totalFetched >= MAX_TOTAL_NODES) return [];
+
       const result = await query<ChildRow>(
         `SELECT id, confluence_id, title, space_key
          FROM pages
          WHERE parent_id = $1 AND deleted_at IS NULL
          ORDER BY ${sortColumn} ${sortOrder}
          LIMIT $2`,
-        [parentId, limit],
+        [parentId, Math.min(limit, MAX_TOTAL_NODES - totalFetched)],
       );
+
+      totalFetched += result.rows.length;
 
       const children = [];
       for (const row of result.rows) {

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -592,6 +592,80 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     return { hasChildren: parseInt(result.rows[0].count, 10) > 0 };
   });
 
+  // GET /api/pages/:id/children - list child pages for the Confluence Children macro
+  const ChildrenQuerySchema = z.object({
+    sort: z.enum(['title', 'created_at']).default('title'),
+    order: z.enum(['asc', 'desc']).default('asc'),
+    depth: z.coerce.number().int().min(1).max(3).default(1),
+    limit: z.coerce.number().int().min(1).max(100).default(50),
+  });
+
+  fastify.get('/pages/:id/children', async (request) => {
+    const { id } = IdParamSchema.parse(request.params);
+    const params = ChildrenQuerySchema.parse(request.query);
+    const { sort, order, depth, limit } = params;
+
+    // Resolve page: try confluence_id first, then integer id
+    const isNumericId = /^\d+$/.test(id);
+    const pageResult = await query<{ id: number; confluence_id: string | null }>(
+      `SELECT id, confluence_id FROM pages
+       WHERE ${isNumericId ? '(confluence_id = $1 OR id = $1::int)' : 'confluence_id = $1'}
+         AND deleted_at IS NULL
+       LIMIT 1`,
+      [isNumericId ? id : id],
+    );
+
+    if (pageResult.rows.length === 0) {
+      throw fastify.httpErrors.notFound('Page not found');
+    }
+
+    const page = pageResult.rows[0];
+    // Children are linked via parent_id which stores the confluence_id string
+    const parentLookupId = page.confluence_id ?? String(page.id);
+
+    // Validate sort column to prevent SQL injection (only allow whitelisted values)
+    const sortColumn = sort === 'created_at' ? 'created_at' : 'title';
+    const sortOrder = order === 'desc' ? 'DESC' : 'ASC';
+
+    type ChildRow = { id: number; confluence_id: string | null; title: string; space_key: string | null };
+
+    async function fetchChildren(parentId: string, currentDepth: number): Promise<Array<{ id: number; confluenceId: string | null; title: string; spaceKey: string | null; children?: Array<unknown> }>> {
+      const result = await query<ChildRow>(
+        `SELECT id, confluence_id, title, space_key
+         FROM pages
+         WHERE parent_id = $1 AND deleted_at IS NULL
+         ORDER BY ${sortColumn} ${sortOrder}
+         LIMIT $2`,
+        [parentId, limit],
+      );
+
+      const children = [];
+      for (const row of result.rows) {
+        const child: { id: number; confluenceId: string | null; title: string; spaceKey: string | null; children?: Array<unknown> } = {
+          id: row.id,
+          confluenceId: row.confluence_id,
+          title: row.title,
+          spaceKey: row.space_key,
+        };
+
+        if (currentDepth < depth) {
+          const childLookupId = row.confluence_id ?? String(row.id);
+          const subChildren = await fetchChildren(childLookupId, currentDepth + 1);
+          if (subChildren.length > 0) {
+            child.children = subChildren;
+          }
+        }
+
+        children.push(child);
+      }
+
+      return children;
+    }
+
+    const children = await fetchChildren(parentLookupId, 1);
+    return { children };
+  });
+
   // POST /api/pages/:id/restore - restore a soft-deleted standalone article from trash
   fastify.post('/pages/:id/restore', async (request) => {
     const { id } = IdParamSchema.parse(request.params);

--- a/frontend/src/shared/components/article/ArticleViewer.test.tsx
+++ b/frontend/src/shared/components/article/ArticleViewer.test.tsx
@@ -21,13 +21,14 @@ vi.mock('../../hooks/use-authenticated-src', () => ({
 }));
 
 // Mock react-router-dom for ChildrenMacroView (uses useParams + Link)
-vi.mock('react-router-dom', () => ({
-  useParams: () => ({ id: 'test-page-id' }),
-  Link: ({ to, children, ...props }: { to: string; children: React.ReactNode; [key: string]: unknown }) => {
-    const React = require('react');
-    return React.createElement('a', { href: to, ...props }, children);
-  },
-}));
+vi.mock('react-router-dom', async () => {
+  const React = await import('react');
+  return {
+    useParams: () => ({ id: 'test-page-id' }),
+    Link: ({ to, children, ...props }: { to: string; children: React.ReactNode; [key: string]: unknown }) =>
+      React.createElement('a', { href: to, ...props }, children),
+  };
+});
 
 // Mock apiFetch for ChildrenMacroView
 vi.mock('../../lib/api', () => ({

--- a/frontend/src/shared/components/article/ArticleViewer.test.tsx
+++ b/frontend/src/shared/components/article/ArticleViewer.test.tsx
@@ -20,6 +20,20 @@ vi.mock('../../hooks/use-authenticated-src', () => ({
   fetchAuthenticatedBlob: (...args: unknown[]) => mockFetchAuthenticatedBlob(...args),
 }));
 
+// Mock react-router-dom for ChildrenMacroView (uses useParams + Link)
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ id: 'test-page-id' }),
+  Link: ({ to, children, ...props }: { to: string; children: React.ReactNode; [key: string]: unknown }) => {
+    const React = require('react');
+    return React.createElement('a', { href: to, ...props }, children);
+  },
+}));
+
+// Mock apiFetch for ChildrenMacroView
+vi.mock('../../lib/api', () => ({
+  apiFetch: vi.fn().mockResolvedValue({ children: [] }),
+}));
+
 import { ArticleViewer } from './ArticleViewer';
 
 describe('ArticleViewer', () => {

--- a/frontend/src/shared/components/article/ArticleViewer.test.tsx
+++ b/frontend/src/shared/components/article/ArticleViewer.test.tsx
@@ -384,12 +384,17 @@ describe('ArticleViewer', () => {
 
     const { container } = render(<ArticleViewer content={html} />);
 
+    // The ConfluenceChildren TipTap node now renders a React NodeView
+    // (ChildrenMacroView) instead of static placeholder text.
+    // Without a page context the component shows "Child Pages" header
+    // and "No child pages" empty state.
     await waitFor(() => {
-      expect(container.querySelector('.confluence-children-macro')).toBeTruthy();
+      expect(container.querySelector('[data-testid="children-macro-view"]')).toBeTruthy();
     });
 
-    const placeholder = container.querySelector('.confluence-children-macro')!;
-    expect(placeholder.textContent).toContain('Children pages listed here');
+    const view = container.querySelector('[data-testid="children-macro-view"]')!;
+    expect(view.textContent).toContain('Child Pages');
+    expect(view.textContent).toContain('No child pages');
   });
 
   it('renders collapsible details/summary sections', async () => {

--- a/frontend/src/shared/components/article/ChildrenMacroView.test.tsx
+++ b/frontend/src/shared/components/article/ChildrenMacroView.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ChildrenMacroView } from './ChildrenMacroView';
+import type { NodeViewProps } from '@tiptap/react';
+
+// Mock the NodeViewWrapper since it's a TipTap component
+vi.mock('@tiptap/react', () => ({
+  NodeViewWrapper: ({ children, className, ...props }: { children: React.ReactNode; className?: string; [key: string]: unknown }) => (
+    <div className={className} {...props}>{children}</div>
+  ),
+}));
+
+// Mock apiFetch
+const mockApiFetch = vi.fn();
+vi.mock('../../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+function makeProps(attrs: Record<string, string | null> = {}): NodeViewProps {
+  return {
+    node: {
+      attrs: {
+        sort: null,
+        reverse: null,
+        depth: null,
+        first: null,
+        page: null,
+        style: null,
+        excerptType: null,
+        'macro-name': null,
+        ...attrs,
+      },
+    },
+    updateAttributes: vi.fn(),
+    deleteNode: vi.fn(),
+    editor: { isEditable: false },
+    getPos: () => 0,
+    extension: {} as NodeViewProps['extension'],
+    HTMLAttributes: {},
+    decorations: [],
+    selected: false,
+  } as unknown as NodeViewProps;
+}
+
+function renderWithRouter(props: NodeViewProps, pageId = '42') {
+  return render(
+    <MemoryRouter initialEntries={[`/pages/${pageId}`]}>
+      <Routes>
+        <Route path="/pages/:id" element={<ChildrenMacroView {...props} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ChildrenMacroView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    mockApiFetch.mockReturnValue(new Promise(() => {})); // never resolves
+    renderWithRouter(makeProps());
+
+    expect(screen.getByTestId('children-loading')).toBeTruthy();
+    expect(screen.getByText('Child Pages')).toBeTruthy();
+  });
+
+  it('renders a list of child pages', async () => {
+    mockApiFetch.mockResolvedValueOnce({
+      children: [
+        { id: 1, confluenceId: 'child-1', title: 'Getting Started', spaceKey: 'DEV' },
+        { id: 2, confluenceId: 'child-2', title: 'Installation Guide', spaceKey: 'DEV' },
+      ],
+    });
+
+    renderWithRouter(makeProps());
+
+    await waitFor(() => {
+      expect(screen.getByTestId('children-list')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Getting Started')).toBeTruthy();
+    expect(screen.getByText('Installation Guide')).toBeTruthy();
+
+    // Links should point to page routes using integer IDs
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0].getAttribute('href')).toBe('/pages/1');
+    expect(links[1].getAttribute('href')).toBe('/pages/2');
+  });
+
+  it('shows empty message when no children exist', async () => {
+    mockApiFetch.mockResolvedValueOnce({ children: [] });
+
+    renderWithRouter(makeProps());
+
+    await waitFor(() => {
+      expect(screen.getByTestId('children-empty')).toBeTruthy();
+    });
+
+    expect(screen.getByText('No child pages')).toBeTruthy();
+  });
+
+  it('shows error state on fetch failure', async () => {
+    mockApiFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    renderWithRouter(makeProps());
+
+    await waitFor(() => {
+      expect(screen.getByTestId('children-error')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Network error')).toBeTruthy();
+  });
+
+  it('renders nested children when depth > 1', async () => {
+    mockApiFetch.mockResolvedValueOnce({
+      children: [
+        {
+          id: 1,
+          confluenceId: 'parent',
+          title: 'Parent Page',
+          spaceKey: 'DEV',
+          children: [
+            { id: 2, confluenceId: 'child', title: 'Nested Child', spaceKey: 'DEV' },
+          ],
+        },
+      ],
+    });
+
+    renderWithRouter(makeProps({ depth: '2' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('children-list')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Parent Page')).toBeTruthy();
+    expect(screen.getByText('Nested Child')).toBeTruthy();
+  });
+
+  it('passes correct query params to the API', async () => {
+    mockApiFetch.mockResolvedValueOnce({ children: [] });
+
+    renderWithRouter(makeProps({ sort: 'creation', depth: '2', reverse: 'true' }));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledTimes(1);
+    });
+
+    const callPath = mockApiFetch.mock.calls[0][0] as string;
+    expect(callPath).toContain('/pages/42/children');
+    expect(callPath).toContain('sort=created_at');
+    expect(callPath).toContain('order=desc');
+    expect(callPath).toContain('depth=2');
+  });
+
+  it('does not fetch when no page ID is available', async () => {
+    render(
+      <MemoryRouter initialEntries={['/other']}>
+        <Routes>
+          <Route path="/other" element={<ChildrenMacroView {...makeProps()} />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // Should not call the API and should not show loading
+    await waitFor(() => {
+      expect(mockApiFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/shared/components/article/ChildrenMacroView.tsx
+++ b/frontend/src/shared/components/article/ChildrenMacroView.tsx
@@ -1,0 +1,117 @@
+import { NodeViewWrapper } from '@tiptap/react';
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { apiFetch } from '../../lib/api';
+import type { NodeViewProps } from '@tiptap/react';
+
+interface ChildPage {
+  id: number;
+  confluenceId: string | null;
+  title: string;
+  spaceKey: string | null;
+  children?: ChildPage[];
+}
+
+/**
+ * React NodeView for the ConfluenceChildren TipTap node.
+ *
+ * Fetches the current page's child pages from the backend and renders
+ * them as a nested list of clickable links. Supports sort, depth,
+ * and reverse attributes from the Confluence children/ui-children macros.
+ */
+export function ChildrenMacroView({ node }: NodeViewProps) {
+  const { id: pageId } = useParams<{ id: string }>();
+  const [children, setChildren] = useState<ChildPage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const sort = node.attrs.sort || 'title';
+  const depth = parseInt(node.attrs.depth || '1', 10);
+  const reverse = node.attrs.reverse === 'true';
+
+  useEffect(() => {
+    if (!pageId) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const order = reverse ? 'desc' : 'asc';
+    const sortParam = sort === 'creation' ? 'created_at' : 'title';
+
+    apiFetch<{ children: ChildPage[] }>(
+      `/pages/${pageId}/children?sort=${sortParam}&order=${order}&depth=${depth}`,
+    )
+      .then((data) => {
+        if (!cancelled) {
+          setChildren(data.children);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load children');
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pageId, sort, depth, reverse]);
+
+  function renderChildren(items: ChildPage[]) {
+    return (
+      <ul className="list-disc pl-4 space-y-1">
+        {items.map((child) => (
+          <li key={child.id}>
+            <Link
+              to={`/pages/${child.id}`}
+              className="text-primary hover:underline"
+            >
+              {child.title}
+            </Link>
+            {child.children && child.children.length > 0
+              ? renderChildren(child.children)
+              : null}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  return (
+    <NodeViewWrapper
+      className="confluence-children-view my-4 p-4 border border-border rounded-lg"
+      data-testid="children-macro-view"
+    >
+      <div
+        className="text-sm font-medium text-muted-foreground mb-2"
+        contentEditable={false}
+      >
+        Child Pages
+      </div>
+      {loading ? (
+        <div className="animate-pulse space-y-2" data-testid="children-loading">
+          <div className="h-4 bg-muted rounded w-48" />
+          <div className="h-4 bg-muted rounded w-36" />
+          <div className="h-4 bg-muted rounded w-52" />
+        </div>
+      ) : error ? (
+        <p className="text-sm text-destructive italic" data-testid="children-error">
+          {error}
+        </p>
+      ) : children.length > 0 ? (
+        <div data-testid="children-list">{renderChildren(children)}</div>
+      ) : (
+        <p
+          className="text-sm text-muted-foreground italic"
+          data-testid="children-empty"
+        >
+          No child pages
+        </p>
+      )}
+    </NodeViewWrapper>
+  );
+}

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -17,7 +17,7 @@ import {
   ArrowUpFromLine, ArrowDownFromLine, ArrowLeftFromLine, ArrowRightFromLine,
   Trash2, Columns3, Rows3, Merge, SplitSquareHorizontal, Square,
   ToggleLeft, PanelTop, Workflow, Underline, Highlighter, Palette,
-  Badge, ChevronsUpDown, Hash, Paperclip,
+  Badge, ChevronsUpDown, Hash, Paperclip, ListTree,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '../../lib/cn';
@@ -30,6 +30,7 @@ import {
   ConfluenceLayoutCell,
   ConfluenceSection,
   ConfluenceColumn,
+  ConfluenceChildren,
   ConfluenceStatus,
   ConfluenceAttachments,
   Details,
@@ -435,6 +436,14 @@ export function EditorToolbar({ editor, headerNumbering, onToggleHeaderNumbering
         title="Insert Attachments Block"
       >
         <Paperclip size={16} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => {
+          editor.chain().focus().insertContent({ type: 'confluenceChildren' }).run();
+        }}
+        title="Insert Children Pages"
+      >
+        <ListTree size={16} />
       </ToolbarButton>
 
       <LayoutPresetPicker editor={editor} />
@@ -875,6 +884,7 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
       ConfluenceSection,
       ConfluenceColumn,
       ConfluenceAttachments,
+      ConfluenceChildren,
       DrawioDiagram,
       TitledCodeBlock.configure({ lowlight }),
       ConfluenceImage.configure({ inline: false }),

--- a/frontend/src/shared/components/article/article-extensions.ts
+++ b/frontend/src/shared/components/article/article-extensions.ts
@@ -3,6 +3,7 @@ import { ReactNodeViewRenderer } from '@tiptap/react';
 import { DrawioDiagramNodeView } from './DrawioDiagramNodeView';
 import { StatusBadgeView } from './StatusBadgeView';
 import { AttachmentsMacroView } from './AttachmentsMacroView';
+import { ChildrenMacroView } from './ChildrenMacroView';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -316,6 +317,10 @@ export const ConfluenceChildren = Node.create({
       if (node.attrs[name] != null) htmlAttrs[`data-${name}`] = node.attrs[name];
     }
     return ['div', htmlAttrs, '[Children pages listed here]'];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ChildrenMacroView);
   },
 });
 


### PR DESCRIPTION
## Summary
- New `GET /api/pages/:id/children` endpoint with sort/order/depth/limit params
- Recursive BFS child page fetching up to 3 levels deep
- `ChildrenMacroView` NodeView: fetches and renders nested linked page list
- Wired to existing `ConfluenceChildren` TipTap node via `addNodeView()`
- Toolbar button (ListTree icon) to insert children macro block
- Loading skeleton, empty state, error handling

Closes #25

## Test plan
- [x] Returns children for a page
- [x] Empty result for page with no children
- [x] 404 for missing page
- [x] Recursive depth works correctly
- [x] confluence_id string resolution
- [x] Query validation (depth > 3 rejected)
- [x] Frontend: loading state, children list, empty message, error state, nested rendering
- [x] 14 new tests, 78 existing tests passing
- [ ] Manual: sync page with children macro, verify clickable page links

🤖 Generated with [Claude Code](https://claude.com/claude-code)