### PR TITLE
feat(editor): add image/table captions with auto-numbering and figure/table index

### DIFF
--- a/backend/src/core/services/content-converter.test.ts
+++ b/backend/src/core/services/content-converter.test.ts
@@ -851,3 +851,71 @@ describe('content-converter', () => {
     });
   });
 });
+
+describe('content-converter: figure/caption round-trip (#13)', () => {
+  it('passes <figure> and <figcaption> through confluenceToHtml unchanged', () => {
+    const html = '<figure class="figure-block"><img src="test.png" alt="Test" /><figcaption>My caption</figcaption></figure>';
+    // confluenceToHtml processes Confluence XHTML; standard HTML elements should pass through
+    const result = confluenceToHtml(html);
+    expect(result).toContain('<figure');
+    expect(result).toContain('<figcaption>');
+    expect(result).toContain('My caption');
+  });
+
+  it('passes <div class="table-caption"> through confluenceToHtml unchanged', () => {
+    const html = '<div class="table-caption">Revenue by Quarter</div>';
+    const result = confluenceToHtml(html);
+    expect(result).toContain('table-caption');
+    expect(result).toContain('Revenue by Quarter');
+  });
+
+  it('preserves <figure> and <figcaption> in htmlToConfluence', () => {
+    const html = '<figure class="figure-block"><img src="test.png" alt="Test" /><figcaption>My caption</figcaption></figure>';
+    const result = htmlToConfluence(html);
+    expect(result).toContain('<figure');
+    expect(result).toContain('<figcaption>');
+    expect(result).toContain('My caption');
+  });
+
+  it('preserves <div class="table-caption"> in htmlToConfluence', () => {
+    const html = '<div class="table-caption">Revenue by Quarter</div>';
+    const result = htmlToConfluence(html);
+    expect(result).toContain('table-caption');
+    expect(result).toContain('Revenue by Quarter');
+  });
+});
+
+describe('content-converter: index block stripping (#13)', () => {
+  it('strips <div class="figure-index"> during htmlToConfluence', () => {
+    const html = '<p>Hello</p><div class="figure-index"><h3>List of Figures</h3><ol><li>Figure 1: Test</li></ol></div><p>World</p>';
+    const result = htmlToConfluence(html);
+    expect(result).not.toContain('figure-index');
+    expect(result).not.toContain('List of Figures');
+    expect(result).toContain('Hello');
+    expect(result).toContain('World');
+  });
+
+  it('strips <div class="table-index"> during htmlToConfluence', () => {
+    const html = '<p>Hello</p><div class="table-index"><h3>List of Tables</h3><ol><li>Table 1: Test</li></ol></div><p>World</p>';
+    const result = htmlToConfluence(html);
+    expect(result).not.toContain('table-index');
+    expect(result).not.toContain('List of Tables');
+    expect(result).toContain('Hello');
+    expect(result).toContain('World');
+  });
+
+  it('strips multiple index blocks at once', () => {
+    const html = '<div class="figure-index">figures</div><div class="table-index">tables</div><p>Content</p>';
+    const result = htmlToConfluence(html);
+    expect(result).not.toContain('figure-index');
+    expect(result).not.toContain('table-index');
+    expect(result).toContain('Content');
+  });
+
+  it('does not strip index blocks during confluenceToHtml (inbound pass-through)', () => {
+    // Index blocks in stored HTML should be preserved when loading into the editor
+    const html = '<div class="figure-index">figures</div><p>Content</p>';
+    const result = confluenceToHtml(html);
+    expect(result).toContain('figure-index');
+  });
+});

--- a/backend/src/core/services/content-converter.test.ts
+++ b/backend/src/core/services/content-converter.test.ts
@@ -852,6 +852,8 @@ describe('content-converter', () => {
   });
 });
 
+// ========== Figure/Caption pass-through tests (#13) ==========
+
 describe('content-converter: figure/caption round-trip (#13)', () => {
   it('passes <figure> and <figcaption> through confluenceToHtml unchanged', () => {
     const html = '<figure class="figure-block"><img src="test.png" alt="Test" /><figcaption>My caption</figcaption></figure>';
@@ -884,6 +886,8 @@ describe('content-converter: figure/caption round-trip (#13)', () => {
     expect(result).toContain('Revenue by Quarter');
   });
 });
+
+// ========== Index block stripping tests (#13) ==========
 
 describe('content-converter: index block stripping (#13)', () => {
   it('strips <div class="figure-index"> during htmlToConfluence', () => {

--- a/backend/src/core/services/content-converter.ts
+++ b/backend/src/core/services/content-converter.ts
@@ -356,6 +356,11 @@ export function htmlToConfluence(html: string): string {
   const dom = new JSDOM(`<body>${html}</body>`, { contentType: 'text/html' });
   const doc = dom.window.document;
 
+  // Strip auto-generated index blocks before export to Confluence (#13)
+  for (const div of doc.querySelectorAll('div.figure-index, div.table-index')) {
+    div.remove();
+  }
+
   // Convert code blocks back
   for (const pre of doc.querySelectorAll('pre')) {
     const codeEl = pre.querySelector('code');

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1960,3 +1960,37 @@ pre:hover .code-copy-btn {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-muted-foreground);
 }
+
+/* ============================================
+   Figure & Table Caption Auto-Numbering
+   ============================================ */
+
+/* Editor (ProseMirror) counters */
+.ProseMirror { counter-reset: figure-counter table-counter; }
+
+.ProseMirror figure { counter-increment: figure-counter; }
+.ProseMirror figure figcaption::before {
+  content: "Figure " counter(figure-counter) ": ";
+  font-weight: 600;
+}
+
+.ProseMirror .table-caption { counter-increment: table-counter; }
+.ProseMirror .table-caption::before {
+  content: "Table " counter(table-counter) ": ";
+  font-weight: 600;
+}
+
+/* ArticleViewer (read-only) counters */
+.article-viewer { counter-reset: figure-counter table-counter; }
+
+.article-viewer figure { counter-increment: figure-counter; }
+.article-viewer figure figcaption::before {
+  content: "Figure " counter(figure-counter) ": ";
+  font-weight: 600;
+}
+
+.article-viewer .table-caption { counter-increment: table-counter; }
+.article-viewer .table-caption::before {
+  content: "Table " counter(table-counter) ": ";
+  font-weight: 600;
+}

--- a/frontend/src/shared/components/article/ArticleViewer.tsx
+++ b/frontend/src/shared/components/article/ArticleViewer.tsx
@@ -20,6 +20,11 @@ import {
   ConfluenceLayoutCell,
   ConfluenceSection,
   ConfluenceColumn,
+  Figure,
+  Figcaption,
+  TableCaption,
+  FigureIndex,
+  TableIndex,
   UnknownMacro,
 } from './article-extensions';
 import { MermaidBlock } from './MermaidBlockExtension';
@@ -134,6 +139,11 @@ export function ArticleViewer({
       ConfluenceLayoutCell,
       ConfluenceSection,
       ConfluenceColumn,
+      Figure,
+      Figcaption,
+      TableCaption,
+      FigureIndex,
+      TableIndex,
       MermaidBlock,
       UnknownMacro,
     ],

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -17,7 +17,7 @@ import {
   ArrowUpFromLine, ArrowDownFromLine, ArrowLeftFromLine, ArrowRightFromLine,
   Trash2, Columns3, Rows3, Merge, SplitSquareHorizontal, Square,
   ToggleLeft, PanelTop, Workflow, Underline, Highlighter, Palette,
-  Badge, ChevronsUpDown, Hash, Paperclip, ListTree,
+  Badge, ChevronsUpDown, Hash, Paperclip, ListTree, ImagePlus, TableProperties, Table2,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '../../lib/cn';
@@ -36,6 +36,11 @@ import {
   Details,
   DetailsSummary,
   DrawioDiagram,
+  Figure,
+  Figcaption,
+  TableCaption,
+  FigureIndex,
+  TableIndex,
   isInConfluenceSection,
   isInConfluenceLayout,
   LAYOUT_PRESETS,
@@ -448,6 +453,57 @@ export function EditorToolbar({ editor, headerNumbering, onToggleHeaderNumbering
 
       <LayoutPresetPicker editor={editor} />
 
+      <ToolbarSeparator />
+
+      {/* Caption & Index tools (#13) */}
+      <ToolbarButton
+        onClick={() => {
+          // Wrap selected image in a figure with caption
+          const { from } = editor.state.selection;
+          const node = editor.state.doc.nodeAt(from);
+          if (node?.type.name === 'image') {
+            editor.chain()
+              .deleteRange({ from, to: from + node.nodeSize })
+              .insertContentAt(from, {
+                type: 'figure',
+                content: [
+                  { type: 'image', attrs: node.attrs },
+                  { type: 'figcaption' },
+                ],
+              })
+              .run();
+          }
+        }}
+        title="Add Caption to Selected Image"
+      >
+        <ImagePlus size={16} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => {
+          // Insert a table caption after the current position
+          editor.chain().focus().insertContent({ type: 'tableCaption' }).run();
+        }}
+        title="Insert Table Caption"
+      >
+        <TableProperties size={16} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => {
+          editor.chain().focus().insertContent({ type: 'figureIndex' }).run();
+        }}
+        title="Insert List of Figures"
+      >
+        <ListTree size={16} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => {
+          editor.chain().focus().insertContent({ type: 'tableIndex' }).run();
+        }}
+        title="Insert List of Tables"
+      >
+        <Table2 size={16} />
+      </ToolbarButton>
+
       <div className="flex-1" />
 
       <ToolbarButton onClick={() => editor.chain().focus().undo().run()} disabled={!editor.can().undo()} title="Undo">
@@ -559,6 +615,19 @@ export function TableContextToolbar({ editor }: { editor: EditorType }) {
         title="Toggle header column"
       >
         <ToggleLeft size={15} />
+      </ToolbarButton>
+
+      <ToolbarSeparator />
+
+      {/* Add table caption (#13) */}
+      <ToolbarButton
+        onClick={() => {
+          // Insert a table caption node after the current table
+          editor.chain().focus().insertContent({ type: 'tableCaption' }).run();
+        }}
+        title="Add Table Caption"
+      >
+        <TableProperties size={15} />
       </ToolbarButton>
 
       <div className="flex-1" />
@@ -886,6 +955,11 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
       ConfluenceAttachments,
       ConfluenceChildren,
       DrawioDiagram,
+      Figure,
+      Figcaption,
+      TableCaption,
+      FigureIndex,
+      TableIndex,
       TitledCodeBlock.configure({ lowlight }),
       ConfluenceImage.configure({ inline: false }),
       Placeholder.configure({ placeholder: placeholder ?? 'Start writing...' }),

--- a/frontend/src/shared/components/article/FigureIndexView.tsx
+++ b/frontend/src/shared/components/article/FigureIndexView.tsx
@@ -1,5 +1,5 @@
 import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface FigureEntry {
   number: number;
@@ -8,9 +8,10 @@ interface FigureEntry {
 
 export function FigureIndexView({ editor }: NodeViewProps) {
   const [entries, setEntries] = useState<FigureEntry[]>([]);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {
-    const update = () => {
+    const scan = () => {
       const figures: FigureEntry[] = [];
       let count = 0;
       editor.state.doc.descendants((node) => {
@@ -22,9 +23,14 @@ export function FigureIndexView({ editor }: NodeViewProps) {
       });
       setEntries(figures);
     };
-    update();
+    const update = () => {
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(scan, 250);
+    };
+    scan();
     editor.on('update', update);
     return () => {
+      clearTimeout(timerRef.current);
       editor.off('update', update);
     };
   }, [editor]);

--- a/frontend/src/shared/components/article/FigureIndexView.tsx
+++ b/frontend/src/shared/components/article/FigureIndexView.tsx
@@ -1,0 +1,51 @@
+import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
+import { useEffect, useState } from 'react';
+
+interface FigureEntry {
+  number: number;
+  caption: string;
+}
+
+export function FigureIndexView({ editor }: NodeViewProps) {
+  const [entries, setEntries] = useState<FigureEntry[]>([]);
+
+  useEffect(() => {
+    const update = () => {
+      const figures: FigureEntry[] = [];
+      let count = 0;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === 'figure') {
+          count++;
+          const caption = node.content.lastChild?.textContent || '';
+          figures.push({ number: count, caption });
+        }
+      });
+      setEntries(figures);
+    };
+    update();
+    editor.on('update', update);
+    return () => {
+      editor.off('update', update);
+    };
+  }, [editor]);
+
+  return (
+    <NodeViewWrapper
+      className="figure-index my-4 p-4 border border-border rounded-lg"
+      contentEditable={false}
+    >
+      <h3 className="text-sm font-semibold mb-2">List of Figures</h3>
+      {entries.length > 0 ? (
+        <ol className="list-decimal pl-6 text-sm space-y-1">
+          {entries.map((e) => (
+            <li key={e.number}>
+              Figure {e.number}: {e.caption || <em className="text-muted-foreground">No caption</em>}
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="text-sm text-muted-foreground italic">No figures in this document</p>
+      )}
+    </NodeViewWrapper>
+  );
+}

--- a/frontend/src/shared/components/article/FigureIndexView.tsx
+++ b/frontend/src/shared/components/article/FigureIndexView.tsx
@@ -8,7 +8,7 @@ interface FigureEntry {
 
 export function FigureIndexView({ editor }: NodeViewProps) {
   const [entries, setEntries] = useState<FigureEntry[]>([]);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
     const scan = () => {

--- a/frontend/src/shared/components/article/TableIndexView.tsx
+++ b/frontend/src/shared/components/article/TableIndexView.tsx
@@ -8,7 +8,7 @@ interface TableEntry {
 
 export function TableIndexView({ editor }: NodeViewProps) {
   const [entries, setEntries] = useState<TableEntry[]>([]);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
     const scan = () => {

--- a/frontend/src/shared/components/article/TableIndexView.tsx
+++ b/frontend/src/shared/components/article/TableIndexView.tsx
@@ -1,5 +1,5 @@
 import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface TableEntry {
   number: number;
@@ -8,9 +8,10 @@ interface TableEntry {
 
 export function TableIndexView({ editor }: NodeViewProps) {
   const [entries, setEntries] = useState<TableEntry[]>([]);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {
-    const update = () => {
+    const scan = () => {
       const tables: TableEntry[] = [];
       let count = 0;
       editor.state.doc.descendants((node) => {
@@ -21,9 +22,14 @@ export function TableIndexView({ editor }: NodeViewProps) {
       });
       setEntries(tables);
     };
-    update();
+    const update = () => {
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(scan, 250);
+    };
+    scan();
     editor.on('update', update);
     return () => {
+      clearTimeout(timerRef.current);
       editor.off('update', update);
     };
   }, [editor]);

--- a/frontend/src/shared/components/article/TableIndexView.tsx
+++ b/frontend/src/shared/components/article/TableIndexView.tsx
@@ -1,0 +1,50 @@
+import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
+import { useEffect, useState } from 'react';
+
+interface TableEntry {
+  number: number;
+  caption: string;
+}
+
+export function TableIndexView({ editor }: NodeViewProps) {
+  const [entries, setEntries] = useState<TableEntry[]>([]);
+
+  useEffect(() => {
+    const update = () => {
+      const tables: TableEntry[] = [];
+      let count = 0;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === 'tableCaption') {
+          count++;
+          tables.push({ number: count, caption: node.textContent });
+        }
+      });
+      setEntries(tables);
+    };
+    update();
+    editor.on('update', update);
+    return () => {
+      editor.off('update', update);
+    };
+  }, [editor]);
+
+  return (
+    <NodeViewWrapper
+      className="table-index my-4 p-4 border border-border rounded-lg"
+      contentEditable={false}
+    >
+      <h3 className="text-sm font-semibold mb-2">List of Tables</h3>
+      {entries.length > 0 ? (
+        <ol className="list-decimal pl-6 text-sm space-y-1">
+          {entries.map((e) => (
+            <li key={e.number}>
+              Table {e.number}: {e.caption || <em className="text-muted-foreground">No caption</em>}
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="text-sm text-muted-foreground italic">No tables with captions in this document</p>
+      )}
+    </NodeViewWrapper>
+  );
+}

--- a/frontend/src/shared/components/article/article-extensions.test.ts
+++ b/frontend/src/shared/components/article/article-extensions.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { Details, DetailsSummary, Panel, DrawioDiagram, ConfluenceToc, ConfluenceStatus, ConfluenceChildren, ConfluenceAttachments, ConfluenceLayout, ConfluenceLayoutSection, ConfluenceLayoutCell, ConfluenceSection, ConfluenceColumn, UnknownMacro, LAYOUT_PRESETS } from './article-extensions';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { Image } from '@tiptap/extension-image';
+import { Details, DetailsSummary, Panel, DrawioDiagram, ConfluenceToc, ConfluenceStatus, ConfluenceChildren, ConfluenceAttachments, ConfluenceLayout, ConfluenceLayoutSection, ConfluenceLayoutCell, ConfluenceSection, ConfluenceColumn, UnknownMacro, LAYOUT_PRESETS, Figure, Figcaption, TableCaption, FigureIndex, TableIndex } from './article-extensions';
 
 // Helper to extract parseHTML rules from a TipTap extension config
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -537,5 +540,137 @@ describe('article-extensions', () => {
       expect(parseRules).toBeDefined();
       expect(parseRules).toContainEqual(expect.objectContaining({ tag: 'div.confluence-macro-unknown' }));
     });
+  });
+});
+
+/** Create a minimal TipTap editor with the caption/index extensions. */
+function createEditor(content: string) {
+  return new Editor({
+    extensions: [
+      StarterKit,
+      Image,
+      Figure,
+      Figcaption,
+      TableCaption,
+      // FigureIndex and TableIndex use ReactNodeViewRenderer which requires a DOM
+      // environment with React — register them without NodeView for parse tests.
+      FigureIndex.extend({ addNodeView: undefined }),
+      TableIndex.extend({ addNodeView: undefined }),
+    ],
+    content,
+  });
+}
+
+describe('Figure node', () => {
+  it('parses a <figure> containing an image and figcaption', () => {
+    const html = '<figure><img src="test.png" alt="Test" /><figcaption>My caption</figcaption></figure>';
+    const editor = createEditor(html);
+    const doc = editor.getJSON();
+
+    const figure = doc.content?.find((n) => n.type === 'figure');
+    expect(figure).toBeDefined();
+    expect(figure?.content).toHaveLength(2);
+    expect(figure?.content?.[0].type).toBe('image');
+    expect(figure?.content?.[0].attrs?.src).toBe('test.png');
+    expect(figure?.content?.[1].type).toBe('figcaption');
+    expect(figure?.content?.[1].content?.[0].text).toBe('My caption');
+    editor.destroy();
+  });
+
+  it('renders to HTML with figure-block class', () => {
+    const html = '<figure><img src="test.png" alt="Test" /><figcaption>Caption</figcaption></figure>';
+    const editor = createEditor(html);
+    const output = editor.getHTML();
+
+    expect(output).toContain('<figure class="figure-block">');
+    expect(output).toContain('<figcaption');
+    expect(output).toContain('Caption');
+    editor.destroy();
+  });
+});
+
+describe('Figcaption node', () => {
+  it('parses <figcaption> with inline content including bold marks', () => {
+    const html = '<figure><img src="x.png" /><figcaption>Test <strong>bold</strong> caption</figcaption></figure>';
+    const editor = createEditor(html);
+    const doc = editor.getJSON();
+
+    const figure = doc.content?.find((n) => n.type === 'figure');
+    const figcaption = figure?.content?.find((n) => n.type === 'figcaption');
+    expect(figcaption).toBeDefined();
+    // TipTap splits text around marks: "Test ", "bold" (with bold mark), " caption"
+    expect(figcaption?.content?.length).toBeGreaterThanOrEqual(2);
+    // Verify there is at least one node with a bold mark
+    const boldNode = figcaption?.content?.find((n) =>
+      n.marks?.some((m) => m.type === 'bold'),
+    );
+    expect(boldNode).toBeDefined();
+    expect(boldNode?.text).toBe('bold');
+    editor.destroy();
+  });
+});
+
+describe('TableCaption node', () => {
+  it('parses <div class="table-caption">', () => {
+    const html = '<div class="table-caption">Revenue by Quarter</div>';
+    const editor = createEditor(html);
+    const doc = editor.getJSON();
+
+    const caption = doc.content?.find((n) => n.type === 'tableCaption');
+    expect(caption).toBeDefined();
+    expect(caption?.content?.[0].text).toBe('Revenue by Quarter');
+    editor.destroy();
+  });
+
+  it('renders with table-caption class', () => {
+    const html = '<div class="table-caption">Test</div>';
+    const editor = createEditor(html);
+    const output = editor.getHTML();
+
+    expect(output).toContain('class="table-caption');
+    expect(output).toContain('Test');
+    editor.destroy();
+  });
+});
+
+describe('FigureIndex node', () => {
+  it('parses <div class="figure-index">', () => {
+    const html = '<div class="figure-index"></div>';
+    const editor = createEditor(html);
+    const doc = editor.getJSON();
+
+    const index = doc.content?.find((n) => n.type === 'figureIndex');
+    expect(index).toBeDefined();
+    editor.destroy();
+  });
+
+  it('renders with figure-index class', () => {
+    const html = '<div class="figure-index"></div>';
+    const editor = createEditor(html);
+    const output = editor.getHTML();
+
+    expect(output).toContain('figure-index');
+    editor.destroy();
+  });
+});
+
+describe('TableIndex node', () => {
+  it('parses <div class="table-index">', () => {
+    const html = '<div class="table-index"></div>';
+    const editor = createEditor(html);
+    const doc = editor.getJSON();
+
+    const index = doc.content?.find((n) => n.type === 'tableIndex');
+    expect(index).toBeDefined();
+    editor.destroy();
+  });
+
+  it('renders with table-index class', () => {
+    const html = '<div class="table-index"></div>';
+    const editor = createEditor(html);
+    const output = editor.getHTML();
+
+    expect(output).toContain('table-index');
+    editor.destroy();
   });
 });

--- a/frontend/src/shared/components/article/article-extensions.test.ts
+++ b/frontend/src/shared/components/article/article-extensions.test.ts
@@ -543,8 +543,10 @@ describe('article-extensions', () => {
   });
 });
 
+// ========== Caption & Index extension tests (#13) ==========
+
 /** Create a minimal TipTap editor with the caption/index extensions. */
-function createEditor(content: string) {
+function createCaptionEditor(content: string) {
   return new Editor({
     extensions: [
       StarterKit,
@@ -564,7 +566,7 @@ function createEditor(content: string) {
 describe('Figure node', () => {
   it('parses a <figure> containing an image and figcaption', () => {
     const html = '<figure><img src="test.png" alt="Test" /><figcaption>My caption</figcaption></figure>';
-    const editor = createEditor(html);
+    const editor = createCaptionEditor(html);
     const doc = editor.getJSON();
 
     const figure = doc.content?.find((n) => n.type === 'figure');
@@ -579,7 +581,7 @@ describe('Figure node', () => {
 
   it('renders to HTML with figure-block class', () => {
     const html = '<figure><img src="test.png" alt="Test" /><figcaption>Caption</figcaption></figure>';
-    const editor = createEditor(html);
+    const editor = createCaptionEditor(html);
     const output = editor.getHTML();
 
     expect(output).toContain('<figure class="figure-block">');
@@ -592,7 +594,7 @@ describe('Figure node', () => {
 describe('Figcaption node', () => {
   it('parses <figcaption> with inline content including bold marks', () => {
     const html = '<figure><img src="x.png" /><figcaption>Test <strong>bold</strong> caption</figcaption></figure>';
-    const editor = createEditor(html);
+    const editor = createCaptionEditor(html);
     const doc = editor.getJSON();
 
     const figure = doc.content?.find((n) => n.type === 'figure');
@@ -613,7 +615,7 @@ describe('Figcaption node', () => {
 describe('TableCaption node', () => {
   it('parses <div class="table-caption">', () => {
     const html = '<div class="table-caption">Revenue by Quarter</div>';
-    const editor = createEditor(html);
+    const editor = createCaptionEditor(html);
     const doc = editor.getJSON();
 
     const caption = doc.content?.find((n) => n.type === 'tableCaption');
@@ -624,7 +626,7 @@ describe('TableCaption node', () => {
 
   it('renders with table-caption class', () => {
     const html = '<div class="table-caption">Test</div>';
-    const editor = createEditor(html);
+    const editor = createCaptionEditor(html);
     const output = editor.getHTML();
 
     expect(output).toContain('class="table-caption');
@@ -636,7 +638,7 @@ describe('TableCaption node', () => {
 describe('FigureIndex node', () => {
   it('parses <div class="figure-index">', () => {
     const html = '<div class="figure-index"></div>';
-    const editor = createEditor(html);
+    const editor = createCaptionEditor(html);
     const doc = editor.getJSON();
 
     const index = doc.content?.find((n) => n.type === 'figureIndex');
@@ -646,7 +648,7 @@ describe('FigureIndex node', () => {
 
   it('renders with figure-index class', () => {
     const html = '<div class="figure-index"></div>';
-    const editor = createEditor(html);
+    const editor = createCaptionEditor(html);
     const output = editor.getHTML();
 
     expect(output).toContain('figure-index');
@@ -657,7 +659,7 @@ describe('FigureIndex node', () => {
 describe('TableIndex node', () => {
   it('parses <div class="table-index">', () => {
     const html = '<div class="table-index"></div>';
-    const editor = createEditor(html);
+    const editor = createCaptionEditor(html);
     const doc = editor.getJSON();
 
     const index = doc.content?.find((n) => n.type === 'tableIndex');
@@ -667,7 +669,7 @@ describe('TableIndex node', () => {
 
   it('renders with table-index class', () => {
     const html = '<div class="table-index"></div>';
-    const editor = createEditor(html);
+    const editor = createCaptionEditor(html);
     const output = editor.getHTML();
 
     expect(output).toContain('table-index');

--- a/frontend/src/shared/components/article/article-extensions.ts
+++ b/frontend/src/shared/components/article/article-extensions.ts
@@ -4,6 +4,8 @@ import { DrawioDiagramNodeView } from './DrawioDiagramNodeView';
 import { StatusBadgeView } from './StatusBadgeView';
 import { AttachmentsMacroView } from './AttachmentsMacroView';
 import { ChildrenMacroView } from './ChildrenMacroView';
+import { FigureIndexView } from './FigureIndexView';
+import { TableIndexView } from './TableIndexView';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -817,5 +819,120 @@ export const UnknownMacro = Node.create({
 
   renderHTML({ HTMLAttributes }) {
     return ['div', mergeAttributes(HTMLAttributes, { class: 'confluence-macro-unknown' }), 0];
+  },
+});
+
+/**
+ * Figure node — wraps an image + editable caption.
+ * Renders as <figure class="figure-block">.
+ * The content schema uses `image` which matches the TipTap Image extension node name.
+ */
+export const Figure = Node.create({
+  name: 'figure',
+  group: 'block',
+  content: 'image figcaption',
+  draggable: true,
+
+  parseHTML() {
+    return [{ tag: 'figure' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['figure', mergeAttributes(HTMLAttributes, { class: 'figure-block' }), 0];
+  },
+});
+
+/**
+ * Figcaption node — editable caption text inside a Figure.
+ * Renders as <figcaption> with styling classes.
+ */
+export const Figcaption = Node.create({
+  name: 'figcaption',
+  content: 'inline*',
+
+  parseHTML() {
+    return [{ tag: 'figcaption' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'figcaption',
+      mergeAttributes(HTMLAttributes, {
+        class: 'text-sm text-muted-foreground text-center mt-1 italic',
+      }),
+      0,
+    ];
+  },
+});
+
+/**
+ * TableCaption node — caption for tables.
+ * Renders as <div class="table-caption">.
+ * Parses from both <caption> (standard HTML) and <div class="table-caption">.
+ */
+export const TableCaption = Node.create({
+  name: 'tableCaption',
+  group: 'block',
+  content: 'inline*',
+
+  parseHTML() {
+    return [
+      { tag: 'caption' },
+      { tag: 'div.table-caption' },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        class: 'table-caption text-sm text-muted-foreground text-center mt-1 italic',
+      }),
+      0,
+    ];
+  },
+});
+
+/**
+ * FigureIndex node — auto-generated list of figures in the document.
+ * Atom node rendered via React NodeView that scans for figure nodes.
+ */
+export const FigureIndex = Node.create({
+  name: 'figureIndex',
+  group: 'block',
+  atom: true,
+
+  parseHTML() {
+    return [{ tag: 'div.figure-index' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { class: 'figure-index' })];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(FigureIndexView);
+  },
+});
+
+/**
+ * TableIndex node — auto-generated list of tables in the document.
+ * Atom node rendered via React NodeView that scans for tableCaption nodes.
+ */
+export const TableIndex = Node.create({
+  name: 'tableIndex',
+  group: 'block',
+  atom: true,
+
+  parseHTML() {
+    return [{ tag: 'div.table-index' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { class: 'table-index' })];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(TableIndexView);
   },
 });


### PR DESCRIPTION
## Summary
- New `Figure` node wrapping image + editable `Figcaption`
- New `TableCaption` node for table captions
- CSS counter auto-numbering: "Figure 1:", "Table 1:" (editor + viewer)
- `FigureIndex` and `TableIndex` atom nodes with live NodeViews that scan the document
- "Add Caption" toolbar button for images and in table context toolbar
- Index blocks auto-stripped during Confluence export (auto-generated content)

Closes #13

## Test plan
- [x] Figure, Figcaption, TableCaption parse HTML correctly (9 frontend tests)
- [x] FigureIndex and TableIndex are atom nodes
- [x] Figure/caption passes through content converter unchanged
- [x] Index blocks stripped during htmlToConfluence export (8 backend tests)
- [x] 17 new tests passing, 0 regressions
- [ ] Manual: add caption to image, verify auto-numbering
- [ ] Manual: insert "List of Figures", verify it updates live

🤖 Generated with [Claude Code](https://claude.com/claude-code)