### PR TITLE
fix(docker): connect Confluence test server to compendiq backend network

### DIFF
--- a/docker/docker-compose.confluence.yml
+++ b/docker/docker-compose.confluence.yml
@@ -35,7 +35,15 @@ services:
       CONFLUENCE_LOG_STDOUT: "true"
     volumes:
       - confluence-home:/var/atlassian/application-data/confluence
+    networks:
+      - default
+      - compendiq-backend
 
 volumes:
   confluence-postgres-data:
   confluence-home:
+
+networks:
+  compendiq-backend:
+    name: compendiq_backend-net
+    external: true


### PR DESCRIPTION
## Summary
- Joins the Confluence container to `compendiq_backend-net` as an external network
- Allows the backend's `CONFLUENCE_DOCKER_HOST=confluence` env var to resolve correctly
- Users can keep `http://localhost:8090` as their Confluence URL — the backend auto-rewrites it

Without this fix, `localhost` inside the backend container refers to itself, not the host machine, causing `getaddrinfo ENOTFOUND` when fetching spaces.

## Test plan
- [x] `docker compose -f docker/docker-compose.confluence.yml up -d` starts with shared network
- [x] Backend resolves `confluence` hostname and connects successfully
- [x] "Test Connection" in Settings shows green "Connection successful"

🤖 Generated with [Claude Code](https://claude.com/claude-code)