### PR TITLE
fix: upload pasted images to Confluence before save

### DIFF
--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -11,10 +11,83 @@ import { PageListQuerySchema, PageTreeQuerySchema, CreatePageSchema, UpdatePageS
 import { z } from 'zod';
 import { logger } from '../../core/utils/logger.js';
 import pLimit from 'p-limit';
+import { readFile } from 'fs/promises';
+import path from 'path';
+import type { ConfluenceClient } from '../../domains/confluence/services/confluence-client.js';
+import type { FastifyBaseLogger } from 'fastify';
 
 /** Escape ILIKE metacharacters so user input like "100%" doesn't match all rows. */
 function escapeIlikeTerm(term: string): string {
   return term.replace(/[%_\\]/g, '\\$&');
+}
+
+const ATTACHMENTS_BASE = process.env.ATTACHMENTS_DIR ?? 'data/attachments';
+
+const MIME_BY_EXT: Record<string, string> = {
+  '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif', '.webp': 'image/webp', '.svg': 'image/svg+xml',
+};
+
+/**
+ * Scan editor HTML for locally-pasted images (those with /api/attachments/ src
+ * but missing data-confluence-filename). Upload each to Confluence as a page
+ * attachment, then add data-confluence-filename so htmlToConfluence() generates
+ * a valid ri:attachment reference.
+ */
+async function uploadLocalImagesToConfluence(
+  html: string,
+  confluencePageId: string,
+  client: ConfluenceClient,
+  log: FastifyBaseLogger,
+): Promise<string> {
+  // Quick check — skip DOM parsing if no pasted images
+  if (!html.includes('/api/attachments/')) return html;
+
+  const { JSDOM } = await import('jsdom');
+  const dom = new JSDOM(`<body>${html}</body>`, { contentType: 'text/html' });
+  const doc = dom.window.document;
+
+  const localImages = doc.querySelectorAll('img[src^="/api/attachments/"]');
+  let changed = false;
+
+  for (const img of localImages) {
+    // Skip images that already have a Confluence filename (synced from Confluence)
+    if (img.getAttribute('data-confluence-filename')) continue;
+    if (img.getAttribute('data-confluence-image-source')) continue;
+
+    const src = img.getAttribute('src') ?? '';
+    // src = /api/attachments/{pageId}/{filename}
+    const parts = src.split('/');
+    const filename = decodeURIComponent(parts[parts.length - 1] ?? '');
+    const pageId = parts[parts.length - 2] ?? '';
+    if (!filename || !pageId) continue;
+
+    // Read the file from local attachment cache
+    const filePath = path.join(ATTACHMENTS_BASE, path.basename(pageId), path.basename(filename));
+    let fileData: Buffer;
+    try {
+      fileData = await readFile(filePath);
+    } catch {
+      log.warn({ filePath, filename }, 'Local pasted image not found, skipping upload');
+      continue;
+    }
+
+    const ext = path.extname(filename).toLowerCase();
+    const mimeType = MIME_BY_EXT[ext] ?? 'application/octet-stream';
+
+    try {
+      await client.updateAttachment(confluencePageId, filename, fileData, mimeType);
+      // Mark as a Confluence attachment so htmlToConfluence() uses the right filename
+      img.setAttribute('data-confluence-filename', filename);
+      img.setAttribute('data-confluence-image-source', 'attachment');
+      changed = true;
+      log.info({ confluencePageId, filename }, 'Uploaded pasted image to Confluence');
+    } catch (err) {
+      log.error({ err, confluencePageId, filename }, 'Failed to upload pasted image to Confluence');
+    }
+  }
+
+  return changed ? doc.body.innerHTML : html;
 }
 
 const BulkIdsSchema = z.object({ ids: z.array(z.string().min(1)).min(1).max(100) });
@@ -941,7 +1014,16 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       throw fastify.httpErrors.conflict('Page has been modified since you loaded it. Please refresh and try again.');
     }
 
-    const storageBody = htmlToConfluence(body.bodyHtml);
+    // Upload locally-pasted images to Confluence before converting HTML.
+    // Pasted images have src="/api/attachments/{pageId}/{filename}" but lack
+    // data-confluence-filename, meaning they only exist locally and Confluence
+    // doesn't know about them. We upload them as Confluence attachments so the
+    // ri:attachment reference resolves correctly after save.
+    const uploadedBodyHtml = await uploadLocalImagesToConfluence(
+      body.bodyHtml, existingPage.confluence_id!, client, request.log,
+    );
+
+    const storageBody = htmlToConfluence(uploadedBodyHtml);
     const currentVersion = existingPage.version ?? body.version ?? 1;
 
     const confPage = await client.updatePage(existingPage.confluence_id!, body.title, storageBody, currentVersion);


### PR DESCRIPTION
## Summary
Pasted images were saved locally but never pushed to Confluence as attachments. When the page was saved back to Confluence, it showed "Unknown Attachment" because `ri:attachment` referenced a file that didn't exist on the Confluence server.

**Fix:** Before converting editor HTML to Confluence storage format, scan for local-only images (those with `/api/attachments/` src but no `data-confluence-filename`), upload each to Confluence via the attachment API, then tag the `<img>` with `data-confluence-filename` so `htmlToConfluence()` generates a valid `ri:attachment` reference.

## Test plan
- [x] Upload pasted image to Confluence attachment API confirmed in logs
- [x] `data-confluence-filename` added to img after upload
- [x] Save returns 200 with version bump
- [x] Confluence page renders the image correctly (no "Unknown Attachment")
- [ ] Manual: paste image in editor, save, check Confluence shows the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)