### PR TITLE
feat(editor): Notion-style drag-and-drop for block elements

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@tanstack/react-virtual": "^3.13.21",
     "@tiptap/extension-code-block-lowlight": "^3.0.0",
     "@tiptap/extension-color": "^3.21.0",
+    "@tiptap/extension-drag-handle-react": "^3.22.0",
     "@tiptap/extension-highlight": "^3.21.0",
     "@tiptap/extension-image": "^3.0.0",
     "@tiptap/extension-list": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "@tanstack/react-virtual": "^3.13.21",
     "@tiptap/extension-code-block-lowlight": "^3.0.0",
     "@tiptap/extension-color": "^3.21.0",
-    "@tiptap/extension-drag-handle-react": "^3.22.0",
+    "@tiptap/extension-drag-handle-react": "~3.21.0",
     "@tiptap/extension-highlight": "^3.21.0",
     "@tiptap/extension-image": "^3.0.0",
     "@tiptap/extension-list": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "@tanstack/react-virtual": "^3.13.21",
     "@tiptap/extension-code-block-lowlight": "^3.0.0",
     "@tiptap/extension-color": "^3.21.0",
-    "@tiptap/extension-drag-handle-react": "~3.21.0",
+    "@tiptap/extension-drag-handle-react": "^3.21.0",
     "@tiptap/extension-highlight": "^3.21.0",
     "@tiptap/extension-image": "^3.0.0",
     "@tiptap/extension-list": "^3.0.0",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1568,6 +1568,49 @@ pre:hover .code-copy-btn {
   opacity: 0.6;
 }
 
+/* Drag handle (#49) — Notion-style block drag-and-drop */
+.drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.5rem;
+  border-radius: 0.25rem;
+  cursor: grab;
+  color: var(--color-muted-foreground);
+  opacity: 0;
+  transition: opacity 0.15s ease, background-color 0.15s ease, color 0.15s ease;
+  user-select: none;
+  z-index: 50;
+}
+
+.drag-handle:hover {
+  opacity: 1 !important;
+  background-color: oklch(from var(--color-foreground) l c h / 0.08);
+  color: var(--color-foreground);
+}
+
+.drag-handle:active {
+  cursor: grabbing;
+  background-color: oklch(from var(--color-primary) l c h / 0.15);
+  color: var(--color-primary);
+}
+
+/* Show the handle when it is positioned (visible) by the extension */
+.drag-handle[style*="display: block"],
+.drag-handle[style*="display:block"] {
+  opacity: 0.4;
+}
+
+/* ProseMirror drop cursor — the blue line shown during drag */
+.ProseMirror-dropcursor {
+  color: var(--color-primary) !important;
+  border: none !important;
+  height: 2px !important;
+  background-color: var(--color-primary) !important;
+  opacity: 0.7;
+}
+
 /* Draw.io diagrams (shared between editor and page view) */
 .confluence-drawio {
   position: relative;

--- a/frontend/src/shared/components/article/Editor.test.tsx
+++ b/frontend/src/shared/components/article/Editor.test.tsx
@@ -184,6 +184,34 @@ describe('Editor', () => {
     });
     expect(container.querySelector('.header-numbering')).toBeFalsy();
   });
+
+  describe('drag handle (#49)', () => {
+    it('renders drag handle in edit mode', async () => {
+      const { container } = render(
+        <Editor content="<p>Hello</p>" editable={true} />,
+      );
+
+      await waitFor(() => {
+        expect(container.querySelector('[class*="tiptap"]')).toBeTruthy();
+      });
+
+      const dragHandle = container.querySelector('.drag-handle');
+      expect(dragHandle).toBeTruthy();
+    });
+
+    it('does not render drag handle in read-only mode', async () => {
+      const { container } = render(
+        <Editor content="<p>Hello</p>" editable={false} />,
+      );
+
+      await waitFor(() => {
+        expect(container.querySelector('[class*="tiptap"]')).toBeTruthy();
+      });
+
+      const dragHandle = container.querySelector('.drag-handle');
+      expect(dragHandle).toBeFalsy();
+    });
+  });
 });
 
 describe('EditorToolbar — header numbering toggle', () => {

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { useEditor, useEditorState, EditorContent } from '@tiptap/react';
+import DragHandle from '@tiptap/extension-drag-handle-react';
 import StarterKit from '@tiptap/starter-kit';
 import { Table, TableRow, TableCell, TableHeader } from '@tiptap/extension-table';
 import { TaskList, TaskItem } from '@tiptap/extension-list';
@@ -20,6 +21,7 @@ import {
   Trash2, Columns3, Rows3, Merge, SplitSquareHorizontal, Square,
   ToggleLeft, PanelTop, Workflow, Underline, Highlighter, Palette,
   Badge, ChevronsUpDown, Hash, Paperclip, ListTree, ImagePlus, TableProperties, Table2,
+  GripVertical,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '../../lib/cn';
@@ -1018,6 +1020,11 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
         </div>
       )}
       {editable && editor && <SearchAndReplace editor={editor} />}
+      {editable && editor && (
+        <DragHandle editor={editor} className="drag-handle">
+          <GripVertical size={16} />
+        </DragHandle>
+      )}
       <EditorContent
         editor={editor}
         className={cn(

--- a/package-lock.json
+++ b/package-lock.json
@@ -395,6 +395,7 @@
         "@tanstack/react-virtual": "^3.13.21",
         "@tiptap/extension-code-block-lowlight": "^3.0.0",
         "@tiptap/extension-color": "^3.21.0",
+        "@tiptap/extension-drag-handle-react": "^3.22.0",
         "@tiptap/extension-highlight": "^3.21.0",
         "@tiptap/extension-image": "^3.0.0",
         "@tiptap/extension-list": "^3.0.0",
@@ -451,6 +452,55 @@
         "vitest": "^4.0.18"
       }
     },
+    "frontend/node_modules/@tiptap/core": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.0.tgz",
+      "integrity": "sha512-EA/XFbvvz0yRyccqrgOwB9RQe6+uJ8NszjLKH9+3xPE2/+Sa2imax0IqWl7YOXkWihdQVrlpP+EpQF9APKx3jg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "^3.22.0"
+      }
+    },
+    "frontend/node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.0.tgz",
+      "integrity": "sha512-792CUdP0roO17jQJ+fflSJEWfw2cAric61nV2291a2iL7L/6mNJGP4QFim1FqZzfx3/FwHSXEI3NYT6wdUlh8w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.0",
+        "@tiptap/pm": "^3.22.0"
+      }
+    },
+    "frontend/node_modules/@tiptap/extension-collaboration": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.22.0.tgz",
+      "integrity": "sha512-S/nPIth4/Dr5wmxROk4ELWRYhBXxWt7O6cIi8Fca1rYDBdXofjgt4VDO2iCjnOF0LkIekjQudSOFLWadbM2Z+w==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.0",
+        "@tiptap/pm": "^3.22.0",
+        "@tiptap/y-tiptap": "^3.0.2",
+        "yjs": "^13"
+      }
+    },
     "frontend/node_modules/@tiptap/extension-color": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-3.21.0.tgz",
@@ -462,6 +512,60 @@
       },
       "peerDependencies": {
         "@tiptap/extension-text-style": "^3.21.0"
+      }
+    },
+    "frontend/node_modules/@tiptap/extension-drag-handle": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.22.0.tgz",
+      "integrity": "sha512-OdOCqdgprFrvVhbLCCGX1D0hXo/2SL8o1o50Gy0l1lgiH9vqi/B2LjUJZwYYneQa1K0ME1J4dL4Vp89V4jej0A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.13"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.0",
+        "@tiptap/extension-collaboration": "^3.22.0",
+        "@tiptap/extension-node-range": "^3.22.0",
+        "@tiptap/pm": "^3.22.0",
+        "@tiptap/y-tiptap": "^3.0.2"
+      }
+    },
+    "frontend/node_modules/@tiptap/extension-drag-handle-react": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-react/-/extension-drag-handle-react-3.22.0.tgz",
+      "integrity": "sha512-WzANdIFc/SLxNua0iRHpNMT1P9yhKO+rsCmjqzqchGuCx1acLSooWdrHqGC+8vxCWfSYMpigtzh4NiE0gjh63Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-drag-handle": "^3.22.0",
+        "@tiptap/pm": "^3.22.0",
+        "@tiptap/react": "^3.22.0",
+        "react": "^16.8 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19"
+      }
+    },
+    "frontend/node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.0.tgz",
+      "integrity": "sha512-6Gg3I6n+YaCJyvpcKheWiOtU9Oy0M3lbwUGdLK7jTxgAG2YOJxEcx2CzDv3PtNcoyAVUVk9Eio21awVMOECLAQ==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "^3.22.0",
+        "@tiptap/pm": "^3.22.0"
       }
     },
     "frontend/node_modules/@tiptap/extension-highlight": {
@@ -477,6 +581,21 @@
         "@tiptap/core": "^3.21.0"
       }
     },
+    "frontend/node_modules/@tiptap/extension-node-range": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.22.0.tgz",
+      "integrity": "sha512-tize9T79ABbOmkw3+7k8cFjSU/JMpzv1JyvFXuGD7lmiHSrFH9Ll8uOGJC7qhCGJWMsjVvrKmBHSOGbzfJI5hQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.0",
+        "@tiptap/pm": "^3.22.0"
+      }
+    },
     "frontend/node_modules/@tiptap/extension-text-style": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.21.0.tgz",
@@ -488,6 +607,63 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^3.21.0"
+      }
+    },
+    "frontend/node_modules/@tiptap/pm": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.0.tgz",
+      "integrity": "sha512-O9kpzNnFX5837kFevwAM8yr7ImLHu8noIwIpoci0AwfJjiBMzfZBejhbzxnKEfTpFWnkvZ8rWohlb6CQdJ6Crg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-menu": "^1.2.4",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "frontend/node_modules/@tiptap/react": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.22.0.tgz",
+      "integrity": "sha512-Jt2LxSbwIUTtp+2Fg27tnsUCC5XiRl084o+/uJTa5xcY4Fdce6rsrEDMjw5P7uYObhjdnBxr514tqd2bvC6LUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.22.0",
+        "@tiptap/extension-floating-menu": "^3.22.0"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.0",
+        "@tiptap/pm": "^3.22.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "frontend/node_modules/marked": {
@@ -6507,24 +6683,6 @@
         "@tiptap/core": "^3.20.0"
       }
     },
-    "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.20.0.tgz",
-      "integrity": "sha512-MDosUfs8Tj+nwg8RC+wTMWGkLJORXmbR6YZgbiX4hrc7G90Gopdd6kj6ht5/T8t7dLLaX7N0+DEHdUEPGED7dw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.0",
-        "@tiptap/pm": "^3.20.0"
-      }
-    },
     "node_modules/@tiptap/extension-bullet-list": {
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.20.0.tgz",
@@ -6606,22 +6764,6 @@
       },
       "peerDependencies": {
         "@tiptap/extensions": "^3.20.0"
-      }
-    },
-    "node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.20.0.tgz",
-      "integrity": "sha512-rYs4Bv5pVjqZ/2vvR6oe7ammZapkAwN51As/WDbemvYDjfOGRqK58qGauUjYZiDzPOEIzI2mxGwsZ4eJhPW4Ig==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "^3.20.0",
-        "@tiptap/pm": "^3.20.0"
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
@@ -6883,33 +7025,6 @@
         "url": "https://github.com/sponsors/ueberdosis"
       }
     },
-    "node_modules/@tiptap/react": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.20.0.tgz",
-      "integrity": "sha512-jFLNzkmn18zqefJwPje0PPd9VhZ7Oy28YHiSvSc7YpBnQIbuN/HIxZ2lrOsKyEHta0WjRZjfU5X1pGxlbcGwOA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "fast-equals": "^5.3.3",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.20.0",
-        "@tiptap/extension-floating-menu": "^3.20.0"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.0",
-        "@tiptap/pm": "^3.20.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/@tiptap/starter-kit": {
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.20.0.tgz",
@@ -6944,6 +7059,27 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/y-tiptap": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/y-tiptap/-/y-tiptap-3.0.2.tgz",
+      "integrity": "sha512-flMn/YW6zTbc6cvDaUPh/NfLRTXDIqgpBUkYzM74KA1snqQwhOMjnRcnpu4hDFrTnPO6QGzr99vRyXEA7M44WA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.100"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -13010,6 +13146,17 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -13409,6 +13556,28 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lie": {
@@ -19352,6 +19521,27 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y-protocols": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -19419,6 +19609,24 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.30",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.30.tgz",
+      "integrity": "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -395,7 +395,7 @@
         "@tanstack/react-virtual": "^3.13.21",
         "@tiptap/extension-code-block-lowlight": "^3.0.0",
         "@tiptap/extension-color": "^3.21.0",
-        "@tiptap/extension-drag-handle-react": "^3.22.0",
+        "@tiptap/extension-drag-handle-react": "~3.21.0",
         "@tiptap/extension-highlight": "^3.21.0",
         "@tiptap/extension-image": "^3.0.0",
         "@tiptap/extension-list": "^3.0.0",
@@ -536,18 +536,18 @@
       }
     },
     "frontend/node_modules/@tiptap/extension-drag-handle-react": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-react/-/extension-drag-handle-react-3.22.0.tgz",
-      "integrity": "sha512-WzANdIFc/SLxNua0iRHpNMT1P9yhKO+rsCmjqzqchGuCx1acLSooWdrHqGC+8vxCWfSYMpigtzh4NiE0gjh63Q==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-react/-/extension-drag-handle-react-3.21.0.tgz",
+      "integrity": "sha512-OCL/0yzF12ByQngqYT/zQQC6+SUmiiqFqtpZv/2gKPSaS3smzlhrFjjP8GpJQpC2w+XeXH9VQtCIyuunt13fNQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-drag-handle": "^3.22.0",
-        "@tiptap/pm": "^3.22.0",
-        "@tiptap/react": "^3.22.0",
+        "@tiptap/extension-drag-handle": "^3.21.0",
+        "@tiptap/pm": "^3.21.0",
+        "@tiptap/react": "^3.21.0",
         "react": "^16.8 || ^17 || ^18 || ^19",
         "react-dom": "^16.8 || ^17 || ^18 || ^19"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -395,7 +395,7 @@
         "@tanstack/react-virtual": "^3.13.21",
         "@tiptap/extension-code-block-lowlight": "^3.0.0",
         "@tiptap/extension-color": "^3.21.0",
-        "@tiptap/extension-drag-handle-react": "~3.21.0",
+        "@tiptap/extension-drag-handle-react": "^3.21.0",
         "@tiptap/extension-highlight": "^3.21.0",
         "@tiptap/extension-image": "^3.0.0",
         "@tiptap/extension-list": "^3.0.0",
@@ -452,20 +452,6 @@
         "vitest": "^4.0.18"
       }
     },
-    "frontend/node_modules/@tiptap/core": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.0.tgz",
-      "integrity": "sha512-EA/XFbvvz0yRyccqrgOwB9RQe6+uJ8NszjLKH9+3xPE2/+Sa2imax0IqWl7YOXkWihdQVrlpP+EpQF9APKx3jg==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/pm": "^3.22.0"
-      }
-    },
     "frontend/node_modules/@tiptap/extension-bubble-menu": {
       "version": "3.22.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.0.tgz",
@@ -502,16 +488,16 @@
       }
     },
     "frontend/node_modules/@tiptap/extension-color": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-3.21.0.tgz",
-      "integrity": "sha512-LbzMcUPz148A+4g42GQ3FqkwI4+p8w+9W0s5HAo6aVMjsOaMSL12CqNhG4Kj/6zOq32WkVSa3FxpDNkuMn0jzA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-3.22.0.tgz",
+      "integrity": "sha512-cvhRRA6vH6sFcqzmNjMtxJbKgZH06lP8mVuz810j1bfxxEY2n6Nx5zda992aUy7BWtYjxZ9KjWodH/2uVlOqmg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-text-style": "^3.21.0"
+        "@tiptap/extension-text-style": "^3.22.0"
       }
     },
     "frontend/node_modules/@tiptap/extension-drag-handle": {
@@ -536,18 +522,18 @@
       }
     },
     "frontend/node_modules/@tiptap/extension-drag-handle-react": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-react/-/extension-drag-handle-react-3.21.0.tgz",
-      "integrity": "sha512-OCL/0yzF12ByQngqYT/zQQC6+SUmiiqFqtpZv/2gKPSaS3smzlhrFjjP8GpJQpC2w+XeXH9VQtCIyuunt13fNQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-react/-/extension-drag-handle-react-3.22.0.tgz",
+      "integrity": "sha512-WzANdIFc/SLxNua0iRHpNMT1P9yhKO+rsCmjqzqchGuCx1acLSooWdrHqGC+8vxCWfSYMpigtzh4NiE0gjh63Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-drag-handle": "^3.21.0",
-        "@tiptap/pm": "^3.21.0",
-        "@tiptap/react": "^3.21.0",
+        "@tiptap/extension-drag-handle": "^3.22.0",
+        "@tiptap/pm": "^3.22.0",
+        "@tiptap/react": "^3.22.0",
         "react": "^16.8 || ^17 || ^18 || ^19",
         "react-dom": "^16.8 || ^17 || ^18 || ^19"
       }
@@ -569,16 +555,16 @@
       }
     },
     "frontend/node_modules/@tiptap/extension-highlight": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-highlight/-/extension-highlight-3.21.0.tgz",
-      "integrity": "sha512-3f/bVgfm2dJZxalh07TThDxcTaeXJ+dpYyRY9trnFeHbhyYQXSy6yzkNhNcYB4Ua5jxpKQv4b9Q448QVh+KNzA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-highlight/-/extension-highlight-3.22.0.tgz",
+      "integrity": "sha512-5+u3Rr3EDF4tmXlMblL1RWwHheO00Gdn974HjUNrKus01q6JQcqBpycXfYYq5XHG+iHdWSVzL2XE1KsTwVI+7w==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.21.0"
+        "@tiptap/core": "^3.22.0"
       }
     },
     "frontend/node_modules/@tiptap/extension-node-range": {
@@ -597,46 +583,16 @@
       }
     },
     "frontend/node_modules/@tiptap/extension-text-style": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.21.0.tgz",
-      "integrity": "sha512-MI/3X75D45Wa/+0Fp8nYfNJq5makkjtG7B2/lIzNUe0kEKJ56RVQoV1GQSXxAiFNyAYRfKFq8dJslhesW3EkWA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.22.0.tgz",
+      "integrity": "sha512-Hr+YIFxAAtKBXCxBtqXhAZUSh9sTVa5mz89RnvBoj9tPMbXaeNpxdCkRu1nZJVV5nERJxKVWZjHctqK0WkgMBw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.21.0"
-      }
-    },
-    "frontend/node_modules/@tiptap/pm": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.0.tgz",
-      "integrity": "sha512-O9kpzNnFX5837kFevwAM8yr7ImLHu8noIwIpoci0AwfJjiBMzfZBejhbzxnKEfTpFWnkvZ8rWohlb6CQdJ6Crg==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-changeset": "^2.3.0",
-        "prosemirror-collab": "^1.3.1",
-        "prosemirror-commands": "^1.6.2",
-        "prosemirror-dropcursor": "^1.8.1",
-        "prosemirror-gapcursor": "^1.3.2",
-        "prosemirror-history": "^1.4.1",
-        "prosemirror-inputrules": "^1.4.0",
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-markdown": "^1.13.1",
-        "prosemirror-menu": "^1.2.4",
-        "prosemirror-model": "^1.24.1",
-        "prosemirror-schema-basic": "^1.2.3",
-        "prosemirror-schema-list": "^1.5.0",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.6.4",
-        "prosemirror-trailing-node": "^3.0.0",
-        "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.38.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
+        "@tiptap/core": "^3.22.0"
       }
     },
     "frontend/node_modules/@tiptap/react": {
@@ -6645,16 +6601,16 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.21.0.tgz",
-      "integrity": "sha512-IfnQiuEeabDSPr1C/zHFTbnvlTf5z0DE/d/xz4C6bkL4ZBDJ3rr99h2qsaV0l8F+kbNswZMlQdM8rxNlMy95fQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.0.tgz",
+      "integrity": "sha512-EA/XFbvvz0yRyccqrgOwB9RQe6+uJ8NszjLKH9+3xPE2/+Sa2imax0IqWl7YOXkWihdQVrlpP+EpQF9APKx3jg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.21.0"
+        "@tiptap/pm": "^3.22.0"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
@@ -6863,17 +6819,17 @@
       }
     },
     "node_modules/@tiptap/extension-list": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.20.0.tgz",
-      "integrity": "sha512-+V0/gsVWAv+7vcY0MAe6D52LYTIicMSHw00wz3ISZgprSb2yQhJ4+4gurOnUrQ4Du3AnRQvxPROaofwxIQ66WQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.0.tgz",
+      "integrity": "sha512-NfSCAgX44NVLib6aN4HmsP1wi6fFfK3dt6TBb9EgcR82nzq6n7dq7VEBw9V1aKqeXQEtNpqMnQFd0SDayweyfQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.20.0",
-        "@tiptap/pm": "^3.20.0"
+        "@tiptap/core": "^3.22.0",
+        "@tiptap/pm": "^3.22.0"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
@@ -6982,23 +6938,23 @@
       }
     },
     "node_modules/@tiptap/extensions": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.20.0.tgz",
-      "integrity": "sha512-HIsXX942w3nbxEQBlMAAR/aa6qiMBEP7CsSMxaxmTIVAmW35p6yUASw6GdV1u0o3lCZjXq2OSRMTskzIqi5uLg==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.0.tgz",
+      "integrity": "sha512-En8p1FiFBT3V9CduErCyLPFxDRsYLISb2cCtLKTeYVeCRn2vQZK4B8WuOgHI4IBipz3I3XidmDhra4yt8mmi/w==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.20.0",
-        "@tiptap/pm": "^3.20.0"
+        "@tiptap/core": "^3.22.0",
+        "@tiptap/pm": "^3.22.0"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.21.0.tgz",
-      "integrity": "sha512-I3sNo7oMMsR6FFz1ecvPb9uCF0VQuS2WV67j8Io2M7DJicRWCE/GM5DaiYjTeWBbnByk6BuG0txoJATAqPVliQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.0.tgz",
+      "integrity": "sha512-O9kpzNnFX5837kFevwAM8yr7ImLHu8noIwIpoci0AwfJjiBMzfZBejhbzxnKEfTpFWnkvZ8rWohlb6CQdJ6Crg==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",


### PR DESCRIPTION
## Summary

- Adds a Notion-style drag handle that appears to the left of any block element when hovering in the editor (edit mode only)
- Uses `@tiptap/extension-drag-handle-react` v3.22.0 to render a `GripVertical` icon that allows users to reorder paragraphs, headings, lists, tables, code blocks, and other block-level content via drag-and-drop
- Styled with the glassmorphic dark theme: semi-transparent handle on hover, grab/grabbing cursor states, primary color accent during drag, and a visible blue drop indicator line

## Changes

- **frontend/package.json** -- Added `@tiptap/extension-drag-handle-react` dependency
- **frontend/src/shared/components/article/Editor.tsx** -- Imported `DragHandle` component and `GripVertical` icon; renders the drag handle as a sibling to `EditorContent`, gated on `editable && editor`
- **frontend/src/index.css** -- Added `.drag-handle` styles (opacity transitions, hover/active states, grab cursors) and `.ProseMirror-dropcursor` override for a themed drop indicator
- **frontend/src/shared/components/article/Editor.test.tsx** -- Added 2 tests: drag handle renders in edit mode, hidden in read-only mode

## Test plan

- [x] `vitest run` -- all new tests pass; only pre-existing Mermaid button test fails (unrelated)
- [ ] Manual: open a page in edit mode, hover left of any block, verify grip icon appears
- [ ] Manual: drag a paragraph block to reorder, verify drop indicator and block moves
- [ ] Manual: verify drag handle does NOT appear in read-only/view mode
- [ ] Manual: verify custom blocks (layout, details, diagrams) are draggable

Closes #49

Generated with [Claude Code](https://claude.com/claude-code)