### PR TITLE
feat(editor): add optional Vim mode with modal editing (#40)

### DIFF
--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -145,6 +145,18 @@ export function PageViewPage() {
   const [drawioEditingDiagram, setDrawioEditingDiagram] = useState<string | null>(null);
   const [drawioXml, setDrawioXml] = useState<string>('');
 
+  // Vim mode state — lifted here so we can pass it to the external toolbar
+  const [vimEnabled, setVimEnabled] = useState(() =>
+    localStorage.getItem('compendiq-vim-mode') === 'true'
+  );
+  const toggleVim = useCallback(() => {
+    setVimEnabled(prev => {
+      const next = !prev;
+      localStorage.setItem('compendiq-vim-mode', String(next));
+      return next;
+    });
+  }, []);
+
   // Sync editing state to the shared store (consumed by ArticleRightPane)
   useEffect(() => {
     setStoreEditing(editing);
@@ -448,7 +460,7 @@ export function PageViewPage() {
       {/* Sticky toolbar — ABOVE the card, sticks at top-0 with no movement */}
       {editing && editorInstance && (
         <div className="sticky top-0 z-30 border border-border/25 bg-card rounded-xl shadow-[0_8px_32px_var(--glass-shadow)] before:absolute before:-z-10 before:-top-[100px] before:bottom-0 before:-left-[14px] before:-right-[14px] sm:before:-left-[22px] sm:before:-right-[22px] before:bg-background">
-          <EditorToolbar editor={editorInstance} />
+          <EditorToolbar editor={editorInstance} vimEnabled={vimEnabled} onToggleVim={toggleVim} />
           <TableContextToolbar editor={editorInstance} />
           <LayoutContextToolbar editor={editorInstance} />
           <ColumnContextToolbar editor={editorInstance} />
@@ -602,7 +614,7 @@ export function PageViewPage() {
 
             {/* Editor — naked (no inner glass-card, we are already inside glass-card-xl) */}
             <FeatureErrorBoundary featureName="Editor">
-              <Editor content={editHtml} onChange={setEditHtml} draftKey={draftKey} naked onEditorReady={setEditorInstance} hideToolbar pageId={id} onSave={handleSave} />
+              <Editor content={editHtml} onChange={setEditHtml} draftKey={draftKey} naked onEditorReady={setEditorInstance} hideToolbar pageId={id} onSave={handleSave} vimEnabled={vimEnabled} />
             </FeatureErrorBoundary>
           </>
         ) : !page.bodyHtml?.trim() || page.bodyHtml.trim() === '<p></p>' ? (

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -602,7 +602,7 @@ export function PageViewPage() {
 
             {/* Editor — naked (no inner glass-card, we are already inside glass-card-xl) */}
             <FeatureErrorBoundary featureName="Editor">
-              <Editor content={editHtml} onChange={setEditHtml} draftKey={draftKey} naked onEditorReady={setEditorInstance} hideToolbar pageId={id} />
+              <Editor content={editHtml} onChange={setEditHtml} draftKey={draftKey} naked onEditorReady={setEditorInstance} hideToolbar pageId={id} onSave={handleSave} />
             </FeatureErrorBoundary>
           </>
         ) : !page.bodyHtml?.trim() || page.bodyHtml.trim() === '<p></p>' ? (

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -112,6 +112,8 @@ interface EditorProps {
   hideToolbar?: boolean;
   /** Page ID for image paste/drop uploads. When set, clipboard images are uploaded to this page. */
   pageId?: string;
+  /** Callback to trigger a server-side save (used by vim :w command). */
+  onSave?: () => void;
 }
 
 function ToolbarButton({
@@ -892,7 +894,7 @@ function defaultVimDisplayState(): VimState {
   return { mode: 'normal', pendingKeys: '', countPrefix: '', register: '', commandBuffer: null };
 }
 
-export function Editor({ content, onChange, editable = true, placeholder, draftKey, naked = false, onEditorReady, hideToolbar = false, pageId }: EditorProps) {
+export function Editor({ content, onChange, editable = true, placeholder, draftKey, naked = false, onEditorReady, hideToolbar = false, pageId, onSave }: EditorProps) {
   const isLight = useIsLightTheme();
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   // Ref for the editor instance so async paste/drop handlers can insert images
@@ -900,6 +902,9 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
   // Keep pageId in a ref so editorProps closures see the latest value
   const pageIdRef = useRef(pageId);
   pageIdRef.current = pageId;
+  // Keep onSave in a ref so the VimExtension closure always sees the latest callback
+  const onSaveRef = useRef(onSave);
+  onSaveRef.current = onSave;
 
   const [headerNumbering, setHeaderNumbering] = useState(() =>
     localStorage.getItem('editor-header-numbering') === 'true'
@@ -1003,10 +1008,11 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
       ...(vimEnabled ? [VimExtension.configure({
         onStateChange: setVimDisplayState,
         onSave: () => {
-          // Trigger save via onChange with current content
+          // Flush current editor content to React state, then trigger server-side save
           if (editorRef.current) {
             onChange?.(editorRef.current.getHTML());
           }
+          onSaveRef.current?.();
         },
       })] : []),
     ],

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -22,6 +22,7 @@ import {
   ToggleLeft, PanelTop, Workflow, Underline, Highlighter, Palette,
   Badge, ChevronsUpDown, Hash, Paperclip, ListTree, ImagePlus, TableProperties, Table2,
   GripVertical,
+  Terminal,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '../../lib/cn';
@@ -50,6 +51,8 @@ import {
   LAYOUT_PRESETS,
 } from './article-extensions';
 import type { Editor as EditorType } from '@tiptap/react';
+import { VimExtension, type VimState } from './vim-extension';
+import { VimModeIndicator } from './VimModeIndicator';
 
 const ConfluenceImage = Image.extend({
   addAttributes() {
@@ -295,7 +298,7 @@ function ColorPickerDropdown({
   );
 }
 
-export function EditorToolbar({ editor, headerNumbering, onToggleHeaderNumbering }: { editor: EditorType; headerNumbering?: boolean; onToggleHeaderNumbering?: () => void }) {
+export function EditorToolbar({ editor, headerNumbering, onToggleHeaderNumbering, vimEnabled, onToggleVim }: { editor: EditorType; headerNumbering?: boolean; onToggleHeaderNumbering?: () => void; vimEnabled?: boolean; onToggleVim?: () => void }) {
   // Subscribe to editor state changes so toolbar re-renders on selection/formatting changes (#16)
   const activeState = useEditorState({
     editor,
@@ -509,6 +512,14 @@ export function EditorToolbar({ editor, headerNumbering, onToggleHeaderNumbering
       </ToolbarButton>
 
       <div className="flex-1" />
+
+      {onToggleVim && (
+        <ToolbarButton onClick={onToggleVim} active={vimEnabled} title="Toggle Vim Mode">
+          <Terminal size={16} />
+        </ToolbarButton>
+      )}
+
+      <ToolbarSeparator />
 
       <ToolbarButton onClick={() => editor.chain().focus().undo().run()} disabled={!editor.can().undo()} title="Undo">
         <Undo2 size={16} />
@@ -875,6 +886,12 @@ export function clearDraft(key: string): void {
   } catch { /* ignore */ }
 }
 
+const VIM_STORAGE_KEY = 'compendiq-vim-mode';
+
+function defaultVimDisplayState(): VimState {
+  return { mode: 'normal', pendingKeys: '', countPrefix: '', register: '', commandBuffer: null };
+}
+
 export function Editor({ content, onChange, editable = true, placeholder, draftKey, naked = false, onEditorReady, hideToolbar = false, pageId }: EditorProps) {
   const isLight = useIsLightTheme();
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -892,6 +909,21 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
     setHeaderNumbering(prev => {
       localStorage.setItem('editor-header-numbering', String(!prev));
       return !prev;
+    });
+  };
+
+  // Vim mode state
+  const [vimEnabled, setVimEnabled] = useState(() =>
+    localStorage.getItem(VIM_STORAGE_KEY) === 'true'
+  );
+  const [vimDisplayState, setVimDisplayState] = useState<VimState>(defaultVimDisplayState);
+
+  const toggleVim = () => {
+    setVimEnabled(prev => {
+      const next = !prev;
+      localStorage.setItem(VIM_STORAGE_KEY, String(next));
+      if (!next) setVimDisplayState(defaultVimDisplayState());
+      return next;
     });
   };
 
@@ -968,6 +1000,15 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
       ConfluenceImage.configure({ inline: false }),
       Placeholder.configure({ placeholder: placeholder ?? 'Start writing...' }),
       SearchAndReplaceExtension,
+      ...(vimEnabled ? [VimExtension.configure({
+        onStateChange: setVimDisplayState,
+        onSave: () => {
+          // Trigger save via onChange with current content
+          if (editorRef.current) {
+            onChange?.(editorRef.current.getHTML());
+          }
+        },
+      })] : []),
     ],
     editorProps: {
       handlePaste(_view, event) {
@@ -998,7 +1039,7 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
       onChange?.(html);
       saveDraft(html);
     },
-  });
+  }, [vimEnabled]);
 
   // Keep the editor ref in sync
   editorRef.current = editor;
@@ -1013,7 +1054,7 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
     <div className={cn('relative', naked ? '' : 'glass-card', headerNumbering && 'header-numbering')}>
       {editable && editor && !hideToolbar && (
         <div className="sticky top-0 z-30 rounded-t-xl border-b border-border/50 bg-card before:absolute before:-z-10 before:-top-[100px] before:bottom-0 before:left-0 before:right-0 before:bg-background">
-          <EditorToolbar editor={editor} headerNumbering={headerNumbering} onToggleHeaderNumbering={toggleHeaderNumbering} />
+          <EditorToolbar editor={editor} headerNumbering={headerNumbering} onToggleHeaderNumbering={toggleHeaderNumbering} vimEnabled={vimEnabled} onToggleVim={toggleVim} />
           <TableContextToolbar editor={editor} />
           <LayoutContextToolbar editor={editor} />
           <ColumnContextToolbar editor={editor} />
@@ -1036,6 +1077,7 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
           '[&_ul[data-type=taskList]]:list-none [&_ul[data-type=taskList]]:pl-0',
         )}
       />
+      {vimEnabled && editable && <VimModeIndicator vimState={vimDisplayState} />}
     </div>
   );
 }

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -114,6 +114,8 @@ interface EditorProps {
   pageId?: string;
   /** Callback to trigger a server-side save (used by vim :w command). */
   onSave?: () => void;
+  /** Controlled vim mode — when provided, overrides internal vim state. */
+  vimEnabled?: boolean;
 }
 
 function ToolbarButton({
@@ -894,7 +896,7 @@ function defaultVimDisplayState(): VimState {
   return { mode: 'normal', pendingKeys: '', countPrefix: '', register: '', commandBuffer: null };
 }
 
-export function Editor({ content, onChange, editable = true, placeholder, draftKey, naked = false, onEditorReady, hideToolbar = false, pageId, onSave }: EditorProps) {
+export function Editor({ content, onChange, editable = true, placeholder, draftKey, naked = false, onEditorReady, hideToolbar = false, pageId, onSave, vimEnabled: vimEnabledProp }: EditorProps) {
   const isLight = useIsLightTheme();
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   // Ref for the editor instance so async paste/drop handlers can insert images
@@ -917,14 +919,15 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
     });
   };
 
-  // Vim mode state
-  const [vimEnabled, setVimEnabled] = useState(() =>
+  // Vim mode state — use controlled prop when provided, otherwise internal state
+  const [vimEnabledInternal, setVimEnabledInternal] = useState(() =>
     localStorage.getItem(VIM_STORAGE_KEY) === 'true'
   );
+  const vimEnabled = vimEnabledProp ?? vimEnabledInternal;
   const [vimDisplayState, setVimDisplayState] = useState<VimState>(defaultVimDisplayState);
 
   const toggleVim = () => {
-    setVimEnabled(prev => {
+    setVimEnabledInternal(prev => {
       const next = !prev;
       localStorage.setItem(VIM_STORAGE_KEY, String(next));
       if (!next) setVimDisplayState(defaultVimDisplayState());

--- a/frontend/src/shared/components/article/VimModeIndicator.test.tsx
+++ b/frontend/src/shared/components/article/VimModeIndicator.test.tsx
@@ -56,7 +56,7 @@ describe('VimModeIndicator', () => {
   });
 
   it('does not show pending keys when empty', () => {
-    const { container } = render(<VimModeIndicator vimState={makeState()} />);
+    render(<VimModeIndicator vimState={makeState()} />);
     // Only the mode label should be present, no extra text nodes
     const indicator = screen.getByTestId('vim-mode-indicator');
     expect(indicator.children.length).toBe(1); // only the mode label span

--- a/frontend/src/shared/components/article/VimModeIndicator.test.tsx
+++ b/frontend/src/shared/components/article/VimModeIndicator.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { VimModeIndicator } from './VimModeIndicator';
+import type { VimState } from './vim-extension';
+
+function makeState(overrides: Partial<VimState> = {}): VimState {
+  return {
+    mode: 'normal',
+    pendingKeys: '',
+    countPrefix: '',
+    register: '',
+    commandBuffer: null,
+    ...overrides,
+  };
+}
+
+describe('VimModeIndicator', () => {
+  it('renders the mode indicator element', () => {
+    render(<VimModeIndicator vimState={makeState()} />);
+    expect(screen.getByTestId('vim-mode-indicator')).toBeTruthy();
+  });
+
+  it('shows NORMAL mode label', () => {
+    render(<VimModeIndicator vimState={makeState({ mode: 'normal' })} />);
+    expect(screen.getByText('-- NORMAL --')).toBeTruthy();
+  });
+
+  it('shows INSERT mode label', () => {
+    render(<VimModeIndicator vimState={makeState({ mode: 'insert' })} />);
+    expect(screen.getByText('-- INSERT --')).toBeTruthy();
+  });
+
+  it('shows VISUAL mode label', () => {
+    render(<VimModeIndicator vimState={makeState({ mode: 'visual' })} />);
+    expect(screen.getByText('-- VISUAL --')).toBeTruthy();
+  });
+
+  it('shows pending keys when present', () => {
+    render(<VimModeIndicator vimState={makeState({ pendingKeys: 'd' })} />);
+    expect(screen.getByText('d')).toBeTruthy();
+  });
+
+  it('shows count prefix with pending keys', () => {
+    render(<VimModeIndicator vimState={makeState({ countPrefix: '3', pendingKeys: 'd' })} />);
+    expect(screen.getByText('3d')).toBeTruthy();
+  });
+
+  it('shows command buffer when active', () => {
+    render(<VimModeIndicator vimState={makeState({ commandBuffer: 'w' })} />);
+    expect(screen.getByText(/:w/)).toBeTruthy();
+  });
+
+  it('does not show command buffer when null', () => {
+    const { container } = render(<VimModeIndicator vimState={makeState({ commandBuffer: null })} />);
+    expect(container.textContent).not.toContain(':');
+  });
+
+  it('does not show pending keys when empty', () => {
+    const { container } = render(<VimModeIndicator vimState={makeState()} />);
+    // Only the mode label should be present, no extra text nodes
+    const indicator = screen.getByTestId('vim-mode-indicator');
+    expect(indicator.children.length).toBe(1); // only the mode label span
+  });
+});

--- a/frontend/src/shared/components/article/VimModeIndicator.tsx
+++ b/frontend/src/shared/components/article/VimModeIndicator.tsx
@@ -1,0 +1,53 @@
+import { cn } from '../../lib/cn';
+import type { VimMode, VimState } from './vim-extension';
+
+interface VimModeIndicatorProps {
+  vimState: VimState;
+}
+
+const MODE_LABELS: Record<VimMode, string> = {
+  normal: '-- NORMAL --',
+  insert: '-- INSERT --',
+  visual: '-- VISUAL --',
+};
+
+const MODE_COLORS: Record<VimMode, string> = {
+  normal: 'bg-primary/15 text-primary',
+  insert: 'bg-emerald-500/15 text-emerald-400',
+  visual: 'bg-amber-500/15 text-amber-400',
+};
+
+export function VimModeIndicator({ vimState }: VimModeIndicatorProps) {
+  const { mode, pendingKeys, countPrefix, commandBuffer } = vimState;
+
+  return (
+    <div
+      data-testid="vim-mode-indicator"
+      className="flex items-center gap-2 border-t border-border/50 bg-card/80 px-3 py-1 text-xs font-mono"
+    >
+      <span
+        className={cn(
+          'rounded px-2 py-0.5 font-bold tracking-wider',
+          MODE_COLORS[mode],
+        )}
+      >
+        {MODE_LABELS[mode]}
+      </span>
+
+      {/* Show pending operator / count prefix */}
+      {(countPrefix || pendingKeys) && (
+        <span className="text-muted-foreground">
+          {countPrefix}{pendingKeys}
+        </span>
+      )}
+
+      {/* Command-line buffer */}
+      {commandBuffer !== null && (
+        <span className="text-foreground">
+          :{commandBuffer}
+          <span className="animate-pulse">|</span>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/shared/components/article/vim-extension.test.ts
+++ b/frontend/src/shared/components/article/vim-extension.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { VimExtension, VIM_PLUGIN_KEY, type VimMode, type VimState } from './vim-extension';
+
+describe('VimExtension', () => {
+  it('exports the extension with name "vim"', () => {
+    const ext = VimExtension.configure({});
+    expect(ext.name).toBe('vim');
+  });
+
+  it('has the correct default options', () => {
+    const ext = VimExtension.configure({});
+    expect(ext.options.onModeChange).toBeUndefined();
+    expect(ext.options.onSave).toBeUndefined();
+    expect(ext.options.onStateChange).toBeUndefined();
+  });
+
+  it('accepts callbacks via configure', () => {
+    const onModeChange = vi.fn();
+    const onSave = vi.fn();
+    const onStateChange = vi.fn();
+    const ext = VimExtension.configure({ onModeChange, onSave, onStateChange });
+    expect(ext.options.onModeChange).toBe(onModeChange);
+    expect(ext.options.onSave).toBe(onSave);
+    expect(ext.options.onStateChange).toBe(onStateChange);
+  });
+
+  it('exports VIM_PLUGIN_KEY', () => {
+    expect(VIM_PLUGIN_KEY).toBeDefined();
+    expect(VIM_PLUGIN_KEY.key).toContain('vim');
+  });
+
+  it('creates ProseMirror plugins', () => {
+    const ext = VimExtension.configure({});
+    // The extension should have addProseMirrorPlugins
+    expect(ext.config.addProseMirrorPlugins).toBeDefined();
+  });
+});
+
+describe('VimMode type', () => {
+  it('allows valid mode values', () => {
+    const normal: VimMode = 'normal';
+    const insert: VimMode = 'insert';
+    const visual: VimMode = 'visual';
+    expect(normal).toBe('normal');
+    expect(insert).toBe('insert');
+    expect(visual).toBe('visual');
+  });
+});
+
+describe('VimState type', () => {
+  it('can construct a valid VimState', () => {
+    const state: VimState = {
+      mode: 'normal',
+      pendingKeys: '',
+      countPrefix: '',
+      register: '',
+      commandBuffer: null,
+    };
+    expect(state.mode).toBe('normal');
+    expect(state.pendingKeys).toBe('');
+    expect(state.countPrefix).toBe('');
+    expect(state.register).toBe('');
+    expect(state.commandBuffer).toBeNull();
+  });
+
+  it('can represent a command buffer state', () => {
+    const state: VimState = {
+      mode: 'normal',
+      pendingKeys: '',
+      countPrefix: '',
+      register: '',
+      commandBuffer: 'w',
+    };
+    expect(state.commandBuffer).toBe('w');
+  });
+
+  it('can represent pending operator state', () => {
+    const state: VimState = {
+      mode: 'normal',
+      pendingKeys: 'd',
+      countPrefix: '3',
+      register: 'some text',
+      commandBuffer: null,
+    };
+    expect(state.pendingKeys).toBe('d');
+    expect(state.countPrefix).toBe('3');
+    expect(state.register).toBe('some text');
+  });
+});

--- a/frontend/src/shared/components/article/vim-extension.ts
+++ b/frontend/src/shared/components/article/vim-extension.ts
@@ -419,17 +419,20 @@ function handleNormalKey(
   const count = parseInt(vim.countPrefix || '1', 10);
   const pending = vim.pendingKeys;
 
-  // Pending operator (d, y, g)
+  // Pending operator (d, y, g) — count was preserved when operator key was pressed
   if (pending === 'd') {
     updateVimState(view, { pendingKeys: '', countPrefix: '' });
     if (key === 'd') {
-      // dd — delete line
-      const text = deleteLine(view);
-      updateVimState(view, { register: text });
+      // dd — delete line(s)
+      const lines: string[] = [];
+      for (let i = 0; i < count; i++) {
+        lines.push(deleteLine(view));
+      }
+      updateVimState(view, { register: lines.join('\n') });
       return true;
     }
     if (key === 'w') {
-      // dw — delete word
+      // dw — delete word(s)
       for (let i = 0; i < count; i++) deleteWord(view);
       return true;
     }
@@ -458,48 +461,54 @@ function handleNormalKey(
     return true;
   }
 
-  // Clear count prefix after processing
-  if (vim.countPrefix) {
-    updateVimState(view, { countPrefix: '' });
-  }
-
-  // Movement keys
+  // Movement keys — clear count prefix after use (but NOT before operators that need it)
   switch (key) {
     case 'h':
       moveLeft(view, count);
+      if (vim.countPrefix) updateVimState(view, { countPrefix: '' });
       return true;
     case 'j':
       moveDown(view, count);
+      if (vim.countPrefix) updateVimState(view, { countPrefix: '' });
       return true;
     case 'k':
       moveUp(view, count);
+      if (vim.countPrefix) updateVimState(view, { countPrefix: '' });
       return true;
     case 'l':
       moveRight(view, count);
+      if (vim.countPrefix) updateVimState(view, { countPrefix: '' });
       return true;
     case 'w':
       moveWordForward(view, count);
+      if (vim.countPrefix) updateVimState(view, { countPrefix: '' });
       return true;
     case 'b':
       moveWordBackward(view, count);
+      if (vim.countPrefix) updateVimState(view, { countPrefix: '' });
       return true;
     case '0':
       moveLineStart(view);
+      if (vim.countPrefix) updateVimState(view, { countPrefix: '' });
       return true;
     case '$':
       moveLineEnd(view);
+      if (vim.countPrefix) updateVimState(view, { countPrefix: '' });
       return true;
     case 'G':
       moveDocEnd(view);
+      if (vim.countPrefix) updateVimState(view, { countPrefix: '' });
       return true;
     case 'x':
       for (let i = 0; i < count; i++) deleteChar(view);
+      if (vim.countPrefix) updateVimState(view, { countPrefix: '' });
       return true;
     case 'u':
       // Undo
       for (let i = 0; i < count; i++) {
         undo(view.state, view.dispatch);
       }
+      if (vim.countPrefix) updateVimState(view, { countPrefix: '' });
       return true;
     case 'p': {
       // Paste from register
@@ -517,6 +526,7 @@ function handleNormalKey(
         );
         view.dispatch(tr);
       }
+      if (vim.countPrefix) updateVimState(view, { countPrefix: '' });
       return true;
     }
 
@@ -552,7 +562,7 @@ function handleNormalKey(
       updateVimState(view, { mode: 'visual', pendingKeys: '', countPrefix: '' });
       return true;
 
-    // Operators (wait for second key)
+    // Operators (wait for second key — preserve countPrefix so it propagates)
     case 'd':
       updateVimState(view, { pendingKeys: 'd' });
       return true;

--- a/frontend/src/shared/components/article/vim-extension.ts
+++ b/frontend/src/shared/components/article/vim-extension.ts
@@ -1,0 +1,766 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey, TextSelection, type EditorState } from '@tiptap/pm/state';
+import type { EditorView } from '@tiptap/pm/view';
+import { undo, redo } from '@tiptap/pm/history';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type VimMode = 'normal' | 'insert' | 'visual';
+
+export interface VimState {
+  mode: VimMode;
+  /** Pending operator key buffer (e.g. 'd' waiting for motion) */
+  pendingKeys: string;
+  /** Number prefix for repeat count (e.g. '3' in '3j') */
+  countPrefix: string;
+  /** Clipboard for yy/dd/p */
+  register: string;
+  /** Command-line buffer when ':' is active */
+  commandBuffer: string | null;
+}
+
+export const VIM_PLUGIN_KEY = new PluginKey<VimState>('vim');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getVimState(state: EditorState): VimState {
+  return VIM_PLUGIN_KEY.getState(state) ?? defaultVimState();
+}
+
+function defaultVimState(): VimState {
+  return {
+    mode: 'normal',
+    pendingKeys: '',
+    countPrefix: '',
+    register: '',
+    commandBuffer: null,
+  };
+}
+
+/** Apply a partial VimState update via a transaction meta key. */
+function updateVimState(view: EditorView, patch: Partial<VimState>): void {
+  const tr = view.state.tr;
+  tr.setMeta(VIM_PLUGIN_KEY, patch);
+  view.dispatch(tr);
+}
+
+/** Move the cursor left by `n` characters, clamped to line start. */
+function moveLeft(view: EditorView, n = 1): boolean {
+  const { state } = view;
+  const { from } = state.selection;
+  const $pos = state.doc.resolve(from);
+  const lineStart = from - $pos.parentOffset;
+  const newPos = Math.max(lineStart, from - n);
+  const tr = state.tr.setSelection(TextSelection.create(state.doc, newPos));
+  view.dispatch(tr);
+  return true;
+}
+
+/** Move the cursor right by `n` characters, clamped to line end. */
+function moveRight(view: EditorView, n = 1): boolean {
+  const { state } = view;
+  const { from } = state.selection;
+  const $pos = state.doc.resolve(from);
+  const lineEnd = from - $pos.parentOffset + $pos.parent.content.size;
+  const newPos = Math.min(lineEnd, from + n);
+  const tr = state.tr.setSelection(TextSelection.create(state.doc, newPos));
+  view.dispatch(tr);
+  return true;
+}
+
+/**
+ * Resolve a position one line down (or up) from the current cursor.
+ * Returns the new absolute position in the document, or null if we
+ * cannot move.
+ */
+function resolveVerticalPos(
+  state: EditorState,
+  direction: 'up' | 'down',
+): number | null {
+  const { from } = state.selection;
+  const $pos = state.doc.resolve(from);
+  const currentOffset = $pos.parentOffset;
+
+  // Walk through the document to find the next/previous text block
+  let targetBlockStart: number | null = null;
+  let targetBlockSize = 0;
+
+  if (direction === 'down') {
+    // Find the start of the next textblock after the current one
+    const currentBlockEnd = from - currentOffset + $pos.parent.content.size + 1;
+    state.doc.nodesBetween(currentBlockEnd, state.doc.content.size, (node, pos) => {
+      if (targetBlockStart !== null) return false;
+      if (node.isTextblock) {
+        targetBlockStart = pos + 1; // +1 to enter the textblock
+        targetBlockSize = node.content.size;
+        return false;
+      }
+      return true;
+    });
+  } else {
+    // Find the start of the previous textblock before the current one
+    const currentBlockStart = from - currentOffset;
+    // We need to find textblocks before the current position
+    let lastBlockStart: number | null = null;
+    let lastBlockSize = 0;
+    state.doc.nodesBetween(0, Math.max(0, currentBlockStart - 1), (node, pos) => {
+      if (node.isTextblock) {
+        lastBlockStart = pos + 1;
+        lastBlockSize = node.content.size;
+      }
+      return true;
+    });
+    targetBlockStart = lastBlockStart;
+    targetBlockSize = lastBlockSize;
+  }
+
+  if (targetBlockStart === null) return null;
+
+  // Try to maintain the same column offset
+  const newPos = targetBlockStart + Math.min(currentOffset, targetBlockSize);
+  return newPos;
+}
+
+function moveDown(view: EditorView, n = 1): boolean {
+  for (let i = 0; i < n; i++) {
+    const newPos = resolveVerticalPos(view.state, 'down');
+    if (newPos === null) break;
+    const tr = view.state.tr.setSelection(
+      TextSelection.create(view.state.doc, newPos),
+    );
+    view.dispatch(tr);
+  }
+  return true;
+}
+
+function moveUp(view: EditorView, n = 1): boolean {
+  for (let i = 0; i < n; i++) {
+    const newPos = resolveVerticalPos(view.state, 'up');
+    if (newPos === null) break;
+    const tr = view.state.tr.setSelection(
+      TextSelection.create(view.state.doc, newPos),
+    );
+    view.dispatch(tr);
+  }
+  return true;
+}
+
+/** Move to the start of the current line (0 in vim). */
+function moveLineStart(view: EditorView): boolean {
+  const { state } = view;
+  const { from } = state.selection;
+  const $pos = state.doc.resolve(from);
+  const lineStart = from - $pos.parentOffset;
+  const tr = state.tr.setSelection(TextSelection.create(state.doc, lineStart));
+  view.dispatch(tr);
+  return true;
+}
+
+/** Move to the end of the current line ($ in vim). */
+function moveLineEnd(view: EditorView): boolean {
+  const { state } = view;
+  const { from } = state.selection;
+  const $pos = state.doc.resolve(from);
+  const lineEnd = from - $pos.parentOffset + $pos.parent.content.size;
+  const tr = state.tr.setSelection(TextSelection.create(state.doc, lineEnd));
+  view.dispatch(tr);
+  return true;
+}
+
+/** Move to the start of the document (gg). */
+function moveDocStart(view: EditorView): boolean {
+  const { state } = view;
+  // Find first valid text position
+  let pos = 0;
+  state.doc.nodesBetween(0, state.doc.content.size, (node, nodePos) => {
+    if (pos > 0) return false;
+    if (node.isTextblock) {
+      pos = nodePos + 1;
+      return false;
+    }
+    return true;
+  });
+  if (pos > 0) {
+    const tr = state.tr.setSelection(TextSelection.create(state.doc, pos));
+    view.dispatch(tr);
+  }
+  return true;
+}
+
+/** Move to the end of the document (G). */
+function moveDocEnd(view: EditorView): boolean {
+  const { state } = view;
+  const endPos = state.doc.content.size;
+  // Find the last text block and position at its end
+  let lastPos = endPos;
+  state.doc.nodesBetween(0, endPos, (node, nodePos) => {
+    if (node.isTextblock) {
+      lastPos = nodePos + 1 + node.content.size;
+    }
+    return true;
+  });
+  const tr = state.tr.setSelection(
+    TextSelection.create(state.doc, Math.min(lastPos, endPos)),
+  );
+  view.dispatch(tr);
+  return true;
+}
+
+/** Move forward by word (w). */
+function moveWordForward(view: EditorView, n = 1): boolean {
+  const { state } = view;
+  let { from } = state.selection;
+  const text = state.doc.textBetween(from, state.doc.content.size, '\n');
+
+  for (let i = 0; i < n; i++) {
+    // Skip current word characters
+    const match = text.slice(from - state.selection.from).match(/^(\S*\s+|\s+)/);
+    if (match) {
+      from += match[0].length;
+    } else {
+      from = state.selection.from + text.length;
+      break;
+    }
+  }
+
+  const newPos = Math.min(state.selection.from + text.length, from);
+  try {
+    const tr = state.tr.setSelection(
+      TextSelection.create(state.doc, Math.min(newPos, state.doc.content.size)),
+    );
+    view.dispatch(tr);
+  } catch {
+    // Position may be invalid, ignore
+  }
+  return true;
+}
+
+/** Move backward by word (b). */
+function moveWordBackward(view: EditorView, n = 1): boolean {
+  const { state } = view;
+  let { from } = state.selection;
+  const text = state.doc.textBetween(0, from, '\n');
+
+  for (let i = 0; i < n; i++) {
+    // From end of text, find previous word boundary
+    const reversed = text.slice(0, from).split('').reverse().join('');
+    const match = reversed.match(/^(\s*\S+)/);
+    if (match) {
+      from -= match[0].length;
+    } else {
+      from = 0;
+      break;
+    }
+  }
+
+  const newPos = Math.max(0, from);
+  try {
+    const tr = state.tr.setSelection(TextSelection.create(state.doc, newPos));
+    view.dispatch(tr);
+  } catch {
+    // Position may be invalid, ignore
+  }
+  return true;
+}
+
+/** Delete the current line (dd). */
+function deleteLine(view: EditorView): string {
+  const { state } = view;
+  const { from } = state.selection;
+  const $pos = state.doc.resolve(from);
+
+  // Get the parent block node
+  const blockStart = $pos.before($pos.depth);
+  const blockEnd = $pos.after($pos.depth);
+  const lineText = state.doc.textBetween(blockStart, blockEnd, '\n');
+
+  const tr = state.tr.delete(blockStart, blockEnd);
+  view.dispatch(tr);
+  return lineText;
+}
+
+/** Delete a word forward (dw). */
+function deleteWord(view: EditorView): void {
+  const { state } = view;
+  const { from } = state.selection;
+  const text = state.doc.textBetween(from, state.doc.content.size, '\n');
+  const match = text.match(/^(\S+\s*|\s+)/);
+  if (match) {
+    const to = from + match[0].length;
+    const tr = state.tr.delete(from, to);
+    view.dispatch(tr);
+  }
+}
+
+/** Delete character at cursor (x). */
+function deleteChar(view: EditorView): void {
+  const { state } = view;
+  const { from } = state.selection;
+  const $pos = state.doc.resolve(from);
+  const lineEnd = from - $pos.parentOffset + $pos.parent.content.size;
+  if (from < lineEnd) {
+    const tr = state.tr.delete(from, from + 1);
+    view.dispatch(tr);
+  }
+}
+
+/** Yank (copy) the current line (yy). */
+function yankLine(view: EditorView): string {
+  const { state } = view;
+  const { from } = state.selection;
+  const $pos = state.doc.resolve(from);
+  const blockStart = $pos.before($pos.depth);
+  const blockEnd = $pos.after($pos.depth);
+  return state.doc.textBetween(blockStart, blockEnd, '\n');
+}
+
+/** Insert a new line below and enter insert mode (o). */
+function openLineBelow(view: EditorView): boolean {
+  const { state } = view;
+  const { from } = state.selection;
+  const $pos = state.doc.resolve(from);
+  const blockEnd = $pos.after($pos.depth);
+
+  // Insert a new paragraph after the current block
+  const tr = state.tr.insert(blockEnd, state.schema.nodes.paragraph.create());
+  // Position cursor inside the new paragraph
+  const newPos = blockEnd + 1;
+  tr.setSelection(TextSelection.create(tr.doc, newPos));
+  view.dispatch(tr);
+  return true;
+}
+
+/** Insert a new line above and enter insert mode (O). */
+function openLineAbove(view: EditorView): boolean {
+  const { state } = view;
+  const { from } = state.selection;
+  const $pos = state.doc.resolve(from);
+  const blockStart = $pos.before($pos.depth);
+
+  const tr = state.tr.insert(blockStart, state.schema.nodes.paragraph.create());
+  const newPos = blockStart + 1;
+  tr.setSelection(TextSelection.create(tr.doc, newPos));
+  view.dispatch(tr);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Visual mode selection helpers
+// ---------------------------------------------------------------------------
+
+function extendSelection(view: EditorView, anchor: number, head: number): void {
+  const tr = view.state.tr.setSelection(
+    TextSelection.create(view.state.doc, anchor, head),
+  );
+  view.dispatch(tr);
+}
+
+// ---------------------------------------------------------------------------
+// Normal mode key handler
+// ---------------------------------------------------------------------------
+
+function handleNormalKey(
+  view: EditorView,
+  event: KeyboardEvent,
+  vim: VimState,
+  onSave?: () => void,
+): boolean {
+  const key = event.key;
+
+  // Command mode (:)
+  if (vim.commandBuffer !== null) {
+    if (key === 'Escape') {
+      updateVimState(view, { commandBuffer: null });
+      return true;
+    }
+    if (key === 'Enter') {
+      const cmd = vim.commandBuffer;
+      updateVimState(view, { commandBuffer: null });
+      if (cmd === 'w' || cmd === 'wq') {
+        onSave?.();
+      }
+      return true;
+    }
+    if (key === 'Backspace') {
+      const newBuf = vim.commandBuffer.slice(0, -1);
+      if (newBuf.length === 0) {
+        updateVimState(view, { commandBuffer: null });
+      } else {
+        updateVimState(view, { commandBuffer: newBuf });
+      }
+      return true;
+    }
+    if (key.length === 1) {
+      updateVimState(view, { commandBuffer: vim.commandBuffer + key });
+      return true;
+    }
+    return true;
+  }
+
+  // Count prefix
+  if (/^[1-9]$/.test(key) && !vim.pendingKeys) {
+    updateVimState(view, { countPrefix: vim.countPrefix + key });
+    return true;
+  }
+  if (/^[0-9]$/.test(key) && vim.countPrefix && !vim.pendingKeys) {
+    // '0' is valid as second digit of count, but also line-start
+    if (key === '0' && vim.countPrefix === '') {
+      // line start
+    } else {
+      updateVimState(view, { countPrefix: vim.countPrefix + key });
+      return true;
+    }
+  }
+
+  const count = parseInt(vim.countPrefix || '1', 10);
+  const pending = vim.pendingKeys;
+
+  // Pending operator (d, y, g)
+  if (pending === 'd') {
+    updateVimState(view, { pendingKeys: '', countPrefix: '' });
+    if (key === 'd') {
+      // dd — delete line
+      const text = deleteLine(view);
+      updateVimState(view, { register: text });
+      return true;
+    }
+    if (key === 'w') {
+      // dw — delete word
+      for (let i = 0; i < count; i++) deleteWord(view);
+      return true;
+    }
+    // Unknown second key — cancel
+    return true;
+  }
+
+  if (pending === 'y') {
+    updateVimState(view, { pendingKeys: '', countPrefix: '' });
+    if (key === 'y') {
+      // yy — yank line
+      const text = yankLine(view);
+      updateVimState(view, { register: text });
+      return true;
+    }
+    return true;
+  }
+
+  if (pending === 'g') {
+    updateVimState(view, { pendingKeys: '', countPrefix: '' });
+    if (key === 'g') {
+      // gg — go to start
+      moveDocStart(view);
+      return true;
+    }
+    return true;
+  }
+
+  // Clear count prefix after processing
+  if (vim.countPrefix) {
+    updateVimState(view, { countPrefix: '' });
+  }
+
+  // Movement keys
+  switch (key) {
+    case 'h':
+      moveLeft(view, count);
+      return true;
+    case 'j':
+      moveDown(view, count);
+      return true;
+    case 'k':
+      moveUp(view, count);
+      return true;
+    case 'l':
+      moveRight(view, count);
+      return true;
+    case 'w':
+      moveWordForward(view, count);
+      return true;
+    case 'b':
+      moveWordBackward(view, count);
+      return true;
+    case '0':
+      moveLineStart(view);
+      return true;
+    case '$':
+      moveLineEnd(view);
+      return true;
+    case 'G':
+      moveDocEnd(view);
+      return true;
+    case 'x':
+      for (let i = 0; i < count; i++) deleteChar(view);
+      return true;
+    case 'u':
+      // Undo
+      for (let i = 0; i < count; i++) {
+        undo(view.state, view.dispatch);
+      }
+      return true;
+    case 'p': {
+      // Paste from register
+      if (vim.register) {
+        const { state } = view;
+        const { from } = state.selection;
+        const $pos = state.doc.resolve(from);
+        const blockEnd = $pos.after($pos.depth);
+        const tr = state.tr.insert(
+          blockEnd,
+          state.schema.nodes.paragraph.create(
+            null,
+            state.schema.text(vim.register),
+          ),
+        );
+        view.dispatch(tr);
+      }
+      return true;
+    }
+
+    // Enter insert mode
+    case 'i':
+      updateVimState(view, { mode: 'insert', pendingKeys: '', countPrefix: '' });
+      return true;
+    case 'a': {
+      // Insert after cursor
+      moveRight(view, 1);
+      updateVimState(view, { mode: 'insert', pendingKeys: '', countPrefix: '' });
+      return true;
+    }
+    case 'A':
+      moveLineEnd(view);
+      updateVimState(view, { mode: 'insert', pendingKeys: '', countPrefix: '' });
+      return true;
+    case 'I':
+      moveLineStart(view);
+      updateVimState(view, { mode: 'insert', pendingKeys: '', countPrefix: '' });
+      return true;
+    case 'o':
+      openLineBelow(view);
+      updateVimState(view, { mode: 'insert', pendingKeys: '', countPrefix: '' });
+      return true;
+    case 'O':
+      openLineAbove(view);
+      updateVimState(view, { mode: 'insert', pendingKeys: '', countPrefix: '' });
+      return true;
+
+    // Visual mode
+    case 'v':
+      updateVimState(view, { mode: 'visual', pendingKeys: '', countPrefix: '' });
+      return true;
+
+    // Operators (wait for second key)
+    case 'd':
+      updateVimState(view, { pendingKeys: 'd' });
+      return true;
+    case 'y':
+      updateVimState(view, { pendingKeys: 'y' });
+      return true;
+    case 'g':
+      updateVimState(view, { pendingKeys: 'g' });
+      return true;
+
+    // Command mode
+    case ':':
+      updateVimState(view, { commandBuffer: '' });
+      return true;
+
+    // Ctrl+r for redo
+    default:
+      if (event.ctrlKey && key === 'r') {
+        // Redo
+        redo(view.state, view.dispatch);
+        return true;
+      }
+      break;
+  }
+
+  // Prevent all other keypresses from reaching the editor in normal mode
+  // (except Ctrl/Meta combos that may be browser shortcuts)
+  if (!event.ctrlKey && !event.metaKey && key.length === 1) {
+    return true;
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Visual mode key handler
+// ---------------------------------------------------------------------------
+
+function handleVisualKey(
+  view: EditorView,
+  event: KeyboardEvent,
+  vim: VimState,
+): boolean {
+  const key = event.key;
+  const { anchor } = view.state.selection;
+
+  if (key === 'Escape' || key === 'v') {
+    // Exit visual mode
+    const { from } = view.state.selection;
+    const tr = view.state.tr.setSelection(TextSelection.create(view.state.doc, from));
+    view.dispatch(tr);
+    updateVimState(view, { mode: 'normal', pendingKeys: '', countPrefix: '' });
+    return true;
+  }
+
+  // Movement extends selection
+  const count = parseInt(vim.countPrefix || '1', 10);
+  let { head } = view.state.selection;
+
+  switch (key) {
+    case 'h':
+      head = Math.max(0, head - count);
+      extendSelection(view, anchor, head);
+      return true;
+    case 'l':
+      head = Math.min(view.state.doc.content.size, head + count);
+      extendSelection(view, anchor, head);
+      return true;
+    case 'j': {
+      const newPos = resolveVerticalPos(view.state, 'down');
+      if (newPos !== null) extendSelection(view, anchor, newPos);
+      return true;
+    }
+    case 'k': {
+      const newPos = resolveVerticalPos(view.state, 'up');
+      if (newPos !== null) extendSelection(view, anchor, newPos);
+      return true;
+    }
+    case 'd':
+    case 'x': {
+      // Delete selection
+      const { from: selFrom, to: selTo } = view.state.selection;
+      if (selFrom !== selTo) {
+        const text = view.state.doc.textBetween(selFrom, selTo);
+        const tr = view.state.tr.delete(selFrom, selTo);
+        view.dispatch(tr);
+        updateVimState(view, { mode: 'normal', register: text, pendingKeys: '', countPrefix: '' });
+      }
+      return true;
+    }
+    case 'y': {
+      // Yank selection
+      const { from: selFrom, to: selTo } = view.state.selection;
+      if (selFrom !== selTo) {
+        const text = view.state.doc.textBetween(selFrom, selTo);
+        const tr = view.state.tr.setSelection(TextSelection.create(view.state.doc, selFrom));
+        view.dispatch(tr);
+        updateVimState(view, { mode: 'normal', register: text, pendingKeys: '', countPrefix: '' });
+      }
+      return true;
+    }
+    default:
+      break;
+  }
+
+  // Block other keys
+  if (!event.ctrlKey && !event.metaKey && key.length === 1) {
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Change callback type for mode notifications
+// ---------------------------------------------------------------------------
+
+export type VimModeChangeCallback = (mode: VimMode) => void;
+export type VimStateChangeCallback = (state: VimState) => void;
+
+// ---------------------------------------------------------------------------
+// TipTap Extension
+// ---------------------------------------------------------------------------
+
+export interface VimExtensionOptions {
+  /** Callback when the vim mode changes (used to update React state). */
+  onModeChange?: VimModeChangeCallback;
+  /** Callback when full vim state changes (mode, pending keys, command buffer). */
+  onStateChange?: VimStateChangeCallback;
+  /** Callback when :w is executed. */
+  onSave?: () => void;
+}
+
+export const VimExtension = Extension.create<VimExtensionOptions>({
+  name: 'vim',
+
+  addOptions() {
+    return {
+      onModeChange: undefined,
+      onSave: undefined,
+      onStateChange: undefined,
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const options = this.options;
+
+    return [
+      new Plugin<VimState>({
+        key: VIM_PLUGIN_KEY,
+
+        state: {
+          init(): VimState {
+            return defaultVimState();
+          },
+          apply(tr, value): VimState {
+            const meta = tr.getMeta(VIM_PLUGIN_KEY) as Partial<VimState> | undefined;
+            if (meta) {
+              const next = { ...value, ...meta };
+              // Fire callbacks
+              if (meta.mode !== undefined && meta.mode !== value.mode) {
+                options.onModeChange?.(meta.mode);
+              }
+              options.onStateChange?.(next);
+              return next;
+            }
+            return value;
+          },
+        },
+
+        props: {
+          handleKeyDown(view, event): boolean {
+            const vim = getVimState(view.state);
+
+            // Escape always returns to normal mode
+            if (event.key === 'Escape') {
+              if (vim.mode !== 'normal' || vim.commandBuffer !== null) {
+                // Collapse selection if in visual mode
+                if (vim.mode === 'visual') {
+                  const { from } = view.state.selection;
+                  const tr = view.state.tr.setSelection(
+                    TextSelection.create(view.state.doc, from),
+                  );
+                  view.dispatch(tr);
+                }
+                updateVimState(view, {
+                  mode: 'normal',
+                  pendingKeys: '',
+                  countPrefix: '',
+                  commandBuffer: null,
+                });
+                return true;
+              }
+              return false;
+            }
+
+            if (vim.mode === 'normal') {
+              return handleNormalKey(view, event, vim, options.onSave);
+            }
+
+            if (vim.mode === 'visual') {
+              return handleVisualKey(view, event, vim);
+            }
+
+            // Insert mode — let everything through (TipTap handles it)
+            return false;
+          },
+        },
+      }),
+    ];
+  },
+});


### PR DESCRIPTION
## Summary
- Custom TipTap extension (`vim-extension.ts`) that implements vim-style modal editing with Normal, Insert, and Visual modes
- Toolbar toggle button (Terminal icon) to enable/disable vim mode, with preference persisted to localStorage (`compendiq-vim-mode`)
- Mode indicator bar at the bottom of the editor showing current mode, pending operators (e.g. `d` waiting for motion), count prefix, and command buffer (`:w`)

## Supported Vim Motions
- **Navigation**: `h/j/k/l`, `w/b` (word), `0/$` (line), `gg/G` (document)
- **Insert entry**: `i/a/o/O/A/I`
- **Editing**: `dd` (delete line), `dw` (delete word), `x` (delete char), `u` (undo), `Ctrl+r` (redo)
- **Yank/Paste**: `yy/p`
- **Visual mode**: `v` to enter, `h/j/k/l` to extend selection, `d/x/y` to operate
- **Command**: `:w` to save
- **Count prefix**: e.g. `3j` moves down 3 lines

## Files Changed
- `frontend/src/shared/components/article/vim-extension.ts` — core ProseMirror plugin with vim state machine
- `frontend/src/shared/components/article/VimModeIndicator.tsx` — mode indicator component
- `frontend/src/shared/components/article/Editor.tsx` — toolbar toggle integration, conditional extension loading
- `frontend/src/shared/components/article/vim-extension.test.ts` — extension unit tests
- `frontend/src/shared/components/article/VimModeIndicator.test.tsx` — indicator component tests

## Test plan
- [x] 18 new tests pass (extension config, types, indicator rendering)
- [x] All 1708 existing tests continue to pass (1 pre-existing Mermaid test failure unrelated)
- [x] TypeScript type-check passes (no new errors)
- [x] ESLint passes with zero warnings
- [ ] Manual: toggle vim mode on, verify h/j/k/l navigation works
- [ ] Manual: verify `i` enters insert mode, Escape returns to normal
- [ ] Manual: verify `:w` triggers save
- [ ] Manual: verify toggle off disables vim completely
- [ ] Manual: verify setting persists across page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)