### PR TITLE
fix: summary regeneration silently fails for pages matched by id

### DIFF
--- a/backend/src/domains/knowledge/services/summary-worker.test.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.test.ts
@@ -148,13 +148,14 @@ describe.skipIf(!dbAvailable)('Summary Worker', () => {
 
   describe('regenerateSummary', () => {
     it('should reset a single page to pending', async () => {
-      await query(
+      const insertResult = await query<{ id: number }>(
         `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status, summary_retry_count, summary_error)
-         VALUES ('p1', $1, 'Page 1', 'content one', 'failed', 3, 'some error')`,
+         VALUES ('p1', $1, 'Page 1', 'content one', 'failed', 3, 'some error')
+         RETURNING id`,
         [testSpaceKey],
       );
 
-      await regenerateSummary('p1');
+      await regenerateSummary(insertResult.rows[0].id);
 
       const result = await query<{ summary_status: string; summary_retry_count: number; summary_error: string | null }>(
         'SELECT summary_status, summary_retry_count, summary_error FROM pages WHERE confluence_id = $1',

--- a/backend/src/domains/knowledge/services/summary-worker.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.ts
@@ -402,14 +402,14 @@ export async function rescanAllSummaries(): Promise<number> {
 /**
  * Trigger re-summarization for a single page.
  */
-export async function regenerateSummary(pageId: string): Promise<void> {
+export async function regenerateSummary(pageId: number): Promise<void> {
   await query(
     `UPDATE pages
      SET summary_status = 'pending',
          summary_content_hash = NULL,
          summary_retry_count = 0,
          summary_error = NULL
-     WHERE confluence_id = $1`,
+     WHERE id = $1`,
     [pageId],
   );
 }

--- a/backend/src/routes/knowledge/knowledge-admin.test.ts
+++ b/backend/src/routes/knowledge/knowledge-admin.test.ts
@@ -259,7 +259,7 @@ describe('knowledge-admin routes - happy path', () => {
   });
 
   it('should regenerate summary for a specific page', async () => {
-    mockQueryFn.mockResolvedValue({ rows: [{ confluence_id: 'page-42' }] });
+    mockQueryFn.mockResolvedValue({ rows: [{ id: 42 }] });
     mockRegenerateSummary.mockResolvedValue(undefined);
 
     const response = await app.inject({
@@ -271,7 +271,7 @@ describe('knowledge-admin routes - happy path', () => {
     const body = response.json();
     expect(body.pageId).toBe('page-42');
     expect(body.message).toContain('queued');
-    expect(mockRegenerateSummary).toHaveBeenCalledWith('page-42');
+    expect(mockRegenerateSummary).toHaveBeenCalledWith(42);
   });
 
   it('should return 404 when regenerating summary for non-existent page', async () => {

--- a/backend/src/routes/knowledge/knowledge-admin.ts
+++ b/backend/src/routes/knowledge/knowledge-admin.ts
@@ -63,7 +63,8 @@ export async function knowledgeAdminRoutes(fastify: FastifyInstance) {
       throw fastify.httpErrors.notFound('Page not found');
     }
 
-    await regenerateSummary(pageId);
+    const resolvedId = pageResult.rows[0].id;
+    await regenerateSummary(resolvedId);
 
     // Fire off a batch immediately for this page
     runSummaryBatch().catch((err) => {


### PR DESCRIPTION
## Summary

- `regenerateSummary()` was matching pages by `confluence_id` but the route passes the numeric `id` from the page existence check — so the `UPDATE` always matched 0 rows and the summary was never re-queued
- Fixed by changing the function signature to accept `number` and matching on `WHERE id = $1`
- Route handler now passes `pageResult.rows[0].id` (the resolved integer id) instead of the raw `pageId` string param

## Root cause

The frontend sends the serial integer `page.id` to `POST /api/admin/knowledge/regenerate-summary/:pageId`. The route looked up the page by `confluence_id` first but then passed the original string param to `regenerateSummary()` — which also filtered by `confluence_id`. Since `id ≠ confluence_id`, the update was a silent no-op.

## Test plan

- [x] `summary-worker.test.ts` — `regenerateSummary` test updated to use numeric id and `RETURNING id`
- [x] `knowledge-admin.test.ts` — mock updated to return `{ id: 42 }` and assert call with numeric id
- [ ] Manual: trigger summary regeneration from admin panel, confirm page transitions to `pending` then `summarized`

🤖 Generated with [Claude Code](https://claude.com/claude-code)