### PR TITLE
fix: prevent error handler from leaking internal error names (#87)

### DIFF
--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -88,6 +88,76 @@ vi.mock('./routes/knowledge/knowledge-requests.js', () => ({ knowledgeRequestRou
 vi.mock('./routes/knowledge/search.js', () => ({ searchRoutes: noopRoute }));
 vi.mock('./routes/knowledge/local-spaces.js', () => ({ localSpacesRoutes: noopRoute }));
 
+describe('buildApp — error handler information leakage', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('should not leak internal error names like TypeError for non-500 errors', async () => {
+    process.env.NODE_ENV = 'development';
+    const { buildApp } = await import('./app.js');
+    const app = await buildApp();
+
+    // Register a test route that throws a TypeError with a non-500 status code
+    app.get('/test/type-error', async () => {
+      const err = new TypeError('Cannot read properties of undefined') as TypeError & {
+        statusCode: number;
+      };
+      err.statusCode = 400;
+      throw err;
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/test/type-error' });
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    // Should NOT expose "TypeError" — should use generic name
+    expect(body.error).not.toBe('TypeError');
+    expect(body.error).toBe('ClientError');
+
+    await app.close();
+  });
+
+  it('should expose known Fastify HTTP error names', async () => {
+    process.env.NODE_ENV = 'development';
+    const { buildApp } = await import('./app.js');
+    const app = await buildApp();
+
+    // Register a test route that throws a known Fastify error
+    app.get('/test/not-found', async (_request, reply) => {
+      return reply.notFound('Resource not found');
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/test/not-found' });
+    expect(response.statusCode).toBe(404);
+    const body = JSON.parse(response.body);
+    expect(body.error).toBe('NotFoundError');
+
+    await app.close();
+  });
+
+  it('should always use InternalServerError for 500 errors regardless of error name', async () => {
+    process.env.NODE_ENV = 'development';
+    const { buildApp } = await import('./app.js');
+    const app = await buildApp();
+
+    // Register a test route that throws a RangeError with 500 status
+    app.get('/test/range-error', async () => {
+      throw new RangeError('Value out of range');
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/test/range-error' });
+    expect(response.statusCode).toBe(500);
+    const body = JSON.parse(response.body);
+    expect(body.error).toBe('InternalServerError');
+    // Should NOT expose the actual error message for 500 errors
+    expect(body.message).toBe('Internal Server Error');
+
+    await app.close();
+  });
+});
+
 describe('buildApp — Swagger UI gating', () => {
   const originalNodeEnv = process.env.NODE_ENV;
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -138,6 +138,34 @@ export async function buildApp() {
   // Let the enterprise plugin register its own routes (e.g., full license endpoint)
   await enterprise.registerRoutes(app, license);
 
+  // Known Fastify HTTP error names that are safe to expose to clients.
+  // Anything not in this set could leak internal details (e.g. TypeError, RangeError).
+  const KNOWN_HTTP_ERROR_NAMES = new Set([
+    'BadRequestError',
+    'UnauthorizedError',
+    'ForbiddenError',
+    'NotFoundError',
+    'MethodNotAllowedError',
+    'NotAcceptableError',
+    'ConflictError',
+    'GoneError',
+    'PayloadTooLargeError',
+    'UnsupportedMediaTypeError',
+    'UnprocessableEntityError',
+    'TooManyRequestsError',
+    'ServiceUnavailableError',
+    'GatewayTimeoutError',
+  ]);
+
+  /** Map status code range to a generic error name when the real name is not safe to expose. */
+  function safeErrorName(statusCode: number, errorName?: string): string {
+    if (statusCode === 500) return 'InternalServerError';
+    if (errorName && KNOWN_HTTP_ERROR_NAMES.has(errorName)) return errorName;
+    // Generic fallback based on status code range
+    if (statusCode >= 400 && statusCode < 500) return 'ClientError';
+    return 'InternalServerError';
+  }
+
   // Error handler
   app.setErrorHandler((error: Error & { statusCode?: number }, request, reply) => {
     // Zod validation errors → 400
@@ -169,7 +197,7 @@ export async function buildApp() {
     }
 
     reply.status(statusCode).send({
-      error: error.name ?? 'InternalServerError',
+      error: safeErrorName(statusCode, error.name),
       message: statusCode === 500 ? 'Internal Server Error' : error.message,
       statusCode,
     });


### PR DESCRIPTION
## Summary
- For non-500 errors, the error handler now only exposes error names that are known Fastify HTTP errors (e.g. `BadRequestError`, `NotFoundError`). Internal JS error names like `TypeError` or `RangeError` are replaced with a generic `ClientError` to prevent information disclosure.
- For 500 errors, always returns `InternalServerError` regardless of the actual error type.
- Adds allowlist of 14 known Fastify HTTP error names used by `@fastify/sensible`.

## Test plan
- [x] Verify a `TypeError` with `statusCode: 400` returns `ClientError`, not `TypeError`
- [x] Verify known Fastify errors (e.g. `reply.notFound()`) still return their proper names
- [x] Verify 500 errors always return `InternalServerError`
- [x] All existing tests pass

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)