### PR TITLE
perf: switch LazyMotion from domMax to domAnimation (#99)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense } from 'react';
 import { Routes, Route, Navigate, useSearchParams } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { useAuthStore } from './stores/auth-store';
 import { useSessionInit } from './shared/hooks/useSessionInit';
 import { useThemeEffect } from './shared/hooks/useThemeEffect';
@@ -106,7 +106,7 @@ export function App() {
   useThemeEffect();
 
   return (
-    <LazyMotion features={domMax}>
+    <LazyMotion features={domAnimation}>
       <ErrorBoundary>
         <Suspense fallback={<PageLoadingFallback />}>
           <Routes>

--- a/frontend/src/features/admin/RbacPage.test.tsx
+++ b/frontend/src/features/admin/RbacPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RbacPage } from './RbacPage';
 import { useAuthStore } from '../../stores/auth-store';
@@ -14,7 +14,7 @@ function createWrapper() {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             {children}
           </LazyMotion>
         </MemoryRouter>

--- a/frontend/src/features/ai/AiAssistantPage.test.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { AiAssistantPage } from './AiAssistantPage';
 import { useAuthStore } from '../../stores/auth-store';
 
@@ -46,7 +46,7 @@ function createWrapper(initialEntries = ['/ai']) {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={initialEntries}>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             {children}
           </LazyMotion>
         </MemoryRouter>

--- a/frontend/src/features/ai/SourceCitations.test.tsx
+++ b/frontend/src/features/ai/SourceCitations.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { SourceCitations, type Source } from './SourceCitations';
 
 const mockNavigate = vi.fn();
@@ -16,7 +16,7 @@ vi.mock('react-router-dom', async () => {
 function Wrapper({ children }: { children: React.ReactNode }) {
   return (
     <MemoryRouter>
-      <LazyMotion features={domMax}>
+      <LazyMotion features={domAnimation}>
         {children}
       </LazyMotion>
     </MemoryRouter>

--- a/frontend/src/features/ai/StreamingMessage.test.tsx
+++ b/frontend/src/features/ai/StreamingMessage.test.tsx
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { StreamingMessage } from './StreamingMessage';
 
 function Wrapper({ children }: { children: React.ReactNode }) {
-  return <LazyMotion features={domMax}>{children}</LazyMotion>;
+  return <LazyMotion features={domAnimation}>{children}</LazyMotion>;
 }
 
 describe('StreamingMessage', () => {

--- a/frontend/src/features/ai/modes/AskMode.test.tsx
+++ b/frontend/src/features/ai/modes/AskMode.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { AskModeInput, ASK_EMPTY_TITLE, ASK_EMPTY_SUBTITLE } from './AskMode';
 import { AiProvider } from '../AiContext';
 import { useAuthStore } from '../../../stores/auth-store';
@@ -40,7 +40,7 @@ function createWrapper(initialEntries = ['/ai']) {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={initialEntries}>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             <AiProvider>
               {children}
             </AiProvider>

--- a/frontend/src/features/ai/modes/DiagramMode.test.tsx
+++ b/frontend/src/features/ai/modes/DiagramMode.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { DiagramTypeSelector, DiagramModeInput, DIAGRAM_EMPTY_TITLE, diagramEmptySubtitle } from './DiagramMode';
 import { AiProvider } from '../AiContext';
 import { useAuthStore } from '../../../stores/auth-store';
@@ -42,7 +42,7 @@ function createWrapper(initialEntries = ['/ai']) {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={initialEntries}>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             <AiProvider>
               {children}
             </AiProvider>

--- a/frontend/src/features/ai/modes/GenerateMode.test.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { GenerateModeInput, GenerateSavePanel, GENERATE_EMPTY_TITLE, GENERATE_EMPTY_SUBTITLE } from './GenerateMode';
 import { AiProvider } from '../AiContext';
 import { useAuthStore } from '../../../stores/auth-store';
@@ -66,7 +66,7 @@ function createWrapper(initialEntries = ['/ai?mode=generate']) {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={initialEntries}>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             <AiProvider>
               {children}
             </AiProvider>

--- a/frontend/src/features/ai/modes/ImproveMode.test.tsx
+++ b/frontend/src/features/ai/modes/ImproveMode.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { ImproveTypeSelector, ImproveModeInput, IMPROVE_EMPTY_TITLE, improveEmptySubtitle } from './ImproveMode';
 import { AiProvider } from '../AiContext';
 import { useAuthStore } from '../../../stores/auth-store';
@@ -48,7 +48,7 @@ function createWrapper(initialEntries = ['/ai?pageId=page-1&mode=improve']) {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={initialEntries}>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             <AiProvider>
               {children}
             </AiProvider>

--- a/frontend/src/features/ai/modes/QualityMode.test.tsx
+++ b/frontend/src/features/ai/modes/QualityMode.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QualityModeInput, QUALITY_EMPTY_TITLE, qualityEmptySubtitle } from './QualityMode';
 import { AiProvider } from '../AiContext';
 import { useAuthStore } from '../../../stores/auth-store';
@@ -50,7 +50,7 @@ function createWrapper(initialEntries = ['/ai?pageId=page-1&mode=quality']) {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={initialEntries}>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             <AiProvider>
               {children}
             </AiProvider>

--- a/frontend/src/features/ai/modes/SummarizeMode.test.tsx
+++ b/frontend/src/features/ai/modes/SummarizeMode.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { SummarizeModeInput, SUMMARIZE_EMPTY_TITLE, summarizeEmptySubtitle } from './SummarizeMode';
 import { AiProvider } from '../AiContext';
 import { useAuthStore } from '../../../stores/auth-store';
@@ -50,7 +50,7 @@ function createWrapper(initialEntries = ['/ai?pageId=page-1&mode=summarize']) {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={initialEntries}>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             <AiProvider>
               {children}
             </AiProvider>

--- a/frontend/src/features/analytics/AnalyticsDashboardPage.test.tsx
+++ b/frontend/src/features/analytics/AnalyticsDashboardPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AnalyticsDashboardPage } from './AnalyticsDashboardPage';
 import { useAuthStore } from '../../stores/auth-store';
@@ -23,7 +23,7 @@ function createWrapper() {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             {children}
           </LazyMotion>
         </MemoryRouter>

--- a/frontend/src/features/analytics/ContentGapsPage.test.tsx
+++ b/frontend/src/features/analytics/ContentGapsPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ContentGapsPage } from './ContentGapsPage';
 import { useAuthStore } from '../../stores/auth-store';
@@ -23,7 +23,7 @@ function createWrapper() {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             {children}
           </LazyMotion>
         </MemoryRouter>

--- a/frontend/src/features/analytics/VerificationHealth.test.tsx
+++ b/frontend/src/features/analytics/VerificationHealth.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { VerificationHealth } from './VerificationHealth';
 import { useAuthStore } from '../../stores/auth-store';
@@ -23,7 +23,7 @@ function createWrapper() {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             {children}
           </LazyMotion>
         </MemoryRouter>

--- a/frontend/src/features/dashboard/KnowledgeGaps.test.tsx
+++ b/frontend/src/features/dashboard/KnowledgeGaps.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { KnowledgeGaps } from './KnowledgeGaps';
 import { useAuthStore } from '../../stores/auth-store';
@@ -23,7 +23,7 @@ function createWrapper() {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             {children}
           </LazyMotion>
         </MemoryRouter>

--- a/frontend/src/features/knowledge-requests/KnowledgeRequestsPage.test.tsx
+++ b/frontend/src/features/knowledge-requests/KnowledgeRequestsPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { KnowledgeRequestsPage } from './KnowledgeRequestsPage';
 import { useAuthStore } from '../../stores/auth-store';
@@ -22,7 +22,7 @@ function createWrapper() {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             {children}
           </LazyMotion>
         </MemoryRouter>

--- a/frontend/src/features/pages/AutoTagger.test.tsx
+++ b/frontend/src/features/pages/AutoTagger.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AutoTagger } from './AutoTagger';
 import { useAuthStore } from '../../stores/auth-store';
@@ -14,7 +14,7 @@ function createWrapper() {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             {children}
           </LazyMotion>
         </MemoryRouter>

--- a/frontend/src/features/pages/DuplicateDetector.test.tsx
+++ b/frontend/src/features/pages/DuplicateDetector.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { DuplicateDetector } from './DuplicateDetector';
 import { useAuthStore } from '../../stores/auth-store';
@@ -23,7 +23,7 @@ function createWrapper() {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             {children}
           </LazyMotion>
         </MemoryRouter>

--- a/frontend/src/features/pages/KPICards.test.tsx
+++ b/frontend/src/features/pages/KPICards.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { KPICards } from './KPICards';
 import { formatRelativeTime } from '../../shared/lib/format-relative-time';
 
 function Wrapper({ children }: { children: React.ReactNode }) {
   return (
-    <LazyMotion features={domMax}>
+    <LazyMotion features={domAnimation}>
       {children}
     </LazyMotion>
   );

--- a/frontend/src/features/pages/PageViewPage.test.tsx
+++ b/frontend/src/features/pages/PageViewPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { PageViewPage } from './PageViewPage';
 import { useAuthStore } from '../../stores/auth-store';
@@ -203,7 +203,7 @@ function createWrapper() {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={['/pages/page-1']}>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             <Routes>
               <Route path="/pages/:id" element={children} />
             </Routes>

--- a/frontend/src/features/pages/VersionHistory.test.tsx
+++ b/frontend/src/features/pages/VersionHistory.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { VersionHistory } from './VersionHistory';
 import { useAuthStore } from '../../stores/auth-store';
@@ -14,7 +14,7 @@ function createWrapper() {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             {children}
           </LazyMotion>
         </MemoryRouter>

--- a/frontend/src/features/settings/LoginPage.test.tsx
+++ b/frontend/src/features/settings/LoginPage.test.tsx
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { LoginPage } from './LoginPage';
 import { useAuthStore } from '../../stores/auth-store';
 
 function renderLoginPage(initialEntry = '/login') {
   return render(
-    <LazyMotion features={domMax}>
+    <LazyMotion features={domAnimation}>
       <MemoryRouter initialEntries={[initialEntry]}>
         <LoginPage />
       </MemoryRouter>

--- a/frontend/src/features/settings/WorkersTab.test.tsx
+++ b/frontend/src/features/settings/WorkersTab.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { WorkersTab } from './WorkersTab';
 
 // Mock auth store - supports both hook-style (selector) and getState() calls
@@ -61,7 +61,7 @@ function createWrapper() {
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return (
       <QueryClientProvider client={queryClient}>
-        <LazyMotion features={domMax}>
+        <LazyMotion features={domAnimation}>
           {children}
         </LazyMotion>
       </QueryClientProvider>

--- a/frontend/src/shared/components/article/ArticleOutline.test.tsx
+++ b/frontend/src/shared/components/article/ArticleOutline.test.tsx
@@ -1,11 +1,11 @@
 import { createRef } from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { ArticleOutline } from './ArticleOutline';
 
 function Wrapper({ children }: { children: React.ReactNode }) {
-  return <LazyMotion features={domMax}>{children}</LazyMotion>;
+  return <LazyMotion features={domAnimation}>{children}</LazyMotion>;
 }
 
 describe('ArticleOutline', () => {

--- a/frontend/src/shared/components/article/ArticleRightPane.test.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ArticleRightPane } from './ArticleRightPane';
 import { useArticleViewStore } from '../../../stores/article-view-store';
@@ -102,7 +102,7 @@ function createWrapper() {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={['/pages/page-1']}>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             <Routes>
               <Route path="/pages/:id" element={children} />
             </Routes>

--- a/frontend/src/shared/components/article/DiffView.test.tsx
+++ b/frontend/src/shared/components/article/DiffView.test.tsx
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { DiffView } from './DiffView';
 
 function Wrapper({ children }: { children: React.ReactNode }) {
-  return <LazyMotion features={domMax}>{children}</LazyMotion>;
+  return <LazyMotion features={domAnimation}>{children}</LazyMotion>;
 }
 
 describe('DiffView', () => {

--- a/frontend/src/shared/components/article/PagePreview.test.tsx
+++ b/frontend/src/shared/components/article/PagePreview.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { PagePreview } from './PagePreview';
 
@@ -13,7 +13,7 @@ function createWrapper() {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             {children}
           </LazyMotion>
         </MemoryRouter>

--- a/frontend/src/shared/components/article/TableOfContents.test.tsx
+++ b/frontend/src/shared/components/article/TableOfContents.test.tsx
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { TableOfContents, parseHeadings, buildTree } from './TableOfContents';
 
 function Wrapper({ children }: { children: React.ReactNode }) {
-  return <LazyMotion features={domMax}>{children}</LazyMotion>;
+  return <LazyMotion features={domAnimation}>{children}</LazyMotion>;
 }
 
 // ---------- parseHeadings ----------

--- a/frontend/src/shared/components/badges/ServiceStatus.test.tsx
+++ b/frontend/src/shared/components/badges/ServiceStatus.test.tsx
@@ -3,10 +3,10 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ServiceStatus } from './ServiceStatus';
 
 // Wrap in LazyMotion for framer-motion
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 
 function Wrapper({ children }: { children: React.ReactNode }) {
-  return <LazyMotion features={domMax}>{children}</LazyMotion>;
+  return <LazyMotion features={domAnimation}>{children}</LazyMotion>;
 }
 
 describe('ServiceStatus', () => {

--- a/frontend/src/shared/components/layout/AppLayout.test.tsx
+++ b/frontend/src/shared/components/layout/AppLayout.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { AppLayout } from './AppLayout';
 import { useCommandPaletteStore } from '../../../stores/command-palette-store';
 import { useUiStore } from '../../../stores/ui-store';
@@ -39,7 +39,7 @@ function createWrapper(initialPath = '/') {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={[initialPath]}>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             {children}
           </LazyMotion>
         </MemoryRouter>

--- a/frontend/src/shared/components/layout/CommandPalette.test.tsx
+++ b/frontend/src/shared/components/layout/CommandPalette.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CommandPalette } from './CommandPalette';
 import { useCommandPaletteStore } from '../../../stores/command-palette-store';
@@ -14,7 +14,7 @@ function createWrapper() {
     return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LazyMotion features={domMax}>
+          <LazyMotion features={domAnimation}>
             {children}
           </LazyMotion>
         </MemoryRouter>

--- a/frontend/src/shared/components/layout/PageTransition.test.tsx
+++ b/frontend/src/shared/components/layout/PageTransition.test.tsx
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domMax } from 'framer-motion';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { PageTransition, routeDepth } from './PageTransition';
 
 function Wrapper({ children, initialPath = '/' }: { children: React.ReactNode; initialPath?: string }) {
   return (
     <MemoryRouter initialEntries={[initialPath]}>
-      <LazyMotion features={domMax}>
+      <LazyMotion features={domAnimation}>
         {children}
       </LazyMotion>
     </MemoryRouter>


### PR DESCRIPTION
## Summary
- Switches `LazyMotion` from `domMax` to `domAnimation` in `App.tsx` and all 31 test files
- `domAnimation` is ~30% smaller than `domMax` — excludes layout animations (`layout`, `layoutId`) and drag gestures that Compendiq does not use via Framer Motion
- TipTap's `@tiptap/extension-drag-handle-react` uses its own drag implementation, not Framer Motion's `drag` prop
- Verified: no `layoutId` usage anywhere in the codebase; all `layout`/`drag` references are CSS/HTML or TipTap, not Framer Motion props

## Test plan
- [x] `npm run typecheck` passes
- [x] All 140 frontend test files pass (1728 tests)
- [x] Verified no Framer Motion `layout`, `layoutId`, or `drag` props are used in any component

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)