### PR TITLE
feat: add cache stampede protection via RedisCache.getOrCompute (#98)

### DIFF
--- a/backend/src/core/services/redis-cache.test.ts
+++ b/backend/src/core/services/redis-cache.test.ts
@@ -15,6 +15,7 @@ import {
   getAttachmentFailureCount,
   clearAttachmentFailures,
   MAX_ATTACHMENT_FAILURES,
+  RedisCache,
 } from './redis-cache.js';
 
 /**
@@ -331,5 +332,104 @@ describe('redis-cache embedding lock', () => {
         expect.objectContaining({ keys: ['embedding:lock:test-user'] }),
       );
     });
+  });
+});
+
+describe('RedisCache.getOrCompute', () => {
+  let mockRedis: ReturnType<typeof createMockRedisClient>;
+  let cache: RedisCache;
+
+  beforeEach(() => {
+    mockRedis = createMockRedisClient();
+    cache = new RedisCache(asRedis(mockRedis));
+  });
+
+  it('returns cached value on cache hit without calling computeFn', async () => {
+    mockRedis.get.mockResolvedValue(JSON.stringify({ data: 42 }));
+    const computeFn = vi.fn();
+
+    const result = await cache.getOrCompute('key1', computeFn, 300);
+
+    expect(result).toEqual({ data: 42 });
+    expect(computeFn).not.toHaveBeenCalled();
+  });
+
+  it('computes, stores, and returns value on cache miss when lock acquired', async () => {
+    // Cache miss
+    mockRedis.get.mockResolvedValueOnce(null);
+    // Lock acquired
+    mockRedis.set.mockResolvedValue('OK');
+    // setEx succeeds
+    mockRedis.setEx.mockResolvedValue('OK');
+    // del (lock release) succeeds
+    mockRedis.del.mockResolvedValue(1);
+
+    const computeFn = vi.fn().mockResolvedValue({ data: 99 });
+
+    const result = await cache.getOrCompute('key2', computeFn, 600);
+
+    expect(result).toEqual({ data: 99 });
+    expect(computeFn).toHaveBeenCalledOnce();
+    expect(mockRedis.setEx).toHaveBeenCalledWith('key2', 600, JSON.stringify({ data: 99 }));
+    expect(mockRedis.del).toHaveBeenCalledWith('key2:lock');
+  });
+
+  it('polls and returns value when another caller holds the lock', async () => {
+    // Cache miss on initial get
+    mockRedis.get.mockResolvedValueOnce(null);
+    // Lock NOT acquired (another caller has it)
+    mockRedis.set.mockResolvedValue(null);
+    // Polling: miss on first poll, hit on second poll
+    mockRedis.get
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(JSON.stringify({ data: 'from-other-caller' }));
+
+    const computeFn = vi.fn();
+
+    const result = await cache.getOrCompute('key3', computeFn, 300);
+
+    expect(result).toEqual({ data: 'from-other-caller' });
+    expect(computeFn).not.toHaveBeenCalled();
+  });
+
+  it('falls through to compute when poll times out', async () => {
+    // Cache miss
+    mockRedis.get.mockResolvedValue(null);
+    // Lock NOT acquired
+    mockRedis.set.mockResolvedValue(null);
+    // setEx for the fallback compute
+    mockRedis.setEx.mockResolvedValue('OK');
+
+    const computeFn = vi.fn().mockResolvedValue('fallback-value');
+
+    const result = await cache.getOrCompute('key4', computeFn, 300);
+
+    expect(result).toBe('fallback-value');
+    expect(computeFn).toHaveBeenCalledOnce();
+  }, 15_000);
+
+  it('releases lock even when computeFn throws', async () => {
+    mockRedis.get.mockResolvedValueOnce(null);
+    mockRedis.set.mockResolvedValue('OK');
+    mockRedis.del.mockResolvedValue(1);
+
+    const computeFn = vi.fn().mockRejectedValue(new Error('compute error'));
+
+    await expect(cache.getOrCompute('key5', computeFn, 300)).rejects.toThrow('compute error');
+    expect(mockRedis.del).toHaveBeenCalledWith('key5:lock');
+  });
+
+  it('falls through to compute when Redis read fails', async () => {
+    mockRedis.get.mockRejectedValue(new Error('Redis down'));
+    // Lock acquisition also fails
+    mockRedis.set.mockRejectedValue(new Error('Redis down'));
+    mockRedis.setEx.mockRejectedValue(new Error('Redis down'));
+
+    const computeFn = vi.fn().mockResolvedValue('computed');
+
+    const result = await cache.getOrCompute('key6', computeFn, 300);
+
+    expect(result).toBe('computed');
+    expect(computeFn).toHaveBeenCalledOnce();
   });
 });

--- a/backend/src/core/services/redis-cache.ts
+++ b/backend/src/core/services/redis-cache.ts
@@ -253,6 +253,77 @@ export class RedisCache {
     }
   }
 
+  /**
+   * Cache-aside with stampede protection.
+   *
+   * On cache miss, acquires a short-lived NX lock so only one caller computes
+   * the value. Other concurrent callers poll the cache for up to 5 seconds;
+   * if the value still does not appear they fall through and compute it
+   * themselves (safe fallback — better than hanging forever).
+   */
+  async getOrCompute<T>(
+    cacheKey: string,
+    computeFn: () => Promise<T>,
+    ttl: number,
+  ): Promise<T> {
+    // 1. Fast path: cache hit
+    try {
+      const cached = await this.redis.get(cacheKey);
+      if (cached !== null) return JSON.parse(cached) as T;
+    } catch {
+      // Redis read failure — fall through to compute
+    }
+
+    // 2. Try to acquire a stampede lock
+    const lockKey = `${cacheKey}:lock`;
+    let lockAcquired = false;
+    try {
+      const result = await this.redis.set(lockKey, '1', { NX: true, EX: 30 });
+      lockAcquired = result !== null;
+    } catch {
+      // Redis failure — proceed without lock
+    }
+
+    if (lockAcquired) {
+      try {
+        const value = await computeFn();
+        try {
+          await this.redis.setEx(cacheKey, ttl, JSON.stringify(value));
+        } catch {
+          // Cache store failed — not critical, value is still returned
+        }
+        return value;
+      } finally {
+        try {
+          await this.redis.del(lockKey);
+        } catch {
+          // Lock cleanup failed — TTL will expire it
+        }
+      }
+    }
+
+    // 3. Another caller holds the lock — poll for the result
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 100));
+      try {
+        const cached = await this.redis.get(cacheKey);
+        if (cached !== null) return JSON.parse(cached) as T;
+      } catch {
+        // Redis read failure during poll — keep trying until deadline
+      }
+    }
+
+    // 4. Timeout waiting — compute it ourselves (safe fallback)
+    const value = await computeFn();
+    try {
+      await this.redis.setEx(cacheKey, ttl, JSON.stringify(value));
+    } catch {
+      // Best-effort cache store
+    }
+    return value;
+  }
+
   private async scanAndDelete(pattern: string): Promise<void> {
     let cursor = '0';
     do {


### PR DESCRIPTION
## Summary
- Adds `RedisCache.getOrCompute<T>(key, computeFn, ttl)` method with built-in stampede protection
- Uses Redis SET NX lock (30s TTL) so only one caller computes the value on a cache miss
- Concurrent callers poll the cache for up to 5s, then fall through to compute as safe fallback
- All error paths degrade gracefully (Redis failure = compute without caching)

## Test plan
- [x] Cache hit returns cached value without calling computeFn
- [x] Cache miss with lock acquired: computes, stores, returns, releases lock
- [x] Lock held by another caller: polls and returns when value appears
- [x] Poll timeout: falls through to compute (safe degradation)
- [x] Lock released even when computeFn throws
- [x] Redis failure: falls through to compute without caching

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)