### PR TITLE
fix: enterprise type alignment — feature flag validation + shared license contract (#103, #105)

### DIFF
--- a/backend/src/core/enterprise/features.test.ts
+++ b/backend/src/core/enterprise/features.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { ENTERPRISE_FEATURES } from './features.js';
+import {
+  ENTERPRISE_FEATURES,
+  FEATURE_ID_PATTERN,
+  validateFeatureIdentifier,
+} from './features.js';
 import type { EnterpriseFeature } from './features.js';
 
 describe('ENTERPRISE_FEATURES', () => {
   it('should export a frozen object of feature flag constants', () => {
-    // TypeScript const assertion makes it readonly, but we can verify values are strings
     expect(typeof ENTERPRISE_FEATURES).toBe('object');
     expect(Object.keys(ENTERPRISE_FEATURES).length).toBeGreaterThanOrEqual(24);
   });
@@ -54,9 +57,49 @@ describe('ENTERPRISE_FEATURES', () => {
   });
 
   it('should export the EnterpriseFeature type (compile-time check)', () => {
-    // This is a compile-time type check. If EnterpriseFeature is not exported
-    // or the values don't match, TypeScript will fail to compile.
     const feature: EnterpriseFeature = ENTERPRISE_FEATURES.OIDC_SSO;
     expect(feature).toBe('oidc_sso');
+  });
+
+  it('should have ALL values matching snake_case pattern (FEATURE_ID_PATTERN)', () => {
+    const values = Object.values(ENTERPRISE_FEATURES);
+    for (const value of values) {
+      expect(
+        FEATURE_ID_PATTERN.test(value),
+        `Feature flag "${value}" does not match snake_case pattern ${FEATURE_ID_PATTERN}`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('validateFeatureIdentifier', () => {
+  it('should accept valid snake_case identifiers', () => {
+    expect(validateFeatureIdentifier('oidc_sso')).toBe(true);
+    expect(validateFeatureIdentifier('pii_detection')).toBe(true);
+    expect(validateFeatureIdentifier('a')).toBe(true);
+    expect(validateFeatureIdentifier('feature123')).toBe(true);
+    expect(validateFeatureIdentifier('advanced_rbac')).toBe(true);
+  });
+
+  it('should reject identifiers starting with a number', () => {
+    expect(validateFeatureIdentifier('1_feature')).toBe(false);
+    expect(validateFeatureIdentifier('123')).toBe(false);
+  });
+
+  it('should reject identifiers with uppercase letters', () => {
+    expect(validateFeatureIdentifier('OIDC_SSO')).toBe(false);
+    expect(validateFeatureIdentifier('OidcSso')).toBe(false);
+    expect(validateFeatureIdentifier('oidc_SSO')).toBe(false);
+  });
+
+  it('should reject identifiers with hyphens or special characters', () => {
+    expect(validateFeatureIdentifier('oidc-sso')).toBe(false);
+    expect(validateFeatureIdentifier('feature.name')).toBe(false);
+    expect(validateFeatureIdentifier('feature name')).toBe(false);
+    expect(validateFeatureIdentifier('')).toBe(false);
+  });
+
+  it('should reject identifiers starting with underscore', () => {
+    expect(validateFeatureIdentifier('_private')).toBe(false);
   });
 });

--- a/backend/src/core/enterprise/features.ts
+++ b/backend/src/core/enterprise/features.ts
@@ -49,3 +49,16 @@ export const ENTERPRISE_FEATURES = {
 
 export type EnterpriseFeature =
   (typeof ENTERPRISE_FEATURES)[keyof typeof ENTERPRISE_FEATURES];
+
+/**
+ * Pattern that all feature flag identifiers must match: lowercase snake_case
+ * starting with a letter, e.g. `oidc_sso`, `pii_detection`.
+ */
+export const FEATURE_ID_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+/**
+ * Validate that a feature identifier follows the required snake_case format.
+ */
+export function validateFeatureIdentifier(id: string): boolean {
+  return FEATURE_ID_PATTERN.test(id);
+}

--- a/frontend/src/shared/enterprise/types.ts
+++ b/frontend/src/shared/enterprise/types.ts
@@ -1,17 +1,17 @@
 import type { ReactNode, ComponentType } from 'react';
+import type { LicenseInfoResponse } from '@compendiq/contracts';
 
-// ─── License Types (mirrors backend types.ts) ─────────────────────
+// ─── License Types ────────────────────────────────────────────────
+// The canonical API response shape is defined in @compendiq/contracts
+// (LicenseInfoResponseSchema). This interface extends it with UI-only
+// fields that the backend may also include.
 
 export type LicenseTier = 'community' | 'team' | 'business' | 'enterprise';
 
-export interface LicenseInfo {
-  edition: string;
+export interface LicenseInfo extends LicenseInfoResponse {
   tier: LicenseTier;
-  seats?: number;
-  expiresAt?: string;
   isValid?: boolean;
   displayKey?: string;
-  features: string[];
 }
 
 // ─── Enterprise UI Component Contract ──────────────────────────────

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5,4 +5,5 @@ export * from './schemas/spaces.js';
 export * from './schemas/llm.js';
 export * from './schemas/admin.js';
 export * from './schemas/templates.js';
+export * from './schemas/license.js';
 export * from './types/common.js';

--- a/packages/contracts/src/schemas/license.ts
+++ b/packages/contracts/src/schemas/license.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Shared schema for the license info API response shape.
+ *
+ * The backend stores LicenseInfo internally with `expiresAt: Date` and
+ * `seats: number` (required), but serializes to this schema at the API
+ * boundary. The frontend consumes this shape directly.
+ */
+export const LicenseInfoResponseSchema = z.object({
+  edition: z.string(),
+  tier: z.string(),
+  features: z.array(z.string()),
+  expiresAt: z.string().optional(),
+  seats: z.number().optional(),
+  valid: z.boolean(),
+});
+
+export type LicenseInfoResponse = z.infer<typeof LicenseInfoResponseSchema>;


### PR DESCRIPTION
## Summary
- **#103 Feature Flag Format Validation**: Adds `FEATURE_ID_PATTERN` regex and `validateFeatureIdentifier()` to `features.ts` to enforce snake_case format on all enterprise feature flags. Tests validate all 24+ existing flags match the pattern.
- **#105 LicenseInfo Shared Type**: Creates `LicenseInfoResponseSchema` (Zod) in `@compendiq/contracts` as the single source of truth for the license API response shape. Frontend `LicenseInfo` now extends `LicenseInfoResponse` from contracts instead of maintaining a separate definition.

## Test plan
- [x] All 24+ existing feature flags pass snake_case validation
- [x] `validateFeatureIdentifier` accepts valid identifiers and rejects invalid ones (uppercase, hyphens, numbers-first, underscores-first, empty)
- [x] `npm run typecheck` passes across all workspaces (contracts, backend, frontend)
- [x] Existing features tests still pass (14 total)

Closes #103, closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)