### PR TITLE
perf: replace SHA-256 recomputation with timestamp check in summary worker (#97)

### DIFF
--- a/backend/src/domains/knowledge/services/summary-worker.test.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.test.ts
@@ -216,15 +216,15 @@ describe.skipIf(!dbAvailable)('Summary Worker', () => {
       expect(result.rows[0].summary_content_hash).toHaveLength(64);
     });
 
-    it('should detect content changes via hash mismatch and re-summarize', async () => {
+    it('should detect content changes via timestamp and re-summarize', async () => {
       const longContent = 'B'.repeat(200);
-      const staleHash = 'aaaa'.repeat(16); // 64-char fake hash that won't match
 
       // Insert a page that was previously summarized but whose content has since changed
+      // (last_modified_at is after summary_generated_at)
       await query(
-        `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status, summary_content_hash, summary_text)
-         VALUES ('changed1', $1, 'Changed Page', $2, 'summarized', $3, 'old summary')`,
-        [testSpaceKey, longContent, staleHash],
+        `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status, summary_content_hash, summary_text, summary_generated_at, last_modified_at)
+         VALUES ('changed1', $1, 'Changed Page', $2, 'summarized', $3, 'old summary', NOW() - INTERVAL '1 hour', NOW())`,
+        [testSpaceKey, longContent, computeContentHash('old content')],
       );
 
       const { processed, errors } = await runSummaryBatch('test-model');
@@ -244,14 +244,15 @@ describe.skipIf(!dbAvailable)('Summary Worker', () => {
       expect(result.rows[0].summary_content_hash).toBe(computeContentHash(longContent));
     });
 
-    it('should not re-summarize when content hash matches', async () => {
+    it('should not re-summarize when content has not changed since last summary', async () => {
       const longContent = 'C'.repeat(200);
       const correctHash = computeContentHash(longContent);
 
-      // Insert a page that is already summarized with the correct hash
+      // Insert a page that is already summarized and has not been modified since
+      // (summary_generated_at is after last_modified_at)
       await query(
-        `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status, summary_content_hash, summary_text)
-         VALUES ('unchanged1', $1, 'Unchanged Page', $2, 'summarized', $3, 'existing summary')`,
+        `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status, summary_content_hash, summary_text, summary_generated_at, last_modified_at)
+         VALUES ('unchanged1', $1, 'Unchanged Page', $2, 'summarized', $3, 'existing summary', NOW(), NOW() - INTERVAL '1 hour')`,
         [testSpaceKey, longContent, correctHash],
       );
 
@@ -265,18 +266,18 @@ describe.skipIf(!dbAvailable)('Summary Worker', () => {
       expect(result.rows[0].summary_text).toBe('existing summary');
     });
 
-    it('should handle body_text with special characters in hash comparison', async () => {
-      // Content with backslashes, unicode, and special chars that would break ::bytea cast
+    it('should handle body_text with special characters in timestamp comparison', async () => {
+      // Content with backslashes, unicode, and special chars
       const specialContent = 'A'.repeat(100) + ' backslash: \\ quote: " unicode: ü emoji: 🎉 tab:\t newline:\n end';
       const correctHash = computeContentHash(specialContent);
 
       await query(
-        `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status, summary_content_hash, summary_text)
-         VALUES ('special1', $1, 'Special Chars Page', $2, 'summarized', $3, 'existing summary')`,
+        `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status, summary_content_hash, summary_text, summary_generated_at, last_modified_at)
+         VALUES ('special1', $1, 'Special Chars Page', $2, 'summarized', $3, 'existing summary', NOW(), NOW() - INTERVAL '1 hour')`,
         [testSpaceKey, specialContent, correctHash],
       );
 
-      // Should NOT crash and should NOT re-summarize (hash matches)
+      // Should NOT crash and should NOT re-summarize (not modified since summary)
       const { processed, errors } = await runSummaryBatch('test-model');
       expect(errors).toBe(0);
       expect(processed).toBe(0);

--- a/backend/src/domains/knowledge/services/summary-worker.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.ts
@@ -288,16 +288,19 @@ export async function runSummaryBatch(model?: string): Promise<{ processed: numb
     return { processed: 0, errors: 0 };
   }
 
-  // Phase 1: Detect content changes (hash mismatch) and mark as pending
+  // Phase 1: Detect content changes via timestamp and mark as pending.
+  // Uses last_modified_at > summary_generated_at instead of recomputing
+  // SHA-256 hashes for every summarized page on every batch cycle.
   await query(
     `UPDATE pages
      SET summary_status = 'pending'
      WHERE summary_status = 'summarized'
        AND deleted_at IS NULL
-       AND summary_content_hash IS NOT NULL
+       AND summary_generated_at IS NOT NULL
+       AND last_modified_at IS NOT NULL
+       AND last_modified_at > summary_generated_at
        AND body_text IS NOT NULL
-       AND length(body_text) >= $1
-       AND summary_content_hash != encode(sha256(convert_to(body_text, 'UTF-8')), 'hex')`,
+       AND length(body_text) >= $1`,
     [MIN_BODY_LENGTH],
   );
 


### PR DESCRIPTION
## Summary
- Replace the expensive `sha256(convert_to(body_text, 'UTF-8'))` SQL computation with a `last_modified_at > summary_generated_at` timestamp comparison
- The old query recomputed SHA-256 hashes for every summarized page on every batch cycle, which is O(n * body_size)
- The new query uses indexed timestamp columns and is O(n * constant), short-circuiting on the index

## Test plan
- [x] Updated 3 tests to use timestamp-based change detection instead of hash comparison
- [x] Tests are DB integration tests (skip in CI without PostgreSQL, pass with real DB)
- [x] Content hash is still computed and stored when summarizing (for data integrity), just not used for change detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)