### PR TITLE
perf: add dedicated pgvector pool to isolate similarity queries (#114)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ PAT_ENCRYPTION_KEY=change-me-to-a-random-32-char-string-min
 POSTGRES_URL=postgresql://kb_user:changeme-postgres@localhost:5432/kb_creator
 
 # PG_POOL_MAX=20                       # PostgreSQL connection pool max (default: 20)
+# PG_VECTOR_POOL_MAX=5                 # Separate pool for pgvector similarity queries (default: 5)
 # PG_STATEMENT_TIMEOUT=30000           # Global query timeout in ms (default: none)
 
 # --- PostgreSQL (Test - port 5433) ---

--- a/backend/src/core/db/postgres.test.ts
+++ b/backend/src/core/db/postgres.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { setupTestDb, truncateAllTables, teardownTestDb, isDbAvailable } from '../../test-db-helper.js';
-import { query } from './postgres.js';
+import { query, getVectorPool, closeVectorPool } from './postgres.js';
 
 const dbAvailable = await isDbAvailable();
 
@@ -48,5 +48,43 @@ describe.skipIf(!dbAvailable)('Database', () => {
       "SELECT '[1,2,3]'::vector(3) <=> '[4,5,6]'::vector(3) AS distance",
     );
     expect(result.rows[0].distance).toBeGreaterThan(0);
+  });
+
+  describe('vector pool', () => {
+    afterAll(async () => {
+      await closeVectorPool();
+    });
+
+    it('getVectorPool returns a working pool that can query', async () => {
+      const vPool = getVectorPool();
+      const result = await vPool.query<{ one: number }>('SELECT 1 AS one');
+      expect(result.rows[0].one).toBe(1);
+    });
+
+    it('getVectorPool returns the same instance on repeated calls', () => {
+      const pool1 = getVectorPool();
+      const pool2 = getVectorPool();
+      expect(pool1).toBe(pool2);
+    });
+
+    it('vector pool supports pgvector operations', async () => {
+      const vPool = getVectorPool();
+      const result = await vPool.query<{ distance: number }>(
+        "SELECT '[1,2,3]'::vector(3) <=> '[4,5,6]'::vector(3) AS distance",
+      );
+      expect(result.rows[0].distance).toBeGreaterThan(0);
+    });
+
+    it('closeVectorPool closes the pool and allows re-creation', async () => {
+      const poolBefore = getVectorPool();
+      await closeVectorPool();
+      const poolAfter = getVectorPool();
+      // After closing and re-getting, it should be a new instance
+      expect(poolAfter).not.toBe(poolBefore);
+      // And it should still work
+      const result = await poolAfter.query('SELECT 1');
+      expect(result.rows).toHaveLength(1);
+      await closeVectorPool();
+    });
   });
 });

--- a/backend/src/core/db/postgres.ts
+++ b/backend/src/core/db/postgres.ts
@@ -33,6 +33,34 @@ export async function closePool(): Promise<void> {
   }
 }
 
+// ── Dedicated vector search pool ─────────────────────────────────────────
+// Keeps long-running pgvector similarity queries from consuming the
+// main pool's connections and starving CRUD routes.
+
+let vectorPool: pg.Pool | null = null;
+
+export function getVectorPool(): pg.Pool {
+  if (!vectorPool) {
+    vectorPool = new pg.Pool({
+      connectionString: process.env.POSTGRES_URL,
+      max: parseInt(process.env.PG_VECTOR_POOL_MAX ?? '5', 10),
+      connectionTimeoutMillis: 10_000,
+      idleTimeoutMillis: 30_000,
+    });
+    vectorPool.on('error', (err) => {
+      logger.error({ err }, 'Unexpected PostgreSQL vector pool error');
+    });
+  }
+  return vectorPool;
+}
+
+export async function closeVectorPool(): Promise<void> {
+  if (vectorPool) {
+    await vectorPool.end();
+    vectorPool = null;
+  }
+}
+
 export async function query<T extends pg.QueryResultRow = pg.QueryResultRow>(
   text: string,
   params?: unknown[],

--- a/backend/src/domains/llm/services/rag-service.test.ts
+++ b/backend/src/domains/llm/services/rag-service.test.ts
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => {
 vi.mock('../../../core/db/postgres.js', () => ({
   query: (...args: unknown[]) => mocks.mockQuery(...args),
   getPool: () => mocks.mockPool,
+  getVectorPool: () => mocks.mockPool,
 }));
 
 vi.mock('./llm-provider.js', () => ({

--- a/backend/src/domains/llm/services/rag-service.ts
+++ b/backend/src/domains/llm/services/rag-service.ts
@@ -1,4 +1,4 @@
-import { query, getPool } from '../../../core/db/postgres.js';
+import { query, getVectorPool } from '../../../core/db/postgres.js';
 import { providerGenerateEmbedding } from './llm-provider.js';
 import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
 import { CircuitBreakerOpenError } from '../../../core/services/circuit-breaker.js';
@@ -32,8 +32,9 @@ interface SearchResult {
  */
 export async function vectorSearch(userId: string, questionEmbedding: number[], limit = 10): Promise<SearchResult[]> {
   const vecSpaces = await getUserAccessibleSpaces(userId);
-  // Use a dedicated client so SET LOCAL applies to our query
-  const client = await getPool().connect();
+  // Use the dedicated vector pool so long-running similarity queries
+  // do not starve the main pool used by CRUD routes.
+  const client = await getVectorPool().connect();
   try {
     await client.query('BEGIN');
     await client.query(`SET LOCAL hnsw.ef_search = ${Number(RAG_EF_SEARCH)}`);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,7 +3,7 @@
 import { initTelemetry, shutdownTelemetry } from './telemetry.js';
 
 import { buildApp } from './app.js';
-import { runMigrations, closePool, query } from './core/db/postgres.js';
+import { runMigrations, closePool, closeVectorPool, query } from './core/db/postgres.js';
 import { startSyncWorker, stopSyncWorker } from './domains/confluence/services/sync-service.js';
 import { addAllowedBaseUrl } from './core/utils/ssrf-guard.js';
 import { startQualityWorker, stopQualityWorker, triggerQualityBatch } from './domains/knowledge/services/quality-worker.js';
@@ -98,6 +98,7 @@ async function start() {
     stopTokenCleanupWorker();
     try { const { closeBrowser } = await import('./core/services/pdf-service.js'); await closeBrowser(); } catch { /* shutdown cleanup is best-effort */ }
     await app.close();
+    await closeVectorPool();
     await closePool();
     await shutdownTelemetry();
     process.exit(0);


### PR DESCRIPTION
## Summary
- Creates a second PostgreSQL connection pool (`getVectorPool()`) dedicated to pgvector similarity queries
- Configurable via `PG_VECTOR_POOL_MAX` env var (default: 5 connections)
- Updates `rag-service.ts` `vectorSearch()` to use the vector pool instead of the main pool
- Adds `closeVectorPool()` to graceful shutdown sequence in `index.ts`
- Prevents long-running cosine similarity searches from starving CRUD routes under concurrent load

## Test plan
- [x] `npm run typecheck` passes
- [x] `getVectorPool()` returns a working pool (DB integration test)
- [x] Singleton: returns same instance on repeated calls
- [x] `closeVectorPool()` allows pool re-creation
- [x] Vector operations work through the dedicated pool

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)