### PR TITLE
feat: add data retention cleanup for append-only tables (#101)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,12 @@ EMBEDDING_MODEL=bge-m3
 # --- RAG / Vector Search ---
 # RAG_EF_SEARCH=100                  # HNSW ef_search parameter for pgvector similarity queries (default: 100)
 
+# --- Data Retention ---
+# RETENTION_AUDIT_LOG_DAYS=365       # Keep audit_log rows for N days (default: 365)
+# RETENTION_SEARCH_ANALYTICS_DAYS=90 # Keep search_analytics rows for N days (default: 90)
+# RETENTION_ERROR_LOG_DAYS=30        # Keep error_log rows for N days (default: 30)
+# RETENTION_VERSIONS_MAX=50          # Keep last N page_versions per page (default: 50)
+
 # --- Enterprise License ---
 # COMPENDIQ_LICENSE_KEY=              # Enterprise license key (format: ATM-{tier}-{seats}-{expiryYYYYMMDD}.{signature})
 

--- a/backend/src/core/services/data-retention-service.test.ts
+++ b/backend/src/core/services/data-retention-service.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockPool = {
+  query: vi.fn(),
+};
+
+vi.mock('../db/postgres.js', () => ({
+  getPool: () => mockPool,
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { runRetentionCleanup, startRetentionWorker, stopRetentionWorker, RETENTION_DEFAULTS } from './data-retention-service.js';
+
+describe('data-retention-service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    stopRetentionWorker();
+    // Clean up env var overrides
+    delete process.env.RETENTION_AUDIT_LOG_DAYS;
+    delete process.env.RETENTION_SEARCH_ANALYTICS_DAYS;
+    delete process.env.RETENTION_ERROR_LOG_DAYS;
+    delete process.env.RETENTION_VERSIONS_MAX;
+  });
+
+  describe('RETENTION_DEFAULTS', () => {
+    it('exports sensible default retention periods', () => {
+      expect(RETENTION_DEFAULTS.audit_log).toBe(365);
+      expect(RETENTION_DEFAULTS.search_analytics).toBe(90);
+      expect(RETENTION_DEFAULTS.error_log).toBe(30);
+      expect(RETENTION_DEFAULTS.page_versions).toBe(50);
+    });
+  });
+
+  describe('runRetentionCleanup', () => {
+    it('deletes old rows from time-based tables and excess page_versions', async () => {
+      mockPool.query
+        // audit_log
+        .mockResolvedValueOnce({ rowCount: 10 })
+        // search_analytics
+        .mockResolvedValueOnce({ rowCount: 5 })
+        // error_log
+        .mockResolvedValueOnce({ rowCount: 3 })
+        // page_versions
+        .mockResolvedValueOnce({ rowCount: 2 });
+
+      const results = await runRetentionCleanup();
+
+      expect(results.audit_log).toBe(10);
+      expect(results.search_analytics).toBe(5);
+      expect(results.error_log).toBe(3);
+      expect(results.page_versions).toBe(2);
+    });
+
+    it('uses parameterized queries for time-based tables', async () => {
+      mockPool.query.mockResolvedValue({ rowCount: 0 });
+
+      await runRetentionCleanup();
+
+      // 3 time-based + 1 count-based = 4 queries
+      expect(mockPool.query).toHaveBeenCalledTimes(4);
+
+      // Verify audit_log uses default 365 days
+      const auditCall = mockPool.query.mock.calls[0];
+      expect(auditCall[0]).toContain('DELETE FROM audit_log');
+      expect(auditCall[1]).toEqual([365]);
+
+      // Verify search_analytics uses default 90 days
+      const searchCall = mockPool.query.mock.calls[1];
+      expect(searchCall[0]).toContain('DELETE FROM search_analytics');
+      expect(searchCall[1]).toEqual([90]);
+
+      // Verify error_log uses default 30 days
+      const errorCall = mockPool.query.mock.calls[2];
+      expect(errorCall[0]).toContain('DELETE FROM error_log');
+      expect(errorCall[1]).toEqual([30]);
+    });
+
+    it('uses ROW_NUMBER for count-based page_versions cleanup', async () => {
+      mockPool.query.mockResolvedValue({ rowCount: 0 });
+
+      await runRetentionCleanup();
+
+      const versionsCall = mockPool.query.mock.calls[3];
+      expect(versionsCall[0]).toContain('ROW_NUMBER()');
+      expect(versionsCall[0]).toContain('PARTITION BY page_id');
+      expect(versionsCall[1]).toEqual([50]);
+    });
+
+    it('respects env var overrides', async () => {
+      process.env.RETENTION_AUDIT_LOG_DAYS = '7';
+      process.env.RETENTION_VERSIONS_MAX = '10';
+      mockPool.query.mockResolvedValue({ rowCount: 0 });
+
+      await runRetentionCleanup();
+
+      // Audit log should use overridden value
+      const auditCall = mockPool.query.mock.calls[0];
+      expect(auditCall[1]).toEqual([7]);
+
+      // page_versions should use overridden max
+      const versionsCall = mockPool.query.mock.calls[3];
+      expect(versionsCall[1]).toEqual([10]);
+    });
+
+    it('handles query errors gracefully and returns 0 for failed tables', async () => {
+      mockPool.query
+        .mockRejectedValueOnce(new Error('table does not exist'))
+        .mockResolvedValueOnce({ rowCount: 5 })
+        .mockResolvedValueOnce({ rowCount: 3 })
+        .mockResolvedValueOnce({ rowCount: 0 });
+
+      const results = await runRetentionCleanup();
+
+      expect(results.audit_log).toBe(0);
+      expect(results.search_analytics).toBe(5);
+      expect(results.error_log).toBe(3);
+      expect(results.page_versions).toBe(0);
+    });
+
+    it('handles null rowCount gracefully', async () => {
+      mockPool.query.mockResolvedValue({ rowCount: null });
+
+      const results = await runRetentionCleanup();
+
+      expect(results.audit_log).toBe(0);
+      expect(results.search_analytics).toBe(0);
+      expect(results.error_log).toBe(0);
+      expect(results.page_versions).toBe(0);
+    });
+  });
+
+  describe('worker lifecycle', () => {
+    it('startRetentionWorker is idempotent (second call is no-op)', () => {
+      vi.useFakeTimers();
+      startRetentionWorker(1);
+      startRetentionWorker(1); // second call should not create another interval
+      vi.useRealTimers();
+      stopRetentionWorker();
+    });
+
+    it('stopRetentionWorker clears the interval', () => {
+      vi.useFakeTimers();
+      startRetentionWorker(1);
+      stopRetentionWorker();
+      // Calling stop again should not throw
+      stopRetentionWorker();
+      vi.useRealTimers();
+    });
+  });
+});

--- a/backend/src/core/services/data-retention-service.ts
+++ b/backend/src/core/services/data-retention-service.ts
@@ -1,0 +1,115 @@
+/**
+ * Data retention service.
+ *
+ * Cleans up append-only tables that grow unbounded:
+ *   - audit_log       (time-based: default 365 days)
+ *   - search_analytics (time-based: default 90 days)
+ *   - error_log       (time-based: default 30 days)
+ *   - page_versions   (count-based: keep last N per page, default 50)
+ *
+ * Retention periods are configurable via environment variables:
+ *   RETENTION_AUDIT_LOG_DAYS, RETENTION_SEARCH_ANALYTICS_DAYS,
+ *   RETENTION_ERROR_LOG_DAYS, RETENTION_VERSIONS_MAX
+ */
+
+import { getPool } from '../db/postgres.js';
+import { logger } from '../utils/logger.js';
+
+export const RETENTION_DEFAULTS: Record<string, number> = {
+  audit_log: 365,          // days
+  search_analytics: 90,    // days
+  error_log: 30,           // days
+  page_versions: 50,       // keep last N per page
+};
+
+/**
+ * Run retention cleanup across all configured tables.
+ * Returns a map of table name to number of deleted rows.
+ */
+export async function runRetentionCleanup(): Promise<Record<string, number>> {
+  const pool = getPool();
+  const results: Record<string, number> = {};
+
+  // Time-based retention for audit_log, search_analytics, error_log
+  for (const [table, days] of Object.entries(RETENTION_DEFAULTS)) {
+    if (table === 'page_versions') continue;
+
+    const envKey = `RETENTION_${table.toUpperCase()}_DAYS`;
+    const retentionDays = parseInt(process.env[envKey] ?? String(days), 10);
+
+    try {
+      const { rowCount } = await pool.query(
+        `DELETE FROM ${table} WHERE created_at < NOW() - INTERVAL '1 day' * $1`,
+        [retentionDays],
+      );
+      results[table] = rowCount ?? 0;
+      if (results[table] > 0) {
+        logger.info({ table, deleted: results[table], retentionDays }, 'Retention cleanup completed');
+      }
+    } catch (err) {
+      logger.error({ err, table }, 'Retention cleanup failed for table');
+      results[table] = 0;
+    }
+  }
+
+  // Count-based retention for page_versions
+  const maxVersions = parseInt(process.env.RETENTION_VERSIONS_MAX ?? '50', 10);
+  try {
+    const { rowCount } = await pool.query(`
+      DELETE FROM page_versions WHERE id IN (
+        SELECT id FROM (
+          SELECT id, ROW_NUMBER() OVER (PARTITION BY page_id ORDER BY version_number DESC) AS rn
+          FROM page_versions
+        ) ranked WHERE rn > $1
+      )
+    `, [maxVersions]);
+    results.page_versions = rowCount ?? 0;
+    if (results.page_versions > 0) {
+      logger.info({ deleted: results.page_versions, maxVersions }, 'Page versions retention cleanup completed');
+    }
+  } catch (err) {
+    logger.error({ err }, 'Page versions retention cleanup failed');
+    results.page_versions = 0;
+  }
+
+  return results;
+}
+
+// ── Scheduler ────────────────────────────────────────────────────────────────
+
+let retentionIntervalHandle: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start the daily retention cleanup scheduler.
+ * Default interval: 24 hours.
+ */
+export function startRetentionWorker(intervalHours = 24): void {
+  if (retentionIntervalHandle) return;
+
+  const intervalMs = intervalHours * 60 * 60 * 1000;
+
+  retentionIntervalHandle = setInterval(async () => {
+    try {
+      const results = await runRetentionCleanup();
+      const totalDeleted = Object.values(results).reduce((a, b) => a + b, 0);
+      if (totalDeleted > 0) {
+        logger.info({ results }, 'Scheduled retention cleanup completed');
+      }
+    } catch (err) {
+      logger.error({ err }, 'Scheduled retention cleanup error');
+    }
+  }, intervalMs);
+
+  logger.info({ intervalHours }, 'Data retention worker started');
+}
+
+/**
+ * Stop the retention cleanup scheduler.
+ */
+export function stopRetentionWorker(): void {
+  if (retentionIntervalHandle) {
+    clearInterval(retentionIntervalHandle);
+    retentionIntervalHandle = null;
+    logger.info('Data retention worker stopped');
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import { addAllowedBaseUrl } from './core/utils/ssrf-guard.js';
 import { startQualityWorker, stopQualityWorker, triggerQualityBatch } from './domains/knowledge/services/quality-worker.js';
 import { startSummaryWorker, stopSummaryWorker, triggerSummaryBatch } from './domains/knowledge/services/summary-worker.js';
 import { startTokenCleanupWorker, stopTokenCleanupWorker } from './core/services/token-cleanup-service.js';
+import { startRetentionWorker, stopRetentionWorker } from './core/services/data-retention-service.js';
 import { markStartupComplete } from './routes/foundation/health.js';
 import { logger } from './core/utils/logger.js';
 import { getSharedLlmSettings } from './core/services/admin-settings-service.js';
@@ -81,6 +82,9 @@ async function start() {
   // Start background token cleanup worker
   startTokenCleanupWorker();
 
+  // Start daily data retention cleanup worker
+  startRetentionWorker();
+
   // Run initial worker batches after 30s delay to let server stabilize.
   // Uses lock-guarded trigger functions to prevent concurrent execution
   // if a worker interval fires at the same time.
@@ -96,6 +100,7 @@ async function start() {
     stopSyncWorker();
     stopSummaryWorker();
     stopTokenCleanupWorker();
+    stopRetentionWorker();
     try { const { closeBrowser } = await import('./core/services/pdf-service.js'); await closeBrowser(); } catch { /* shutdown cleanup is best-effort */ }
     await app.close();
     await closePool();


### PR DESCRIPTION
## Summary
- Adds `data-retention-service.ts` with daily background worker that prunes append-only tables
- Time-based retention: `audit_log` (365d), `search_analytics` (90d), `error_log` (30d)
- Count-based retention: `page_versions` (keep last 50 per page)
- All retention periods configurable via `RETENTION_*` env vars
- Graceful error handling: failures in one table don't block others
- No migration needed: `created_at` indexes already exist from original table creation

## Test plan
- [x] Deletes old rows from all time-based tables with correct retention days
- [x] Uses ROW_NUMBER windowing for count-based page_versions cleanup
- [x] Respects env var overrides
- [x] Handles query errors gracefully (returns 0 for failed tables)
- [x] Handles null rowCount
- [x] Worker lifecycle: idempotent start, clean stop
- [x] `npm run typecheck` passes

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)