### PR TITLE
perf: parallelize keyword search queries with Promise.all (#96)

### DIFF
--- a/backend/src/routes/knowledge/search.test.ts
+++ b/backend/src/routes/knowledge/search.test.ts
@@ -105,9 +105,6 @@ describe('Search Routes', () => {
             ],
           };
         }
-        if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
-          return { rows: [{ count: '2' }] };
-        }
         if (typeof sql === 'string' && sql.includes('ts_rank')) {
           return {
             rows: [
@@ -121,6 +118,7 @@ describe('Search Routes', () => {
                 labels: ['howto'],
                 rank: 0.85,
                 snippet: 'How to use <mark>Redis</mark> caching',
+                total_count: '2',
               },
               {
                 id: 2,
@@ -132,6 +130,7 @@ describe('Search Routes', () => {
                 labels: ['architecture'],
                 rank: 0.72,
                 snippet: 'Configure <mark>Redis</mark> for production',
+                total_count: '2',
               },
             ],
           };
@@ -175,18 +174,19 @@ describe('Search Routes', () => {
     });
 
     it('should include access control JOIN and deleted_at filter', async () => {
-      mockQueryFn.mockResolvedValue({ rows: [{ count: '0' }] });
+      mockQueryFn.mockResolvedValue({ rows: [] });
 
       await app.inject({
         method: 'GET',
         url: '/api/search?q=test',
       });
 
-      const countCall = mockQueryFn.mock.calls.find(
-        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('COUNT(*)'),
+      // Access control is in the FTS data query (which now includes COUNT(*) OVER())
+      const dataCall = mockQueryFn.mock.calls.find(
+        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('ts_rank'),
       );
-      expect(countCall).toBeDefined();
-      const sql = countCall![0] as string;
+      expect(dataCall).toBeDefined();
+      const sql = dataCall![0] as string;
       expect(sql).toContain('cp.space_key = ANY');
       expect(sql).toContain('cp.deleted_at IS NULL');
       expect(sql).toContain('cp.source');
@@ -194,75 +194,70 @@ describe('Search Routes', () => {
     });
 
     it('should filter by spaceKey', async () => {
-      mockQueryFn.mockResolvedValue({ rows: [{ count: '0' }] });
+      mockQueryFn.mockResolvedValue({ rows: [] });
 
       await app.inject({
         method: 'GET',
         url: '/api/search?q=test&spaceKey=DEV',
       });
 
-      const countCall = mockQueryFn.mock.calls.find(
-        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('COUNT(*)'),
+      const dataCall = mockQueryFn.mock.calls.find(
+        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('ts_rank'),
       );
-      expect(countCall).toBeDefined();
-      expect(countCall![0] as string).toContain('cp.space_key = $');
-      expect(countCall![1] as unknown[]).toContain('DEV');
+      expect(dataCall).toBeDefined();
+      expect(dataCall![0] as string).toContain('cp.space_key = $');
+      expect(dataCall![1] as unknown[]).toContain('DEV');
     });
 
     it('should filter by author', async () => {
-      mockQueryFn.mockResolvedValue({ rows: [{ count: '0' }] });
+      mockQueryFn.mockResolvedValue({ rows: [] });
 
       await app.inject({
         method: 'GET',
         url: '/api/search?q=test&author=Alice',
       });
 
-      const countCall = mockQueryFn.mock.calls.find(
-        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('COUNT(*)'),
+      const dataCall = mockQueryFn.mock.calls.find(
+        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('ts_rank'),
       );
-      expect(countCall![0] as string).toContain('cp.author = $');
-      expect(countCall![1] as unknown[]).toContain('Alice');
+      expect(dataCall![0] as string).toContain('cp.author = $');
+      expect(dataCall![1] as unknown[]).toContain('Alice');
     });
 
     it('should filter by date range', async () => {
-      mockQueryFn.mockResolvedValue({ rows: [{ count: '0' }] });
+      mockQueryFn.mockResolvedValue({ rows: [] });
 
       await app.inject({
         method: 'GET',
         url: '/api/search?q=test&dateFrom=2025-01-01&dateTo=2025-12-31',
       });
 
-      const countCall = mockQueryFn.mock.calls.find(
-        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('COUNT(*)'),
+      const dataCall = mockQueryFn.mock.calls.find(
+        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('ts_rank'),
       );
-      expect(countCall![0] as string).toContain('cp.last_modified_at >=');
-      expect(countCall![0] as string).toContain('cp.last_modified_at <=');
-      expect(countCall![1] as unknown[]).toContain('2025-01-01');
-      expect(countCall![1] as unknown[]).toContain('2025-12-31');
+      expect(dataCall![0] as string).toContain('cp.last_modified_at >=');
+      expect(dataCall![0] as string).toContain('cp.last_modified_at <=');
+      expect(dataCall![1] as unknown[]).toContain('2025-01-01');
+      expect(dataCall![1] as unknown[]).toContain('2025-12-31');
     });
 
     it('should filter by tags', async () => {
-      mockQueryFn.mockResolvedValue({ rows: [{ count: '0' }] });
+      mockQueryFn.mockResolvedValue({ rows: [] });
 
       await app.inject({
         method: 'GET',
         url: '/api/search?q=test&tags=howto,architecture',
       });
 
-      const countCall = mockQueryFn.mock.calls.find(
-        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('COUNT(*)'),
+      const dataCall = mockQueryFn.mock.calls.find(
+        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('ts_rank'),
       );
-      expect(countCall![0] as string).toContain('cp.labels @>');
-      expect(countCall![1] as unknown[]).toContainEqual(['howto', 'architecture']);
+      expect(dataCall![0] as string).toContain('cp.labels @>');
+      expect(dataCall![1] as unknown[]).toContainEqual(['howto', 'architecture']);
     });
 
     it('should support sort by modified date', async () => {
-      mockQueryFn.mockImplementation((sql: string) => {
-        if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
-          return { rows: [{ count: '0' }] };
-        }
-        return { rows: [] };
-      });
+      mockQueryFn.mockResolvedValue({ rows: [] });
 
       await app.inject({
         method: 'GET',
@@ -278,11 +273,10 @@ describe('Search Routes', () => {
 
     it('should paginate results correctly', async () => {
       mockQueryFn.mockImplementation((sql: string) => {
-        if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
-          return { rows: [{ count: '50' }] };
-        }
         if (typeof sql === 'string' && sql.includes('ts_rank')) {
-          return { rows: [] };
+          return {
+            rows: [{ id: 1, confluence_id: 'p-1', title: 'T', space_key: 'DEV', author: null, last_modified_at: null, labels: [], rank: 0.5, snippet: 's', total_count: '50' }],
+          };
         }
         return { rows: [] };
       });
@@ -328,9 +322,6 @@ describe('Search Routes', () => {
             ],
           };
         }
-        if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
-          return { rows: [{ count: '1' }] };
-        }
         if (typeof sql === 'string' && sql.includes('ts_rank')) {
           return {
             rows: [{
@@ -343,6 +334,7 @@ describe('Search Routes', () => {
               labels: [],
               rank: 0.9,
               snippet: 'Redis intro',
+              total_count: '1',
             }],
           };
         }
@@ -502,9 +494,6 @@ describe('Search Routes', () => {
   describe('GET /api/search — includeFacets parameter', () => {
     it('should skip facet query when includeFacets=false', async () => {
       mockQueryFn.mockImplementation((sql: string) => {
-        if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
-          return { rows: [{ count: '1' }] };
-        }
         if (typeof sql === 'string' && sql.includes('ts_rank')) {
           return {
             rows: [{
@@ -517,6 +506,7 @@ describe('Search Routes', () => {
               labels: [],
               rank: 0.8,
               snippet: 'Redis snippet',
+              total_count: '1',
             }],
           };
         }
@@ -554,9 +544,6 @@ describe('Search Routes', () => {
             ],
           };
         }
-        if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
-          return { rows: [{ count: '1' }] };
-        }
         if (typeof sql === 'string' && sql.includes('ts_rank')) {
           return {
             rows: [{
@@ -569,6 +556,7 @@ describe('Search Routes', () => {
               labels: [],
               rank: 0.5,
               snippet: 'snippet',
+              total_count: '1',
             }],
           };
         }
@@ -605,9 +593,6 @@ describe('Search Routes', () => {
               { facet: 'tag', value: 'howto', count: '5' },
             ],
           };
-        }
-        if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
-          return { rows: [{ count: '0' }] };
         }
         if (typeof sql === 'string' && sql.includes('ts_rank')) {
           return { rows: [] };

--- a/backend/src/routes/knowledge/search.ts
+++ b/backend/src/routes/knowledge/search.ts
@@ -270,18 +270,12 @@ export async function searchRoutes(fastify: FastifyInstance) {
         break;
     }
 
-    // Count total matches
-    const countResult = await query<{ count: string }>(
-      `SELECT COUNT(*) AS count FROM pages cp WHERE ${whereClause}`,
-      values,
-    );
-    const total = parseInt(countResult.rows[0].count, 10);
-
-    // Fetch paginated FTS results with rank and snippet
+    // Run FTS data query (with COUNT(*) OVER() to eliminate separate count query),
+    // trigram query, and facet query in parallel since they are independent.
     const limitParamIndex = paramIndex;
     const offsetParamIndex = paramIndex + 1;
 
-    const dataResult = await query<{
+    const dataQueryPromise = query<{
       id: number;
       confluence_id: string;
       title: string;
@@ -291,12 +285,14 @@ export async function searchRoutes(fastify: FastifyInstance) {
       labels: string[];
       rank: number;
       snippet: string;
+      total_count: string;
     }>(
       `SELECT cp.id, cp.confluence_id, cp.title, cp.space_key, cp.author,
               cp.last_modified_at, cp.labels,
               ts_rank(cp.tsv, plainto_tsquery('${ftsLang}', $1)) AS rank,
               ts_headline('${ftsLang}', COALESCE(cp.body_text, ''), plainto_tsquery('${ftsLang}', $1),
-                          'MaxWords=30, MinWords=15, StartSel=<mark>, StopSel=</mark>') AS snippet
+                          'MaxWords=30, MinWords=15, StartSel=<mark>, StopSel=</mark>') AS snippet,
+              COUNT(*) OVER() AS total_count
        FROM pages cp
        WHERE ${whereClause}
        ORDER BY ${orderClause}
@@ -306,7 +302,7 @@ export async function searchRoutes(fastify: FastifyInstance) {
 
     // Path B: Fuzzy title matching via pg_trgm (separate from FTS)
     // Merges additional title-match results that the FTS query may have missed.
-    const trgmResult = await query<{
+    const trgmQueryPromise = query<{
       id: number;
       confluence_id: string;
       title: string;
@@ -330,6 +326,59 @@ export async function searchRoutes(fastify: FastifyInstance) {
        LIMIT $5`,
       [q, searchSpaces, userId, TRGM_SIMILARITY_THRESHOLD, limit],
     );
+
+    // Facet aggregation — opt-in via includeFacets (default: true).
+    // Skipping facets avoids 3 UNION ALL subqueries when the caller doesn't need them.
+    const facetQueryPromise = includeFacets
+      ? query<{ facet: string; value: string; count: string }>(
+          `SELECT 'space' AS facet, cp.space_key AS value, COUNT(*)::TEXT AS count
+           FROM pages cp
+           WHERE cp.tsv @@ plainto_tsquery('${ftsLang}', $1)
+             AND (
+               (cp.source = 'confluence' AND cp.space_key = ANY($2::text[]))
+               OR (cp.source = 'standalone' AND cp.visibility = 'shared')
+               OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $3)
+             )
+             AND cp.deleted_at IS NULL
+             AND cp.space_key IS NOT NULL
+           GROUP BY cp.space_key
+           UNION ALL
+           SELECT 'author' AS facet, cp.author AS value, COUNT(*)::TEXT AS count
+           FROM pages cp
+           WHERE cp.tsv @@ plainto_tsquery('${ftsLang}', $1)
+             AND (
+               (cp.source = 'confluence' AND cp.space_key = ANY($2::text[]))
+               OR (cp.source = 'standalone' AND cp.visibility = 'shared')
+               OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $3)
+             )
+             AND cp.deleted_at IS NULL
+             AND cp.author IS NOT NULL
+           GROUP BY cp.author
+           UNION ALL
+           SELECT 'tag' AS facet, tag AS value, COUNT(*)::TEXT AS count
+           FROM pages cp
+           CROSS JOIN unnest(cp.labels) AS tag
+           WHERE cp.tsv @@ plainto_tsquery('${ftsLang}', $1)
+             AND (
+               (cp.source = 'confluence' AND cp.space_key = ANY($2::text[]))
+               OR (cp.source = 'standalone' AND cp.visibility = 'shared')
+               OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $3)
+             )
+             AND cp.deleted_at IS NULL
+           GROUP BY tag`,
+          [q, searchSpaces, userId],
+        )
+      : Promise.resolve({ rows: [] as Array<{ facet: string; value: string; count: string }> });
+
+    // Execute all three queries in parallel
+    const [dataResult, trgmResult, facetResult] = await Promise.all([
+      dataQueryPromise,
+      trgmQueryPromise,
+      facetQueryPromise,
+    ]);
+
+    // Extract total from window function (available on every row, take from first)
+    const total = dataResult.rows.length > 0 ? parseInt(dataResult.rows[0].total_count, 10) : 0;
 
     // Merge: start with FTS results (higher weight), add trgm-only hits
     const ftsItems = dataResult.rows.map((row) => ({
@@ -369,71 +418,25 @@ export async function searchRoutes(fastify: FastifyInstance) {
     const maxFtsScore = ftsItems.length > 0 ? Math.max(...ftsItems.map((r) => r.rank)) : null;
     recordSearchAnalytics(userId, q, ftsItems.length, maxFtsScore, 'keyword').catch(() => {});
 
-    // Facet aggregation — opt-in via includeFacets (default: true).
-    // Skipping facets avoids 3 UNION ALL subqueries when the caller doesn't need them.
+    // Parse facets from result
     const facets: Record<string, Array<{ value: string; count: number }>> = {
       spaces: [],
       authors: [],
       tags: [],
     };
 
-    if (includeFacets) {
-      const facetResult = await query<{
-        facet: string;
-        value: string;
-        count: string;
-      }>(
-        `SELECT 'space' AS facet, cp.space_key AS value, COUNT(*)::TEXT AS count
-         FROM pages cp
-         WHERE cp.tsv @@ plainto_tsquery('${ftsLang}', $1)
-           AND (
-             (cp.source = 'confluence' AND cp.space_key = ANY($2::text[]))
-             OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-             OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $3)
-           )
-           AND cp.deleted_at IS NULL
-           AND cp.space_key IS NOT NULL
-         GROUP BY cp.space_key
-         UNION ALL
-         SELECT 'author' AS facet, cp.author AS value, COUNT(*)::TEXT AS count
-         FROM pages cp
-         WHERE cp.tsv @@ plainto_tsquery('${ftsLang}', $1)
-           AND (
-             (cp.source = 'confluence' AND cp.space_key = ANY($2::text[]))
-             OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-             OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $3)
-           )
-           AND cp.deleted_at IS NULL
-           AND cp.author IS NOT NULL
-         GROUP BY cp.author
-         UNION ALL
-         SELECT 'tag' AS facet, tag AS value, COUNT(*)::TEXT AS count
-         FROM pages cp
-         CROSS JOIN unnest(cp.labels) AS tag
-         WHERE cp.tsv @@ plainto_tsquery('${ftsLang}', $1)
-           AND (
-             (cp.source = 'confluence' AND cp.space_key = ANY($2::text[]))
-             OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-             OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $3)
-           )
-           AND cp.deleted_at IS NULL
-         GROUP BY tag`,
-        [q, searchSpaces, userId],
-      );
-
-      for (const row of facetResult.rows) {
-        const entry = { value: row.value, count: parseInt(row.count, 10) };
-        switch (row.facet) {
-          case 'space':
-            facets.spaces.push(entry);
-            break;
-          case 'author':
-            facets.authors.push(entry);
-            break;
-          case 'tag':
-            facets.tags.push(entry);
-            break;
-        }
+    for (const row of facetResult.rows) {
+      const entry = { value: row.value, count: parseInt(row.count, 10) };
+      switch (row.facet) {
+        case 'space':
+          facets.spaces.push(entry);
+          break;
+        case 'author':
+          facets.authors.push(entry);
+          break;
+        case 'tag':
+          facets.tags.push(entry);
+          break;
       }
     }
 


### PR DESCRIPTION
## Summary
- Wrap the FTS data query, trigram title query, and facet query in `Promise.all()` since they are independent
- Eliminate the separate `SELECT COUNT(*)` query by using `COUNT(*) OVER()` window function in the data query
- Reduces keyword search from 4 sequential queries to 3 parallel queries (measured latency improvement scales with DB round-trip time)

## Test plan
- [x] All 22 search.test.ts tests pass
- [x] Updated mocks to include `total_count` field from window function
- [x] Verified facet, filter, sort, and pagination behavior unchanged
- [x] `includeFacets=false` still skips the facet query

🤖 Generated with [Claude Code](https://claude.com/claude-code)