### PR TITLE
perf: batch admin settings upserts and deletes (#73, #80)

### DIFF
--- a/backend/src/core/services/admin-settings-service.test.ts
+++ b/backend/src/core/services/admin-settings-service.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Use vi.hoisted to create mocks that are available in vi.mock factories
+const { mockClientQuery, mockClientRelease } = vi.hoisted(() => ({
+  mockClientQuery: vi.fn(),
+  mockClientRelease: vi.fn(),
+}));
+
+vi.mock('../db/postgres.js', () => ({
+  query: vi.fn(),
+  getPool: vi.fn().mockReturnValue({
+    connect: vi.fn().mockResolvedValue({
+      query: (...args: unknown[]) => mockClientQuery(...args),
+      release: mockClientRelease,
+    }),
+  }),
+  runMigrations: vi.fn(),
+  closePool: vi.fn(),
+}));
+
+vi.mock('../utils/crypto.js', () => ({
+  encryptPat: vi.fn((val: string) => `encrypted:${val}`),
+  decryptPat: vi.fn((val: string) => val.replace('encrypted:', '')),
+}));
+
+import { upsertSharedLlmSettings } from './admin-settings-service.js';
+
+describe('upsertSharedLlmSettings - batch operations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClientQuery.mockResolvedValue({ rows: [] });
+  });
+
+  it('should batch upserts into a single INSERT...ON CONFLICT with unnest()', async () => {
+    await upsertSharedLlmSettings({
+      llmProvider: 'openai',
+      ollamaModel: 'llama3',
+      openaiModel: 'gpt-4',
+    });
+
+    // Expect: BEGIN, batch INSERT, COMMIT
+    const calls = mockClientQuery.mock.calls.map((c) => String(c[0]));
+    expect(calls[0]).toBe('BEGIN');
+
+    // The unnest batch INSERT
+    const insertCall = calls.find((sql) => sql.includes('unnest'));
+    expect(insertCall).toBeDefined();
+    expect(insertCall).toContain('INSERT INTO admin_settings');
+    expect(insertCall).toContain('ON CONFLICT');
+
+    // Verify the keys and values were passed as arrays
+    const insertArgs = mockClientQuery.mock.calls.find(
+      (c) => String(c[0]).includes('unnest'),
+    );
+    expect(insertArgs![1]).toEqual([
+      ['llm_provider', 'ollama_model', 'openai_model'],
+      ['openai', 'llama3', 'gpt-4'],
+    ]);
+
+    // No individual INSERT loops
+    const individualInserts = calls.filter(
+      (sql) => sql.includes('INSERT') && !sql.includes('unnest') && sql !== 'BEGIN',
+    );
+    expect(individualInserts).toHaveLength(0);
+
+    expect(calls[calls.length - 1]).toBe('COMMIT');
+  });
+
+  it('should batch deletes into a single DELETE with ANY()', async () => {
+    await upsertSharedLlmSettings({
+      openaiBaseUrl: '',
+      openaiApiKey: '',
+      openaiModel: '',
+    });
+
+    const calls = mockClientQuery.mock.calls.map((c) => String(c[0]));
+
+    // The batch DELETE with ANY()
+    const deleteCall = calls.find((sql) => sql.includes('ANY'));
+    expect(deleteCall).toBeDefined();
+    expect(deleteCall).toContain('DELETE FROM admin_settings');
+    expect(deleteCall).toContain('ANY($1::text[])');
+
+    // Verify the keys were passed as a single array
+    const deleteArgs = mockClientQuery.mock.calls.find(
+      (c) => String(c[0]).includes('ANY'),
+    );
+    expect(deleteArgs![1]).toEqual([['openai_base_url', 'openai_api_key', 'openai_model']]);
+
+    // No individual DELETE queries
+    const individualDeletes = calls.filter(
+      (sql) => sql.includes('DELETE') && !sql.includes('ANY'),
+    );
+    expect(individualDeletes).toHaveLength(0);
+  });
+
+  it('should handle mixed upserts and deletes in a single transaction', async () => {
+    await upsertSharedLlmSettings({
+      llmProvider: 'ollama',
+      openaiBaseUrl: '',
+      ollamaModel: 'llama3',
+      openaiApiKey: null,
+    });
+
+    const calls = mockClientQuery.mock.calls.map((c) => String(c[0]));
+    expect(calls[0]).toBe('BEGIN');
+
+    // Should have both batch INSERT and batch DELETE
+    expect(calls.some((sql) => sql.includes('unnest'))).toBe(true);
+    expect(calls.some((sql) => sql.includes('ANY'))).toBe(true);
+
+    expect(calls[calls.length - 1]).toBe('COMMIT');
+  });
+
+  it('should rollback on error', async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({})  // BEGIN
+      .mockRejectedValueOnce(new Error('DB error')); // INSERT fails
+
+    await expect(
+      upsertSharedLlmSettings({ llmProvider: 'ollama' }),
+    ).rejects.toThrow('DB error');
+
+    const calls = mockClientQuery.mock.calls.map((c) => String(c[0]));
+    expect(calls).toContain('ROLLBACK');
+    expect(mockClientRelease).toHaveBeenCalled();
+  });
+});

--- a/backend/src/core/services/admin-settings-service.ts
+++ b/backend/src/core/services/admin-settings-service.ts
@@ -87,56 +87,70 @@ export async function upsertSharedLlmSettings(
   try {
     await client.query('BEGIN');
 
-    const rows: Array<{ key: string; value: string }> = [];
+    const upsertRows: Array<{ key: string; value: string }> = [];
+    const deleteKeys: string[] = [];
 
     if (updates.llmProvider !== undefined) {
-      rows.push({ key: 'llm_provider', value: updates.llmProvider });
+      upsertRows.push({ key: 'llm_provider', value: updates.llmProvider });
     }
     if (updates.ollamaModel !== undefined) {
-      rows.push({ key: 'ollama_model', value: updates.ollamaModel });
+      upsertRows.push({ key: 'ollama_model', value: updates.ollamaModel });
     }
     if (updates.openaiBaseUrl !== undefined) {
       if (updates.openaiBaseUrl) {
-        rows.push({ key: 'openai_base_url', value: updates.openaiBaseUrl });
+        upsertRows.push({ key: 'openai_base_url', value: updates.openaiBaseUrl });
       } else {
-        await client.query(`DELETE FROM admin_settings WHERE setting_key = 'openai_base_url'`);
+        deleteKeys.push('openai_base_url');
       }
     }
     if (updates.openaiApiKey !== undefined) {
       if (updates.openaiApiKey) {
-        rows.push({ key: 'openai_api_key', value: encryptPat(updates.openaiApiKey) });
+        upsertRows.push({ key: 'openai_api_key', value: encryptPat(updates.openaiApiKey) });
       } else {
-        await client.query(`DELETE FROM admin_settings WHERE setting_key = 'openai_api_key'`);
+        deleteKeys.push('openai_api_key');
       }
     }
     if (updates.openaiModel !== undefined) {
       if (updates.openaiModel) {
-        rows.push({ key: 'openai_model', value: updates.openaiModel });
+        upsertRows.push({ key: 'openai_model', value: updates.openaiModel });
       } else {
-        await client.query(`DELETE FROM admin_settings WHERE setting_key = 'openai_model'`);
+        deleteKeys.push('openai_model');
       }
     }
     if (updates.embeddingModel !== undefined) {
       if (updates.embeddingModel) {
-        rows.push({ key: 'embedding_model', value: updates.embeddingModel });
+        upsertRows.push({ key: 'embedding_model', value: updates.embeddingModel });
       } else {
-        await client.query(`DELETE FROM admin_settings WHERE setting_key = 'embedding_model'`);
+        deleteKeys.push('embedding_model');
       }
     }
     if (updates.ftsLanguage !== undefined) {
       if (updates.ftsLanguage) {
-        rows.push({ key: 'fts_language', value: updates.ftsLanguage });
+        upsertRows.push({ key: 'fts_language', value: updates.ftsLanguage });
       } else {
-        await client.query(`DELETE FROM admin_settings WHERE setting_key = 'fts_language'`);
+        deleteKeys.push('fts_language');
       }
     }
 
-    for (const row of rows) {
+    // Batch upsert: single INSERT...ON CONFLICT using unnest() (#73)
+    if (upsertRows.length > 0) {
+      const keys = upsertRows.map((r) => r.key);
+      const values = upsertRows.map((r) => r.value);
       await client.query(
         `INSERT INTO admin_settings (setting_key, setting_value, updated_at)
-         VALUES ($1, $2, NOW())
-         ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2, updated_at = NOW()`,
-        [row.key, row.value],
+         SELECT key, value, NOW()
+         FROM unnest($1::text[], $2::text[]) AS t(key, value)
+         ON CONFLICT (setting_key) DO UPDATE
+         SET setting_value = EXCLUDED.setting_value, updated_at = NOW()`,
+        [keys, values],
+      );
+    }
+
+    // Batch delete: single DELETE with ANY() (#80)
+    if (deleteKeys.length > 0) {
+      await client.query(
+        `DELETE FROM admin_settings WHERE setting_key = ANY($1::text[])`,
+        [deleteKeys],
       );
     }
 


### PR DESCRIPTION
## Summary
- **#73**: Replace the individual `INSERT...ON CONFLICT` loop with a single `INSERT` using `unnest($1::text[], $2::text[])` for batch upserts
- **#80**: Replace individual `DELETE` queries with a single `DELETE WHERE setting_key = ANY($1::text[])` for batch deletes
- Reduces N+M individual queries to at most 2 queries (one batch upsert, one batch delete) within the same transaction

## Test plan
- [x] New `admin-settings-service.test.ts` with 4 tests
- [x] Verifies batch upsert uses `unnest()` with array parameters
- [x] Verifies batch delete uses `ANY()` with array parameter
- [x] Verifies mixed upserts and deletes work in a single transaction
- [x] Verifies rollback on error with client release

🤖 Generated with [Claude Code](https://claude.com/claude-code)