### PR TITLE
chore: add missing .claudeignore entries

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,9 +1,15 @@
 .gitignore
 backend/node_modules/
+backend/node_modules.old/
 backend/dist/
 frontend/node_modules/
 frontend/dist/
 packages/*/node_modules/
 packages/*/dist/
+mcp-docs/node_modules/
+mcp-docs/dist/
 *.log
 .git/
+coverage/
+playwright-report/
+test-results/


### PR DESCRIPTION
## Summary
- Adds `playwright-report/`, `test-results/`, `coverage/` (build/test artifacts)
- Adds `mcp-docs/node_modules/`, `mcp-docs/dist/` (mcp-docs workspace)
- Adds `backend/node_modules.old/` (stale vendored files)
- Does NOT add `e2e/` -- tests are important context for Claude

Closes #86

## Test plan
- [x] `.claudeignore` contains all new entries
- [x] `e2e/` is NOT excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)