### PR TITLE
feat: add distributed worker locks via Redis (#111)

### DIFF
--- a/backend/src/core/services/redis-cache.test.ts
+++ b/backend/src/core/services/redis-cache.test.ts
@@ -16,6 +16,8 @@ import {
   clearAttachmentFailures,
   MAX_ATTACHMENT_FAILURES,
   RedisCache,
+  acquireWorkerLock,
+  releaseWorkerLock,
 } from './redis-cache.js';
 
 /**
@@ -331,6 +333,78 @@ describe('redis-cache embedding lock', () => {
       expect(mockRedis.eval.mock.calls[0][1]).toEqual(
         expect.objectContaining({ keys: ['embedding:lock:test-user'] }),
       );
+    });
+  });
+
+  describe('acquireWorkerLock', () => {
+    it('returns true when lock is acquired (SET NX returns OK)', async () => {
+      mockRedis.set.mockResolvedValue('OK');
+
+      const acquired = await acquireWorkerLock('quality-worker');
+
+      expect(acquired).toBe(true);
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        'worker:lock:quality-worker',
+        '1',
+        { NX: true, EX: 300 },
+      );
+    });
+
+    it('returns false when lock is already held', async () => {
+      mockRedis.set.mockResolvedValue(null);
+
+      const acquired = await acquireWorkerLock('quality-worker');
+
+      expect(acquired).toBe(false);
+    });
+
+    it('uses custom TTL when provided', async () => {
+      mockRedis.set.mockResolvedValue('OK');
+
+      await acquireWorkerLock('summary-worker', 600);
+
+      const call = mockRedis.set.mock.calls[0];
+      expect(call[2]).toEqual({ NX: true, EX: 600 });
+    });
+
+    it('falls back to true when Redis is not available', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setRedisClient(null as any);
+
+      const acquired = await acquireWorkerLock('test-worker');
+
+      expect(acquired).toBe(true);
+    });
+
+    it('falls back to true when Redis throws', async () => {
+      mockRedis.set.mockRejectedValue(new Error('Redis down'));
+
+      const acquired = await acquireWorkerLock('test-worker');
+
+      expect(acquired).toBe(true);
+    });
+  });
+
+  describe('releaseWorkerLock', () => {
+    it('deletes the lock key', async () => {
+      mockRedis.del.mockResolvedValue(1);
+
+      await releaseWorkerLock('quality-worker');
+
+      expect(mockRedis.del).toHaveBeenCalledWith('worker:lock:quality-worker');
+    });
+
+    it('is a no-op when Redis is not available', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setRedisClient(null as any);
+
+      await expect(releaseWorkerLock('test-worker')).resolves.toBeUndefined();
+    });
+
+    it('does not throw when Redis throws', async () => {
+      mockRedis.del.mockRejectedValue(new Error('Redis timeout'));
+
+      await expect(releaseWorkerLock('test-worker')).resolves.toBeUndefined();
     });
   });
 });

--- a/backend/src/core/services/redis-cache.ts
+++ b/backend/src/core/services/redis-cache.ts
@@ -109,6 +109,44 @@ export async function isEmbeddingLocked(userId: string): Promise<boolean> {
   }
 }
 
+// ── Generic worker lock (distributed via Redis) ──────────────────────────
+// Provides a simple distributed lock for background workers (quality, summary,
+// token-cleanup) so that only one process runs a given worker at a time.
+// Falls back to returning true (lock acquired) when Redis is unavailable,
+// preserving single-node behaviour.
+
+/**
+ * Attempt to acquire a named worker lock via Redis SET NX EX.
+ * Returns true if the lock was acquired, false if another holder has it.
+ * Falls back to true when Redis is not available (single-node fallback).
+ */
+export async function acquireWorkerLock(name: string, ttlSeconds = 300): Promise<boolean> {
+  if (!_redisClient) return true; // single-node fallback
+  try {
+    const result = await _redisClient.set(`worker:lock:${name}`, '1', {
+      NX: true,
+      EX: ttlSeconds,
+    });
+    return result !== null;
+  } catch (err) {
+    logger.error({ err, name }, 'Failed to acquire worker lock');
+    return true; // degrade to local execution
+  }
+}
+
+/**
+ * Release a named worker lock.
+ * Safe to call when Redis is unavailable (no-op).
+ */
+export async function releaseWorkerLock(name: string): Promise<void> {
+  if (!_redisClient) return;
+  try {
+    await _redisClient.del(`worker:lock:${name}`);
+  } catch (err) {
+    logger.error({ err, name }, 'Failed to release worker lock');
+  }
+}
+
 // ── Attachment download-failure tracking (persisted in Redis) ──────────────
 // Tracks per-attachment download failures so we can skip Confluence calls
 // for attachments that have persistently failed, even across container restarts.

--- a/backend/src/core/services/token-cleanup-service.ts
+++ b/backend/src/core/services/token-cleanup-service.ts
@@ -8,6 +8,7 @@
 
 import { cleanupExpiredTokens } from '../plugins/auth.js';
 import { logger } from '../utils/logger.js';
+import { acquireWorkerLock, releaseWorkerLock } from './redis-cache.js';
 
 // ─── State ────────────────────────────────────────────────────────────────────
 
@@ -39,6 +40,8 @@ export function startTokenCleanupWorker(): void {
 
   cleanupIntervalHandle = setInterval(async () => {
     if (cleanupLock) return;
+    const acquired = await acquireWorkerLock('token-cleanup', 300);
+    if (!acquired) return;
     cleanupLock = true;
 
     try {
@@ -48,6 +51,7 @@ export function startTokenCleanupWorker(): void {
       logger.error({ err }, 'Token cleanup worker error');
     } finally {
       cleanupLock = false;
+      await releaseWorkerLock('token-cleanup');
     }
   }, intervalHours * 60 * 60 * 1000);
 

--- a/backend/src/domains/knowledge/services/quality-worker.ts
+++ b/backend/src/domains/knowledge/services/quality-worker.ts
@@ -12,6 +12,7 @@ import { sanitizeLlmInput } from '../../../core/utils/sanitize-llm-input.js';
 import { htmlToMarkdown } from '../../../core/services/content-converter.js';
 import { logger } from '../../../core/utils/logger.js';
 import { getSharedLlmSettings } from '../../../core/services/admin-settings-service.js';
+import { acquireWorkerLock, releaseWorkerLock } from '../../../core/services/redis-cache.js';
 
 // ─── Configuration ────────────────────────────────────────────────────────────
 
@@ -321,6 +322,8 @@ export function startQualityWorker(intervalMinutes?: number): void {
 
   qualityIntervalHandle = setInterval(async () => {
     if (qualityLock) return;
+    const acquired = await acquireWorkerLock('quality-worker', 600);
+    if (!acquired) return;
     qualityLock = true;
     isProcessing = true;
 
@@ -334,6 +337,7 @@ export function startQualityWorker(intervalMinutes?: number): void {
     } finally {
       qualityLock = false;
       isProcessing = false;
+      await releaseWorkerLock('quality-worker');
     }
   }, intervalMs);
 
@@ -346,6 +350,8 @@ export function startQualityWorker(intervalMinutes?: number): void {
  */
 export async function triggerQualityBatch(): Promise<void> {
   if (qualityLock) return;
+  const acquired = await acquireWorkerLock('quality-worker', 600);
+  if (!acquired) return;
   qualityLock = true;
   isProcessing = true;
 
@@ -359,6 +365,7 @@ export async function triggerQualityBatch(): Promise<void> {
   } finally {
     qualityLock = false;
     isProcessing = false;
+    await releaseWorkerLock('quality-worker');
   }
 }
 

--- a/backend/src/domains/knowledge/services/summary-worker.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.ts
@@ -16,6 +16,7 @@ import { query } from '../../../core/db/postgres.js';
 import { summarizeContent } from '../../llm/services/ollama-service.js';
 import { logger } from '../../../core/utils/logger.js';
 import { getSharedLlmSettings } from '../../../core/services/admin-settings-service.js';
+import { acquireWorkerLock, releaseWorkerLock } from '../../../core/services/redis-cache.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -333,6 +334,8 @@ export function startSummaryWorker(intervalMinutes?: number): void {
 
   workerIntervalHandle = setInterval(async () => {
     if (workerLock) return;
+    const acquired = await acquireWorkerLock('summary-worker', 600);
+    if (!acquired) return;
     workerLock = true;
     isProcessing = true;
 
@@ -346,6 +349,7 @@ export function startSummaryWorker(intervalMinutes?: number): void {
     } finally {
       workerLock = false;
       isProcessing = false;
+      await releaseWorkerLock('summary-worker');
     }
   }, interval);
 
@@ -361,6 +365,8 @@ export function startSummaryWorker(intervalMinutes?: number): void {
  */
 export async function triggerSummaryBatch(): Promise<void> {
   if (workerLock) return;
+  const acquired = await acquireWorkerLock('summary-worker', 600);
+  if (!acquired) return;
   workerLock = true;
   isProcessing = true;
 
@@ -374,6 +380,7 @@ export async function triggerSummaryBatch(): Promise<void> {
   } finally {
     workerLock = false;
     isProcessing = false;
+    await releaseWorkerLock('summary-worker');
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds generic `acquireWorkerLock(name, ttl)` / `releaseWorkerLock(name)` to `redis-cache.ts`
- Uses Redis SET NX EX for atomic lock acquisition with configurable TTL
- Replaces in-memory `let lock = false` in quality-worker, summary-worker, and token-cleanup-service
- Falls back to local execution when Redis is unavailable (single-node compatibility preserved)
- In-memory guard (`workerLock`) is retained as a fast-path to avoid Redis round-trip when already running locally

## Test plan
- [x] acquireWorkerLock returns true when lock acquired (SET NX OK)
- [x] acquireWorkerLock returns false when lock already held
- [x] Custom TTL is passed through
- [x] Falls back to true when Redis unavailable
- [x] Falls back to true when Redis throws
- [x] releaseWorkerLock deletes the correct key
- [x] releaseWorkerLock is safe when Redis unavailable or throws
- [x] All 103 backend test files pass (1639 tests)

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)