### PR TITLE
feat: support comma-separated CORS origins in FRONTEND_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ REDIS_URL=redis://:changeme-redis@localhost:6379
 # --- Server ---
 NODE_ENV=development
 BACKEND_PORT=3051
-# FRONTEND_URL=http://localhost:5273    # Used for CORS origin (default: http://localhost:5273)
+# FRONTEND_URL=http://localhost:5273    # Used for CORS origin (default: http://localhost:5273). Comma-separated for multiple origins: http://localhost:5273,https://app.example.com
 # LOG_LEVEL=info                        # Pino log level: 'fatal','error','warn','info','debug','trace' (default: info)
 
 # --- Session ---

--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -88,6 +88,85 @@ vi.mock('./routes/knowledge/knowledge-requests.js', () => ({ knowledgeRequestRou
 vi.mock('./routes/knowledge/search.js', () => ({ searchRoutes: noopRoute }));
 vi.mock('./routes/knowledge/local-spaces.js', () => ({ localSpacesRoutes: noopRoute }));
 
+describe('buildApp — CORS multi-origin support', () => {
+  const originalFrontendUrl = process.env.FRONTEND_URL;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    if (originalFrontendUrl === undefined) {
+      delete process.env.FRONTEND_URL;
+    } else {
+      process.env.FRONTEND_URL = originalFrontendUrl;
+    }
+  });
+
+  it('should default to http://localhost:5273 when FRONTEND_URL is unset', async () => {
+    delete process.env.FRONTEND_URL;
+    process.env.NODE_ENV = 'development';
+    const { buildApp } = await import('./app.js');
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'OPTIONS',
+      url: '/api/health',
+      headers: { origin: 'http://localhost:5273' },
+    });
+    expect(res.headers['access-control-allow-origin']).toBe('http://localhost:5273');
+
+    await app.close();
+  });
+
+  it('should accept a single custom origin', async () => {
+    process.env.FRONTEND_URL = 'https://app.example.com';
+    process.env.NODE_ENV = 'development';
+    const { buildApp } = await import('./app.js');
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'OPTIONS',
+      url: '/api/health',
+      headers: { origin: 'https://app.example.com' },
+    });
+    expect(res.headers['access-control-allow-origin']).toBe('https://app.example.com');
+
+    await app.close();
+  });
+
+  it('should accept comma-separated origins', async () => {
+    process.env.FRONTEND_URL = 'http://localhost:5273, https://app.example.com';
+    process.env.NODE_ENV = 'development';
+    const { buildApp } = await import('./app.js');
+    const app = await buildApp();
+
+    // First origin
+    const res1 = await app.inject({
+      method: 'OPTIONS',
+      url: '/api/health',
+      headers: { origin: 'http://localhost:5273' },
+    });
+    expect(res1.headers['access-control-allow-origin']).toBe('http://localhost:5273');
+
+    // Second origin
+    const res2 = await app.inject({
+      method: 'OPTIONS',
+      url: '/api/health',
+      headers: { origin: 'https://app.example.com' },
+    });
+    expect(res2.headers['access-control-allow-origin']).toBe('https://app.example.com');
+
+    // Unknown origin should not be reflected
+    const res3 = await app.inject({
+      method: 'OPTIONS',
+      url: '/api/health',
+      headers: { origin: 'https://evil.example.com' },
+    });
+    expect(res3.headers['access-control-allow-origin']).not.toBe('https://evil.example.com');
+
+    await app.close();
+  });
+});
+
 describe('buildApp — Swagger UI gating', () => {
   const originalNodeEnv = process.env.NODE_ENV;
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -72,9 +72,15 @@ export async function buildApp() {
   app.setValidatorCompiler(validatorCompiler);
   app.setSerializerCompiler(serializerCompiler);
 
-  // Core plugins
+  // Core plugins — CORS with multi-origin support (comma-separated FRONTEND_URL)
+  const frontendUrls = (process.env.FRONTEND_URL ?? 'http://localhost:5273')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const corsOrigin = frontendUrls.length === 1 ? frontendUrls[0] : frontendUrls;
+
   await app.register(cors, {
-    origin: process.env.FRONTEND_URL ?? 'http://localhost:5273',
+    origin: corsOrigin,
     credentials: true,
   });
 


### PR DESCRIPTION
## Summary
- Parses `FRONTEND_URL` as comma-separated so multiple domains can be allowed (e.g. `http://localhost:5273,https://app.example.com`)
- A single value works exactly as before (no behavior change for existing deployments)
- Updates `.env.example` with documentation of the new format

Closes #90

## Changes
- `backend/src/app.ts`: Split `FRONTEND_URL` on commas, pass array to `@fastify/cors` when multiple origins
- `backend/src/app.test.ts`: 3 new tests (default origin, single custom origin, comma-separated multi-origin with unknown-origin rejection)
- `.env.example`: Documents comma-separated format

## Test plan
- [x] `npx vitest run src/app.test.ts` -- 5 tests pass (3 new + 2 existing)
- [x] Single origin still works (backward compatible)
- [x] Comma-separated origins are individually validated
- [x] Unknown origins are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)