### PR TITLE
perf: batch DB operations in embedding service (#78)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,7 @@ BACKEND_PORT=3051
 OLLAMA_BASE_URL=http://localhost:11434
 EMBEDDING_MODEL=bge-m3
 # EMBEDDING_DIMENSIONS=1024            # Vector dimensions — must match the embedding model output
+# EMBEDDING_CONCURRENCY=1              # Pages to embed concurrently (default: 1, sequential)
 # FTS_LANGUAGE=simple                   # Full-text search language: simple, english, german, french, etc.
 # BGE-M3 via Ollama (1024 dims). Run: ollama pull bge-m3
 # LLM_BEARER_TOKEN=           # Optional: Bearer token for authenticated Ollama/LLM proxies

--- a/backend/src/domains/llm/services/embedding-service.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.test.ts
@@ -451,11 +451,9 @@ describe('embedding-service', () => {
       // Batch SELECT returns 3 pages
       const pages = [makePage('p1'), makePage('p2'), makePage('p3')];
       mocks.query.mockResolvedValueOnce({ rows: pages });
-      // For each page: only mark embedding goes through pool query()
+      // Batch UPDATE: mark all pages as 'embedding' in one query (via ANY($1::int[]))
       // Phase 2 (BEGIN/DELETE/INSERT×N/UPDATE/COMMIT) handled by mockClient.query default
-      for (let i = 0; i < 3; i++) {
-        mocks.query.mockResolvedValueOnce({ rows: [] }); // UPDATE embedding_status='embedding'
-      }
+      mocks.query.mockResolvedValueOnce({ rows: [] }); // batch UPDATE embedding_status='embedding'
       // computePageRelationships (post-embed hook) handled by mockClient.query default
       // Batch was < DIRTY_PAGE_BATCH_SIZE so loop breaks after first batch
 

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -16,6 +16,16 @@ export const CHUNK_HARD_LIMIT = 6_000;  // absolute character ceiling (~1,500–
 /** Delay between embedding pages to reduce LLM server pressure (ms). */
 export const INTER_PAGE_DELAY_MS = 200;
 
+/**
+ * Number of pages to embed concurrently within a batch.
+ * Default 1 (sequential) to respect LLM rate limits.
+ * Increase only if the embedding server supports parallel requests.
+ */
+export const EMBEDDING_CONCURRENCY = Math.max(
+  1,
+  parseInt(process.env.EMBEDDING_CONCURRENCY ?? '1', 10) || 1,
+);
+
 /** Max retries when circuit breaker is open before stopping the batch. */
 export const MAX_CIRCUIT_BREAKER_RETRIES = 3;
 
@@ -474,13 +484,15 @@ export async function processDirtyPages(
       let batchErrors = 0;
       const batchTotal = totalDirty; // Use totalDirty for progress percentage
 
+      // Batch-mark all pages in this DB batch as 'embedding' in a single UPDATE
+      const batchPageIds = batch.rows.map((p) => p.id);
+      await query(
+        `UPDATE pages SET embedding_status = 'embedding', embedding_error = NULL WHERE id = ANY($1::int[])`,
+        [batchPageIds],
+      );
+
       for (const page of batch.rows) {
         try {
-          // Mark page as currently embedding and clear any previous error
-          await query(
-            `UPDATE pages SET embedding_status = 'embedding', embedding_error = NULL WHERE id = $1`,
-            [page.id],
-          );
 
           await embedPage(userId, page.id, page.title, page.space_key, page.body_html, chunkOpts);
           totalProcessed++;


### PR DESCRIPTION
## Summary
- Replaces per-page `UPDATE pages SET embedding_status = 'embedding'` with a single batch `UPDATE ... WHERE id = ANY($1::int[])` per DB batch
- Reduces DB round-trips from N to 1 per batch (N = up to 100 pages per batch)
- Adds `EMBEDDING_CONCURRENCY` env var (default: 1) for future parallel embedding support
- Sequential page processing preserved (LLM rate limiting needed)
- #89 skipped per instructions (already done in quick-wins PR #117)

## Test plan
- [x] All 70 embedding service tests pass
- [x] Test updated to reflect batch UPDATE pattern (1 call instead of N)
- [x] `npm run typecheck` passes

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)