### PR TITLE
feat: CORS multi-origin support via comma-separated FRONTEND_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@ REDIS_URL=redis://:changeme-redis@localhost:6379
 # --- Server ---
 NODE_ENV=development
 BACKEND_PORT=3051
-# FRONTEND_URL=http://localhost:5273    # Used for CORS origin (default: http://localhost:5273)
+# FRONTEND_URL=http://localhost:5273    # Used for CORS origin (default: http://localhost:5273). Comma-separated for multiple origins: http://localhost:5273,https://app.example.com
 # LOG_LEVEL=info                        # Pino log level: 'fatal','error','warn','info','debug','trace' (default: info)
 
 # --- Session ---

--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -87,6 +87,74 @@ vi.mock('./routes/knowledge/verification.js', () => ({ verificationRoutes: noopR
 vi.mock('./routes/knowledge/knowledge-requests.js', () => ({ knowledgeRequestRoutes: noopRoute }));
 vi.mock('./routes/knowledge/search.js', () => ({ searchRoutes: noopRoute }));
 vi.mock('./routes/knowledge/local-spaces.js', () => ({ localSpacesRoutes: noopRoute }));
+vi.mock('./routes/foundation/setup.js', () => ({ setupRoutes: noopRoute }));
+
+describe('buildApp — CORS multi-origin support', () => {
+  const originalFrontendUrl = process.env.FRONTEND_URL;
+
+  afterEach(() => {
+    if (originalFrontendUrl === undefined) {
+      delete process.env.FRONTEND_URL;
+    } else {
+      process.env.FRONTEND_URL = originalFrontendUrl;
+    }
+  });
+
+  it('should allow a single CORS origin', async () => {
+    process.env.FRONTEND_URL = 'https://app.example.com';
+    const { buildApp } = await import('./app.js');
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: 'OPTIONS',
+      url: '/api/health',
+      headers: { origin: 'https://app.example.com' },
+    });
+
+    expect(response.headers['access-control-allow-origin']).toBe('https://app.example.com');
+    await app.close();
+  });
+
+  it('should allow multiple CORS origins (comma-separated)', async () => {
+    process.env.FRONTEND_URL = 'https://app.example.com, https://staging.example.com';
+    const { buildApp } = await import('./app.js');
+    const app = await buildApp();
+
+    // First origin
+    const res1 = await app.inject({
+      method: 'OPTIONS',
+      url: '/api/health',
+      headers: { origin: 'https://app.example.com' },
+    });
+    expect(res1.headers['access-control-allow-origin']).toBe('https://app.example.com');
+
+    // Second origin
+    const res2 = await app.inject({
+      method: 'OPTIONS',
+      url: '/api/health',
+      headers: { origin: 'https://staging.example.com' },
+    });
+    expect(res2.headers['access-control-allow-origin']).toBe('https://staging.example.com');
+
+    await app.close();
+  });
+
+  it('should reject unknown origins when multiple are configured', async () => {
+    process.env.FRONTEND_URL = 'https://app.example.com, https://staging.example.com';
+    const { buildApp } = await import('./app.js');
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: 'OPTIONS',
+      url: '/api/health',
+      headers: { origin: 'https://evil.example.com' },
+    });
+
+    // @fastify/cors returns false/empty for disallowed origins
+    expect(response.headers['access-control-allow-origin']).not.toBe('https://evil.example.com');
+    await app.close();
+  });
+});
 
 describe('buildApp — error handler information leakage', () => {
   const originalNodeEnv = process.env.NODE_ENV;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -72,9 +72,15 @@ export async function buildApp() {
   app.setValidatorCompiler(validatorCompiler);
   app.setSerializerCompiler(serializerCompiler);
 
-  // Core plugins
+  // Core plugins — CORS origin supports comma-separated FRONTEND_URL
+  const frontendUrls = (process.env.FRONTEND_URL ?? 'http://localhost:5273')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const corsOrigin = frontendUrls.length === 1 ? frontendUrls[0] : frontendUrls;
+
   await app.register(cors, {
-    origin: process.env.FRONTEND_URL ?? 'http://localhost:5273',
+    origin: corsOrigin,
     credentials: true,
   });
 


### PR DESCRIPTION
## Summary
- Parse `FRONTEND_URL` env var as comma-separated list for multi-origin CORS support
- Single origin continues to work as a plain string; multiple origins are passed as an array to `@fastify/cors`
- Added 3 tests covering single origin, multiple origins, and rejected unknown origins
- Updated `.env.example` with comma-separated format documentation

Replaces #139 (rebased onto current `dev` to resolve merge conflicts).

## Test plan
- [x] `cd backend && npx vitest run src/app.test.ts` — all 8 tests pass
- [ ] Manual: set `FRONTEND_URL=http://localhost:5273,http://localhost:3000` and verify both origins are allowed

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>