### PR TITLE
feat: enable runtime EE frontend gating via URL-based dynamic import

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -221,6 +221,7 @@ export async function buildApp() {
     app.get('/api/admin/license', { onRequest: [app.requireAdmin] }, async () => ({
       edition: 'community',
       tier: 'community',
+      valid: true,
       features: [],
     }));
   }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import { App } from './App';
+import { EnterpriseProvider } from './shared/enterprise/context';
 import { useThemeStore, isLightTheme } from './stores/theme-store';
 import { createQueryClient } from './shared/lib/query-client';
 import './index.css';
@@ -34,8 +35,10 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <App />
-        <ThemedToaster />
+        <EnterpriseProvider>
+          <App />
+          <ThemedToaster />
+        </EnterpriseProvider>
       </BrowserRouter>
     </QueryClientProvider>
   </StrictMode>,

--- a/frontend/src/shared/enterprise/context.test.tsx
+++ b/frontend/src/shared/enterprise/context.test.tsx
@@ -80,8 +80,13 @@ describe('EnterpriseProvider (community mode)', () => {
     expect(screen.getByTestId('has-oidc').textContent).toBe('false');
   });
 
-  it('should not make API calls in community mode (no enterprise UI loaded)', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+  it('always fetches /admin/license to determine edition', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ edition: 'community', tier: 'community', features: [], valid: false }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
 
     render(
       <EnterpriseProvider>
@@ -93,8 +98,32 @@ describe('EnterpriseProvider (community mode)', () => {
       expect(screen.getByTestId('loading').textContent).toBe('false');
     });
 
-    // In community mode, loadEnterpriseUI returns null, so no API call to /admin/license
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(screen.getByTestId('enterprise').textContent).toBe('false');
+    expect(screen.getByTestId('license').textContent).toBe('community');
+  });
+
+  it('isEnterprise is true when backend returns valid non-community edition', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ edition: 'enterprise', tier: 'enterprise', features: ['oidc_sso'], valid: true }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(
+      <EnterpriseProvider>
+        <TestConsumer />
+      </EnterpriseProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    expect(screen.getByTestId('enterprise').textContent).toBe('true');
+    expect(screen.getByTestId('license').textContent).toBe('enterprise');
+    expect(screen.getByTestId('has-oidc').textContent).toBe('true');
   });
 });
 

--- a/frontend/src/shared/enterprise/context.tsx
+++ b/frontend/src/shared/enterprise/context.tsx
@@ -25,14 +25,12 @@ export function EnterpriseProvider({ children }: { children: ReactNode }) {
       if (cancelled) return;
       setUi(enterpriseUi);
 
-      // Only fetch license info if enterprise module is present
-      if (enterpriseUi) {
-        try {
-          const info = await apiFetch<LicenseInfo>('/admin/license');
-          if (!cancelled) setLicense(info);
-        } catch {
-          // Not admin, or endpoint unavailable — license stays null
-        }
+      // Always fetch license info — CE returns edition:'community', EE returns actual tier
+      try {
+        const info = await apiFetch<LicenseInfo>('/admin/license');
+        if (!cancelled) setLicense(info);
+      } catch {
+        // Not admin, or endpoint unavailable — license stays null
       }
 
       if (!cancelled) setIsLoading(false);
@@ -45,7 +43,7 @@ export function EnterpriseProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const hasFeature = (feature: string): boolean => {
-    if (!license || !license.isValid) return false;
+    if (!license || !license.valid) return false;
     return (license.features ?? []).includes(feature);
   };
 
@@ -54,7 +52,7 @@ export function EnterpriseProvider({ children }: { children: ReactNode }) {
       value={{
         ui,
         license,
-        isEnterprise: !!ui,
+        isEnterprise: license?.edition !== 'community' && license?.valid === true,
         hasFeature,
         isLoading,
       }}

--- a/frontend/src/shared/enterprise/context.tsx
+++ b/frontend/src/shared/enterprise/context.tsx
@@ -7,9 +7,10 @@ import { apiFetch } from '../lib/api';
 /**
  * Provider that loads the enterprise UI module and fetches license info.
  *
- * In community mode (no @compendiq/enterprise installed), this resolves
- * almost instantly with ui=null, license=null, isEnterprise=false.
- * The rest of the app renders normally with no awareness of enterprise.
+ * Always fetches /admin/license so isEnterprise is derived from the backend
+ * response (edition + valid), not from whether the overlay bundle loaded.
+ * In CE deployments the endpoint returns edition:'community'; in EE it returns
+ * the actual tier. The fetch is silently swallowed for unauthenticated users.
  */
 export function EnterpriseProvider({ children }: { children: ReactNode }) {
   const [ui, setUi] = useState<EnterpriseUI | null>(null);

--- a/frontend/src/shared/enterprise/loader.test.ts
+++ b/frontend/src/shared/enterprise/loader.test.ts
@@ -6,7 +6,7 @@ describe('Enterprise frontend loader', () => {
     _resetForTesting();
   });
 
-  it('should return null when @compendiq/enterprise/frontend is not installed', async () => {
+  it('should return null when /enterprise/frontend.js is not available', async () => {
     const ui = await loadEnterpriseUI();
     expect(ui).toBeNull();
   });

--- a/frontend/src/shared/enterprise/loader.ts
+++ b/frontend/src/shared/enterprise/loader.ts
@@ -3,19 +3,17 @@ import type { EnterpriseUI } from './types';
 let cached: EnterpriseUI | null = null;
 let loaded = false;
 
-// Module specifier stored in a variable so Vite's static import analysis
-// does not attempt to resolve it at build time. When @compendiq/enterprise
-// is not installed (community edition), the dynamic import simply throws
-// and we return null.
-const ENTERPRISE_FRONTEND_MODULE = '@compendiq/enterprise/frontend';
+// URL stored in a variable so Vite's static import analysis does not attempt
+// to resolve /enterprise/frontend.js as a local file at build time.
+// In EE, nginx serves this path → import succeeds → components are cached.
+// In CE, no such file exists → 404 → import throws → null returned silently.
+const ENTERPRISE_BUNDLE_URL = '/enterprise/frontend.js';
 
 /**
  * Attempts to load the enterprise frontend module via dynamic import.
  *
- * - If @compendiq/enterprise/frontend is installed and exports valid
- *   components, they are returned and cached.
- * - If the package is not installed (normal for community edition),
- *   null is returned silently. No console errors, no warnings.
+ * - In EE: nginx serves /enterprise/frontend.js → import succeeds → components cached.
+ * - In CE: no /enterprise/frontend.js → 404 → import throws → null returned silently.
  * - Result is cached after the first call.
  */
 export async function loadEnterpriseUI(): Promise<EnterpriseUI | null> {
@@ -23,12 +21,12 @@ export async function loadEnterpriseUI(): Promise<EnterpriseUI | null> {
 
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const mod = await (import(/* @vite-ignore */ ENTERPRISE_FRONTEND_MODULE) as Promise<any>);
+    const mod = await (import(/* @vite-ignore */ ENTERPRISE_BUNDLE_URL) as Promise<any>);
     if (mod && typeof mod.LicenseStatusCard === 'function') {
       cached = mod as EnterpriseUI;
     }
   } catch {
-    // Not installed — community mode. This is not an error.
+    // Not available — community mode. This is not an error.
     cached = null;
   }
 

--- a/frontend/src/shared/enterprise/types.ts
+++ b/frontend/src/shared/enterprise/types.ts
@@ -10,7 +10,6 @@ export type LicenseTier = 'community' | 'team' | 'business' | 'enterprise';
 
 export interface LicenseInfo extends LicenseInfoResponse {
   tier: LicenseTier;
-  isValid?: boolean;
   displayKey?: string;
 }
 
@@ -49,7 +48,7 @@ export interface EnterpriseContextValue {
   ui: EnterpriseUI | null;
   /** License info from the backend */
   license: LicenseInfo | null;
-  /** Whether the enterprise plugin is available (even if license is invalid) */
+  /** Whether the active license is a valid, non-community edition */
   isEnterprise: boolean;
   /** Whether a specific feature is enabled */
   hasFeature: (feature: string) => boolean;

--- a/frontend/src/shared/enterprise/types.ts
+++ b/frontend/src/shared/enterprise/types.ts
@@ -22,8 +22,8 @@ export interface LicenseInfo extends LicenseInfoResponse {
  * the community edition renders without them.
  */
 export interface EnterpriseUI {
-  /** License status card for the admin panel. */
-  LicenseStatusCard: ComponentType<{ license: LicenseInfo | null }>;
+  /** License status card for the admin panel (self-fetching, zero props). */
+  LicenseStatusCard: ComponentType;
 
   /** Banner shown when an enterprise feature is required. */
   EnterpriseBanner: ComponentType<{ feature: string }>;


### PR DESCRIPTION
## Summary

- **Fix loader.ts**: Replace bare module specifier `@compendiq/enterprise/frontend` (always throws in browsers) with a URL-based dynamic import of `/enterprise/frontend.js` stored in a variable — Vite skips static analysis, browser resolves the absolute URL at runtime
- **Fix context.tsx**: Call `/admin/license` unconditionally (CE returns `edition:'community'`); derive `isEnterprise` from `license.edition !== 'community' && license.valid === true` instead of `!!ui` (which was always `false`); fix `hasFeature` to use `license.valid` (the contract field)
- **Fix types.ts**: Correct `LicenseStatusCard` signature to `ComponentType` — the actual component takes zero props and self-fetches
- **Mount EnterpriseProvider**: Was not in the component tree at all; now wraps `<App />` inside `QueryClientProvider` and `BrowserRouter`
- **Update tests**: Replace the "no API calls in community mode" assertion with unconditional-fetch verification and an EE happy-path test

## Why

The existing `loadEnterpriseUI()` always returned `null` in production because bare specifiers (`@compendiq/enterprise/frontend`) cannot be resolved by browsers without an import map. Additionally, `EnterpriseProvider` was never mounted, so `isEnterprise` was always `false` regardless.

This PR is Phase 1 of the unified CE/EE frontend architecture. Phase 2 (EE overlay) adds the Vite lib build that compiles overlay components to `/enterprise/frontend.js` served by nginx.

## Test plan

- [x] All 1668 frontend tests pass (`npm run test -w frontend`)
- [x] `loader.test.ts`: verifies null return when URL unavailable (jsdom 404)
- [x] `context.test.tsx`: unconditional fetch test + EE happy-path with mocked enterprise edition response

🤖 Generated with [Claude Code](https://claude.com/claude-code)