### PR TITLE
refactor: centralize innerHTML into Semgrep-suppressed helper (#72)

### DIFF
--- a/backend/src/core/services/content-converter.ts
+++ b/backend/src/core/services/content-converter.ts
@@ -8,6 +8,12 @@ import {
   getLocalFilenameForImageSource,
 } from './image-references.js';
 
+// SECURITY: All innerHTML usage below is in server-side JSDOM context (Node.js),
+// NOT browser DOM. JSDOM is used purely as an HTML parser/transformer for
+// Confluence XHTML <-> HTML conversion. Content originates from authenticated
+// Confluence API responses and is sanitized by DOMPurify before browser display.
+// Semgrep "insecure-document-method" findings are false positives here.
+
 // JSDOM 28's HTML parser treats <![CDATA[...]]> as comments. Pre-process to
 // convert CDATA sections into text that survives HTML parsing.
 function stripCdata(xhtml: string): string {
@@ -36,6 +42,15 @@ function getParamValue(macro: Element, name: string): string | null {
     }
   }
   return null;
+}
+
+/**
+ * Transfer innerHTML from a source element to a target element.
+ * Server-side JSDOM only — used for Confluence macro conversion.
+ */
+// nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
+function transferInnerHtml(target: Element, source: Element | undefined | null, fallback = ''): void {
+  target.innerHTML = source?.innerHTML ?? fallback;
 }
 
 /**
@@ -74,7 +89,7 @@ export function confluenceToHtml(storageXhtml: string, pageId?: string, spaceKey
       const li = doc.createElement('li');
       li.setAttribute('data-type', 'taskItem');
       li.setAttribute('data-checked', checked ? 'true' : 'false');
-      li.innerHTML = bodyEl?.innerHTML ?? '';
+      transferInnerHtml(li, bodyEl);
       ul.appendChild(li);
     }
 
@@ -89,7 +104,7 @@ export function confluenceToHtml(storageXhtml: string, pageId?: string, spaceKey
     const bodyEl = byTag(macro, 'ac:rich-text-body')[0];
     const div = doc.createElement('div');
     div.className = `panel-${name}`;
-    div.innerHTML = bodyEl?.innerHTML ?? '';
+    transferInnerHtml(div, bodyEl);
     macro.replaceWith(div);
   }
 
@@ -125,7 +140,7 @@ export function confluenceToHtml(storageXhtml: string, pageId?: string, spaceKey
       const pageTitle = pageRef.getAttribute('ri:content-title') ?? '';
       a.href = `#confluence-page:${pageTitle}`;
       if (bodyEl && bodyEl.tagName.toLowerCase() === 'ac:link-body') {
-        a.innerHTML = bodyEl.innerHTML;
+        transferInnerHtml(a, bodyEl);
       } else {
         a.textContent = bodyEl?.textContent ?? pageTitle;
       }
@@ -134,14 +149,14 @@ export function confluenceToHtml(storageXhtml: string, pageId?: string, spaceKey
       const filename = attachRef.getAttribute('ri:filename') ?? '';
       a.href = `#confluence-attachment:${filename}`;
       if (bodyEl && bodyEl.tagName.toLowerCase() === 'ac:link-body') {
-        a.innerHTML = bodyEl.innerHTML;
+        transferInnerHtml(a, bodyEl);
       } else {
         a.textContent = bodyEl?.textContent ?? filename;
       }
       a.setAttribute('data-confluence-link', 'attachment');
     } else {
       if (bodyEl && bodyEl.tagName.toLowerCase() === 'ac:link-body') {
-        a.innerHTML = bodyEl.innerHTML;
+        transferInnerHtml(a, bodyEl);
       } else {
         a.textContent = bodyEl?.textContent ?? '';
       }
@@ -260,7 +275,7 @@ export function confluenceToHtml(storageXhtml: string, pageId?: string, spaceKey
         div.setAttribute('style', `flex: 0 0 ${safeWidth}`);
       }
     }
-    div.innerHTML = bodyEl?.innerHTML ?? '';
+    transferInnerHtml(div, bodyEl);
     macro.replaceWith(div);
   }
 
@@ -272,7 +287,7 @@ export function confluenceToHtml(storageXhtml: string, pageId?: string, spaceKey
     const div = doc.createElement('div');
     div.className = 'confluence-section';
     if (border) div.setAttribute('data-border', border);
-    div.innerHTML = bodyEl?.innerHTML ?? '';
+    transferInnerHtml(div, bodyEl);
     macro.replaceWith(div);
   }
 
@@ -310,7 +325,7 @@ export function confluenceToHtml(storageXhtml: string, pageId?: string, spaceKey
   for (const cell of byTag(doc, 'ac:layout-cell')) {
     const div = doc.createElement('div');
     div.className = 'confluence-layout-cell';
-    div.innerHTML = cell.innerHTML;
+    transferInnerHtml(div, cell);
     cell.replaceWith(div);
   }
   for (const section of byTag(doc, 'ac:layout-section')) {
@@ -318,13 +333,13 @@ export function confluenceToHtml(storageXhtml: string, pageId?: string, spaceKey
     const div = doc.createElement('div');
     div.className = 'confluence-layout-section';
     div.setAttribute('data-layout-type', layoutType);
-    div.innerHTML = section.innerHTML;
+    transferInnerHtml(div, section);
     section.replaceWith(div);
   }
   for (const layout of byTag(doc, 'ac:layout')) {
     const div = doc.createElement('div');
     div.className = 'confluence-layout';
-    div.innerHTML = layout.innerHTML;
+    transferInnerHtml(div, layout);
     layout.replaceWith(div);
   }
 
@@ -336,7 +351,7 @@ export function confluenceToHtml(storageXhtml: string, pageId?: string, spaceKey
     const div = doc.createElement('div');
     div.className = 'confluence-macro-unknown';
     div.setAttribute('data-macro-name', name);
-    div.innerHTML = bodyEl?.innerHTML ?? `[Confluence macro: ${name}]`;
+    transferInnerHtml(div, bodyEl, `[Confluence macro: ${name}]`);
     macro.replaceWith(div);
   }
 
@@ -397,7 +412,7 @@ export function htmlToConfluence(html: string): string {
       const taskStatus = doc.createElement('ac:task-status');
       taskStatus.textContent = li.getAttribute('data-checked') === 'true' ? 'complete' : 'incomplete';
       const taskBody = doc.createElement('ac:task-body');
-      taskBody.innerHTML = li.innerHTML;
+      transferInnerHtml(taskBody, li);
 
       task.appendChild(taskId);
       task.appendChild(taskStatus);
@@ -414,7 +429,7 @@ export function htmlToConfluence(html: string): string {
       const macro = doc.createElement('ac:structured-macro');
       macro.setAttribute('ac:name', panelType);
       const body = doc.createElement('ac:rich-text-body');
-      body.innerHTML = div.innerHTML;
+      transferInnerHtml(body, div);
       macro.appendChild(body);
       div.replaceWith(macro);
     }
@@ -435,7 +450,7 @@ export function htmlToConfluence(html: string): string {
     }
 
     const body = doc.createElement('ac:rich-text-body');
-    body.innerHTML = details.innerHTML;
+    transferInnerHtml(body, details);
     macro.appendChild(body);
     details.replaceWith(macro);
   }
@@ -452,7 +467,7 @@ export function htmlToConfluence(html: string): string {
       macro.appendChild(param);
     }
     const body = doc.createElement('ac:rich-text-body');
-    body.innerHTML = div.innerHTML;
+    transferInnerHtml(body, div);
     macro.appendChild(body);
     div.replaceWith(macro);
   }
@@ -475,7 +490,7 @@ export function htmlToConfluence(html: string): string {
       macro.appendChild(param);
     }
     const body = doc.createElement('ac:rich-text-body');
-    body.innerHTML = div.innerHTML;
+    transferInnerHtml(body, div);
     macro.appendChild(body);
     div.replaceWith(macro);
   }


### PR DESCRIPTION
## Summary

- Centralizes all 16 `innerHTML` assignments in `content-converter.ts` into a single `transferInnerHtml()` helper function with a `nosemgrep` annotation
- Adds a security documentation comment explaining why these are false positives (server-side JSDOM context, not browser DOM)
- Zero runtime behavior change -- all 98 existing round-trip tests pass unmodified

## Context

Semgrep flags every `innerHTML` assignment with `insecure-document-method`, but all 16 occurrences in this file are server-side JSDOM operations used purely as an HTML parser/transformer for Confluence XHTML <-> HTML conversion. Content originates from authenticated Confluence API responses and is sanitized by DOMPurify before browser display.

Rather than adding 16 individual `nosemgrep` comments, this PR:
1. Adds a security rationale comment at the top of the file
2. Introduces a private `transferInnerHtml(target, source, fallback?)` helper with a single `nosemgrep` suppression
3. Replaces all 16 direct `innerHTML` assignments with calls to this helper

The existing `while (firstChild)` patterns (expand macro and layout reverse conversion) are left untouched as they don't use `innerHTML`.

Closes #72

## Test plan

- [x] All 98 content-converter round-trip tests pass (panels, links, task lists, layouts, code blocks, expand macros, status badges, etc.)
- [x] Full backend test suite passes (106 files, 1686 tests)
- [x] No new test files needed -- existing coverage validates all macro conversions

🤖 Generated with [Claude Code](https://claude.com/claude-code)