### PR TITLE
feat: lazy-load @dnd-kit/react from SidebarTreeView (#77)

### DIFF
--- a/frontend/src/shared/components/layout/DndLocalSpaceTree.test.tsx
+++ b/frontend/src/shared/components/layout/DndLocalSpaceTree.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import DndLocalSpaceTree from './DndLocalSpaceTree';
 import type { DndLocalSpaceTreeProps } from './DndLocalSpaceTree';
-import type { TreeNode } from './SidebarTreeView';
+import type { TreeNode } from './sidebar-types';
 
 // Mock @dnd-kit so we can test component logic without the full DnD runtime
 vi.mock('@dnd-kit/react', () => ({

--- a/frontend/src/shared/components/layout/DndLocalSpaceTree.test.tsx
+++ b/frontend/src/shared/components/layout/DndLocalSpaceTree.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DndLocalSpaceTree from './DndLocalSpaceTree';
+import type { DndLocalSpaceTreeProps } from './DndLocalSpaceTree';
+import type { TreeNode } from './SidebarTreeView';
+
+// Mock @dnd-kit so we can test component logic without the full DnD runtime
+vi.mock('@dnd-kit/react', () => ({
+  DragDropProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@dnd-kit/react/sortable', () => ({
+  useSortable: () => ({ ref: { current: null }, isDragging: false }),
+  isSortable: () => false,
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+function makeNode(
+  id: string,
+  title: string,
+  children: TreeNode[] = [],
+): TreeNode {
+  return {
+    page: {
+      id,
+      spaceKey: 'NOTES',
+      title,
+      pageType: 'page',
+      parentId: null,
+      labels: [],
+      lastModifiedAt: '2026-03-01T00:00:00Z',
+      embeddingDirty: false,
+    },
+    children,
+  };
+}
+
+function renderTree(overrides: Partial<DndLocalSpaceTreeProps> = {}) {
+  const defaultProps: DndLocalSpaceTreeProps = {
+    tree: [
+      makeNode('p1', 'Page One'),
+      makeNode('p2', 'Page Two', [makeNode('p2-c1', 'Child of Two')]),
+    ],
+    expandedIds: new Set<string>(),
+    toggleExpand: vi.fn(),
+    activePageId: undefined,
+    reorderPage: { mutate: vi.fn() },
+  };
+
+  const props = { ...defaultProps, ...overrides };
+
+  return {
+    ...render(
+      <MemoryRouter>
+        <DndLocalSpaceTree {...props} />
+      </MemoryRouter>,
+    ),
+    props,
+  };
+}
+
+describe('DndLocalSpaceTree', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('renders all root-level pages', () => {
+    renderTree();
+    expect(screen.getByText('Page One')).toBeInTheDocument();
+    expect(screen.getByText('Page Two')).toBeInTheDocument();
+  });
+
+  it('does not render children when not expanded', () => {
+    renderTree();
+    expect(screen.queryByText('Child of Two')).not.toBeInTheDocument();
+  });
+
+  it('renders children when parent is in expandedIds', () => {
+    renderTree({ expandedIds: new Set(['p2']) });
+    expect(screen.getByText('Child of Two')).toBeInTheDocument();
+  });
+
+  it('shows drag handle for each node', () => {
+    renderTree();
+    const handles = screen.getAllByLabelText('Drag to reorder');
+    expect(handles.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('navigates to page on click', () => {
+    renderTree();
+    fireEvent.click(screen.getByText('Page One'));
+    expect(mockNavigate).toHaveBeenCalledWith('/pages/p1');
+  });
+
+  it('calls toggleExpand on expand button click for parent nodes', () => {
+    const toggleExpand = vi.fn();
+    renderTree({ toggleExpand });
+    const expandBtn = screen.getByLabelText('Expand');
+    fireEvent.click(expandBtn);
+    expect(toggleExpand).toHaveBeenCalledWith('p2');
+  });
+
+  it('renders indent guide when a node with children is expanded', () => {
+    renderTree({ expandedIds: new Set(['p2']) });
+    const guide = screen.getByLabelText('Collapse Page Two');
+    expect(guide).toBeInTheDocument();
+    expect(guide).toHaveClass('indent-guide');
+  });
+
+  it('is the default export (compatible with React.lazy)', () => {
+    expect(typeof DndLocalSpaceTree).toBe('function');
+  });
+});

--- a/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
+++ b/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
@@ -1,0 +1,175 @@
+import { memo, useCallback } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import {
+  ChevronRight,
+  ChevronDown,
+  FileText,
+  GripVertical,
+} from 'lucide-react';
+import { DragDropProvider } from '@dnd-kit/react';
+import { useSortable, isSortable } from '@dnd-kit/react/sortable';
+import { cn } from '../../lib/cn';
+import type { TreeNode } from './SidebarTreeView';
+
+export interface DndLocalSpaceTreeProps {
+  tree: TreeNode[];
+  expandedIds: Set<string>;
+  toggleExpand: (id: string) => void;
+  activePageId: string | undefined;
+  reorderPage: { mutate: (args: { id: string; sortOrder: number }) => void };
+}
+
+interface DndSortableTreeNodeProps {
+  node: TreeNode;
+  level?: number;
+  expandedSet: Set<string>;
+  toggleExpand: (id: string) => void;
+  activePageId: string | undefined;
+  sortableIndex: number;
+}
+
+const DndSortableTreeNode = memo(function DndSortableTreeNode({
+  node,
+  level = 0,
+  expandedSet,
+  toggleExpand,
+  activePageId,
+  sortableIndex,
+}: DndSortableTreeNodeProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isExpanded = expandedSet.has(node.page.id);
+  const hasChildren = node.children.length > 0;
+  const isActive = node.page.id === activePageId;
+  const isAiRoute = location.pathname === '/ai';
+
+  const sortable = useSortable({
+    id: node.page.id,
+    index: sortableIndex,
+    disabled: false,
+  });
+
+  const handleNavigate = useCallback(() => {
+    if (hasChildren) toggleExpand(node.page.id);
+    if (isAiRoute) {
+      navigate(`/ai?pageId=${node.page.id}`, { replace: true });
+    } else {
+      navigate(`/pages/${node.page.id}`);
+    }
+  }, [navigate, node.page.id, hasChildren, toggleExpand, isAiRoute]);
+
+  const handleToggle = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      toggleExpand(node.page.id);
+    },
+    [toggleExpand, node.page.id],
+  );
+
+  return (
+    <div ref={sortable.ref}>
+      <div
+        className={cn(
+          'group flex items-center gap-1.5 rounded-[10px] h-9 pr-2 text-sm cursor-pointer transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background',
+          isActive
+            ? 'glass-pill-active text-primary font-medium scale-[1.01]'
+            : 'text-muted-foreground hover:bg-[var(--glass-pill-hover)] hover:text-foreground',
+        )}
+        style={{ paddingLeft: `${level * 16 + 10}px` }}
+        onClick={handleNavigate}
+      >
+        <span className="shrink-0 opacity-0 group-hover:opacity-50 cursor-grab active:cursor-grabbing transition-opacity" aria-label="Drag to reorder">
+          <GripVertical size={12} />
+        </span>
+        {hasChildren ? (
+          <button
+            onClick={handleToggle}
+            className="shrink-0 rounded p-0.5 hover:bg-foreground/10"
+            aria-label={isExpanded ? 'Collapse' : 'Expand'}
+          >
+            {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          </button>
+        ) : (
+          <span className="w-[20px] shrink-0" />
+        )}
+        <FileText size={15} className={cn('shrink-0', isActive ? 'text-primary/80' : 'text-muted-foreground/70')} />
+        <span className="truncate text-sm">{node.page.title}</span>
+      </div>
+
+      {hasChildren && isExpanded && (
+        <div className="relative">
+          {/* Indent guide line -- click to collapse parent */}
+          <button
+            type="button"
+            onClick={handleToggle}
+            className="indent-guide"
+            style={{ left: `${level * 16 + 14}px` }}
+            aria-label={`Collapse ${node.page.title}`}
+            tabIndex={-1}
+          />
+          {node.children.map((child, idx) => (
+            <DndSortableTreeNode
+              key={child.page.id}
+              node={child}
+              level={level + 1}
+              expandedSet={expandedSet}
+              toggleExpand={toggleExpand}
+              activePageId={activePageId}
+              sortableIndex={idx}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}, (prev, next) => {
+  return (
+    prev.node === next.node &&
+    prev.level === next.level &&
+    prev.activePageId === next.activePageId &&
+    prev.expandedSet === next.expandedSet &&
+    prev.sortableIndex === next.sortableIndex
+  );
+});
+
+export default function DndLocalSpaceTree({
+  tree,
+  expandedIds,
+  toggleExpand,
+  activePageId,
+  reorderPage,
+}: DndLocalSpaceTreeProps) {
+  const handleDragEnd = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (event: any) => {
+      if (event.canceled) return;
+      const source = event.operation?.source;
+      if (!source || !isSortable(source)) return;
+
+      const currentIndex = source.index;
+      const startIndex = 'initialIndex' in source ? (source as { initialIndex: number }).initialIndex : currentIndex;
+      if (startIndex === currentIndex) return;
+
+      const pageId = String(source.id);
+      reorderPage.mutate({ id: pageId, sortOrder: currentIndex });
+    },
+    [reorderPage],
+  );
+
+  return (
+    <DragDropProvider onDragEnd={handleDragEnd}>
+      <div className="space-y-0.5">
+        {tree.map((node, idx) => (
+          <DndSortableTreeNode
+            key={node.page.id}
+            node={node}
+            expandedSet={expandedIds}
+            toggleExpand={toggleExpand}
+            activePageId={activePageId}
+            sortableIndex={idx}
+          />
+        ))}
+      </div>
+    </DragDropProvider>
+  );
+}

--- a/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
+++ b/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
@@ -6,10 +6,10 @@ import {
   FileText,
   GripVertical,
 } from 'lucide-react';
-import { DragDropProvider } from '@dnd-kit/react';
+import { DragDropProvider, type DragEndEvent } from '@dnd-kit/react';
 import { useSortable, isSortable } from '@dnd-kit/react/sortable';
 import { cn } from '../../lib/cn';
-import type { TreeNode } from './SidebarTreeView';
+import type { TreeNode } from './sidebar-types';
 
 export interface DndLocalSpaceTreeProps {
   tree: TreeNode[];
@@ -140,8 +140,7 @@ export default function DndLocalSpaceTree({
   reorderPage,
 }: DndLocalSpaceTreeProps) {
   const handleDragEnd = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (event: any) => {
+    (event: Parameters<DragEndEvent>[0]) => {
       if (event.canceled) return;
       const source = event.operation?.source;
       if (!source || !isSortable(source)) return;

--- a/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
@@ -11,13 +11,10 @@ vi.mock('framer-motion', async () => {
   return { ...actual, useReducedMotion: () => true };
 });
 
-vi.mock('@dnd-kit/react', () => ({
-  DragDropProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
-
-vi.mock('@dnd-kit/react/sortable', () => ({
-  useSortable: () => ({ ref: { current: null }, isDragging: false }),
-  isSortable: () => false,
+// DndLocalSpaceTree is lazy-loaded; provide a lightweight stub so Suspense
+// resolves synchronously in tests without pulling in @dnd-kit.
+vi.mock('./DndLocalSpaceTree', () => ({
+  default: () => <div data-testid="dnd-local-space-tree" />,
 }));
 
 const mockNavigate = vi.fn();

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { memo, useState, useMemo, useCallback, useEffect, useRef, lazy, Suspense } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import {
   BookOpen,
@@ -8,7 +8,6 @@ import {
   FileText,
   FolderPlus,
   ChevronsUpDown,
-  GripVertical,
   PanelLeft,
   PanelLeftClose,
   Plus,
@@ -18,8 +17,6 @@ import {
 } from 'lucide-react';
 import { m, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { ShortcutHint } from '../ShortcutHint';
-import { DragDropProvider } from '@dnd-kit/react';
-import { useSortable, isSortable } from '@dnd-kit/react/sortable';
 import { usePageTree, useCreatePage } from '../../hooks/use-pages';
 import { useSpaces } from '../../hooks/use-spaces';
 import { useLocalSpaces, useReorderPage } from '../../hooks/use-standalone';
@@ -27,6 +24,8 @@ import { useClickOutside } from '../../hooks/use-click-outside';
 import { useUiStore } from '../../../stores/ui-store';
 import { cn } from '../../lib/cn';
 import type { PageTreeItem } from '../../hooks/use-pages';
+
+const DndLocalSpaceTree = lazy(() => import('./DndLocalSpaceTree'));
 
 const navItems = [
   { icon: BookOpen, label: 'Pages', path: '/', shortcut: 'G then P' },
@@ -99,8 +98,6 @@ export interface SidebarTreeNodeProps {
   expandedSet: Set<string>;
   toggleExpand: (id: string) => void;
   activePageId: string | undefined;
-  enableDrag?: boolean;
-  sortableIndex?: number;
 }
 
 export const SidebarTreeNode = memo(function SidebarTreeNode({
@@ -109,8 +106,6 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
   expandedSet,
   toggleExpand,
   activePageId,
-  enableDrag = false,
-  sortableIndex,
 }: SidebarTreeNodeProps) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -118,13 +113,6 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
   const hasChildren = node.children.length > 0;
   const isActive = node.page.id === activePageId;
   const isAiRoute = location.pathname === '/ai';
-
-  // Always call hook (React rules), but only use the ref when DnD is active
-  const sortable = useSortable({
-    id: node.page.id,
-    index: sortableIndex ?? 0,
-    disabled: !enableDrag,
-  });
 
   const handleNavigate = useCallback(() => {
     if (hasChildren) toggleExpand(node.page.id);
@@ -144,7 +132,7 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
   );
 
   return (
-    <div ref={enableDrag ? sortable.ref : undefined}>
+    <div>
       <div
         className={cn(
           'group flex items-center gap-1.5 rounded-[10px] h-9 pr-2 text-sm cursor-pointer transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background',
@@ -155,11 +143,6 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
         style={{ paddingLeft: `${level * 16 + 10}px` }}
         onClick={handleNavigate}
       >
-        {enableDrag && (
-          <span className="shrink-0 opacity-0 group-hover:opacity-50 cursor-grab active:cursor-grabbing transition-opacity" aria-label="Drag to reorder">
-            <GripVertical size={12} />
-          </span>
-        )}
         {hasChildren ? (
           <button
             onClick={handleToggle}
@@ -177,7 +160,7 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
 
       {hasChildren && isExpanded && (
         <div className="relative">
-          {/* Indent guide line — click to collapse parent */}
+          {/* Indent guide line -- click to collapse parent */}
           <button
             type="button"
             onClick={handleToggle}
@@ -186,7 +169,7 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
             aria-label={`Collapse ${node.page.title}`}
             tabIndex={-1}
           />
-          {node.children.map((child, idx) => (
+          {node.children.map((child) => (
             <SidebarTreeNode
               key={child.page.id}
               node={child}
@@ -194,8 +177,6 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
               expandedSet={expandedSet}
               toggleExpand={toggleExpand}
               activePageId={activePageId}
-              enableDrag={enableDrag}
-              sortableIndex={enableDrag ? idx : undefined}
             />
           ))}
         </div>
@@ -207,9 +188,7 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
     prev.node === next.node &&
     prev.level === next.level &&
     prev.activePageId === next.activePageId &&
-    prev.expandedSet === next.expandedSet &&
-    prev.enableDrag === next.enableDrag &&
-    prev.sortableIndex === next.sortableIndex
+    prev.expandedSet === next.expandedSet
   );
 });
 
@@ -393,25 +372,7 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
     });
   }, []);
 
-  // Handle drag end for sortable reordering
-  const handleDragEnd = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (event: any) => {
-      if (event.canceled) return;
-      const source = event.operation?.source;
-      if (!source || !isSortable(source)) return;
-
-      const currentIndex = source.index;
-      const startIndex = 'initialIndex' in source ? (source as { initialIndex: number }).initialIndex : currentIndex;
-      if (startIndex === currentIndex) return;
-
-      const pageId = String(source.id);
-      reorderPage.mutate({ id: pageId, sortOrder: currentIndex });
-    },
-    [reorderPage],
-  );
-
-  // Collapsed rail — nav icons + expand toggle
+  // Collapsed rail -- nav icons + expand toggle
   if (treeSidebarCollapsed) {
     return (
       <AnimatePresence mode="wait">
@@ -720,21 +681,21 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
             )}
           </div>
         ) : isLocalSpace ? (
-          <DragDropProvider onDragEnd={handleDragEnd}>
-            <div className="space-y-0.5">
-              {tree.map((node, idx) => (
-                <SidebarTreeNode
-                  key={node.page.id}
-                  node={node}
-                  expandedSet={expandedIds}
-                  toggleExpand={toggleExpand}
-                  activePageId={activePageId}
-                  enableDrag
-                  sortableIndex={idx}
-                />
+          <Suspense fallback={
+            <div className="space-y-1 px-2">
+              {Array.from({ length: 6 }, (_, i) => (
+                <div key={i} className="h-9 animate-pulse rounded-[10px] bg-foreground/5" />
               ))}
             </div>
-          </DragDropProvider>
+          }>
+            <DndLocalSpaceTree
+              tree={tree}
+              expandedIds={expandedIds}
+              toggleExpand={toggleExpand}
+              activePageId={activePageId}
+              reorderPage={reorderPage}
+            />
+          </Suspense>
         ) : (
           <div className="space-y-0.5">
             {tree.map((node) => (

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -24,6 +24,9 @@ import { useClickOutside } from '../../hooks/use-click-outside';
 import { useUiStore } from '../../../stores/ui-store';
 import { cn } from '../../lib/cn';
 import type { PageTreeItem } from '../../hooks/use-pages';
+import type { TreeNode } from './sidebar-types';
+
+export type { TreeNode };
 
 const DndLocalSpaceTree = lazy(() => import('./DndLocalSpaceTree'));
 
@@ -32,11 +35,6 @@ const navItems = [
   { icon: Share2, label: 'Graph', path: '/graph', shortcut: 'G then G' },
   { icon: Bot, label: 'AI', path: '/ai', shortcut: 'G then A' },
 ] as const;
-
-export interface TreeNode {
-  page: PageTreeItem;
-  children: TreeNode[];
-}
 
 function buildTree(pages: PageTreeItem[], homepageId?: string | null): TreeNode[] {
   const nodeMap = new Map<string, TreeNode>();

--- a/frontend/src/shared/components/layout/sidebar-types.ts
+++ b/frontend/src/shared/components/layout/sidebar-types.ts
@@ -1,0 +1,6 @@
+import type { PageTreeItem } from '../../hooks/use-pages';
+
+export interface TreeNode {
+  page: PageTreeItem;
+  children: TreeNode[];
+}


### PR DESCRIPTION
## Summary

- Extract the DnD-aware local space tree (`DragDropProvider` + `useSortable` + `handleDragEnd`) into a new `DndLocalSpaceTree` component
- Lazy-load it via `React.lazy(() => import('./DndLocalSpaceTree'))` with a Suspense skeleton fallback
- Remove all `@dnd-kit` imports from `SidebarTreeView.tsx`, simplifying `SidebarTreeNode` to a read-only tree node (no `useSortable` hook, no `enableDrag`/`sortableIndex` props)
- `@dnd-kit` is now only loaded when a user views a local space, keeping it out of the initial bundle

Closes #77

## Changes

| File | Action |
|------|--------|
| `DndLocalSpaceTree.tsx` | **Created** -- DnD-aware tree with `DragDropProvider`, `useSortable`, `isSortable`, `handleDragEnd` |
| `DndLocalSpaceTree.test.tsx` | **Created** -- 8 tests covering rendering, navigation, expand/collapse, drag handles |
| `SidebarTreeView.tsx` | **Modified** -- removed `@dnd-kit` imports, simplified `SidebarTreeNode`, added `React.lazy` + `Suspense` |
| `SidebarTreeView.test.tsx` | **Modified** -- replaced `@dnd-kit` mocks with a `DndLocalSpaceTree` stub mock |

## Notes

- Vite automatically code-splits dynamic imports into separate chunks; no `manualChunks` config needed
- `mermaid` and `react-force-graph-2d` were already lazy-loaded in the codebase
- The pre-existing build failure in `AiContext.tsx` (operator precedence with `??` and `||`) is unrelated to this PR

## Test plan

- [x] All 53 existing `SidebarTreeView` tests pass
- [x] All 8 new `DndLocalSpaceTree` tests pass
- [x] All 22 `AppLayout` tests pass (no regression)
- [x] ESLint passes on all changed files
- [x] TypeScript reports no errors in changed files
- [ ] Manual: verify local space tree still supports drag-and-drop reordering
- [ ] Manual: verify confluence space tree renders without DnD (read-only)
- [ ] Manual: verify Suspense skeleton appears briefly on first local space load

🤖 Generated with [Claude Code](https://claude.com/claude-code)