### PR TITLE
feat: persist setup wizard step to sessionStorage

### DIFF
--- a/frontend/src/features/setup/SetupWizard.test.tsx
+++ b/frontend/src/features/setup/SetupWizard.test.tsx
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useAuthStore } from '../../stores/auth-store';
 import { SetupWizard } from './SetupWizard';
+
+const STORAGE_KEY = 'compendiq-setup-step';
 
 function renderWizard(initialEntries = ['/setup']) {
   const queryClient = new QueryClient({
@@ -71,6 +73,7 @@ describe('SetupWizard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useAuthStore.getState().clearAuth();
+    sessionStorage.clear();
 
     // Default: mock all API calls to return success (no admin exists)
     mockFetchForSetup({ adminExists: false });
@@ -328,5 +331,104 @@ describe('SetupWizard', () => {
     // Check navigation links
     expect(screen.getByText('Go to Pages')).toBeInTheDocument();
     expect(screen.getByText('Admin Settings')).toBeInTheDocument();
+  });
+
+  describe('sessionStorage persistence', () => {
+    it('persists current step to sessionStorage on step change', async () => {
+      renderWizard();
+
+      // After mount the initial step (0) is persisted
+      await waitFor(() => {
+        expect(sessionStorage.getItem(STORAGE_KEY)).toBe('0');
+      });
+
+      // Advance to admin step (step 1)
+      fireEvent.click(screen.getByTestId('start-setup-btn'));
+      await waitFor(() => {
+        expect(screen.getByText('Create Admin Account')).toBeInTheDocument();
+      });
+
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBe('1');
+    });
+
+    it('restores step from sessionStorage on remount', async () => {
+      // Simulate a previous session that reached the LLM step (step 2)
+      sessionStorage.setItem(STORAGE_KEY, '2');
+
+      renderWizard();
+
+      // Should restore to LLM step, not welcome
+      await waitFor(() => {
+        expect(screen.getByText('Configure LLM Provider')).toBeInTheDocument();
+      });
+    });
+
+    it('clears sessionStorage when wizard reaches complete step', async () => {
+      renderWizard();
+
+      // Navigate through all steps
+      fireEvent.click(screen.getByTestId('start-setup-btn'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('setup-username')).toBeInTheDocument();
+      });
+      typeInto(screen.getByTestId('setup-username'), 'admin');
+      typeInto(screen.getByTestId('setup-password'), 'securepass123');
+      typeInto(screen.getByTestId('setup-confirm-password'), 'securepass123');
+      fireEvent.click(screen.getByTestId('create-admin-btn'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Configure LLM Provider')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByTestId('llm-next-btn'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Connect Confluence')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByTestId('skip-confluence-btn'));
+
+      // Reach the complete step
+      await waitFor(() => {
+        expect(screen.getByText(/You're All Set/i)).toBeInTheDocument();
+      });
+
+      // sessionStorage should be cleared on completion
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it('starts at step 0 after completion even if remounted', async () => {
+      // First, complete the wizard
+      renderWizard();
+
+      fireEvent.click(screen.getByTestId('start-setup-btn'));
+      await waitFor(() => {
+        expect(screen.getByTestId('setup-username')).toBeInTheDocument();
+      });
+      typeInto(screen.getByTestId('setup-username'), 'admin');
+      typeInto(screen.getByTestId('setup-password'), 'securepass123');
+      typeInto(screen.getByTestId('setup-confirm-password'), 'securepass123');
+      fireEvent.click(screen.getByTestId('create-admin-btn'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Configure LLM Provider')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByTestId('llm-next-btn'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Connect Confluence')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByTestId('skip-confluence-btn'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/You're All Set/i)).toBeInTheDocument();
+      });
+
+      // Unmount and remount
+      cleanup();
+      renderWizard();
+
+      // Should start at welcome (step 0) since storage was cleared
+      expect(screen.getByText(/Welcome to/i)).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/features/setup/SetupWizard.tsx
+++ b/frontend/src/features/setup/SetupWizard.tsx
@@ -43,9 +43,14 @@ export function SetupWizard() {
 
   // Skip admin step when admin already exists; on rerun always start at LLM
   const initialStep = isRerun ? 2 : 0;
-  const [currentStep, setCurrentStep] = useState(() =>
-    getPersistedStep(initialStep),
-  );
+  const [currentStep, setCurrentStep] = useState(() => {
+    // On rerun, ignore any stale persisted step and start fresh
+    if (isRerun) {
+      try { sessionStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+      return initialStep;
+    }
+    return getPersistedStep(initialStep);
+  });
 
   // Persist step changes to sessionStorage; clear on the final (complete) step
   useEffect(() => {

--- a/frontend/src/features/setup/SetupWizard.tsx
+++ b/frontend/src/features/setup/SetupWizard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { m, AnimatePresence } from 'framer-motion';
 import { CompendiqLogo } from '../../shared/components/CompendiqLogo';
@@ -17,6 +17,24 @@ const STEPS = [
   { id: 'complete', label: 'Complete' },
 ] as const;
 
+const STORAGE_KEY = 'compendiq-setup-step';
+
+/** Read persisted step from sessionStorage, falling back to the given default. */
+function getPersistedStep(fallback: number): number {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw !== null) {
+      const parsed = Number(raw);
+      if (Number.isInteger(parsed) && parsed >= 0 && parsed < STEPS.length) {
+        return parsed;
+      }
+    }
+  } catch {
+    // sessionStorage may be unavailable (e.g. security policy)
+  }
+  return fallback;
+}
+
 export function SetupWizard() {
   const [searchParams] = useSearchParams();
   const isRerun = searchParams.get('rerun') === 'true';
@@ -25,25 +43,40 @@ export function SetupWizard() {
 
   // Skip admin step when admin already exists; on rerun always start at LLM
   const initialStep = isRerun ? 2 : 0;
-  const [currentStep, setCurrentStep] = useState(initialStep);
+  const [currentStep, setCurrentStep] = useState(() =>
+    getPersistedStep(initialStep),
+  );
 
-  function goNext() {
+  // Persist step changes to sessionStorage; clear on the final (complete) step
+  useEffect(() => {
+    try {
+      if (currentStep === STEPS.length - 1) {
+        sessionStorage.removeItem(STORAGE_KEY);
+      } else {
+        sessionStorage.setItem(STORAGE_KEY, String(currentStep));
+      }
+    } catch {
+      // sessionStorage may be unavailable
+    }
+  }, [currentStep]);
+
+  const goNext = useCallback(() => {
     setCurrentStep((prev) => {
       let next = prev + 1;
       // Skip admin step if admin already exists
       if (next === 1 && adminExists) next = 2;
       return Math.min(next, STEPS.length - 1);
     });
-  }
+  }, [adminExists]);
 
-  function goBack() {
+  const goBack = useCallback(() => {
     setCurrentStep((prev) => {
       let back = prev - 1;
       // Skip admin step going back if admin already exists
       if (back === 1 && adminExists) back = 0;
       return Math.max(back, 0);
     });
-  }
+  }, [adminExists]);
 
   // Auto-advance past admin step if setup-status query resolves while on it
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Persist the setup wizard's `currentStep` to `sessionStorage` so that a page refresh during setup resumes at the last visited step instead of restarting from step 0
- On reaching the completion step (step 4), the persisted value is cleared so subsequent visits start fresh
- Uses `sessionStorage` (not `localStorage`) so persistence is scoped to the browser tab's lifetime

## Changes
- **`frontend/src/features/setup/SetupWizard.tsx`** -- Added `getPersistedStep()` helper with validation, lazy `useState` initializer from `sessionStorage`, and a `useEffect` that writes/clears `sessionStorage` on step changes
- **`frontend/src/features/setup/SetupWizard.test.tsx`** -- Added 4 tests covering persistence on step change, restore on remount, clearing on completion, and fresh start after completion

## Test plan
- [x] Verify step is written to `sessionStorage` when advancing through the wizard
- [x] Verify remounting the wizard restores the persisted step
- [x] Verify reaching the complete step clears `sessionStorage`
- [x] Verify remounting after completion starts at step 0
- [x] All 17 SetupWizard tests pass (13 existing + 4 new)
- [ ] Manual: open `/setup`, advance to step 2, refresh page, confirm it resumes at step 2
- [ ] Manual: complete wizard, open `/setup` again, confirm it starts at step 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)