### PR TITLE
feat: k6 search load test and seed script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ research/
 .claude/
 frontend/vendor/
 firebase-debug.log
+
+# k6 output files
+perf/*.json
+perf/*.html

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,115 @@
+# Performance Testing
+
+Load tests for the Compendiq search endpoint using [k6](https://k6.io/) and a database seed script for test data.
+
+## Prerequisites
+
+- **k6** installed separately (not an npm dependency):
+  ```bash
+  # macOS
+  brew install k6
+
+  # Linux (Debian/Ubuntu)
+  sudo gpg -k
+  sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+    --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D68
+  echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
+    | sudo tee /etc/apt/sources.list.d/k6.list
+  sudo apt-get update && sudo apt-get install k6
+
+  # Docker (no install)
+  docker run --rm -i grafana/k6 run - < perf/search-load-test.js
+  ```
+
+- **PostgreSQL** running with the Compendiq schema migrated
+- **Node.js 20+** and `npx tsx` available (ships with the project dev dependencies)
+
+## 1. Seed Test Data
+
+Insert 1000 pages with 3 embedding chunks each (3000 total embeddings) across 5 test spaces:
+
+```bash
+# Uses POSTGRES_URL from .env or the default connection string
+npx tsx perf/seed-test-data.ts
+
+# Or specify a custom connection string
+POSTGRES_URL=postgresql://kb_user:changeme-postgres@localhost:5432/kb_creator \
+  npx tsx perf/seed-test-data.ts
+```
+
+The seed script is **idempotent** -- running it again removes existing test data first.
+
+### Clean up test data
+
+```bash
+npx tsx perf/seed-test-data.ts --cleanup
+```
+
+Test pages are identified by their `confluence_id` prefix (`perf-test-*`) so cleanup never touches real data.
+
+## 2. Run the Load Test
+
+```bash
+# Obtain a JWT token (replace credentials as needed)
+TOKEN=$(curl -s -X POST http://localhost:3051/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"admin"}' | jq -r '.token')
+
+# Run with defaults (ramps to 50 VUs over 100s)
+k6 run -e AUTH_TOKEN="$TOKEN" perf/search-load-test.js
+
+# Override base URL
+k6 run -e BASE_URL=http://localhost:3051 -e AUTH_TOKEN="$TOKEN" perf/search-load-test.js
+```
+
+### Test Scenario
+
+The default scenario uses a **ramping-vus** executor:
+
+| Phase     | Duration | Target VUs |
+|-----------|----------|-----------|
+| Warm-up   | 30s      | 0 -> 10   |
+| Sustained | 60s      | 10 -> 50  |
+| Cool-down | 10s      | 50 -> 0   |
+
+Each virtual user picks a random search query and mode (keyword-heavy mix: 60% keyword, 20% semantic, 20% hybrid) then waits 0.5-2s before the next request.
+
+### Thresholds
+
+| Metric             | Threshold     |
+|--------------------|---------------|
+| `http_req_duration` | p(95) < 300ms |
+| `http_req_duration` | p(99) < 500ms |
+| `http_req_failed`   | < 1% errors   |
+| `search_errors`     | < 2% failures |
+
+If any threshold is breached, k6 exits with a non-zero code.
+
+## 3. Interpret Results
+
+k6 prints a summary table at the end of each run. Key metrics:
+
+- **http_req_duration**: End-to-end latency (including network). Check p95 and p99.
+- **http_reqs**: Total requests completed and the throughput (req/s).
+- **search_errors**: Percentage of requests that returned non-200 or had invalid response bodies.
+- **iterations**: Total VU iterations completed.
+
+For detailed analysis, export results to JSON or InfluxDB:
+
+```bash
+# JSON output
+k6 run -e AUTH_TOKEN="$TOKEN" --out json=results.json perf/search-load-test.js
+
+# InfluxDB (requires InfluxDB running)
+k6 run -e AUTH_TOKEN="$TOKEN" --out influxdb=http://localhost:8086/k6 perf/search-load-test.js
+```
+
+## Test Data Details
+
+The seed script creates:
+
+- **1000 pages** as `source='confluence'` with `visibility='shared'`
+- **5 test spaces**: `PERF-DEVOPS`, `PERF-SECURITY`, `PERF-PLATFORM`, `PERF-INFRA`, `PERF-DOCS`
+- **3000 embedding chunks** (3 per page) with random 1024-dim vectors
+- Pages have realistic titles, body text, labels, and authors
+- All test data uses the `perf-test-` confluence_id prefix for safe cleanup

--- a/perf/README.md
+++ b/perf/README.md
@@ -50,7 +50,7 @@ Test pages are identified by their `confluence_id` prefix (`perf-test-*`) so cle
 ## 2. Run the Load Test
 
 ```bash
-# Obtain a JWT token (replace credentials as needed)
+# Obtain a JWT token (example credentials — replace with your actual admin account)
 TOKEN=$(curl -s -X POST http://localhost:3051/api/auth/login \
   -H 'Content-Type: application/json' \
   -d '{"username":"admin","password":"admin"}' | jq -r '.token')

--- a/perf/search-load-test.js
+++ b/perf/search-load-test.js
@@ -1,0 +1,149 @@
+/**
+ * k6 load test for the GET /api/search endpoint.
+ *
+ * Usage:
+ *   k6 run perf/search-load-test.js                                 # defaults
+ *   k6 run -e BASE_URL=http://localhost:3051 -e AUTH_TOKEN=<jwt> perf/search-load-test.js
+ *
+ * The AUTH_TOKEN must be a valid JWT for an authenticated user.
+ * Obtain one by logging in via the UI or calling POST /api/auth/login.
+ *
+ * This script exercises all three search modes (keyword, semantic, hybrid)
+ * with a mix of realistic queries to surface latency and throughput issues
+ * under ramping load.
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+
+// ── Custom metrics ──────────────────────────────────────────────────────────
+
+const searchErrors = new Rate('search_errors');
+const searchDuration = new Trend('search_duration', true);
+
+// ── Configuration ───────────────────────────────────────────────────────────
+
+export const options = {
+  scenarios: {
+    search_load: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: 10 },   // warm-up
+        { duration: '60s', target: 50 },   // sustained load
+        { duration: '10s', target: 0 },    // cool-down
+      ],
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<300', 'p(99)<500'],
+    http_req_failed: ['rate<0.01'],
+    search_errors: ['rate<0.02'],
+  },
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const BASE = __ENV.BASE_URL || 'http://localhost:3051';
+const TOKEN = __ENV.AUTH_TOKEN;
+
+if (!TOKEN) {
+  console.warn(
+    'AUTH_TOKEN not set. All requests will receive 401. ' +
+    'Pass -e AUTH_TOKEN=<jwt> to authenticate.',
+  );
+}
+
+const SEARCH_QUERIES = [
+  'deployment',
+  'kubernetes',
+  'database',
+  'security',
+  'monitoring',
+  'authentication',
+  'docker',
+  'api',
+  'testing',
+  'configuration',
+  'backup',
+  'migration',
+  'network',
+  'storage',
+  'logging',
+];
+
+const SEARCH_MODES = ['keyword', 'keyword', 'keyword', 'semantic', 'hybrid'];
+
+function randomItem(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+// ── Default function (executed per VU iteration) ────────────────────────────
+
+export default function () {
+  const q = randomItem(SEARCH_QUERIES);
+  const mode = randomItem(SEARCH_MODES);
+  const limit = Math.floor(Math.random() * 10) + 5; // 5..14
+
+  const url = `${BASE}/api/search?q=${encodeURIComponent(q)}&mode=${mode}&limit=${limit}`;
+
+  const params = {
+    headers: {},
+    tags: { name: 'search', mode: mode },
+  };
+
+  if (TOKEN) {
+    params.headers['Authorization'] = `Bearer ${TOKEN}`;
+  }
+
+  const res = http.get(url, params);
+
+  searchDuration.add(res.timings.duration);
+
+  const passed = check(res, {
+    'status is 200': (r) => r.status === 200,
+    'response has items array': (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return Array.isArray(body.items);
+      } catch {
+        return false;
+      }
+    },
+    'response time < 500ms': (r) => r.timings.duration < 500,
+  });
+
+  searchErrors.add(!passed);
+
+  // Simulate realistic user think time between searches (0.5s to 2s)
+  sleep(Math.random() * 1.5 + 0.5);
+}
+
+// ── Lifecycle hooks ─────────────────────────────────────────────────────────
+
+export function setup() {
+  // Verify the target is reachable before starting the test
+  const healthRes = http.get(`${BASE}/api/health`);
+  if (healthRes.status !== 200) {
+    throw new Error(
+      `Health check failed (status ${healthRes.status}). ` +
+      `Is the backend running at ${BASE}?`,
+    );
+  }
+
+  // Verify authentication works
+  if (TOKEN) {
+    const searchRes = http.get(`${BASE}/api/search?q=test&mode=keyword&limit=1`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    if (searchRes.status === 401) {
+      throw new Error(
+        'AUTH_TOKEN is invalid or expired. ' +
+        'Obtain a fresh token by logging in.',
+      );
+    }
+  }
+
+  return {};
+}

--- a/perf/seed-test-data.ts
+++ b/perf/seed-test-data.ts
@@ -114,7 +114,12 @@ function randomItem<T>(arr: T[]): T {
 
 function randomSubset<T>(arr: T[], min: number, max: number): T[] {
   const count = Math.floor(Math.random() * (max - min + 1)) + min;
-  const shuffled = [...arr].sort(() => Math.random() - 0.5);
+  // Fisher-Yates shuffle (unbiased)
+  const shuffled = [...arr];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j]!, shuffled[i]!];
+  }
   return shuffled.slice(0, count);
 }
 
@@ -134,7 +139,7 @@ function generateRandomEmbedding(): number[] {
   let norm = 0;
   for (let i = 0; i < EMBEDDING_DIMS; i++) {
     // Box-Muller transform for normally distributed values
-    const u1 = Math.random();
+    const u1 = Math.random() || Number.EPSILON;  // guard against log(0) → NaN
     const u2 = Math.random();
     vec[i] = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
     norm += vec[i] * vec[i];

--- a/perf/seed-test-data.ts
+++ b/perf/seed-test-data.ts
@@ -1,0 +1,287 @@
+/**
+ * Seed script for performance testing.
+ *
+ * Inserts 1000 standalone pages with realistic text content and random
+ * 1024-dimensional embeddings across 5 test spaces. Uses the `pg` driver
+ * directly so it runs independently of the backend application.
+ *
+ * Usage:
+ *   npx tsx perf/seed-test-data.ts                          # uses default POSTGRES_URL
+ *   POSTGRES_URL=postgresql://... npx tsx perf/seed-test-data.ts
+ *
+ * Cleanup:
+ *   npx tsx perf/seed-test-data.ts --cleanup
+ *
+ * The script is idempotent: running it again replaces existing test data.
+ */
+
+import pg from 'pg';
+import pgvector from 'pgvector';
+
+const { Pool } = pg;
+
+// ── Configuration ───────────────────────────────────────────────────────────
+
+const POSTGRES_URL =
+  process.env.POSTGRES_URL ??
+  'postgresql://kb_user:changeme-postgres@localhost:5432/kb_creator';
+
+const TOTAL_PAGES = 1000;
+const CHUNKS_PER_PAGE = 3;
+const EMBEDDING_DIMS = 1024;
+const BATCH_SIZE = 50;
+
+const TEST_SPACES = [
+  'PERF-DEVOPS',
+  'PERF-SECURITY',
+  'PERF-PLATFORM',
+  'PERF-INFRA',
+  'PERF-DOCS',
+];
+
+// Prefixed with "perf-test-" so cleanup can target them precisely.
+const CONFLUENCE_ID_PREFIX = 'perf-test-';
+
+// ── Realistic content generation ────────────────────────────────────────────
+
+const TITLES = [
+  'Deployment Pipeline Overview',
+  'Kubernetes Cluster Setup Guide',
+  'Database Migration Runbook',
+  'Security Hardening Checklist',
+  'Monitoring and Alerting Strategy',
+  'Authentication Flow Architecture',
+  'Docker Container Best Practices',
+  'API Gateway Configuration',
+  'Load Testing Methodology',
+  'Configuration Management',
+  'Backup and Recovery Procedures',
+  'Network Architecture Diagram',
+  'Storage Tier Selection Guide',
+  'Logging Infrastructure Setup',
+  'CI/CD Pipeline Troubleshooting',
+  'Incident Response Playbook',
+  'Service Mesh Configuration',
+  'Secrets Management Policy',
+  'Performance Tuning Guide',
+  'Capacity Planning Document',
+  'Disaster Recovery Plan',
+  'Compliance Requirements',
+  'Onboarding Developer Guide',
+  'Microservices Communication Patterns',
+  'Data Retention Policy',
+];
+
+const PARAGRAPHS = [
+  'This document outlines the standard operating procedures for deploying services to production. All deployments must go through the staging environment first and pass automated smoke tests before promotion.',
+  'Kubernetes clusters are provisioned using Infrastructure as Code with Terraform. Each environment (dev, staging, production) has its own cluster with dedicated node pools for compute-intensive workloads.',
+  'Database migrations should be backward-compatible to support zero-downtime deployments. Always test migrations against a copy of production data before applying them to the live database.',
+  'Security scanning is integrated into the CI pipeline. All container images are scanned for known vulnerabilities, and any critical or high severity findings block the deployment.',
+  'The monitoring stack consists of Prometheus for metrics collection, Grafana for visualization, and Alertmanager for notification routing. Custom dashboards are version-controlled alongside the application code.',
+  'Authentication uses JWT tokens with short-lived access tokens (15 minutes) and longer-lived refresh tokens (7 days). Tokens are rotated automatically on each refresh to prevent replay attacks.',
+  'Docker images follow a multi-stage build pattern to minimize the final image size. Base images are pinned to specific digest hashes to ensure reproducible builds across environments.',
+  'The API gateway handles rate limiting, request routing, and TLS termination. Rate limits are configured per-endpoint based on expected traffic patterns and resource consumption.',
+  'Load tests simulate realistic user behavior with ramping virtual users. Tests run in a dedicated environment that mirrors production infrastructure to ensure accurate results.',
+  'Configuration is managed through environment variables with sensible defaults. Sensitive values are stored in a secrets manager and injected at runtime, never committed to source control.',
+  'Backups are taken every six hours with point-in-time recovery enabled. Recovery procedures are tested quarterly to ensure the documented RPO and RTO targets can be met.',
+  'The network architecture uses a hub-and-spoke model with private subnets for databases and internal services. Only the load balancer and bastion host are exposed to the public internet.',
+  'Storage tiers are selected based on access patterns. Frequently accessed data uses SSD-backed volumes, while archival data is moved to object storage with lifecycle policies.',
+  'Structured logging in JSON format enables efficient querying and analysis. Log levels are configurable at runtime without requiring a service restart.',
+  'The CI/CD pipeline uses GitHub Actions with self-hosted runners for builds that require access to internal resources. Pipeline definitions are stored in the repository alongside the application code.',
+  'Incident response follows a structured process: detect, triage, mitigate, resolve, and post-mortem. All incidents above severity 2 require a written post-mortem within 48 hours.',
+  'The service mesh provides mutual TLS between services, traffic management, and observability. Service-to-service communication is encrypted by default with certificates rotated automatically.',
+  'Secrets are rotated on a regular schedule and are never stored in plain text. Access to secrets is audited and follows the principle of least privilege.',
+  'Performance tuning starts with profiling to identify bottlenecks. Common optimizations include connection pooling, query optimization, caching strategies, and horizontal scaling.',
+  'Capacity planning uses historical metrics to forecast resource requirements. Autoscaling policies are configured with appropriate cooldown periods to prevent thrashing.',
+];
+
+const LABELS_POOL = [
+  'deployment', 'kubernetes', 'database', 'security', 'monitoring',
+  'authentication', 'docker', 'api', 'testing', 'configuration',
+  'backup', 'network', 'storage', 'logging', 'ci-cd',
+  'incident-response', 'service-mesh', 'secrets', 'performance', 'capacity',
+  'devops', 'sre', 'platform', 'infrastructure', 'compliance',
+];
+
+const AUTHORS = [
+  'alice.johnson', 'bob.smith', 'carol.williams', 'dave.brown',
+  'eve.davis', 'frank.miller', 'grace.wilson', 'hank.moore',
+];
+
+function randomItem<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)]!;
+}
+
+function randomSubset<T>(arr: T[], min: number, max: number): T[] {
+  const count = Math.floor(Math.random() * (max - min + 1)) + min;
+  const shuffled = [...arr].sort(() => Math.random() - 0.5);
+  return shuffled.slice(0, count);
+}
+
+function generateBodyText(index: number): string {
+  // Combine 3-5 paragraphs for each page to create realistic content length
+  const count = Math.floor(Math.random() * 3) + 3;
+  const selected: string[] = [];
+  for (let i = 0; i < count; i++) {
+    selected.push(PARAGRAPHS[(index + i) % PARAGRAPHS.length]!);
+  }
+  return selected.join('\n\n');
+}
+
+function generateRandomEmbedding(): number[] {
+  // Generate a normalized random vector (unit length) to mimic real embeddings
+  const vec = new Array(EMBEDDING_DIMS);
+  let norm = 0;
+  for (let i = 0; i < EMBEDDING_DIMS; i++) {
+    // Box-Muller transform for normally distributed values
+    const u1 = Math.random();
+    const u2 = Math.random();
+    vec[i] = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+    norm += vec[i] * vec[i];
+  }
+  norm = Math.sqrt(norm);
+  for (let i = 0; i < EMBEDDING_DIMS; i++) {
+    vec[i] /= norm;
+  }
+  return vec;
+}
+
+function randomDate(daysBack: number): Date {
+  const now = Date.now();
+  const offset = Math.floor(Math.random() * daysBack * 24 * 60 * 60 * 1000);
+  return new Date(now - offset);
+}
+
+// ── Database operations ─────────────────────────────────────────────────────
+
+async function cleanup(pool: pg.Pool): Promise<void> {
+  console.log('Cleaning up existing test data...');
+
+  // page_embeddings cascade-deletes when pages are deleted
+  const result = await pool.query(
+    `DELETE FROM pages WHERE confluence_id LIKE $1 RETURNING id`,
+    [`${CONFLUENCE_ID_PREFIX}%`],
+  );
+
+  console.log(`  Removed ${result.rowCount} test pages (and their embeddings).`);
+}
+
+async function seed(pool: pg.Pool): Promise<void> {
+  await cleanup(pool);
+
+  console.log(`Seeding ${TOTAL_PAGES} pages across ${TEST_SPACES.length} spaces...`);
+
+  let pagesInserted = 0;
+  let embeddingsInserted = 0;
+
+  for (let batch = 0; batch < TOTAL_PAGES; batch += BATCH_SIZE) {
+    const batchEnd = Math.min(batch + BATCH_SIZE, TOTAL_PAGES);
+
+    // Use a transaction per batch for atomicity and performance
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      for (let i = batch; i < batchEnd; i++) {
+        const confluenceId = `${CONFLUENCE_ID_PREFIX}${i.toString().padStart(5, '0')}`;
+        const spaceKey = TEST_SPACES[i % TEST_SPACES.length]!;
+        const title = `${TITLES[i % TITLES.length]} (#${i})`;
+        const bodyText = generateBodyText(i);
+        const labels = randomSubset(LABELS_POOL, 1, 5);
+        const author = randomItem(AUTHORS);
+        const lastModifiedAt = randomDate(180);
+
+        // Insert the page.
+        // The tsv column is maintained by a trigger (trg_pages_tsv) and computed automatically.
+        const pageResult = await client.query(
+          `INSERT INTO pages (
+            confluence_id, space_key, title, body_text, body_html,
+            version, labels, author, last_modified_at, last_synced,
+            embedding_dirty, embedding_status, embedded_at,
+            source, visibility, page_type
+          ) VALUES (
+            $1, $2, $3, $4, $5,
+            1, $6, $7, $8, NOW(),
+            FALSE, 'embedded', NOW(),
+            'confluence', 'shared', 'page'
+          ) RETURNING id`,
+          [
+            confluenceId,
+            spaceKey,
+            title,
+            bodyText,
+            `<p>${bodyText.replace(/\n\n/g, '</p><p>')}</p>`,
+            labels,
+            author,
+            lastModifiedAt,
+          ],
+        );
+
+        const pageId = pageResult.rows[0]!.id as number;
+        pagesInserted++;
+
+        // Insert embedding chunks for this page
+        for (let chunk = 0; chunk < CHUNKS_PER_PAGE; chunk++) {
+          const chunkStart = Math.floor((bodyText.length / CHUNKS_PER_PAGE) * chunk);
+          const chunkEnd = Math.floor((bodyText.length / CHUNKS_PER_PAGE) * (chunk + 1));
+          const chunkText = bodyText.slice(chunkStart, chunkEnd);
+          const embedding = generateRandomEmbedding();
+
+          await client.query(
+            `INSERT INTO page_embeddings (page_id, chunk_index, chunk_text, embedding, metadata)
+             VALUES ($1, $2, $3, $4, $5)`,
+            [
+              pageId,
+              chunk,
+              chunkText,
+              pgvector.toSql(embedding),
+              JSON.stringify({ source: 'perf-test', chunk_method: 'fixed' }),
+            ],
+          );
+
+          embeddingsInserted++;
+        }
+      }
+
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+
+    const progress = Math.round((batchEnd / TOTAL_PAGES) * 100);
+    process.stdout.write(`\r  Progress: ${progress}% (${batchEnd}/${TOTAL_PAGES} pages)`);
+  }
+
+  console.log(''); // newline after progress
+  console.log(`  Inserted ${pagesInserted} pages and ${embeddingsInserted} embedding chunks.`);
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const pool = new Pool({ connectionString: POSTGRES_URL });
+
+  try {
+    // Verify connection
+    const result = await pool.query('SELECT NOW() AS now');
+    console.log(`Connected to PostgreSQL at ${new Date(result.rows[0]!.now as string).toISOString()}`);
+
+    if (process.argv.includes('--cleanup')) {
+      await cleanup(pool);
+    } else {
+      await seed(pool);
+    }
+
+    console.log('Done.');
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Seed script failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add `perf/search-load-test.js` -- k6 load test that exercises all three search modes (keyword 60%, semantic 20%, hybrid 20%) with realistic queries, ramping from 0 to 50 VUs over 100 seconds
- Add `perf/seed-test-data.ts` -- TypeScript seed script that inserts 1000 pages with 3000 embedding chunks (1024-dim vectors) across 5 test spaces (`PERF-DEVOPS`, `PERF-SECURITY`, `PERF-PLATFORM`, `PERF-INFRA`, `PERF-DOCS`), with safe cleanup via `perf-test-*` confluence_id prefix
- Add `perf/README.md` -- instructions for installing k6, seeding data, running tests, and interpreting results

## Test plan

- [ ] Run `npx tsx perf/seed-test-data.ts` against a local PostgreSQL instance and verify 1000 pages + 3000 embeddings are inserted
- [ ] Run `npx tsx perf/seed-test-data.ts --cleanup` and verify all test data is removed
- [ ] Run `k6 run -e AUTH_TOKEN=<jwt> perf/search-load-test.js` and verify the test completes with passing thresholds
- [ ] Verify the k6 `setup()` function correctly detects when the backend is unreachable or the token is invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)