### PR TITLE
feat(enterprise): inline License/OIDC UI + build-info in SystemTab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,21 +124,23 @@ Compendiq uses an open-core model. The CE (Community Edition) is this repo. The 
 | `backend/src/core/enterprise/loader.ts` | Dynamic `import('@compendiq/enterprise')` with fallback to noop |
 | `backend/src/core/types/compendiq-enterprise.d.ts` | TypeScript declaration for the optional EE package |
 | `frontend/src/shared/enterprise/types.ts` | `EnterpriseUI` interface, `LicenseInfo`, `EnterpriseContextValue` |
-| `frontend/src/shared/enterprise/loader.ts` | Loads IIFE bundle via `<script>` tag injection; populates `window.__COMPENDIQ_DEPS__` with shared React instances |
-| `frontend/src/shared/enterprise/enterprise-context.ts` | React context object |
-| `frontend/src/shared/enterprise/context.tsx` | `EnterpriseProvider` component |
+| `frontend/src/shared/enterprise/context.tsx` | `EnterpriseProvider` — fetches `/api/admin/license` once per load; derives `isEnterprise` |
 | `frontend/src/shared/enterprise/use-enterprise.ts` | `useEnterprise()` hook |
+| `frontend/src/features/admin/LicenseStatusCard.tsx` | License status + key-entry form (admin Settings → License tab) |
+| `frontend/src/features/admin/OidcSettingsPage.tsx` | OIDC/SSO admin UI (admin Settings → SSO tab, gated by `isEnterprise`) |
+| `frontend/src/features/auth/OidcCallbackPage.tsx` | Route `/auth/oidc/callback` — exchanges login_code for JWT |
 | `docker/Dockerfile.enterprise` | Multi-stage Dockerfile template for EE builds (Layer 2+3 protection) |
 | `scripts/build-enterprise.sh` | Template script documenting the EE overlay merge process |
 
 **Rules for the enterprise extension points:**
-- CE defines types, loader, noop stub, and feature constants only. No enterprise logic.
+- CE defines types, loader, noop stub, and feature constants — plus the enterprise UI surfaces (`LicenseStatusCard`, `OidcSettingsPage`, `OidcCallbackPage`), which render their own state based on the live license API response.
 - The noop plugin must be completely inert (zero dependencies, zero side effects).
-- `app.ts` calls `loadEnterprisePlugin()` during bootstrap and decorates Fastify with `license` and `enterprise`.
+- `app.ts` calls `loadEnterprisePlugin()` during bootstrap and decorates Fastify with `license` and `enterprise`. The EE plugin's `registerRoutes()` additionally loads the persisted license key from the `admin_settings` table and refreshes the in-memory cache, so runtime `PUT /api/admin/license` updates take effect without a restart.
 - `GET /api/admin/license` returns `{ edition: 'community', tier: 'community', valid: true, features: [] }` in CE mode. The fallback route is only registered when `enterprise.version === 'community'` (noop plugin) to avoid duplicate-route errors when the EE plugin registers its own version via `registerRoutes()`.
+- The EE plugin's response additionally includes `displayKey`, `licenseId`, and `canUpdate: true` — the frontend reads `canUpdate` to decide whether to render the key-entry form in `LicenseStatusCard`. The CE noop fallback omits this flag.
 - OIDC routes are conditionally registered only when the enterprise plugin enables `ENTERPRISE_FEATURES.OIDC_SSO`.
-- Frontend `loadEnterpriseUI()` populates `window.__COMPENDIQ_DEPS__` with the CE SPA's live React/ReactQuery/FramerMotion instances, then injects a `<script src="/api/enterprise/frontend.js">` tag. The EE IIFE bundle registers `window.__COMPENDIQ_UI__` on load; the loader reads it back. In CE deployments the script returns 404 — the error is silently caught and `ui` stays null. `isEnterprise` is derived from the `/admin/license` API response (`edition !== 'community' && valid === true`), not from whether the overlay bundle loaded. Both CE and EE deployments use the same CE frontend image — no separate EE frontend image is needed.
-- License format: `ATM-{tier}-{seats}-{expiryYYYYMMDD}.{ed25519SignatureBase64url}` via `COMPENDIQ_LICENSE_KEY` env var.
+- Both CE and EE deployments ship the **same** unmodified CE frontend image. There is no EE-specific frontend image, no IIFE bundle, and no build-time patching of the CE SPA source. Enterprise UI is gated at runtime by `useEnterprise().isEnterprise`, derived from the `/admin/license` API response (`edition !== 'community' && valid === true`).
+- License format: `ATM-{tier}-{seats}-{expiryYYYYMMDD}-{licenseId}.{ed25519SignatureBase64url}` (v2) or legacy v1 without `licenseId`. Persisted in the `admin_settings` table under key `license_key` by the EE plugin. The `COMPENDIQ_LICENSE_KEY` env var is a **deprecated bootstrap fallback** — consulted only when the DB row is absent.
 
 ## Security (Mandatory)
 
@@ -257,6 +259,6 @@ Copy `.env.example` to `.env`. Key vars:
 - `OTEL_SERVICE_NAME` (optional, default: `compendiq-backend`)
 - `OTEL_EXPORTER_OTLP_ENDPOINT` (optional, OTLP collector endpoint)
 
-- `COMPENDIQ_LICENSE_KEY` (optional, enterprise license key, format: `ATM-{tier}-{seats}-{expiryYYYYMMDD}.{signature}`)
+- `COMPENDIQ_LICENSE_KEY` (deprecated bootstrap fallback — new installs should leave this unset and paste the key into Settings → License after first login; the EE plugin persists it in the `admin_settings` table and the env var is only consulted when the DB row is absent)
 
 OIDC/SSO is available in the Enterprise Edition only.

--- a/backend/src/core/utils/version.ts
+++ b/backend/src/core/utils/version.ts
@@ -23,4 +23,41 @@ function loadVersion(): string {
   return '0.0.0';
 }
 
+// Build metadata (edition, commit, builtAt). Written by the build pipeline
+// to <repo root>/build-info.json. EE builds overwrite the committed CE
+// placeholder with real git commit hashes via scripts/build-enterprise.sh.
+// The runtime image copies this file so we can read it here.
+export interface AppBuildInfo {
+  edition: string;
+  commit: string;
+  builtAt: string;
+}
+
+const DEFAULT_BUILD_INFO: AppBuildInfo = {
+  edition: 'community',
+  commit: 'unknown',
+  builtAt: '',
+};
+
+function loadBuildInfo(): AppBuildInfo {
+  const candidates = [
+    resolve(__dirname, '../../../../build-info.json'),  // dev (monorepo root)
+    resolve(__dirname, '../../../build-info.json'),     // Docker (/app/build-info.json)
+  ];
+  for (const p of candidates) {
+    try {
+      const parsed = JSON.parse(readFileSync(p, 'utf-8')) as Partial<AppBuildInfo>;
+      return {
+        edition: parsed.edition ?? DEFAULT_BUILD_INFO.edition,
+        commit: parsed.commit ?? DEFAULT_BUILD_INFO.commit,
+        builtAt: parsed.builtAt ?? DEFAULT_BUILD_INFO.builtAt,
+      };
+    } catch {
+      // try next candidate
+    }
+  }
+  return DEFAULT_BUILD_INFO;
+}
+
 export const APP_VERSION: string = loadVersion();
+export const APP_BUILD_INFO: AppBuildInfo = loadBuildInfo();

--- a/backend/src/routes/foundation/health.ts
+++ b/backend/src/routes/foundation/health.ts
@@ -5,7 +5,7 @@ import { getOllamaCircuitBreakerStatus, getOpenaiCircuitBreakerStatus } from '..
 import { getProvider } from '../../domains/llm/services/ollama-service.js';
 import { logger } from '../../core/utils/logger.js';
 import { getSharedLlmSettings } from '../../core/services/admin-settings-service.js';
-import { APP_VERSION } from '../../core/utils/version.js';
+import { APP_VERSION, APP_BUILD_INFO } from '../../core/utils/version.js';
 
 // Track whether startup checks have passed
 let startupComplete = false;
@@ -58,6 +58,9 @@ export async function healthRoutes(fastify: FastifyInstance) {
         redis,
       },
       version: APP_VERSION,
+      edition: APP_BUILD_INFO.edition,
+      commit: APP_BUILD_INFO.commit,
+      builtAt: APP_BUILD_INFO.builtAt,
       uptime: process.uptime(),
     });
   });
@@ -84,6 +87,9 @@ export async function healthRoutes(fastify: FastifyInstance) {
         llmProvider: sharedLlmSettings.llmProvider,
       },
       version: APP_VERSION,
+      edition: APP_BUILD_INFO.edition,
+      commit: APP_BUILD_INFO.commit,
+      builtAt: APP_BUILD_INFO.builtAt,
     });
   });
 
@@ -110,6 +116,9 @@ export async function healthRoutes(fastify: FastifyInstance) {
           openai: getOpenaiCircuitBreakerStatus(),
         },
         version: APP_VERSION,
+        edition: APP_BUILD_INFO.edition,
+        commit: APP_BUILD_INFO.commit,
+        builtAt: APP_BUILD_INFO.builtAt,
         uptime: process.uptime(),
       });
     } catch {
@@ -120,6 +129,9 @@ export async function healthRoutes(fastify: FastifyInstance) {
         status: allHealthy ? 'ok' : 'degraded',
         services: { postgres, redis, llm: false },
         version: APP_VERSION,
+        edition: APP_BUILD_INFO.edition,
+        commit: APP_BUILD_INFO.commit,
+        builtAt: APP_BUILD_INFO.builtAt,
         uptime: process.uptime(),
       });
     }

--- a/build-info.json
+++ b/build-info.json
@@ -1,0 +1,5 @@
+{
+  "edition": "community",
+  "commit": "unknown",
+  "builtAt": ""
+}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -27,6 +27,10 @@ RUN npm run build -w @compendiq/contracts
 COPY frontend/index.html frontend/vite.config.ts frontend/tsconfig.json frontend/tsconfig.node.json ./frontend/
 COPY frontend/public/ frontend/public/
 COPY frontend/src/ frontend/src/
+# Build-time metadata (edition + commit hash). Ships as a committed
+# placeholder in the CE repo; overwritten by scripts/build-enterprise.sh
+# in the EE flow. Read by vite.config.ts and injected as __BUILD_INFO__.
+COPY build-info.json ./build-info.json
 ENV VITE_API_URL=$VITE_API_URL
 RUN npm run build -w frontend
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { AppLayout } from './shared/components/layout/AppLayout';
 import { ErrorBoundary } from './shared/components/feedback/ErrorBoundary';
 
 import { LoginPage } from './features/settings/LoginPage';
+import { OidcCallbackPage } from './features/auth/OidcCallbackPage';
 import { SetupWizard } from './features/setup/SetupWizard';
 // Route-based code splitting: lazy-load all page components (#186)
 // LoginPage is statically imported — it's the first screen for
@@ -111,6 +112,7 @@ export function App() {
           <Routes>
             <Route path="/setup" element={<SetupRoute><SetupWizard /></SetupRoute>} />
             <Route path="/login" element={<LoginPage />} />
+            <Route path="/auth/oidc/callback" element={<OidcCallbackPage />} />
             <Route
               path="/*"
               element={

--- a/frontend/src/features/admin/LicenseStatusCard.test.tsx
+++ b/frontend/src/features/admin/LicenseStatusCard.test.tsx
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { LazyMotion, domMax } from 'framer-motion';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { LicenseStatusCard } from './LicenseStatusCard';
+import { useAuthStore } from '../../stores/auth-store';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LazyMotion features={domMax}>
+            {children}
+          </LazyMotion>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+interface LicenseMock {
+  edition: string;
+  tier: string;
+  seats?: number;
+  expiresAt?: string;
+  features: string[];
+  valid: boolean;
+  canUpdate?: boolean;
+  displayKey?: string;
+}
+
+function mockFetch(license: LicenseMock) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+    return new Response(JSON.stringify(license), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+}
+
+describe('LicenseStatusCard', () => {
+  beforeEach(() => {
+    useAuthStore.getState().setAuth('test-token', {
+      id: '1',
+      username: 'admin',
+      role: 'admin',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useAuthStore.getState().clearAuth();
+  });
+
+  it('shows community tier when no license', async () => {
+    mockFetch({
+      edition: 'community',
+      tier: 'community',
+      features: [],
+      valid: true,
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    expect(await screen.findByText('Community Edition')).toBeInTheDocument();
+    expect(screen.getByText(/Upgrade to unlock/)).toBeInTheDocument();
+  });
+
+  it('shows enterprise tier with features when licensed', async () => {
+    mockFetch({
+      edition: 'enterprise',
+      tier: 'enterprise',
+      seats: 50,
+      expiresAt: '2027-12-31T23:59:59.999Z',
+      features: ['oidc', 'audit-export', 'custom-branding', 'multi-instance', 'priority-support'],
+      valid: true,
+      canUpdate: true,
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    expect(await screen.findByText('Enterprise Edition')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('50')).toBeInTheDocument();
+  });
+
+  it('shows feature availability based on license', async () => {
+    mockFetch({
+      edition: 'enterprise',
+      tier: 'team',
+      seats: 10,
+      expiresAt: '2027-06-15T00:00:00.000Z',
+      features: ['oidc'],
+      valid: true,
+      canUpdate: true,
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    expect(await screen.findByText('Team Edition')).toBeInTheDocument();
+
+    const oidcFeature = screen.getByTestId('feature-oidc');
+    expect(oidcFeature).toBeInTheDocument();
+  });
+
+  it('does not show upgrade notice for licensed tiers', async () => {
+    mockFetch({
+      edition: 'enterprise',
+      tier: 'enterprise',
+      seats: 50,
+      expiresAt: '2027-12-31T23:59:59.999Z',
+      features: ['oidc'],
+      valid: true,
+      canUpdate: true,
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    expect(await screen.findByText('Enterprise Edition')).toBeInTheDocument();
+    expect(screen.queryByText(/Upgrade to unlock/)).not.toBeInTheDocument();
+  });
+
+  it('does not show seat/expiry stats for community tier', async () => {
+    mockFetch({
+      edition: 'community',
+      tier: 'community',
+      features: [],
+      valid: true,
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    expect(await screen.findByText('Community Edition')).toBeInTheDocument();
+    expect(screen.queryByText('Licensed Seats')).not.toBeInTheDocument();
+    expect(screen.queryByText('Expires')).not.toBeInTheDocument();
+  });
+
+  it('hides key entry form when backend cannot accept updates (CE noop)', async () => {
+    mockFetch({
+      edition: 'community',
+      tier: 'community',
+      features: [],
+      valid: true,
+      // canUpdate omitted — CE noop fallback
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    await screen.findByText('Community Edition');
+    expect(screen.queryByTestId('license-key-form')).not.toBeInTheDocument();
+    // Static upgrade message is shown instead
+    expect(screen.getByText(/Upgrade to unlock/)).toBeInTheDocument();
+  });
+
+  it('shows key entry form when backend declares canUpdate (EE community)', async () => {
+    mockFetch({
+      edition: 'community',
+      tier: 'community',
+      features: [],
+      valid: false,
+      canUpdate: true,
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    await screen.findByText('Community Edition');
+    expect(screen.getByTestId('license-key-form')).toBeInTheDocument();
+    expect(screen.getByTestId('license-key-input')).toBeInTheDocument();
+    expect(screen.getByTestId('license-key-save-btn')).toBeInTheDocument();
+    // No stored key yet, so Clear button is absent
+    expect(screen.queryByTestId('license-key-clear-btn')).not.toBeInTheDocument();
+  });
+
+  it('shows masked display key and Clear button when a key is stored', async () => {
+    mockFetch({
+      edition: 'enterprise',
+      tier: 'enterprise',
+      seats: 50,
+      expiresAt: '2027-12-31T23:59:59.999Z',
+      features: ['oidc'],
+      valid: true,
+      canUpdate: true,
+      displayKey: 'ATM-enterprise-50-20271231-CPQ1a2b3c4d.****',
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    await screen.findByText('Enterprise Edition');
+    const display = screen.getByTestId('license-key-display');
+    expect(display.textContent).toContain('ATM-enterprise-50-20271231');
+    expect(screen.getByTestId('license-key-clear-btn')).toBeInTheDocument();
+  });
+
+  it('sends PUT /admin/license when Save is clicked', async () => {
+    const savedLicense = {
+      edition: 'enterprise',
+      tier: 'enterprise' as const,
+      seats: 50,
+      expiresAt: '2027-12-31T23:59:59.999Z',
+      features: ['oidc'],
+      valid: true,
+      canUpdate: true,
+      displayKey: 'ATM-enterprise-50-20271231-CPQ1a2b3c4d.****',
+    };
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as Request).url;
+      const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+      if (method === 'PUT' && url.includes('/admin/license')) {
+        return new Response(JSON.stringify(savedLicense), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      // Initial GET — no stored key yet, canUpdate true
+      return new Response(
+        JSON.stringify({
+          edition: 'community',
+          tier: 'community',
+          features: [],
+          valid: false,
+          canUpdate: true,
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    const input = await screen.findByTestId('license-key-input');
+    fireEvent.change(input, { target: { value: 'ATM-enterprise-50-20271231-CPQ1a2b3c4d.signature' } });
+    fireEvent.click(screen.getByTestId('license-key-save-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Enterprise Edition')).toBeInTheDocument();
+    });
+
+    const putCall = fetchSpy.mock.calls.find((call) => {
+      const method = call[1]?.method;
+      return method === 'PUT';
+    });
+    expect(putCall).toBeTruthy();
+    expect(putCall?.[1]?.body).toContain('ATM-enterprise-50-20271231-CPQ1a2b3c4d.signature');
+  });
+});

--- a/frontend/src/features/admin/LicenseStatusCard.tsx
+++ b/frontend/src/features/admin/LicenseStatusCard.tsx
@@ -1,0 +1,299 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { m } from 'framer-motion';
+import { toast } from 'sonner';
+import { Shield, Crown, Users, Calendar, CheckCircle2, XCircle, AlertTriangle, KeyRound, Loader2, Save, Trash2 } from 'lucide-react';
+import type { LicenseInfoResponse } from '@compendiq/contracts';
+import { apiFetch } from '../../shared/lib/api';
+import { cn } from '../../shared/lib/cn';
+
+function useLicenseStatus() {
+  return useQuery<LicenseInfoResponse>({
+    queryKey: ['admin', 'license'],
+    queryFn: () => apiFetch('/admin/license'),
+    staleTime: 60_000,
+  });
+}
+
+const tierConfig: Record<string, { label: string; color: string; bgColor: string; borderColor: string }> = {
+  community: {
+    label: 'Community',
+    color: 'text-zinc-400',
+    bgColor: 'bg-zinc-500/10',
+    borderColor: 'border-zinc-500/30',
+  },
+  team: {
+    label: 'Team',
+    color: 'text-blue-400',
+    bgColor: 'bg-blue-500/10',
+    borderColor: 'border-blue-500/30',
+  },
+  business: {
+    label: 'Business',
+    color: 'text-purple-400',
+    bgColor: 'bg-purple-500/10',
+    borderColor: 'border-purple-500/30',
+  },
+  enterprise: {
+    label: 'Enterprise',
+    color: 'text-amber-400',
+    bgColor: 'bg-amber-500/10',
+    borderColor: 'border-amber-500/30',
+  },
+};
+
+export function LicenseStatusCard() {
+  const { data, isLoading } = useLicenseStatus();
+  const queryClient = useQueryClient();
+  const [keyInput, setKeyInput] = useState('');
+
+  const saveMutation = useMutation({
+    mutationFn: (key: string) =>
+      apiFetch<LicenseInfoResponse>('/admin/license', {
+        method: 'PUT',
+        body: JSON.stringify({ key }),
+      }),
+    onSuccess: (result) => {
+      queryClient.setQueryData(['admin', 'license'], result);
+      setKeyInput('');
+      if (result.valid && result.tier !== 'community') {
+        toast.success(`License activated — ${result.tier} edition`);
+      } else if (!result.valid) {
+        toast.error('License key saved but is invalid or expired');
+      } else {
+        toast.warning('License key saved (community tier)');
+      }
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const clearMutation = useMutation({
+    mutationFn: () =>
+      apiFetch<LicenseInfoResponse>('/admin/license', { method: 'DELETE' }),
+    onSuccess: (result) => {
+      queryClient.setQueryData(['admin', 'license'], result);
+      setKeyInput('');
+      toast.success('License key cleared');
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-16 animate-pulse rounded-lg bg-foreground/5" />
+        ))}
+      </div>
+    );
+  }
+
+  const tier = data?.tier ?? 'community';
+  const config = (tier in tierConfig ? tierConfig[tier] : tierConfig.community)!;
+  const isCommunity = tier === 'community';
+  const isValid = data?.valid === true;
+  const canUpdate = data?.canUpdate === true;
+  const hasStoredKey = Boolean(data?.displayKey && data.displayKey.length > 0);
+
+  const handleSave = () => {
+    const trimmed = keyInput.trim();
+    if (!trimmed) {
+      toast.error('Paste a license key first');
+      return;
+    }
+    saveMutation.mutate(trimmed);
+  };
+
+  return (
+    <div className="space-y-6" data-testid="license-status">
+      {/* Header */}
+      <div>
+        <h2 className="text-lg font-semibold">License</h2>
+        <p className="text-sm text-muted-foreground">
+          Your current license tier and available features
+        </p>
+      </div>
+
+      {/* Tier card */}
+      <m.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="glass-card overflow-hidden"
+      >
+        <div className="flex items-center justify-between p-5">
+          <div className="flex items-center gap-3">
+            <div className={cn(
+              'flex h-10 w-10 items-center justify-center rounded-lg',
+              config.bgColor,
+            )}>
+              <Crown size={20} className={config.color} />
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="text-lg font-semibold">{config.label} Edition</span>
+                <span className={cn(
+                  'inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium',
+                  config.borderColor,
+                  config.bgColor,
+                  config.color,
+                )}>
+                  {isValid ? 'Active' : isCommunity ? 'Free' : 'Inactive'}
+                </span>
+              </div>
+              {isCommunity && !canUpdate && (
+                <p className="text-sm text-muted-foreground">
+                  Enterprise features require the EE backend and a valid license key.
+                </p>
+              )}
+              {isCommunity && canUpdate && (
+                <p className="text-sm text-muted-foreground">
+                  Paste an enterprise license key below to activate paid features.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Stats */}
+        {!isCommunity && (
+          <div className="grid grid-cols-2 gap-px border-t border-border/40 bg-border/40">
+            <div className="bg-card p-4">
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Users size={12} />
+                Licensed Seats
+              </div>
+              <div className="mt-1 text-xl font-semibold">{data?.seats ?? 0}</div>
+            </div>
+            <div className="bg-card p-4">
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Calendar size={12} />
+                Expires
+              </div>
+              <div className="mt-1 text-xl font-semibold">
+                {data?.expiresAt ? new Date(data.expiresAt).toLocaleDateString() : 'N/A'}
+              </div>
+            </div>
+          </div>
+        )}
+      </m.div>
+
+      {/* License key management form — only visible when the responding
+          backend declares canUpdate (i.e. the EE plugin is loaded). The CE
+          noop fallback omits this flag so community deployments stay clean. */}
+      {canUpdate && (
+        <div className="glass-card p-5" data-testid="license-key-form">
+          <div className="mb-3 flex items-center gap-2">
+            <KeyRound size={16} className="text-muted-foreground" />
+            <h3 className="text-sm font-medium">License Key</h3>
+          </div>
+          {hasStoredKey && (
+            <div className="mb-3 rounded-md border border-border/40 bg-foreground/5 px-3 py-2 font-mono text-xs text-muted-foreground" data-testid="license-key-display">
+              Stored: {data?.displayKey}
+            </div>
+          )}
+          <textarea
+            value={keyInput}
+            onChange={(e) => setKeyInput(e.target.value)}
+            placeholder="ATM-enterprise-50-20271231-CPQ1a2b3.abcd..."
+            rows={3}
+            className="w-full resize-none rounded-md bg-foreground/5 px-3 py-2 font-mono text-xs outline-none focus:ring-1 focus:ring-primary disabled:opacity-60"
+            data-testid="license-key-input"
+            disabled={saveMutation.isPending || clearMutation.isPending}
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Paste the full license key including the signature after the dot. Stored securely in the backend database.
+          </p>
+          <div className="mt-3 flex items-center gap-2">
+            <button
+              onClick={handleSave}
+              disabled={!keyInput.trim() || saveMutation.isPending || clearMutation.isPending}
+              className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              data-testid="license-key-save-btn"
+            >
+              {saveMutation.isPending ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Save size={14} />
+              )}
+              Save Key
+            </button>
+            {hasStoredKey && (
+              <button
+                onClick={() => clearMutation.mutate()}
+                disabled={saveMutation.isPending || clearMutation.isPending}
+                className="flex items-center gap-2 rounded-lg border border-border/50 bg-transparent px-4 py-2 text-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
+                data-testid="license-key-clear-btn"
+              >
+                {clearMutation.isPending ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <Trash2 size={14} />
+                )}
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Features */}
+      <div className="glass-card p-5">
+        <h3 className="mb-3 text-sm font-medium">Available Features</h3>
+        <div className="space-y-2">
+          {[
+            { key: 'oidc', label: 'SSO / OIDC Authentication', description: 'Single sign-on with your identity provider' },
+            { key: 'audit-export', label: 'Audit Log Export', description: 'Export audit logs for compliance' },
+            { key: 'custom-branding', label: 'Custom Branding', description: 'White-label with your organization branding' },
+            { key: 'multi-instance', label: 'Multi-Instance', description: 'Deploy multiple isolated instances' },
+            { key: 'priority-support', label: 'Priority Support', description: 'Dedicated support channel' },
+          ].map((feature) => {
+            const isAvailable = data?.features?.includes(feature.key) ?? false;
+            return (
+              <div
+                key={feature.key}
+                className="flex items-center justify-between rounded-lg border border-border/30 px-4 py-3"
+                data-testid={`feature-${feature.key}`}
+              >
+                <div className="flex items-center gap-3">
+                  <Shield size={16} className={isAvailable ? 'text-emerald-500' : 'text-muted-foreground/40'} />
+                  <div>
+                    <div className={cn('text-sm font-medium', !isAvailable && 'text-muted-foreground')}>
+                      {feature.label}
+                    </div>
+                    <div className="text-xs text-muted-foreground">{feature.description}</div>
+                  </div>
+                </div>
+                {isAvailable ? (
+                  <CheckCircle2 size={16} className="text-emerald-500" />
+                ) : (
+                  <XCircle size={16} className="text-muted-foreground/30" />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Upgrade notice for community deployments that cannot self-activate
+          (i.e. the CE backend is noop — no canUpdate). EE community shows
+          the form above instead, which lets the admin paste a key directly. */}
+      {isCommunity && !canUpdate && (
+        <m.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.2 }}
+          className="flex items-start gap-3 rounded-lg border border-amber-500/20 bg-amber-500/5 p-4"
+        >
+          <AlertTriangle size={18} className="mt-0.5 shrink-0 text-amber-500" />
+          <div>
+            <div className="text-sm font-medium text-amber-200">Upgrade to unlock enterprise features</div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              Enterprise features like SSO/OIDC, audit log export, and custom branding require a Compendiq enterprise license.
+              Contact your administrator or visit the Compendiq website for licensing options.
+            </div>
+          </div>
+        </m.div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/admin/OidcSettingsPage.test.tsx
+++ b/frontend/src/features/admin/OidcSettingsPage.test.tsx
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { LazyMotion, domMax } from 'framer-motion';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { OidcSettingsPage } from './OidcSettingsPage';
+import { useAuthStore } from '../../stores/auth-store';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LazyMotion features={domMax}>
+            {children}
+          </LazyMotion>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+const mockProvider = {
+  id: 1,
+  name: 'default',
+  issuerUrl: 'https://idp.example.com',
+  clientId: 'test-client-id',
+  redirectUri: 'http://localhost:3051/api/auth/oidc/callback',
+  groupsClaim: 'groups',
+  enabled: true,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+const mockMappings = [
+  { id: 1, oidcGroup: 'engineering', roleId: 3, roleName: 'editor', spaceKey: 'DEV' },
+  { id: 2, oidcGroup: 'admin-team', roleId: 1, roleName: 'system_admin', spaceKey: null },
+];
+
+const mockRoles = [
+  { id: 1, name: 'system_admin', displayName: 'System Administrator' },
+  { id: 3, name: 'editor', displayName: 'Editor' },
+  { id: 5, name: 'viewer', displayName: 'Viewer' },
+];
+
+function mockFetch(options?: { configured?: boolean; enabled?: boolean }) {
+  const configured = options?.configured ?? true;
+  const enabled = options?.enabled ?? true;
+
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = typeof input === 'string' ? input : (input as Request).url;
+
+    if (url.includes('/admin/license')) {
+      return new Response(
+        JSON.stringify({
+          edition: 'enterprise',
+          tier: 'enterprise',
+          seats: 50,
+          expiresAt: '2027-12-31T23:59:59Z',
+          features: ['oidc'],
+          valid: true,
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    if (url.includes('/admin/oidc/mappings')) {
+      return new Response(JSON.stringify(mockMappings), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('/admin/oidc')) {
+      return new Response(
+        JSON.stringify({
+          configured,
+          provider: configured ? { ...mockProvider, enabled } : null,
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    if (url.includes('/roles')) {
+      return new Response(JSON.stringify(mockRoles), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify({}), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+}
+
+describe('OidcSettingsPage', () => {
+  beforeEach(() => {
+    useAuthStore.getState().setAuth('test-token', {
+      id: '1',
+      username: 'admin',
+      role: 'admin',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useAuthStore.getState().clearAuth();
+  });
+
+  it('renders the page heading', () => {
+    mockFetch();
+    render(<OidcSettingsPage />, { wrapper: createWrapper() });
+    expect(screen.getByText('SSO / OIDC')).toBeInTheDocument();
+  });
+
+  it('renders both tab buttons', () => {
+    mockFetch();
+    render(<OidcSettingsPage />, { wrapper: createWrapper() });
+    expect(screen.getByTestId('oidc-tab-provider')).toBeInTheDocument();
+    expect(screen.getByTestId('oidc-tab-mappings')).toBeInTheDocument();
+  });
+
+  it('shows provider tab by default with config form', async () => {
+    mockFetch();
+    render(<OidcSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oidc-provider-form')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('oidc-issuer-url')).toBeInTheDocument();
+    expect(screen.getByTestId('oidc-client-id')).toBeInTheDocument();
+    expect(screen.getByTestId('oidc-client-secret')).toBeInTheDocument();
+    expect(screen.getByTestId('oidc-redirect-uri')).toBeInTheDocument();
+    expect(screen.getByTestId('oidc-groups-claim')).toBeInTheDocument();
+  });
+
+  it('shows SSO Active status when configured and enabled', async () => {
+    mockFetch({ configured: true, enabled: true });
+    render(<OidcSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('SSO Active')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Not configured" status when no provider', async () => {
+    mockFetch({ configured: false });
+    render(<OidcSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Not configured')).toBeInTheDocument();
+    });
+  });
+
+  it('has a test connection button', async () => {
+    mockFetch();
+    render(<OidcSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oidc-test-btn')).toBeInTheDocument();
+    });
+  });
+
+  it('has a save button', async () => {
+    mockFetch();
+    render(<OidcSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oidc-save-btn')).toBeInTheDocument();
+    });
+  });
+
+  it('switches to mappings tab', async () => {
+    mockFetch();
+    render(<OidcSettingsPage />, { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByTestId('oidc-tab-mappings'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oidc-mappings')).toBeInTheDocument();
+    });
+  });
+
+  it('shows existing mappings in table', async () => {
+    mockFetch();
+    render(<OidcSettingsPage />, { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByTestId('oidc-tab-mappings'));
+
+    await waitFor(() => {
+      expect(screen.getByText('engineering')).toBeInTheDocument();
+    });
+    expect(screen.getByText('editor')).toBeInTheDocument();
+    expect(screen.getByText('DEV')).toBeInTheDocument();
+  });
+
+  it('shows enterprise-required banner in community mode', async () => {
+    // Override fetch to return community license
+    vi.restoreAllMocks();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : (input as Request).url;
+      if (url.includes('/admin/license')) {
+        return new Response(
+          JSON.stringify({
+            edition: 'community',
+            tier: 'community',
+            features: [],
+            valid: true,
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (url.includes('/admin/oidc/mappings')) {
+        return new Response(JSON.stringify([]), { headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url.includes('/admin/oidc')) {
+        return new Response(
+          JSON.stringify({ configured: false, provider: null }),
+          { headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (url.includes('/roles')) {
+        return new Response(JSON.stringify([]), { headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({}), { headers: { 'Content-Type': 'application/json' } });
+    });
+
+    render(<OidcSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('enterprise-required-banner')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Enterprise License Required')).toBeInTheDocument();
+    // Save button should be disabled
+    expect(screen.getByTestId('oidc-save-btn')).toBeDisabled();
+  });
+
+  it('shows create mapping form when button clicked', async () => {
+    mockFetch();
+    render(<OidcSettingsPage />, { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByTestId('oidc-tab-mappings'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-mapping-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('create-mapping-btn'));
+    expect(screen.getByTestId('create-mapping-form')).toBeInTheDocument();
+    expect(screen.getByTestId('mapping-oidc-group')).toBeInTheDocument();
+    expect(screen.getByTestId('mapping-role')).toBeInTheDocument();
+    expect(screen.getByTestId('mapping-space-key')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/admin/OidcSettingsPage.tsx
+++ b/frontend/src/features/admin/OidcSettingsPage.tsx
@@ -1,0 +1,663 @@
+import { useState, useCallback } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { m } from 'framer-motion';
+import { toast } from 'sonner';
+import {
+  Shield, Globe, Key, Link2, Plus, Trash2,
+  Loader2, CheckCircle2, XCircle, TestTube2, AlertTriangle,
+} from 'lucide-react';
+import type { LicenseInfoResponse } from '@compendiq/contracts';
+import { apiFetch } from '../../shared/lib/api';
+import { cn } from '../../shared/lib/cn';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface OidcProvider {
+  id: number;
+  name: string;
+  issuerUrl: string;
+  clientId: string;
+  redirectUri: string;
+  groupsClaim: string;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface OidcConfigResponse {
+  configured: boolean;
+  provider: OidcProvider | null;
+}
+
+interface OidcMapping {
+  id: number;
+  oidcGroup: string;
+  roleId: number;
+  roleName: string | null;
+  spaceKey: string | null;
+}
+
+interface Role {
+  id: number;
+  name: string;
+  displayName: string;
+}
+
+interface TestResult {
+  success: boolean;
+  issuer?: string;
+  authorizationEndpoint?: string;
+  tokenEndpoint?: string;
+  endSessionEndpoint?: string | null;
+  error?: string;
+}
+
+type OidcTab = 'provider' | 'mappings';
+
+// ── Hooks ──────────────────────────────────────────────────────────────────────
+
+function useOidcConfig() {
+  return useQuery<OidcConfigResponse>({
+    queryKey: ['admin', 'oidc'],
+    queryFn: () => apiFetch('/admin/oidc'),
+    staleTime: 30_000,
+  });
+}
+
+function useOidcMappings() {
+  return useQuery<OidcMapping[]>({
+    queryKey: ['admin', 'oidc', 'mappings'],
+    queryFn: () => apiFetch('/admin/oidc/mappings'),
+    staleTime: 30_000,
+  });
+}
+
+function useRoles() {
+  return useQuery<Role[]>({
+    queryKey: ['admin', 'roles'],
+    queryFn: () => apiFetch('/roles'),
+    staleTime: 60_000,
+  });
+}
+
+function useLicenseStatus() {
+  return useQuery<LicenseInfoResponse>({
+    queryKey: ['admin', 'license'],
+    queryFn: () => apiFetch('/admin/license'),
+    staleTime: 60_000,
+  });
+}
+
+// ── Provider Configuration Tab ─────────────────────────────────────────────────
+
+function ProviderTab({ disabled }: { disabled?: boolean }) {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useOidcConfig();
+
+  const [issuerUrl, setIssuerUrl] = useState('');
+  const [clientId, setClientId] = useState('');
+  const [clientSecret, setClientSecret] = useState('');
+  const [redirectUri, setRedirectUri] = useState('');
+  const [groupsClaim, setGroupsClaim] = useState('groups');
+  const [enabled, setEnabled] = useState(false);
+  const [initialized, setInitialized] = useState(false);
+  const [testResult, setTestResult] = useState<TestResult | null>(null);
+
+  // Populate form when data loads
+  if (data?.provider && !initialized) {
+    setIssuerUrl(data.provider.issuerUrl);
+    setClientId(data.provider.clientId);
+    setRedirectUri(data.provider.redirectUri);
+    setGroupsClaim(data.provider.groupsClaim);
+    setEnabled(data.provider.enabled);
+    setInitialized(true);
+  }
+
+  const saveMutation = useMutation({
+    mutationFn: (body: Record<string, unknown>) =>
+      apiFetch('/admin/oidc', { method: 'PUT', body: JSON.stringify(body) }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'oidc'] });
+      toast.success('OIDC configuration saved');
+      setClientSecret(''); // Clear secret after save
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const testMutation = useMutation({
+    mutationFn: (body: { issuerUrl: string }) =>
+      apiFetch<TestResult>('/admin/oidc/test', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      }),
+    onSuccess: (result) => {
+      setTestResult(result);
+      if (result.success) {
+        toast.success('Connection successful');
+      } else {
+        toast.error(result.error ?? 'Connection failed');
+      }
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const handleSave = useCallback(() => {
+    if (!issuerUrl || !clientId || !redirectUri) {
+      toast.error('Issuer URL, Client ID, and Redirect URI are required');
+      return;
+    }
+    if (!data?.configured && !clientSecret) {
+      toast.error('Client Secret is required for initial setup');
+      return;
+    }
+
+    saveMutation.mutate({
+      issuerUrl,
+      clientId,
+      // Only send clientSecret when the admin entered a new value.
+      // Omitting it tells the backend to preserve the existing encrypted secret.
+      ...(clientSecret ? { clientSecret } : {}),
+      redirectUri,
+      groupsClaim,
+      enabled,
+    });
+  }, [issuerUrl, clientId, clientSecret, redirectUri, groupsClaim, enabled, data, saveMutation]);
+
+  const handleTest = useCallback(() => {
+    if (!issuerUrl) {
+      toast.error('Enter an Issuer URL to test');
+      return;
+    }
+    setTestResult(null);
+    testMutation.mutate({ issuerUrl });
+  }, [issuerUrl, testMutation]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-16 animate-pulse rounded-lg bg-foreground/5" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6" data-testid="oidc-provider-form">
+      {/* Status indicator */}
+      <div className="glass-card p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <div className={cn(
+              'h-2.5 w-2.5 rounded-full',
+              data?.configured && data.provider?.enabled
+                ? 'bg-emerald-500'
+                : data?.configured
+                  ? 'bg-amber-500'
+                  : 'bg-zinc-500',
+            )} />
+            <span className="text-sm font-medium">
+              {data?.configured && data.provider?.enabled
+                ? 'SSO Active'
+                : data?.configured
+                  ? 'Configured (disabled)'
+                  : 'Not configured'}
+            </span>
+          </div>
+          {data?.configured && (
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={(e) => setEnabled(e.target.checked)}
+                className="h-4 w-4 rounded border-border accent-primary"
+                disabled={disabled}
+              />
+              Enabled
+            </label>
+          )}
+        </div>
+      </div>
+
+      {/* Provider form */}
+      <div className="space-y-4">
+        <div>
+          <label className="mb-1.5 flex items-center gap-1.5 text-sm font-medium">
+            <Globe size={14} className="text-muted-foreground" />
+            Issuer URL
+          </label>
+          <div className="flex gap-2">
+            <input
+              type="url"
+              value={issuerUrl}
+              onChange={(e) => setIssuerUrl(e.target.value)}
+              placeholder="https://idp.example.com/realms/main"
+              className="flex-1 rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary disabled:opacity-60 disabled:cursor-not-allowed"
+              data-testid="oidc-issuer-url"
+              disabled={disabled}
+            />
+            <button
+              onClick={handleTest}
+              disabled={disabled || !issuerUrl || testMutation.isPending}
+              className="flex items-center gap-1.5 rounded-md bg-foreground/5 px-3 py-2 text-sm hover:bg-foreground/10 disabled:opacity-50"
+              data-testid="oidc-test-btn"
+            >
+              {testMutation.isPending ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <TestTube2 size={14} />
+              )}
+              Test
+            </button>
+          </div>
+          {testResult && (
+            <m.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: 'auto' }}
+              className={cn(
+                'mt-2 rounded-md p-3 text-xs',
+                testResult.success
+                  ? 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400'
+                  : 'bg-destructive/10 text-destructive',
+              )}
+            >
+              <div className="flex items-center gap-1.5">
+                {testResult.success ? (
+                  <CheckCircle2 size={14} />
+                ) : (
+                  <XCircle size={14} />
+                )}
+                <span className="font-medium">
+                  {testResult.success ? 'Connection successful' : 'Connection failed'}
+                </span>
+              </div>
+              {testResult.success && testResult.issuer && (
+                <div className="mt-1.5 space-y-0.5 text-muted-foreground">
+                  <div>Issuer: {testResult.issuer}</div>
+                  {testResult.endSessionEndpoint && (
+                    <div>Logout endpoint: available</div>
+                  )}
+                </div>
+              )}
+              {!testResult.success && testResult.error && (
+                <div className="mt-1 text-muted-foreground">{testResult.error}</div>
+              )}
+            </m.div>
+          )}
+        </div>
+
+        <div>
+          <label className="mb-1.5 flex items-center gap-1.5 text-sm font-medium">
+            <Key size={14} className="text-muted-foreground" />
+            Client ID
+          </label>
+          <input
+            type="text"
+            value={clientId}
+            onChange={(e) => setClientId(e.target.value)}
+            placeholder="my-app-client-id"
+            className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary disabled:opacity-60 disabled:cursor-not-allowed"
+            data-testid="oidc-client-id"
+            disabled={disabled}
+          />
+        </div>
+
+        <div>
+          <label className="mb-1.5 flex items-center gap-1.5 text-sm font-medium">
+            <Key size={14} className="text-muted-foreground" />
+            Client Secret
+          </label>
+          <input
+            type="password"
+            value={clientSecret}
+            onChange={(e) => setClientSecret(e.target.value)}
+            placeholder={data?.configured ? '(unchanged — enter new value to rotate)' : 'Enter client secret'}
+            className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary disabled:opacity-60 disabled:cursor-not-allowed"
+            data-testid="oidc-client-secret"
+            disabled={disabled}
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Encrypted at rest with AES-256-GCM. Never exposed in API responses.
+          </p>
+        </div>
+
+        <div>
+          <label className="mb-1.5 flex items-center gap-1.5 text-sm font-medium">
+            <Link2 size={14} className="text-muted-foreground" />
+            Redirect URI
+          </label>
+          <input
+            type="url"
+            value={redirectUri}
+            onChange={(e) => setRedirectUri(e.target.value)}
+            placeholder="http://localhost:3000/api/auth/oidc/callback"
+            className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary disabled:opacity-60 disabled:cursor-not-allowed"
+            data-testid="oidc-redirect-uri"
+            disabled={disabled}
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Must match the redirect URI registered with your identity provider.
+          </p>
+        </div>
+
+        <div>
+          <label className="mb-1.5 flex items-center gap-1.5 text-sm font-medium">
+            <Shield size={14} className="text-muted-foreground" />
+            Groups Claim Name
+          </label>
+          <input
+            type="text"
+            value={groupsClaim}
+            onChange={(e) => setGroupsClaim(e.target.value)}
+            placeholder="groups"
+            className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary disabled:opacity-60 disabled:cursor-not-allowed"
+            data-testid="oidc-groups-claim"
+            disabled={disabled}
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            The claim name in the ID token that contains the user's group memberships.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-t border-border/50 pt-4">
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            className="h-4 w-4 rounded border-border accent-primary"
+            data-testid="oidc-enabled"
+            disabled={disabled}
+          />
+          Enable SSO
+        </label>
+        <button
+          onClick={handleSave}
+          disabled={disabled || saveMutation.isPending}
+          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          data-testid="oidc-save-btn"
+        >
+          {saveMutation.isPending && <Loader2 size={14} className="animate-spin" />}
+          Save Configuration
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Group Mappings Tab ─────────────────────────────────────────────────────────
+
+function MappingsTab({ disabled }: { disabled?: boolean }) {
+  const queryClient = useQueryClient();
+  const { data: mappings, isLoading } = useOidcMappings();
+  const { data: roles } = useRoles();
+
+  const [showForm, setShowForm] = useState(false);
+  const [oidcGroup, setOidcGroup] = useState('');
+  const [roleId, setRoleId] = useState<number>(0);
+  const [spaceKey, setSpaceKey] = useState('');
+
+  const createMutation = useMutation({
+    mutationFn: (body: { oidcGroup: string; roleId: number; spaceKey: string | null }) =>
+      apiFetch('/admin/oidc/mappings', { method: 'POST', body: JSON.stringify(body) }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'oidc', 'mappings'] });
+      setShowForm(false);
+      setOidcGroup('');
+      setRoleId(0);
+      setSpaceKey('');
+      toast.success('Mapping created');
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) =>
+      apiFetch(`/admin/oidc/mappings/${id}`, { method: 'DELETE' }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'oidc', 'mappings'] });
+      toast.success('Mapping deleted');
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const handleCreate = useCallback(() => {
+    if (!oidcGroup.trim() || !roleId) {
+      toast.error('OIDC Group and Role are required');
+      return;
+    }
+    createMutation.mutate({
+      oidcGroup: oidcGroup.trim(),
+      roleId,
+      spaceKey: spaceKey.trim() || null,
+    });
+  }, [oidcGroup, roleId, spaceKey, createMutation]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="glass-card h-16 animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4" data-testid="oidc-mappings">
+      <p className="text-sm text-muted-foreground">
+        Map OIDC group claims to roles. When a user logs in with SSO, their group
+        memberships are synced and role assignments are applied automatically.
+      </p>
+
+      {/* Create mapping */}
+      {!showForm ? (
+        <button
+          onClick={() => setShowForm(true)}
+          disabled={disabled}
+          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          data-testid="create-mapping-btn"
+        >
+          <Plus size={16} />
+          New Mapping
+        </button>
+      ) : (
+        <m.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="glass-card space-y-3 p-4"
+          data-testid="create-mapping-form"
+        >
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                OIDC Group
+              </label>
+              <input
+                type="text"
+                value={oidcGroup}
+                onChange={(e) => setOidcGroup(e.target.value)}
+                placeholder="engineering"
+                className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary"
+                data-testid="mapping-oidc-group"
+                autoFocus
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                Role
+              </label>
+              <select
+                value={roleId}
+                onChange={(e) => setRoleId(Number(e.target.value))}
+                className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary"
+                data-testid="mapping-role"
+              >
+                <option value={0}>Select role...</option>
+                {roles?.map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.displayName || r.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                Space Key (optional)
+              </label>
+              <input
+                type="text"
+                value={spaceKey}
+                onChange={(e) => setSpaceKey(e.target.value)}
+                placeholder="DEV"
+                className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary"
+                data-testid="mapping-space-key"
+              />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={handleCreate}
+              disabled={!oidcGroup.trim() || !roleId || createMutation.isPending}
+              className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              data-testid="submit-mapping"
+            >
+              {createMutation.isPending && <Loader2 size={14} className="animate-spin" />}
+              Create
+            </button>
+            <button
+              onClick={() => setShowForm(false)}
+              className="rounded-md bg-foreground/5 px-3 py-1.5 text-sm hover:bg-foreground/10"
+            >
+              Cancel
+            </button>
+          </div>
+        </m.div>
+      )}
+
+      {/* Mappings list */}
+      {!mappings?.length ? (
+        <div className="glass-card py-12 text-center text-sm text-muted-foreground">
+          No group mappings configured yet
+        </div>
+      ) : (
+        <div className="glass-card overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border/50 text-left text-xs text-muted-foreground">
+                <th className="px-4 py-3 font-medium">OIDC Group</th>
+                <th className="px-4 py-3 font-medium">Role</th>
+                <th className="px-4 py-3 font-medium">Space</th>
+                <th className="w-16 px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/30">
+              {mappings.map((mapping, i) => (
+                <m.tr
+                  key={mapping.id}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ delay: i * 0.03 }}
+                  className="hover:bg-foreground/5"
+                  data-testid={`mapping-${mapping.id}`}
+                >
+                  <td className="px-4 py-2.5 font-mono text-xs">{mapping.oidcGroup}</td>
+                  <td className="px-4 py-2.5">
+                    <span className="rounded bg-primary/10 px-2 py-0.5 text-xs text-primary">
+                      {mapping.roleName ?? `Role #${mapping.roleId}`}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2.5 text-muted-foreground">
+                    {mapping.spaceKey ?? '(global)'}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <button
+                      onClick={() => deleteMutation.mutate(mapping.id)}
+                      disabled={disabled || deleteMutation.isPending}
+                      className="rounded p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
+                      aria-label={`Delete mapping for ${mapping.oidcGroup}`}
+                      data-testid={`delete-mapping-${mapping.id}`}
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </td>
+                </m.tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main Page ──────────────────────────────────────────────────────────────────
+
+const TAB_CONFIG: Array<{ key: OidcTab; label: string; icon: typeof Shield }> = [
+  { key: 'provider', label: 'Provider', icon: Globe },
+  { key: 'mappings', label: 'Group Mappings', icon: Shield },
+];
+
+export function OidcSettingsPage() {
+  const [activeTab, setActiveTab] = useState<OidcTab>('provider');
+  const { data: license, isLoading: licenseLoading } = useLicenseStatus();
+  const isCommunity = !licenseLoading && (license?.valid !== true || license?.tier === 'community');
+
+  return (
+    <div className="space-y-6">
+      {/* Enterprise license banner */}
+      {isCommunity && (
+        <m.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex items-start gap-3 rounded-lg border border-amber-500/20 bg-amber-500/5 p-4"
+          data-testid="enterprise-required-banner"
+        >
+          <AlertTriangle size={18} className="mt-0.5 shrink-0 text-amber-500" />
+          <div>
+            <div className="text-sm font-medium text-amber-200">Enterprise License Required</div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              SSO / OIDC authentication requires an active enterprise license. The configuration below is read-only.
+              Set the <code className="rounded bg-foreground/10 px-1.5 py-0.5">COMPENDIQ_LICENSE_KEY</code> environment variable to enable this feature.
+            </div>
+          </div>
+        </m.div>
+      )}
+
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold">SSO / OIDC</h1>
+        <p className="text-sm text-muted-foreground">
+          Configure single sign-on with your identity provider
+        </p>
+      </div>
+
+      {/* Tabs */}
+      <div className="glass-card p-1.5">
+        <div className="flex gap-1">
+          {TAB_CONFIG.map(({ key, label, icon: Icon }) => (
+            <button
+              key={key}
+              onClick={() => setActiveTab(key)}
+              className={cn(
+                'flex items-center gap-1.5 rounded-md px-4 py-2 text-sm transition-colors',
+                activeTab === key
+                  ? 'bg-primary/15 text-primary font-medium'
+                  : 'text-muted-foreground hover:bg-foreground/5',
+              )}
+              data-testid={`oidc-tab-${key}`}
+            >
+              <Icon size={14} />
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Tab content */}
+      {activeTab === 'provider' && <ProviderTab disabled={isCommunity} />}
+      {activeTab === 'mappings' && <MappingsTab disabled={isCommunity} />}
+    </div>
+  );
+}

--- a/frontend/src/features/auth/OidcCallbackPage.test.tsx
+++ b/frontend/src/features/auth/OidcCallbackPage.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { LazyMotion, domMax } from 'framer-motion';
+import { OidcCallbackPage } from './OidcCallbackPage';
+import { useAuthStore } from '../../stores/auth-store';
+
+function renderWithRouter(initialEntry: string) {
+  return render(
+    <LazyMotion features={domMax}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/auth/oidc/callback" element={<OidcCallbackPage />} />
+          <Route path="/login" element={<div data-testid="login-page">Login</div>} />
+          <Route path="/" element={<div data-testid="home-page">Home</div>} />
+        </Routes>
+      </MemoryRouter>
+    </LazyMotion>,
+  );
+}
+
+describe('OidcCallbackPage', () => {
+  beforeEach(() => {
+    useAuthStore.getState().clearAuth();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    useAuthStore.getState().clearAuth();
+  });
+
+  it('shows error when login_code is missing', () => {
+    renderWithRouter('/auth/oidc/callback');
+    expect(screen.getByText('SSO Login Failed')).toBeInTheDocument();
+    expect(screen.getByText(/Missing login code/)).toBeInTheDocument();
+  });
+
+  it('shows loading state while exchanging code', () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () => new Promise(() => {}), // Never resolves
+    );
+
+    renderWithRouter('/auth/oidc/callback?login_code=test-code');
+    expect(screen.getByText('Completing SSO sign-in...')).toBeInTheDocument();
+  });
+
+  it('exchanges code and navigates to home on success', async () => {
+    const mockResponse = {
+      accessToken: 'test-access-token',
+      user: { id: 'user-1', username: 'jdoe', role: 'user' },
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderWithRouter('/auth/oidc/callback?login_code=valid-code');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home-page')).toBeInTheDocument();
+    });
+
+    // Auth store should be populated
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    expect(useAuthStore.getState().user?.username).toBe('jdoe');
+  });
+
+  it('shows error on failed exchange', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Invalid or expired login code' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderWithRouter('/auth/oidc/callback?login_code=expired-code');
+
+    await waitFor(() => {
+      expect(screen.getByText('SSO Login Failed')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Invalid or expired login code/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/auth/OidcCallbackPage.tsx
+++ b/frontend/src/features/auth/OidcCallbackPage.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuthStore } from '../../stores/auth-store';
+
+/**
+ * OIDC callback page: exchanges the one-time login code from the URL
+ * for JWT tokens via POST /api/auth/oidc/exchange, then stores auth
+ * state and redirects to the home page.
+ *
+ * This route is statically registered in App.tsx so the redirect target
+ * exists regardless of edition, but only the EE backend actually handles
+ * the /api/auth/oidc/exchange endpoint. In community mode no OIDC login
+ * flow can start, so this page is not reached in practice.
+ */
+export function OidcCallbackPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const setAuth = useAuthStore((s) => s.setAuth);
+  const [error, setError] = useState<string | null>(null);
+  const exchanged = useRef(false);
+
+  useEffect(() => {
+    // Prevent double-exchange in React StrictMode
+    if (exchanged.current) return;
+    exchanged.current = true;
+
+    const loginCode = searchParams.get('login_code');
+    if (!loginCode) {
+      setError('Missing login code. Please try signing in again.');
+      return;
+    }
+
+    async function exchangeCode() {
+      try {
+        const response = await fetch('/api/auth/oidc/exchange', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code: loginCode }),
+          credentials: 'include',
+        });
+
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({ message: 'Exchange failed' }));
+          throw new Error(body.message ?? 'SSO login failed');
+        }
+
+        const data = await response.json() as {
+          accessToken: string;
+          user: { id: string; username: string; role: 'user' | 'admin' };
+        };
+
+        setAuth(data.accessToken, data.user);
+        navigate('/', { replace: true });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'SSO login failed');
+      }
+    }
+
+    exchangeCode();
+  }, [searchParams, setAuth, navigate]);
+
+  if (error) {
+    return (
+      <div className="bg-background flex min-h-screen items-center justify-center p-4">
+        <div className="glass-card w-full max-w-md p-8 text-center">
+          <h1 className="mb-4 text-xl font-bold text-destructive">SSO Login Failed</h1>
+          <p className="mb-6 text-sm text-muted-foreground">{error}</p>
+          <button
+            onClick={() => navigate('/login', { replace: true })}
+            className="glass-button-primary px-6 py-2"
+          >
+            Back to Login
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-background flex min-h-screen items-center justify-center p-4">
+      <div className="glass-card w-full max-w-md p-8 text-center">
+        <div className="mb-4 inline-block h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        <p className="text-sm text-muted-foreground">Completing SSO sign-in...</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -1273,15 +1273,42 @@ function AiPromptsTab({ settings, onSave, isAdmin }: { settings: SettingsRespons
   );
 }
 
+interface HealthResponse {
+  status?: string;
+  version?: string;
+  edition?: string;
+  commit?: string;
+  builtAt?: string;
+}
+
+function useBackendBuildInfo() {
+  return useQuery<HealthResponse>({
+    queryKey: ['backend', 'build-info'],
+    // /api/health is public (no auth) and cheap — it's what compose
+    // healthchecks hit. We read it once to surface build metadata.
+    queryFn: async () => {
+      const response = await fetch('/api/health');
+      // 200 (ok) and 503 (degraded) both carry the version payload.
+      return response.json() as Promise<HealthResponse>;
+    },
+    staleTime: 60_000,
+  });
+}
+
 function SystemTab() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { data: backendBuild } = useBackendBuildInfo();
 
   function handleRerunSetup() {
     // Invalidate setup status cache so the wizard re-checks
     queryClient.invalidateQueries({ queryKey: ['setup-status'] });
     navigate('/setup?rerun=true');
   }
+
+  const editionLabel = (backendBuild?.edition ?? __APP_EDITION__) === 'enterprise'
+    ? 'Enterprise (EE)'
+    : 'Community (CE)';
 
   return (
     <div className="space-y-6">
@@ -1301,11 +1328,41 @@ function SystemTab() {
 
       <div className="border-t border-border/40 pt-6">
         <h3 className="text-base font-semibold">Application Info</h3>
-        <div className="mt-3 space-y-2 text-sm text-muted-foreground">
+        <div className="mt-3 space-y-2 text-sm text-muted-foreground" data-testid="application-info">
           <div className="flex items-center justify-between">
             <span>Version</span>
-            <span className="font-mono">{__APP_VERSION__}</span>
+            <span className="font-mono" data-testid="app-version">{__APP_VERSION__}</span>
           </div>
+          <div className="flex items-center justify-between">
+            <span>Edition</span>
+            <span className="font-mono" data-testid="app-edition">{editionLabel}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span>Backend commit</span>
+            <span className="font-mono" data-testid="backend-commit">
+              {backendBuild?.commit ?? '…'}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span>Frontend commit</span>
+            <span className="font-mono" data-testid="frontend-commit">{__APP_COMMIT__}</span>
+          </div>
+          {backendBuild?.builtAt && (
+            <div className="flex items-center justify-between">
+              <span>Backend built at</span>
+              <span className="font-mono text-xs" data-testid="backend-built-at">
+                {backendBuild.builtAt}
+              </span>
+            </div>
+          )}
+          {__APP_BUILT_AT__ && (
+            <div className="flex items-center justify-between">
+              <span>Frontend built at</span>
+              <span className="font-mono text-xs" data-testid="frontend-built-at">
+                {__APP_BUILT_AT__}
+              </span>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -18,13 +18,17 @@ import { AiSafetyTab } from './AiSafetyTab';
 import { RateLimitsTab } from './RateLimitsTab';
 import { SearxngTab } from './SearxngTab';
 import { SkeletonFormFields } from '../../shared/components/feedback/Skeleton';
+import { LicenseStatusCard } from '../admin/LicenseStatusCard';
+import { OidcSettingsPage } from '../admin/OidcSettingsPage';
+import { useEnterprise } from '../../shared/enterprise/use-enterprise';
 
-type TabId = 'confluence' | 'sync' | 'ollama' | 'ai-prompts' | 'ai-safety' | 'rate-limits' | 'spaces' | 'theme' | 'labels' | 'errors' | 'embedding' | 'workers' | 'mcp-docs' | 'searxng' | 'system';
+type TabId = 'confluence' | 'sync' | 'ollama' | 'ai-prompts' | 'ai-safety' | 'rate-limits' | 'spaces' | 'theme' | 'labels' | 'errors' | 'embedding' | 'workers' | 'mcp-docs' | 'searxng' | 'license' | 'sso' | 'system';
 
 export function SettingsPage() {
   const queryClient = useQueryClient();
   const user = useAuthStore((s) => s.user);
   const isAdmin = user?.role === 'admin';
+  const { isEnterprise } = useEnterprise();
   const [activeTab, setActiveTab] = useState<TabId>('confluence');
 
   const { data: settings, isLoading } = useSettings();
@@ -39,7 +43,7 @@ export function SettingsPage() {
     onError: (err) => toast.error(err.message),
   });
 
-  const tabs: { id: TabId; label: string; adminOnly?: boolean }[] = [
+  const tabs: { id: TabId; label: string; adminOnly?: boolean; enterpriseOnly?: boolean }[] = [
     { id: 'confluence', label: 'Confluence' },
     { id: 'sync', label: 'Sync' },
     { id: 'spaces', label: 'Spaces' },
@@ -54,10 +58,19 @@ export function SettingsPage() {
     { id: 'workers', label: 'Workers', adminOnly: true },
     { id: 'mcp-docs', label: 'MCP Docs', adminOnly: true },
     { id: 'searxng', label: 'SearXNG', adminOnly: true },
+    // License tab is always visible to admins so community users can see their
+    // edition status and learn how to upgrade. The SSO tab is gated on a valid
+    // enterprise license AND the EE backend (which returns features:['oidc']).
+    { id: 'license', label: 'License', adminOnly: true },
+    { id: 'sso', label: 'SSO / OIDC', adminOnly: true, enterpriseOnly: true },
     { id: 'system', label: 'System', adminOnly: true },
   ];
 
-  const visibleTabs = tabs.filter((t) => !t.adminOnly || isAdmin);
+  const visibleTabs = tabs.filter((t) => {
+    if (t.adminOnly && !isAdmin) return false;
+    if (t.enterpriseOnly && !isEnterprise) return false;
+    return true;
+  });
 
   return (
     <m.div
@@ -87,7 +100,7 @@ export function SettingsPage() {
         </div>
 
         <div className="p-6">
-          {(isLoading || !settings) && activeTab !== 'labels' && activeTab !== 'errors' && activeTab !== 'theme' && activeTab !== 'embedding' && activeTab !== 'sync' && activeTab !== 'workers' && activeTab !== 'mcp-docs' && activeTab !== 'ai-safety' && activeTab !== 'rate-limits' && activeTab !== 'searxng' ? (
+          {(isLoading || !settings) && activeTab !== 'labels' && activeTab !== 'errors' && activeTab !== 'theme' && activeTab !== 'embedding' && activeTab !== 'sync' && activeTab !== 'workers' && activeTab !== 'mcp-docs' && activeTab !== 'ai-safety' && activeTab !== 'rate-limits' && activeTab !== 'searxng' && activeTab !== 'license' && activeTab !== 'sso' ? (
             <SkeletonFormFields />
           ) : activeTab === 'confluence' ? (
             <ConfluenceTab settings={settings!} onSave={(v) => updateSettings.mutate(v)} />
@@ -121,6 +134,10 @@ export function SettingsPage() {
             <McpDocsTab />
           ) : activeTab === 'searxng' && isAdmin ? (
             <SearxngTab />
+          ) : activeTab === 'license' && isAdmin ? (
+            <LicenseStatusCard />
+          ) : activeTab === 'sso' && isAdmin && isEnterprise ? (
+            <OidcSettingsPage />
           ) : activeTab === 'system' && isAdmin ? (
             <SystemTab />
           ) : (

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,3 +1,6 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string;
+declare const __APP_COMMIT__: string;
+declare const __APP_EDITION__: string;
+declare const __APP_BUILT_AT__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,10 +6,31 @@ import { readFileSync } from 'fs';
 
 const rootPkg = JSON.parse(readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'));
 
+// Build metadata. Committed placeholder lives at <repo root>/build-info.json
+// and is overwritten by scripts/build-enterprise.sh during EE builds with
+// the real CE + EE commit hashes. If the file is missing (fresh dev
+// checkout, for example), fall back to defaults so the build doesn't fail.
+interface BuildInfo {
+  edition: string;
+  commit: string;
+  builtAt: string;
+}
+let buildInfo: BuildInfo = { edition: 'community', commit: 'unknown', builtAt: '' };
+try {
+  buildInfo = JSON.parse(
+    readFileSync(path.resolve(__dirname, '../build-info.json'), 'utf-8'),
+  );
+} catch {
+  // Use defaults; nothing to log since this runs during vite config init.
+}
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   define: {
     __APP_VERSION__: JSON.stringify(rootPkg.version),
+    __APP_COMMIT__: JSON.stringify(buildInfo.commit),
+    __APP_EDITION__: JSON.stringify(buildInfo.edition),
+    __APP_BUILT_AT__: JSON.stringify(buildInfo.builtAt),
   },
   resolve: {
     alias: {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
   plugins: [react()],
   define: {
     __APP_VERSION__: JSON.stringify(rootPkg.version),
+    __APP_COMMIT__: JSON.stringify('test'),
+    __APP_EDITION__: JSON.stringify('community'),
+    __APP_BUILT_AT__: JSON.stringify(''),
   },
   resolve: {
     alias: {

--- a/packages/contracts/src/schemas/license.ts
+++ b/packages/contracts/src/schemas/license.ts
@@ -14,6 +14,22 @@ export const LicenseInfoResponseSchema = z.object({
   expiresAt: z.string().optional(),
   seats: z.number().optional(),
   valid: z.boolean(),
+  /**
+   * Masked display form of the active license key (no signature).
+   * Present on the EE backend; omitted by the CE noop fallback.
+   */
+  displayKey: z.string().optional(),
+  /**
+   * Short license ID (e.g. CPQ1a2b3c4d) for support lookups. EE-only.
+   */
+  licenseId: z.string().nullable().optional(),
+  /**
+   * Signals that the responding backend accepts license-key writes via
+   * PUT/DELETE /api/admin/license. Absent on the CE noop fallback — the
+   * frontend reads it to decide whether to render the edit form in
+   * LicenseStatusCard.
+   */
+  canUpdate: z.boolean().optional(),
 });
 
 export type LicenseInfoResponse = z.infer<typeof LicenseInfoResponseSchema>;


### PR DESCRIPTION
## Summary

- **Inline the enterprise UI into the CE SPA.** `LicenseStatusCard`, `OidcSettingsPage`, and `OidcCallbackPage` move out of the never-shipped EE IIFE overlay into `ce/frontend/src/features/`. The Settings → **License** tab is always visible to admins; the **SSO / OIDC** tab is gated at runtime by `useEnterprise().isEnterprise` (derived from `/api/admin/license`).
- **`LicenseInfoResponseSchema` picks up `canUpdate`** (plus optional `displayKey` / `licenseId`) so the frontend knows when it can render the license-key entry form. The CE noop fallback omits the flag, so the form only appears against the EE plugin. `LicenseStatusCard` now includes the form with Save / Clear mutations against `PUT` / `DELETE /api/admin/license`.
- **Settings → System shows build metadata.** A committed `build-info.json` placeholder at the repo root (`{edition: "community", commit: "unknown", builtAt: ""}`) is copied by the frontend `Dockerfile` into the vite builder; `vite.config.ts` reads it and injects `__APP_COMMIT__` / `__APP_EDITION__` / `__APP_BUILT_AT__` defines. `backend/src/core/utils/version.ts` gains `APP_BUILD_INFO`, read by all three `/api/health*` endpoints. `SystemTab` fetches `/api/health` and shows Version, Edition, Backend commit, Frontend commit, and build timestamps. In pure CE deployments the file keeps its defaults; the EE build pipeline overwrites it with real git commits (see companion EE PR).

## Test plan

- [ ] `npm run test -w frontend` passes (new `LicenseStatusCard`, `OidcSettingsPage`, `OidcCallbackPage` tests + existing `vitest.config.ts` gets safe defaults for the new globals)
- [ ] `npm run test -w backend` passes (new `version.ts` + health endpoint changes are backward compatible; no existing test relies on the exact shape of `/api/health`)
- [ ] `npm run build -w frontend` succeeds with missing `build-info.json` (try/catch fallback) and with the placeholder
- [ ] In a community deployment: Settings → License tab shows the community card and the upgrade notice; no SSO tab; no license-key form
- [ ] In an enterprise deployment (paired with the EE PR): Settings → License shows the key-entry form; pasting a valid key flips the card to Active, SSO tab appears, Clear button surfaces; Settings → System shows `Enterprise (EE)` + real commit hashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)