### PR TITLE
fix(install): point install.sh at the real public repo and image names

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Security Vulnerability
-    url: https://github.com/laboef1900/ai-kb-creator/blob/dev/SECURITY.md
+    url: https://github.com/Compendiq/compendiq-ce/blob/dev/SECURITY.md
     about: Please report security vulnerabilities responsibly. Do NOT open a public issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ PostgreSQL 17 (with pgvector) and Redis 8 run via Docker Compose -- no manual in
 ### 1. Clone the repository
 
 ```bash
-git clone https://github.com/laboef1900/ai-kb-creator.git
-cd ai-kb-creator
+git clone https://github.com/Compendiq/compendiq-ce.git
+cd compendiq-ce
 ```
 
 ### 2. Install dependencies

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
   <img src="frontend/public/logo.svg" alt="Compendiq" width="128" height="128" />
 </p>
 
-[![CI](https://github.com/laboef1900/ai-kb-creator/actions/workflows/pr-check.yml/badge.svg)](https://github.com/laboef1900/ai-kb-creator/actions/workflows/pr-check.yml)
+[![CI](https://github.com/Compendiq/compendiq-ce/actions/workflows/pr-check.yml/badge.svg)](https://github.com/Compendiq/compendiq-ce/actions/workflows/pr-check.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
-[![Docker Backend](https://img.shields.io/docker/pulls/diinlu/compendiq-backend?label=Docker%20pulls%20%28backend%29)](https://hub.docker.com/r/diinlu/compendiq-backend)
-[![Docker Frontend](https://img.shields.io/docker/pulls/diinlu/compendiq-frontend?label=Docker%20pulls%20%28frontend%29)](https://hub.docker.com/r/diinlu/compendiq-frontend)
+[![Docker Backend](https://img.shields.io/docker/pulls/diinlu/compendiq-ce-backend?label=Docker%20pulls%20%28backend%29)](https://hub.docker.com/r/diinlu/compendiq-ce-backend)
+[![Docker Frontend](https://img.shields.io/docker/pulls/diinlu/compendiq-ce-frontend?label=Docker%20pulls%20%28frontend%29)](https://hub.docker.com/r/diinlu/compendiq-ce-frontend)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen)]()
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue)]()
 
@@ -139,7 +139,7 @@ ollama pull qwen3.5            # Or any chat model of your choice
 Get from zero to the Compendiq setup wizard in under 3 minutes — no cloning, no manual config:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/laboef1900/ai-kb-creator/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Compendiq/compendiq-ce/main/scripts/install.sh | bash
 ```
 
 ### System requirements
@@ -152,7 +152,7 @@ curl -fsSL https://raw.githubusercontent.com/laboef1900/ai-kb-creator/main/scrip
 
 1. Generates cryptographically secure secrets (AES-256 keys, passwords)
 2. Writes a self-contained `~/compendiq/docker-compose.yml` with all secrets embedded as literal values
-3. Pulls images from Docker Hub (`diinlu/compendiq-backend`, `diinlu/compendiq-frontend`)
+3. Pulls images from Docker Hub (`diinlu/compendiq-ce-backend`, `diinlu/compendiq-ce-frontend`)
 4. Starts all four containers (frontend, backend, postgres, redis)
 5. Polls the backend health endpoint until ready (up to 3 minutes)
 6. Removes the temporary backend port binding (port 3051 is never permanently exposed to the host)
@@ -161,7 +161,7 @@ curl -fsSL https://raw.githubusercontent.com/laboef1900/ai-kb-creator/main/scrip
 ### Custom install directory
 
 ```bash
-INSTALL_DIR=~/mydir curl -fsSL https://raw.githubusercontent.com/laboef1900/ai-kb-creator/main/scripts/install.sh | bash
+INSTALL_DIR=~/mydir curl -fsSL https://raw.githubusercontent.com/Compendiq/compendiq-ce/main/scripts/install.sh | bash
 ```
 
 ### Uninstall
@@ -178,7 +178,7 @@ Images are published to two registries on every release:
 
 | Registry | Images |
 |----------|--------|
-| Docker Hub | `diinlu/compendiq-backend` · `diinlu/compendiq-frontend` · `diinlu/compendiq-mcp-docs` · `diinlu/compendiq-searxng` |
+| Docker Hub | `diinlu/compendiq-ce-backend` · `diinlu/compendiq-ce-frontend` · `diinlu/compendiq-ce-mcp-docs` · `diinlu/compendiq-ce-searxng` |
 
 Both registries publish `linux/amd64` and `linux/arm64` variants.
 
@@ -204,8 +204,8 @@ ollama pull qwen3:4b           # Or any chat model of your choice
 ### 1. Clone and install
 
 ```bash
-git clone https://github.com/your-org/compendiq.git
-cd compendiq
+git clone https://github.com/Compendiq/compendiq-ce.git
+cd compendiq-ce
 npm install
 ```
 

--- a/docs/ADMIN-GUIDE.md
+++ b/docs/ADMIN-GUIDE.md
@@ -21,8 +21,8 @@ Additionally, you need an **Ollama** server (or OpenAI-compatible API) accessibl
 1. **Clone the repository:**
 
    ```bash
-   git clone https://github.com/laboef1900/ai-kb-creator.git
-   cd ai-kb-creator
+   git clone https://github.com/Compendiq/compendiq-ce.git
+   cd compendiq-ce
    ```
 
 2. **Create your environment file:**

--- a/docs/ENTERPRISE-ARCHITECTURE.md
+++ b/docs/ENTERPRISE-ARCHITECTURE.md
@@ -1318,7 +1318,7 @@ The enterprise repo's CI installs both the open repo and the enterprise package,
 # In enterprise repo CI
 - name: Integration test
   run: |
-    git clone https://github.com/yourorg/compendiq.git /tmp/compendiq
+    git clone https://github.com/Compendiq/compendiq-ce.git /tmp/compendiq-ce
     cd /tmp/compendiq
     npm install
     npm install /path/to/enterprise/dist  # Install local build

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # =============================================================================
 # Compendiq — One-Command Docker Installer
-# https://github.com/diinlu/compendiq
+# https://github.com/Compendiq/compendiq-ce
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/diinlu/compendiq/main/scripts/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/Compendiq/compendiq-ce/main/scripts/install.sh | bash
 #   curl ... | bash -s -- --dir /opt/compendiq --port 9090
 #   bash install.sh --dir /opt/compendiq --port 9090 --version 1.2.0
 #   bash install.sh --dry-run
@@ -234,7 +234,7 @@ write_compose() {
 
 services:
   frontend:
-    image: diinlu/compendiq-frontend:__VERSION__
+    image: diinlu/compendiq-ce-frontend:__VERSION__
     ports:
       - "__PORT__:8081"
     depends_on:
@@ -250,7 +250,7 @@ services:
       - frontend
 
   backend:
-    image: diinlu/compendiq-backend:__VERSION__
+    image: diinlu/compendiq-ce-backend:__VERSION__
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -410,7 +410,7 @@ success_banner() {
   printf '  %bStop:%b    cd %s && docker compose down\n' "$DIM" "$RESET" "$dir"
   printf '  %bUpdate:%b  cd %s && docker compose pull && docker compose up -d\n' "$DIM" "$RESET" "$dir"
   printf '  %bLogs:%b    cd %s && docker compose logs -f\n' "$DIM" "$RESET" "$dir"
-  printf '  %bRemove:%b  curl -fsSL https://raw.githubusercontent.com/diinlu/compendiq/main/scripts/uninstall.sh | bash\n' "$DIM" "$RESET"
+  printf '  %bRemove:%b  curl -fsSL https://raw.githubusercontent.com/Compendiq/compendiq-ce/main/scripts/uninstall.sh | bash\n' "$DIM" "$RESET"
   printf '\n'
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -478,7 +478,7 @@ dry_run_summary() {
   printf '    1. Create directory %s\n' "$dir"
   printf '    2. Generate .env with cryptographic secrets\n'
   printf '    3. Write docker-compose.yml\n'
-  printf '    4. docker compose pull (images: compendiq-frontend:%s, compendiq-backend:%s, pgvector:pg17, redis:8-alpine)\n' "$version" "$version"
+  printf '    4. docker compose pull (images: diinlu/compendiq-ce-frontend:%s, diinlu/compendiq-ce-backend:%s, pgvector/pgvector:pg17, redis:8-alpine)\n' "$version" "$version"
   printf '    5. docker compose up -d\n'
   printf '    6. Wait for backend health check (max 60s)\n'
   printf '    7. Open http://localhost:%s in browser\n' "$port"

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -201,8 +201,8 @@ test_compose_generation() {
   local compose_content
   compose_content="$(cat "${TEST_DIR}/docker-compose.yml")"
 
-  assert_contains "Uses specified image version" "$compose_content" "diinlu/compendiq-backend:1.2.3"
-  assert_contains "Uses specified frontend version" "$compose_content" "diinlu/compendiq-frontend:1.2.3"
+  assert_contains "Uses specified image version" "$compose_content" "diinlu/compendiq-ce-backend:1.2.3"
+  assert_contains "Uses specified frontend version" "$compose_content" "diinlu/compendiq-ce-frontend:1.2.3"
   assert_contains "Maps specified port" "$compose_content" "9090:8081"
   assert_contains "Sets FRONTEND_URL with port" "$compose_content" "http://localhost:9090"
   assert_contains "Has postgres service" "$compose_content" "pgvector/pgvector:pg17"
@@ -232,7 +232,7 @@ test_compose_defaults() {
   local compose_content
   compose_content="$(cat "${TEST_DIR}/docker-compose.yml")"
 
-  assert_contains "Defaults to latest tag" "$compose_content" "diinlu/compendiq-backend:latest"
+  assert_contains "Defaults to latest tag" "$compose_content" "diinlu/compendiq-ce-backend:latest"
   assert_contains "Defaults to port 8080" "$compose_content" "8080:8081"
 
   teardown

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -232,7 +232,8 @@ test_compose_defaults() {
   local compose_content
   compose_content="$(cat "${TEST_DIR}/docker-compose.yml")"
 
-  assert_contains "Defaults to latest tag" "$compose_content" "diinlu/compendiq-ce-backend:latest"
+  assert_contains "Defaults to latest tag (backend)" "$compose_content" "diinlu/compendiq-ce-backend:latest"
+  assert_contains "Defaults to latest tag (frontend)" "$compose_content" "diinlu/compendiq-ce-frontend:latest"
   assert_contains "Defaults to port 8080" "$compose_content" "8080:8081"
 
   teardown


### PR DESCRIPTION
## Summary

Phase 1 Session 1 audit (PR #168) surfaced that \`scripts/install.sh\` still pointed at a stale GitHub namespace and stale image names. If the repo had gone public as-is, every launch-day \`curl … | bash\` would have 404'd or pulled the wrong images.

## The four renames

| Before | After |
|---|---|
| \`github.com/diinlu/compendiq\` (header comment) | \`github.com/Compendiq/compendiq-ce\` |
| \`https://raw.githubusercontent.com/diinlu/compendiq/main/scripts/install.sh\` (usage line) | \`https://raw.githubusercontent.com/Compendiq/compendiq-ce/main/scripts/install.sh\` |
| \`diinlu/compendiq-frontend:__VERSION__\` (generated compose) | \`diinlu/compendiq-ce-frontend:__VERSION__\` |
| \`diinlu/compendiq-backend:__VERSION__\` (generated compose) | \`diinlu/compendiq-ce-backend:__VERSION__\` |
| \`https://raw.githubusercontent.com/diinlu/compendiq/main/scripts/uninstall.sh\` (remove command) | \`https://raw.githubusercontent.com/Compendiq/compendiq-ce/main/scripts/uninstall.sh\` |

Matching assertion updates in \`scripts/install.test.sh\` so the local test harness stays green.

## Test plan

- [x] \`bash scripts/install.test.sh\` — **39 passed, 0 failed** locally
- [ ] CI test-installer workflow (automatic on this PR)
- [ ] Post-merge: re-run the installer smoke test on a fresh macOS VM + a fresh Rocky Linux 10 VM before the repo goes public (A4). This is the last manual verification step before the Phase 1 §3.4 T-48h rehearsal.

## Why this is the launch-critical fix

Phase 0 closed with the installer tested on macOS + Rocky 10, but that test used a local checkout of \`install.sh\`, not the published one-liner. The mismatch went unnoticed until the Phase 1 Session 1 repo audit ran against the version about to ship. Without this fix, the \`curl \\| bash\` command that Product Hunt, Show HN, and Reddit posts will quote would be broken on launch day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)