### PR TITLE
docs(phase1): switch container registry to GHCR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,21 +18,23 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DHI_USER }}
-          password: ${{ secrets.DHI_PAT }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: diinlu/compendiq-ce-backend
+          images: ghcr.io/compendiq/compendiq-ce-backend
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -55,8 +57,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=registry,ref=diinlu/compendiq-ce-backend:buildcache
-          cache-to: type=registry,ref=diinlu/compendiq-ce-backend:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/compendiq/compendiq-ce-backend:buildcache
+          cache-to: type=registry,ref=ghcr.io/compendiq/compendiq-ce-backend:buildcache,mode=max
           sbom: true
           provenance: mode=max
 
@@ -66,21 +68,23 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DHI_USER }}
-          password: ${{ secrets.DHI_PAT }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: diinlu/compendiq-ce-frontend
+          images: ghcr.io/compendiq/compendiq-ce-frontend
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -103,8 +107,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=registry,ref=diinlu/compendiq-ce-frontend:buildcache
-          cache-to: type=registry,ref=diinlu/compendiq-ce-frontend:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/compendiq/compendiq-ce-frontend:buildcache
+          cache-to: type=registry,ref=ghcr.io/compendiq/compendiq-ce-frontend:buildcache,mode=max
           sbom: true
           provenance: mode=max
 
@@ -114,21 +118,23 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DHI_USER }}
-          password: ${{ secrets.DHI_PAT }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: diinlu/compendiq-ce-searxng
+          images: ghcr.io/compendiq/compendiq-ce-searxng
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -151,8 +157,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=registry,ref=diinlu/compendiq-ce-searxng:buildcache
-          cache-to: type=registry,ref=diinlu/compendiq-ce-searxng:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/compendiq/compendiq-ce-searxng:buildcache
+          cache-to: type=registry,ref=ghcr.io/compendiq/compendiq-ce-searxng:buildcache,mode=max
 
   docker-mcp-docs:
     name: MCP Docs Image
@@ -160,21 +166,23 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DHI_USER }}
-          password: ${{ secrets.DHI_PAT }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: diinlu/compendiq-ce-mcp-docs
+          images: ghcr.io/compendiq/compendiq-ce-mcp-docs
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -197,7 +205,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=registry,ref=diinlu/compendiq-ce-mcp-docs:buildcache
-          cache-to: type=registry,ref=diinlu/compendiq-ce-mcp-docs:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/compendiq/compendiq-ce-mcp-docs:buildcache
+          cache-to: type=registry,ref=ghcr.io/compendiq/compendiq-ce-mcp-docs:buildcache,mode=max
           sbom: true
           provenance: mode=max

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 [![CI](https://github.com/Compendiq/compendiq-ce/actions/workflows/pr-check.yml/badge.svg)](https://github.com/Compendiq/compendiq-ce/actions/workflows/pr-check.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
-[![Docker Backend](https://img.shields.io/docker/pulls/diinlu/compendiq-ce-backend?label=Docker%20pulls%20%28backend%29)](https://hub.docker.com/r/diinlu/compendiq-ce-backend)
-[![Docker Frontend](https://img.shields.io/docker/pulls/diinlu/compendiq-ce-frontend?label=Docker%20pulls%20%28frontend%29)](https://hub.docker.com/r/diinlu/compendiq-ce-frontend)
+[![GHCR Backend](https://img.shields.io/badge/ghcr.io-compendiq--ce--backend-blue)](https://github.com/Compendiq/compendiq-ce/pkgs/container/compendiq-ce-backend)
+[![GHCR Frontend](https://img.shields.io/badge/ghcr.io-compendiq--ce--frontend-blue)](https://github.com/Compendiq/compendiq-ce/pkgs/container/compendiq-ce-frontend)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen)]()
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue)]()
 
@@ -152,7 +152,7 @@ curl -fsSL https://raw.githubusercontent.com/Compendiq/compendiq-ce/main/scripts
 
 1. Generates cryptographically secure secrets (AES-256 keys, passwords)
 2. Writes a self-contained `~/compendiq/docker-compose.yml` with all secrets embedded as literal values
-3. Pulls images from Docker Hub (`diinlu/compendiq-ce-backend`, `diinlu/compendiq-ce-frontend`)
+3. Pulls images from GHCR (`ghcr.io/compendiq/compendiq-ce-backend`, `ghcr.io/compendiq/compendiq-ce-frontend`)
 4. Starts all four containers (frontend, backend, postgres, redis)
 5. Polls the backend health endpoint until ready (up to 3 minutes)
 6. Removes the temporary backend port binding (port 3051 is never permanently exposed to the host)
@@ -178,7 +178,7 @@ Images are published to two registries on every release:
 
 | Registry | Images |
 |----------|--------|
-| Docker Hub | `diinlu/compendiq-ce-backend` · `diinlu/compendiq-ce-frontend` · `diinlu/compendiq-ce-mcp-docs` · `diinlu/compendiq-ce-searxng` |
+| GHCR | `ghcr.io/compendiq/compendiq-ce-backend` · `ghcr.io/compendiq/compendiq-ce-frontend` · `ghcr.io/compendiq/compendiq-ce-mcp-docs` · `ghcr.io/compendiq/compendiq-ce-searxng` |
 
 Both registries publish `linux/amd64` and `linux/arm64` variants.
 

--- a/README.md
+++ b/README.md
@@ -174,13 +174,13 @@ This stops all containers, removes all data volumes, and deletes the install dir
 
 ### Image registries
 
-Images are published to two registries on every release:
+Images are published to GHCR on every release:
 
 | Registry | Images |
 |----------|--------|
 | GHCR | `ghcr.io/compendiq/compendiq-ce-backend` · `ghcr.io/compendiq/compendiq-ce-frontend` · `ghcr.io/compendiq/compendiq-ce-mcp-docs` · `ghcr.io/compendiq/compendiq-ce-searxng` |
 
-Both registries publish `linux/amd64` and `linux/arm64` variants.
+All images publish `linux/amd64` and `linux/arm64` variants.
 
 ### Ollama requirement
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ name: compendiq
 
 services:
   frontend:
-    image: diinlu/compendiq-ce-frontend:dev
+    image: ghcr.io/compendiq/compendiq-ce-frontend:dev
     build:
       context: ..
       dockerfile: frontend/Dockerfile
@@ -15,7 +15,7 @@ services:
     networks: [frontend-net, backend-net]
 
   backend:
-    image: diinlu/compendiq-ce-backend:dev
+    image: ghcr.io/compendiq/compendiq-ce-backend:dev
     build:
       context: ..
       dockerfile: backend/Dockerfile
@@ -93,7 +93,7 @@ services:
     networks: [data-net]
 
   mcp-docs:
-    image: diinlu/compendiq-ce-mcp-docs:dev
+    image: ghcr.io/compendiq/compendiq-ce-mcp-docs:dev
     build:
       context: ..
       dockerfile: mcp-docs/Dockerfile
@@ -119,7 +119,7 @@ services:
     networks: [backend-net]
 
   searxng:
-    image: diinlu/compendiq-ce-searxng:dev
+    image: ghcr.io/compendiq/compendiq-ce-searxng:dev
     build:
       context: ./searxng
       dockerfile: Dockerfile

--- a/docs/issues/phase0-implementation-plan.md
+++ b/docs/issues/phase0-implementation-plan.md
@@ -40,7 +40,7 @@ At v0.1.0, only OIDC/SSO and seat enforcement are implemented in the EE overlay.
 **This must happen before Gaps 3, 5, and 6 can proceed.**
 
 Currently three different namespaces are in use:
-- Docker Hub: `diinlu/compendiq-ce-*`
+- GHCR: `ghcr.io/compendiq/compendiq-ce-*`
 - README badge: `laboef1900/ai-kb-creator`
 - EE README: `github.com/Compendiq/compendiq-ee`
 
@@ -107,15 +107,13 @@ However, the EE build script (`build-enterprise.sh`) patches `app.ts` during the
    b. Add GHCR login step.
    c. Use dual `images` list in metadata-action:
       ```yaml
-      images: |
-        diinlu/compendiq-ce-backend
-        ghcr.io/<org>/compendiq-ce-backend
+      images: ghcr.io/compendiq/compendiq-ce-backend
       ```
 2. Test with a workflow dispatch dry run before merging.
 
 **Files:** `/compendiq-ce/.github/workflows/docker-build.yml`
 **Effort:** 3h
-**Acceptance:** Tag push publishes to both Docker Hub and GHCR.
+**Acceptance:** Tag push publishes to GHCR (`ghcr.io/compendiq/*`).
 
 ---
 
@@ -511,6 +509,6 @@ All five on-premise gates pass:
 2. **Security** — Audit pass ✅, no critical/high prod CVEs ✅, auth hardened ✅
 3. **Operational (on-prem)** — New user: zero to running in < 15 min via installer; wizard completes without support
 4. **Documentation** — Admin guide ✅, user guide ✅, API reference ✅, .env.example ✅, stewardship ✅
-5. **Distribution** — Docker Hub images ✅, GHCR mirror, GitHub releases tagged, installer tested cross-platform, repo public
+5. **Distribution** — GHCR images ✅, GitHub releases tagged, installer tested cross-platform, repo public
 
 Gate 6 (SaaS operational) → deferred to post-launch phase.

--- a/docs/issues/phase0-implementation-plan.md
+++ b/docs/issues/phase0-implementation-plan.md
@@ -81,7 +81,7 @@ However, the EE build script (`build-enterprise.sh`) patches `app.ts` during the
    ```yaml
    services:
      backend:
-       image: dhi.io/compendiq-backend:ee
+       image: ghcr.io/compendiq/compendiq-ee-backend:latest
        build: !reset null
        environment:
          COMPENDIQ_LICENSE_KEY: ${COMPENDIQ_LICENSE_KEY}

--- a/docs/phase1/discussions-seed-posts.md
+++ b/docs/phase1/discussions-seed-posts.md
@@ -26,7 +26,7 @@ Tone notes:
 >
 > **What's free and what's not:** the Community Edition you see on the repo is AGPL-3.0 and has no functional limits — full RAG Q&A, full article generation, full sync. The Enterprise Edition adds SSO/OIDC, per-space RAG permissions, audit log export, and seat enforcement, and requires a separate proprietary license key.
 >
-> **Install:** `curl -fsSL https://raw.githubusercontent.com/Compendiq/compendiq-ce/main/scripts/install.sh | bash` — this auto-generates secrets, pulls the images from Docker Hub, and opens the first-run wizard in your browser. Tested on macOS 14 and Rocky Linux 10 so far; Ubuntu / Debian / WSL2 is in Phase 2.
+> **Install:** `curl -fsSL https://raw.githubusercontent.com/Compendiq/compendiq-ce/main/scripts/install.sh | bash` — this auto-generates secrets, pulls the images from GHCR, and opens the first-run wizard in your browser. Tested on macOS 14 and Rocky Linux 10 so far; Ubuntu / Debian / WSL2 is in Phase 2.
 >
 > **What to do from here:**
 > - File bugs you hit in the Q&A category below (please include install platform + Confluence DC version + a copy of the error)

--- a/docs/phase1/prereq-check-2026-04-11.md
+++ b/docs/phase1/prereq-check-2026-04-11.md
@@ -22,7 +22,7 @@
 | P1 | `compendiq.com` DNS controllable | ✅ | Nameservers: `ns69.domaincontrol.com`, `ns70.domaincontrol.com` (GoDaddy). DNS is controllable. Not urgent — with A8 moved to Phase 3, the domain is unused at launch (or optionally set up a simple redirect to the GitHub repo). |
 | P2 | ~~Cloudflare Pages account linked to `compendiq.com`~~ | n/a | **Not needed per 2026-04-11 founder decision.** A8 landing page moved to Phase 3 alongside the SaaS showcase. Phase 1 launch routes all traffic directly to `github.com/Compendiq/compendiq-ce`. |
 | P3 | `gh` CLI scopes | ⚠ | Logged in as `laboef1900`. Token scopes: `gist`, `read:org`, `repo`. **Missing:** `admin:org`, `workflow`. **Action:** `gh auth refresh -s admin:org,workflow` before A4/A5 execution. **Correction:** an earlier draft listed `discussions:write` which is not a valid GitHub OAuth scope — it produced `invalid_scope` errors. The correct singular name is `write:discussion` but even that is unnecessary because the `repo` scope already covers GitHub Discussions operations on `compendiq-ce`. |
-| P4 | Docker Hub admin access | ✅ | Founder confirmed access 2026-04-11. When ready to flip images public at A6, log into Docker Hub, navigate to `diinlu/compendiq-ce-*` (backend, frontend, mcp-docs, searxng), set visibility to public. Claude verifies afterward with `docker pull`. |
+| P4 | GHCR packages on `Compendiq` org | ⚠ | **Revised 2026-04-12: switched from Docker Hub to GHCR.** Needs `write:packages` scope on `gh` CLI and GitHub Packages enabled on the `Compendiq` org. CI workflow (`docker-build.yml`) must be updated to push to `ghcr.io/compendiq/*` instead of Docker Hub. Once the repo is public (A4), packages inherit public visibility. Claude verifies with `docker pull ghcr.io/compendiq/compendiq-ce-backend:latest`. |
 | P5 | GitHub admin on `Compendiq` org | ⚠ | Cannot verify fully from the `laboef1900` session. **Founder confirms** that the same or a parallel session has `admin:org` on `Compendiq`. The P3 scope refresh also satisfies this. |
 | P6 | Hacker News account with karma > 100 | ❓ | **Founder only** — Claude cannot introspect HN accounts. |
 | P7 | Product Hunt account ≥60 days old | ❓ | **Founder only**. Confirm the launch account was created before ~2026-03-06. |
@@ -44,7 +44,7 @@
 
    A15 (GitHub Discussions setup) uses the `repo` scope that's already in place — no additional scope needed.
 
-2. **P4 — Docker Hub UI action.** Founder has access confirmed. When ready: Docker Hub web UI → `diinlu/compendiq-ce-*` images → flip to public. Claude verifies.
+2. **P4 — GHCR setup.** Run `gh auth refresh -s write:packages` to add the packages scope. Ensure GitHub Packages is enabled on the `Compendiq` org (Settings → Packages). The CI workflow needs updating to push to `ghcr.io/compendiq/*` instead of Docker Hub — this is part of A6. Once the repo is public, GHCR packages are publicly pullable by default.
 
 ## What Session 1 delivered
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -234,7 +234,7 @@ write_compose() {
 
 services:
   frontend:
-    image: diinlu/compendiq-ce-frontend:__VERSION__
+    image: ghcr.io/compendiq/compendiq-ce-frontend:__VERSION__
     ports:
       - "__PORT__:8081"
     depends_on:
@@ -250,7 +250,7 @@ services:
       - frontend
 
   backend:
-    image: diinlu/compendiq-ce-backend:__VERSION__
+    image: ghcr.io/compendiq/compendiq-ce-backend:__VERSION__
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -478,7 +478,7 @@ dry_run_summary() {
   printf '    1. Create directory %s\n' "$dir"
   printf '    2. Generate .env with cryptographic secrets\n'
   printf '    3. Write docker-compose.yml\n'
-  printf '    4. docker compose pull (images: diinlu/compendiq-ce-frontend:%s, diinlu/compendiq-ce-backend:%s, pgvector/pgvector:pg17, redis:8-alpine)\n' "$version" "$version"
+  printf '    4. docker compose pull (images: ghcr.io/compendiq/compendiq-ce-frontend:%s, ghcr.io/compendiq/compendiq-ce-backend:%s, pgvector/pgvector:pg17, redis:8-alpine)\n' "$version" "$version"
   printf '    5. docker compose up -d\n'
   printf '    6. Wait for backend health check (max 60s)\n'
   printf '    7. Open http://localhost:%s in browser\n' "$port"

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -201,8 +201,8 @@ test_compose_generation() {
   local compose_content
   compose_content="$(cat "${TEST_DIR}/docker-compose.yml")"
 
-  assert_contains "Uses specified image version" "$compose_content" "diinlu/compendiq-ce-backend:1.2.3"
-  assert_contains "Uses specified frontend version" "$compose_content" "diinlu/compendiq-ce-frontend:1.2.3"
+  assert_contains "Uses specified image version" "$compose_content" "ghcr.io/compendiq/compendiq-ce-backend:1.2.3"
+  assert_contains "Uses specified frontend version" "$compose_content" "ghcr.io/compendiq/compendiq-ce-frontend:1.2.3"
   assert_contains "Maps specified port" "$compose_content" "9090:8081"
   assert_contains "Sets FRONTEND_URL with port" "$compose_content" "http://localhost:9090"
   assert_contains "Has postgres service" "$compose_content" "pgvector/pgvector:pg17"
@@ -232,8 +232,8 @@ test_compose_defaults() {
   local compose_content
   compose_content="$(cat "${TEST_DIR}/docker-compose.yml")"
 
-  assert_contains "Defaults to latest tag (backend)" "$compose_content" "diinlu/compendiq-ce-backend:latest"
-  assert_contains "Defaults to latest tag (frontend)" "$compose_content" "diinlu/compendiq-ce-frontend:latest"
+  assert_contains "Defaults to latest tag (backend)" "$compose_content" "ghcr.io/compendiq/compendiq-ce-backend:latest"
+  assert_contains "Defaults to latest tag (frontend)" "$compose_content" "ghcr.io/compendiq/compendiq-ce-frontend:latest"
   assert_contains "Defaults to port 8080" "$compose_content" "8080:8081"
 
   teardown


### PR DESCRIPTION
## Summary
- Updated prereq-check P4 from Docker Hub admin access to GHCR packages setup on Compendiq org
- Updated discussions seed post to reference GHCR instead of Docker Hub
- Aligns with the revised Phase 1 Implementation Plan (Research wiki)

## Test plan
- [ ] Verify prereq-check P4 instructions are actionable
- [ ] Confirm discussions seed post reads correctly with GHCR reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)