### PR TITLE
release: v0.2.0 — Phase 1 public launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-14
+
 <!--
-  Claude draft 2026-04-11 (Phase 1 Session 1):
-  At launch time (2026-05-05), rename this `[Unreleased]` header to
-  `[1.0.0] - 2026-05-05` and insert a new empty `[Unreleased]` section above it.
-  The entries below now cover everything the v1.0 on-premise CE launch ships.
-  Sections added today for Phase 0 closeout:
+  Phase 1 public launch release. Covers everything from Phase 0 closeout
+  through the public repo launch.
+  Sections added during Phase 0 + Phase 1:
     - First-run setup wizard with backend-derived resume
     - One-command installer
     - Enterprise plugin architecture (open-core extension points)

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compendiq",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compendiq",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "workspaces": [
         "backend",
         "frontend",
@@ -27,7 +27,7 @@
       }
     },
     "backend": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@fastify/compress": "^8.3.1",
@@ -120,7 +120,7 @@
       }
     },
     "frontend": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@dnd-kit/react": "^0.3.2",
@@ -20100,7 +20100,7 @@
     },
     "packages/contracts": {
       "name": "@compendiq/contracts",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "zod": "^4.3.6"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Compendiq - AI-powered knowledge base management with Confluence integration and Ollama LLM backend",
   "workspaces": [

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compendiq/contracts",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.2.0 across all 5 package.json files
- Update CHANGELOG with v0.2.0 release header

## After merge
Merge `dev` → `main`, tag `v0.2.0`, create GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)