### PR TITLE
feat: add users.email and display_name columns

### DIFF
--- a/backend/src/core/db/migrations/051_users_email_display_name.sql
+++ b/backend/src/core/db/migrations/051_users_email_display_name.sql
@@ -1,0 +1,5 @@
+-- Migration 051: Add email, email_verified, and display_name to users
+ALTER TABLE users ADD COLUMN IF NOT EXISTS email TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users(email) WHERE email IS NOT NULL;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS email_verified BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS display_name TEXT;

--- a/backend/src/routes/foundation/auth-routes.test.ts
+++ b/backend/src/routes/foundation/auth-routes.test.ts
@@ -131,9 +131,9 @@ describe('Auth routes', () => {
   describe('POST /api/auth/register', () => {
     it('should create a user and return 201 with accessToken and user', async () => {
       mockBcryptHash.mockResolvedValue('hashed-password');
-      // First query: INSERT user RETURNING id, username, role
+      // First query: INSERT user RETURNING id, username, role, email, display_name
       mockQuery.mockResolvedValueOnce({
-        rows: [{ id: TEST_USER.id, username: TEST_USER.username, role: TEST_USER.role }],
+        rows: [{ id: TEST_USER.id, username: TEST_USER.username, role: TEST_USER.role, email: null, display_name: null }],
       });
       // Second query: INSERT user_settings
       mockQuery.mockResolvedValueOnce({ rows: [] });
@@ -151,6 +151,8 @@ describe('Auth routes', () => {
         id: TEST_USER.id,
         username: TEST_USER.username,
         role: TEST_USER.role,
+        email: null,
+        displayName: null,
       });
 
       // Verify bcrypt was called with password and salt rounds
@@ -202,6 +204,53 @@ describe('Auth routes', () => {
       expect(response.statusCode).toBe(400);
     });
 
+    it('should create a user with email and displayName when provided', async () => {
+      mockBcryptHash.mockResolvedValue('hashed-password');
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: TEST_USER.id, username: TEST_USER.username, role: TEST_USER.role, email: 'user@example.com', display_name: 'Test User' }],
+      });
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/register',
+        payload: { username: 'testuser', password: 'securepassword', email: 'user@example.com', displayName: 'Test User' },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = JSON.parse(response.body);
+      expect(body.user.email).toBe('user@example.com');
+      expect(body.user.displayName).toBe('Test User');
+    });
+
+    it('should return 400 when email format is invalid', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/register',
+        payload: { username: 'testuser', password: 'securepassword', email: 'not-an-email' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 409 when email is already in use', async () => {
+      mockBcryptHash.mockResolvedValue('hashed-password');
+      const duplicateError = new Error('duplicate key value violates unique constraint') as Error & { code: string; detail: string };
+      duplicateError.code = '23505';
+      duplicateError.detail = 'Key (email)=(user@example.com) already exists.';
+      mockQuery.mockRejectedValueOnce(duplicateError);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/auth/register',
+        payload: { username: 'newuser', password: 'securepassword', email: 'user@example.com' },
+      });
+
+      expect(response.statusCode).toBe(409);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('Email already in use');
+    });
+
     it('should return 400 when username or password is missing', async () => {
       const response = await app.inject({
         method: 'POST',
@@ -226,6 +275,8 @@ describe('Auth routes', () => {
           username: TEST_USER.username,
           password_hash: TEST_USER.password_hash,
           role: TEST_USER.role,
+          email: 'test@example.com',
+          display_name: 'Test User',
         }],
       });
       mockBcryptCompare.mockResolvedValue(true);
@@ -243,6 +294,8 @@ describe('Auth routes', () => {
         id: TEST_USER.id,
         username: TEST_USER.username,
         role: TEST_USER.role,
+        email: 'test@example.com',
+        displayName: 'Test User',
       });
 
       // Verify refresh cookie was set
@@ -308,7 +361,7 @@ describe('Auth routes', () => {
       });
       // SELECT user by id
       mockQuery.mockResolvedValueOnce({
-        rows: [{ id: TEST_USER.id, username: TEST_USER.username, role: TEST_USER.role }],
+        rows: [{ id: TEST_USER.id, username: TEST_USER.username, role: TEST_USER.role, email: null, display_name: null }],
       });
       mockRevokeToken.mockResolvedValue(undefined);
       mockGenerateAccessToken.mockResolvedValue('new-access-token');
@@ -327,6 +380,8 @@ describe('Auth routes', () => {
         id: TEST_USER.id,
         username: TEST_USER.username,
         role: TEST_USER.role,
+        email: null,
+        displayName: null,
       });
 
       // Verify old token was revoked

--- a/backend/src/routes/foundation/auth.ts
+++ b/backend/src/routes/foundation/auth.ts
@@ -25,17 +25,20 @@ const AUTH_RATE_LIMIT = { config: { rateLimit: { max: async () => (await getRate
 export async function authRoutes(fastify: FastifyInstance) {
   fastify.post('/register', AUTH_RATE_LIMIT, async (request, reply) => {
     const body = RegisterSchema.parse(request.body);
+    const rawBody = request.body as Record<string, unknown>;
+    const email = typeof rawBody.email === 'string' && rawBody.email.trim() ? rawBody.email.trim().toLowerCase() : null;
+    const displayName = typeof rawBody.displayName === 'string' && rawBody.displayName.trim() ? rawBody.displayName.trim() : null;
 
     const passwordHash = await bcrypt.hash(body.password, SALT_ROUNDS);
 
     try {
       // Atomic first-user-is-admin: the role is determined in the same INSERT
       // to avoid a TOCTOU race between SELECT COUNT and INSERT
-      const result = await query<{ id: string; username: string; role: string }>(
-        `INSERT INTO users (username, password_hash, role)
-         VALUES ($1, $2, CASE WHEN (SELECT COUNT(*) FROM users) = 0 THEN 'admin' ELSE 'user' END)
-         RETURNING id, username, role`,
-        [body.username, passwordHash],
+      const result = await query<{ id: string; username: string; role: string; email: string | null; display_name: string | null }>(
+        `INSERT INTO users (username, password_hash, role, email, display_name)
+         VALUES ($1, $2, CASE WHEN (SELECT COUNT(*) FROM users) = 0 THEN 'admin' ELSE 'user' END, $3, $4)
+         RETURNING id, username, role, email, display_name`,
+        [body.username, passwordHash, email, displayName],
       );
       const user = result.rows[0]!;
 
@@ -66,10 +69,20 @@ export async function authRoutes(fastify: FastifyInstance) {
         .status(201)
         .send({
           accessToken,
-          user: { id: user.id, username: user.username, role: user.role },
+          user: {
+            id: user.id,
+            username: user.username,
+            role: user.role,
+            email: user.email,
+            displayName: user.display_name,
+          },
         });
     } catch (err: unknown) {
       if (err instanceof Error && 'code' in err && (err as { code: string }).code === '23505') {
+        const detail = (err as { detail?: string }).detail ?? '';
+        if (detail.includes('email')) {
+          throw fastify.httpErrors.conflict('Email already in use');
+        }
         throw fastify.httpErrors.conflict('Username already taken');
       }
       throw err;
@@ -79,8 +92,8 @@ export async function authRoutes(fastify: FastifyInstance) {
   fastify.post('/login', AUTH_RATE_LIMIT, async (request, reply) => {
     const body = LoginSchema.parse(request.body);
 
-    const result = await query<{ id: string; username: string; password_hash: string; role: string }>(
-      'SELECT id, username, password_hash, role FROM users WHERE username = $1',
+    const result = await query<{ id: string; username: string; password_hash: string; role: string; email: string | null; display_name: string | null }>(
+      'SELECT id, username, password_hash, role, email, display_name FROM users WHERE username = $1',
       [body.username],
     );
 
@@ -119,7 +132,13 @@ export async function authRoutes(fastify: FastifyInstance) {
       })
       .send({
         accessToken,
-        user: { id: user.id, username: user.username, role: user.role },
+        user: {
+          id: user.id,
+          username: user.username,
+          role: user.role,
+          email: user.email,
+          displayName: user.display_name,
+        },
       });
   });
 
@@ -134,8 +153,8 @@ export async function authRoutes(fastify: FastifyInstance) {
       const payload = await verifyRefreshToken(refreshTokenCookie);
 
       // Verify user still exists
-      const result = await query<{ id: string; username: string; role: string }>(
-        'SELECT id, username, role FROM users WHERE id = $1',
+      const result = await query<{ id: string; username: string; role: string; email: string | null; display_name: string | null }>(
+        'SELECT id, username, role, email, display_name FROM users WHERE id = $1',
         [payload.sub],
       );
       if (result.rows.length === 0) {
@@ -172,7 +191,16 @@ export async function authRoutes(fastify: FastifyInstance) {
           path: '/api/auth',
           maxAge: REFRESH_MAX_AGE,
         })
-        .send({ accessToken, user: { id: user.id, username: user.username, role: user.role } });
+        .send({
+          accessToken,
+          user: {
+            id: user.id,
+            username: user.username,
+            role: user.role,
+            email: user.email,
+            displayName: user.display_name,
+          },
+        });
     } catch (err) {
       logger.debug({ err }, 'Refresh token verification failed');
       throw fastify.httpErrors.unauthorized('Invalid refresh token');

--- a/backend/src/routes/foundation/auth.ts
+++ b/backend/src/routes/foundation/auth.ts
@@ -25,9 +25,8 @@ const AUTH_RATE_LIMIT = { config: { rateLimit: { max: async () => (await getRate
 export async function authRoutes(fastify: FastifyInstance) {
   fastify.post('/register', AUTH_RATE_LIMIT, async (request, reply) => {
     const body = RegisterSchema.parse(request.body);
-    const rawBody = request.body as Record<string, unknown>;
-    const email = typeof rawBody.email === 'string' && rawBody.email.trim() ? rawBody.email.trim().toLowerCase() : null;
-    const displayName = typeof rawBody.displayName === 'string' && rawBody.displayName.trim() ? rawBody.displayName.trim() : null;
+    const email = body.email?.trim().toLowerCase() ?? null;
+    const displayName = body.displayName?.trim() ?? null;
 
     const passwordHash = await bcrypt.hash(body.password, SALT_ROUNDS);
 

--- a/packages/contracts/src/schemas/auth.ts
+++ b/packages/contracts/src/schemas/auth.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 export const RegisterSchema = z.object({
   username: z.string().min(3).max(50),
   password: z.string().min(8).max(128),
+  email: z.string().email().optional(),
+  displayName: z.string().min(1).max(200).optional(),
 });
 
 export const LoginSchema = z.object({
@@ -16,6 +18,8 @@ export const AuthResponseSchema = z.object({
     id: z.string().uuid(),
     username: z.string(),
     role: z.enum(['user', 'admin']),
+    email: z.string().email().nullable().optional(),
+    displayName: z.string().nullable().optional(),
   }),
 });
 


### PR DESCRIPTION
## Summary
- Migration 051: adds `email` (nullable, partial unique index), `email_verified`, `display_name` to users table
- Register endpoint accepts optional `email` and `displayName` fields
- Login and refresh endpoints return `email` and `displayName` in user object
- Duplicate email returns 409 with specific error message

## Test plan
- [x] Migration runs cleanly on fresh DB
- [x] Existing users can log in without email (nullable)
- [x] Registration with email works, duplicate email returns 409
- [x] TypeScript compiles clean

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)