### PR TITLE
feat: LLM request queue with backpressure

### DIFF
--- a/backend/src/domains/llm/services/llm-provider.ts
+++ b/backend/src/domains/llm/services/llm-provider.ts
@@ -13,6 +13,7 @@ import {
   generateEmbedding as ollamaGenerateEmbedding,
 } from './ollama-service.js';
 import { OpenAIProvider } from './openai-service.js';
+import { enqueue } from './llm-queue.js';
 
 // ─── Shared interfaces ──────────────────────────────────────────────────────
 
@@ -116,13 +117,15 @@ export async function providerChat(
   model: string,
   messages: ChatMessage[],
 ): Promise<string> {
-  const provider = await resolveUserProvider(userId);
+  return enqueue(async () => {
+    const provider = await resolveUserProvider(userId);
 
-  if (provider.type === 'openai') {
-    return getOpenAIProvider().chat(model, messages);
-  } else {
-    return ollamaChat(model, messages);
-  }
+    if (provider.type === 'openai') {
+      return getOpenAIProvider().chat(model, messages);
+    } else {
+      return ollamaChat(model, messages);
+    }
+  });
 }
 
 /**

--- a/backend/src/domains/llm/services/llm-queue.test.ts
+++ b/backend/src/domains/llm/services/llm-queue.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../core/utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('llm-queue', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('enqueue executes the function', async () => {
+    const { enqueue } = await import('./llm-queue.js');
+    const result = await enqueue(() => Promise.resolve(42));
+    expect(result).toBe(42);
+  });
+
+  it('enqueue respects concurrency', async () => {
+    const { enqueue, setConcurrency, getMetrics } = await import('./llm-queue.js');
+    setConcurrency(2);
+
+    let running = 0;
+    let maxRunning = 0;
+
+    const task = () => new Promise<void>((resolve) => {
+      running++;
+      maxRunning = Math.max(maxRunning, running);
+      setTimeout(() => { running--; resolve(); }, 50);
+    });
+
+    await Promise.all([enqueue(task), enqueue(task), enqueue(task), enqueue(task)]);
+    expect(maxRunning).toBeLessThanOrEqual(2);
+    expect(getMetrics().totalProcessed).toBeGreaterThanOrEqual(4);
+  });
+
+  it('enqueue rejects when queue is full', async () => {
+    const { enqueue, setConcurrency, setMaxQueueDepth, QueueFullError } = await import('./llm-queue.js');
+    setConcurrency(1);
+    setMaxQueueDepth(1);
+
+    const blocker = enqueue(() => new Promise<void>((resolve) => setTimeout(resolve, 200)));
+    const second = enqueue(() => Promise.resolve());
+
+    await expect(enqueue(() => Promise.resolve())).rejects.toThrow(QueueFullError);
+
+    await blocker;
+    await second;
+  });
+
+  it('getMetrics returns correct counts', async () => {
+    const { getMetrics, setConcurrency } = await import('./llm-queue.js');
+    setConcurrency(4);
+
+    const metrics = getMetrics();
+    expect(metrics.concurrency).toBe(4);
+    expect(metrics.activeCount).toBe(0);
+    expect(metrics.pendingCount).toBe(0);
+    expect(metrics.maxQueueDepth).toBe(50);
+  });
+
+  it('setConcurrency clamps to valid range', async () => {
+    const { setConcurrency, getMetrics } = await import('./llm-queue.js');
+
+    setConcurrency(0);
+    expect(getMetrics().concurrency).toBe(1);
+
+    setConcurrency(200);
+    expect(getMetrics().concurrency).toBe(100);
+  });
+});

--- a/backend/src/domains/llm/services/llm-queue.ts
+++ b/backend/src/domains/llm/services/llm-queue.ts
@@ -1,0 +1,123 @@
+/**
+ * LLM request queue with configurable concurrency and backpressure.
+ */
+
+import pLimit, { type LimitFunction } from 'p-limit';
+import { logger } from '../../../core/utils/logger.js';
+
+export interface LlmQueueMetrics {
+  concurrency: number;
+  activeCount: number;
+  pendingCount: number;
+  maxQueueDepth: number;
+  totalProcessed: number;
+  totalRejected: number;
+  totalTimedOut: number;
+}
+
+const DEFAULT_CONCURRENCY = 4;
+const DEFAULT_MAX_QUEUE_DEPTH = 50;
+const DEFAULT_TIMEOUT_MS = parseInt(process.env.LLM_STREAM_TIMEOUT_MS ?? '300000', 10);
+
+let _limiter: LimitFunction = pLimit(DEFAULT_CONCURRENCY);
+let _concurrency = DEFAULT_CONCURRENCY;
+let _maxQueueDepth = DEFAULT_MAX_QUEUE_DEPTH;
+let _timeoutMs = DEFAULT_TIMEOUT_MS;
+let _totalProcessed = 0;
+let _totalRejected = 0;
+let _totalTimedOut = 0;
+
+export function setConcurrency(n: number): void {
+  const val = Math.max(1, Math.min(n, 100));
+  if (val !== _concurrency) {
+    _concurrency = val;
+    _limiter = pLimit(val);
+    logger.info({ concurrency: val }, 'LLM queue concurrency updated');
+  }
+}
+
+export function setMaxQueueDepth(n: number): void {
+  _maxQueueDepth = Math.max(1, n);
+}
+
+export function setTimeoutMs(ms: number): void {
+  _timeoutMs = Math.max(1000, ms);
+}
+
+export function getMetrics(): LlmQueueMetrics {
+  return {
+    concurrency: _concurrency,
+    activeCount: _limiter.activeCount,
+    pendingCount: _limiter.pendingCount,
+    maxQueueDepth: _maxQueueDepth,
+    totalProcessed: _totalProcessed,
+    totalRejected: _totalRejected,
+    totalTimedOut: _totalTimedOut,
+  };
+}
+
+export class QueueFullError extends Error {
+  constructor(depth: number, max: number) {
+    super(`LLM queue full: ${depth} pending (max: ${max})`);
+    this.name = 'QueueFullError';
+  }
+}
+
+export class LlmTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`LLM request timed out after ${timeoutMs}ms`);
+    this.name = 'LlmTimeoutError';
+  }
+}
+
+export async function enqueue<T>(fn: () => Promise<T>): Promise<T> {
+  if (_limiter.pendingCount >= _maxQueueDepth) {
+    _totalRejected++;
+    throw new QueueFullError(_limiter.pendingCount, _maxQueueDepth);
+  }
+
+  return _limiter(async () => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        _totalTimedOut++;
+        reject(new LlmTimeoutError(_timeoutMs));
+      }, _timeoutMs);
+    });
+
+    try {
+      const result = await Promise.race([fn(), timeoutPromise]);
+      _totalProcessed++;
+      return result;
+    } catch (err) {
+      if (!(err instanceof LlmTimeoutError)) {
+        _totalProcessed++;
+      }
+      throw err;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  });
+}
+
+export async function initLlmQueue(): Promise<void> {
+  try {
+    const { query } = await import('../../../core/db/postgres.js');
+    const result = await query<{ setting_key: string; setting_value: string }>(
+      `SELECT setting_key, setting_value FROM admin_settings
+       WHERE setting_key IN ('llm_concurrency', 'llm_max_queue_depth', 'llm_timeout_ms')`,
+      [],
+    );
+    for (const row of result.rows) {
+      const val = parseInt(row.setting_value, 10);
+      if (isNaN(val)) continue;
+      switch (row.setting_key) {
+        case 'llm_concurrency': setConcurrency(val); break;
+        case 'llm_max_queue_depth': setMaxQueueDepth(val); break;
+        case 'llm_timeout_ms': setTimeoutMs(val); break;
+      }
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Failed to load LLM queue settings, using defaults');
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,7 @@ import { markStartupComplete } from './routes/foundation/health.js';
 import { logger } from './core/utils/logger.js';
 import { getSharedLlmSettings } from './core/services/admin-settings-service.js';
 import { setActiveProvider } from './domains/llm/services/ollama-service.js';
+import { initLlmQueue } from './domains/llm/services/llm-queue.js';
 
 const PORT = parseInt(process.env.BACKEND_PORT ?? '3051', 10);
 const HOST = process.env.NODE_ENV === 'production' ? '0.0.0.0' : '127.0.0.1';
@@ -58,6 +59,7 @@ async function start() {
 
   const sharedLlmSettings = await getSharedLlmSettings();
   setActiveProvider(sharedLlmSettings.llmProvider);
+  await initLlmQueue();
 
   // Build and start the app
   const app = await buildApp();

--- a/backend/src/routes/foundation/health.ts
+++ b/backend/src/routes/foundation/health.ts
@@ -4,6 +4,7 @@ import { checkRedisConnection } from '../../core/plugins/redis.js';
 import { getOllamaCircuitBreakerStatus, getOpenaiCircuitBreakerStatus } from '../../core/services/circuit-breaker.js';
 import { getProvider } from '../../domains/llm/services/ollama-service.js';
 import { logger } from '../../core/utils/logger.js';
+import { getMetrics as getLlmQueueMetrics } from '../../domains/llm/services/llm-queue.js';
 import { getSharedLlmSettings } from '../../core/services/admin-settings-service.js';
 import { APP_VERSION, APP_BUILD_INFO } from '../../core/utils/version.js';
 
@@ -115,6 +116,7 @@ export async function healthRoutes(fastify: FastifyInstance) {
           ollama: getOllamaCircuitBreakerStatus(),
           openai: getOpenaiCircuitBreakerStatus(),
         },
+        llmQueue: getLlmQueueMetrics(),
         version: APP_VERSION,
         edition: APP_BUILD_INFO.edition,
         commit: APP_BUILD_INFO.commit,


### PR DESCRIPTION
## Summary
- Configurable concurrency via p-limit (default: 4, admin-settable)
- Queue depth monitoring with max depth limit (default: 50)
- Per-request timeout handling (default: from LLM_STREAM_TIMEOUT_MS)
- Health endpoint exposes queue metrics (active, pending, processed, rejected, timed out)
- `providerChat()` wrapped with backpressure queue

## Test plan
- [x] `enqueue` executes functions and respects concurrency limits
- [x] `QueueFullError` thrown when queue depth exceeded
- [x] `setConcurrency` clamps to valid range (1-100)
- [x] Metrics report correct counts
- [x] TypeScript compiles clean

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)