### PR TITLE
feat: Confluence API rate limiting

### DIFF
--- a/backend/src/domains/confluence/services/confluence-client.ts
+++ b/backend/src/domains/confluence/services/confluence-client.ts
@@ -5,6 +5,7 @@ import { unlink } from 'fs/promises';
 import { validateUrl, addAllowedBaseUrl, resolveConfluenceUrl } from '../../../core/utils/ssrf-guard.js';
 import { logger } from '../../../core/utils/logger.js';
 import { confluenceDispatcher } from '../../../core/utils/tls-config.js';
+import { acquireToken } from './confluence-rate-limiter.js';
 
 interface ConfluenceSpace {
   key: string;
@@ -84,6 +85,7 @@ export class ConfluenceClient {
     body?: unknown;
     signal?: AbortSignal;
   } = {}): Promise<T> {
+    await acquireToken();
     const url = `${this.baseUrl}${path}`;
 
     // SSRF protection: validate URL before every request
@@ -249,6 +251,7 @@ export class ConfluenceClient {
    * Follows redirects (up to 10 hops) and validates the URL for SSRF.
    */
   private async fetchAttachmentBuffer(url: string): Promise<Buffer> {
+    await acquireToken();
     validateUrl(url);
 
     const opts: Record<string, unknown> = {
@@ -323,6 +326,7 @@ export class ConfluenceClient {
     outputPath: string,
     maxSizeBytes: number,
   ): Promise<void> {
+    await acquireToken();
     validateUrl(url);
 
     const opts: Record<string, unknown> = {

--- a/backend/src/domains/confluence/services/confluence-rate-limiter.test.ts
+++ b/backend/src/domains/confluence/services/confluence-rate-limiter.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  acquireToken,
+  setRateLimit,
+  getRateLimit,
+  resetRateLimiter,
+} from './confluence-rate-limiter.js';
+
+// Mock postgres to avoid DB calls
+vi.mock('../../../core/db/postgres.js', () => ({
+  query: vi.fn().mockResolvedValue({ rows: [] }),
+}));
+
+vi.mock('../../../core/utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('confluence-rate-limiter', () => {
+  beforeEach(() => {
+    resetRateLimiter();
+    setRateLimit(60); // Default: 60 RPM
+  });
+
+  it('acquires tokens immediately when available', async () => {
+    const start = Date.now();
+    await acquireToken();
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  it('getRateLimit returns current configuration', () => {
+    const info = getRateLimit();
+    expect(info.rpm).toBe(60);
+    expect(info.availableTokens).toBeGreaterThan(0);
+    expect(info.queueDepth).toBe(0);
+  });
+
+  it('setRateLimit clamps to valid range', () => {
+    setRateLimit(0);
+    expect(getRateLimit().rpm).toBe(1);
+
+    setRateLimit(1000);
+    expect(getRateLimit().rpm).toBe(600);
+
+    setRateLimit(120);
+    expect(getRateLimit().rpm).toBe(120);
+  });
+
+  it('exhausts tokens and queues requests', async () => {
+    setRateLimit(5); // 5 RPM = very low
+    resetRateLimiter();
+
+    // Drain all 5 tokens quickly
+    for (let i = 0; i < 5; i++) {
+      await acquireToken();
+    }
+
+    const info = getRateLimit();
+    expect(info.availableTokens).toBeLessThanOrEqual(1);
+  });
+
+  it('handles rapid sequential acquisitions', async () => {
+    setRateLimit(60);
+    resetRateLimiter();
+
+    // 10 rapid acquisitions should succeed immediately
+    const promises = Array.from({ length: 10 }, () => acquireToken());
+    await Promise.all(promises);
+    // All resolved without error
+  });
+
+  it('resetRateLimiter restores tokens', () => {
+    // Drain some tokens
+    acquireToken();
+    acquireToken();
+    acquireToken();
+
+    resetRateLimiter();
+    const info = getRateLimit();
+    expect(info.availableTokens).toBeGreaterThanOrEqual(59);
+  });
+});

--- a/backend/src/domains/confluence/services/confluence-rate-limiter.ts
+++ b/backend/src/domains/confluence/services/confluence-rate-limiter.ts
@@ -1,0 +1,133 @@
+/**
+ * Token bucket rate limiter for Confluence API calls.
+ *
+ * Protects the customer's Confluence Data Center instance from being overwhelmed
+ * during sync. Admin-configurable rate (requests/minute) via admin_settings table.
+ *
+ * Default: 60 requests/minute (1 per second).
+ */
+
+import { logger } from '../../../core/utils/logger.js';
+
+const DEFAULT_RATE_RPM = 60;
+const SETTING_KEY = 'confluence_rate_limit_rpm';
+
+let _ratePerMinute = DEFAULT_RATE_RPM;
+let _tokens: number = DEFAULT_RATE_RPM;
+let _lastRefill: number = Date.now();
+let _waitQueue: Array<{ resolve: () => void }> = [];
+let _drainTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Set the rate limit (requests per minute). Called from admin settings.
+ */
+export function setRateLimit(rpm: number): void {
+  const clamped = Math.max(1, Math.min(rpm, 600));
+  if (clamped !== _ratePerMinute) {
+    _ratePerMinute = clamped;
+    _tokens = Math.min(_tokens, clamped);
+    logger.info({ rpm: clamped }, 'Confluence rate limit updated');
+  }
+}
+
+/**
+ * Get the current rate limit configuration.
+ */
+export function getRateLimit(): { rpm: number; availableTokens: number; queueDepth: number } {
+  refillTokens();
+  return {
+    rpm: _ratePerMinute,
+    availableTokens: Math.floor(_tokens),
+    queueDepth: _waitQueue.length,
+  };
+}
+
+/**
+ * Refill tokens based on elapsed time since last refill.
+ */
+function refillTokens(): void {
+  const now = Date.now();
+  const elapsed = now - _lastRefill;
+  const tokensToAdd = (elapsed / 60_000) * _ratePerMinute;
+  _tokens = Math.min(_ratePerMinute, _tokens + tokensToAdd);
+  _lastRefill = now;
+}
+
+/**
+ * Drain the wait queue by resolving waiters as tokens become available.
+ */
+function scheduleDrain(): void {
+  if (_drainTimer || _waitQueue.length === 0) return;
+
+  const msPerToken = 60_000 / _ratePerMinute;
+  _drainTimer = setTimeout(() => {
+    _drainTimer = null;
+    refillTokens();
+    while (_waitQueue.length > 0 && _tokens >= 1) {
+      _tokens -= 1;
+      _waitQueue.shift()!.resolve();
+    }
+    if (_waitQueue.length > 0) {
+      scheduleDrain();
+    }
+  }, msPerToken);
+}
+
+/**
+ * Acquire a rate limit token. Resolves immediately if tokens are available,
+ * otherwise queues the request until a token is available.
+ *
+ * This should be called before every Confluence API request.
+ */
+export async function acquireToken(): Promise<void> {
+  refillTokens();
+
+  if (_tokens >= 1) {
+    _tokens -= 1;
+    return;
+  }
+
+  // Queue the request
+  return new Promise<void>((resolve) => {
+    _waitQueue.push({ resolve });
+    scheduleDrain();
+  });
+}
+
+/**
+ * Initialize the rate limiter from admin_settings.
+ * Falls back to default if the setting doesn't exist.
+ */
+export async function initRateLimiter(): Promise<void> {
+  try {
+    const { query } = await import('../../../core/db/postgres.js');
+    const result = await query<{ setting_value: string }>(
+      'SELECT setting_value FROM admin_settings WHERE setting_key = $1',
+      [SETTING_KEY],
+    );
+    if (result.rows.length > 0) {
+      const rpm = parseInt(result.rows[0]!.setting_value, 10);
+      if (!isNaN(rpm) && rpm > 0) {
+        setRateLimit(rpm);
+      }
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Failed to load Confluence rate limit from admin_settings, using default');
+  }
+}
+
+/**
+ * Reset the rate limiter (for testing).
+ */
+export function resetRateLimiter(): void {
+  _tokens = _ratePerMinute;
+  _lastRefill = Date.now();
+  for (const waiter of _waitQueue) {
+    waiter.resolve();
+  }
+  _waitQueue = [];
+  if (_drainTimer) {
+    clearTimeout(_drainTimer);
+    _drainTimer = null;
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,6 +11,7 @@ import { logger } from './core/utils/logger.js';
 import { getSharedLlmSettings } from './core/services/admin-settings-service.js';
 import { setActiveProvider } from './domains/llm/services/ollama-service.js';
 import { initLlmQueue } from './domains/llm/services/llm-queue.js';
+import { initRateLimiter } from './domains/confluence/services/confluence-rate-limiter.js';
 
 const PORT = parseInt(process.env.BACKEND_PORT ?? '3051', 10);
 const HOST = process.env.NODE_ENV === 'production' ? '0.0.0.0' : '127.0.0.1';
@@ -56,6 +57,7 @@ async function start() {
   const sharedLlmSettings = await getSharedLlmSettings();
   setActiveProvider(sharedLlmSettings.llmProvider);
   await initLlmQueue();
+  await initRateLimiter();
 
   // Build and start the app
   const app = await buildApp();


### PR DESCRIPTION
## Summary
- Token bucket rate limiter for Confluence Data Center API calls
- Default: 60 requests/minute (configurable via `confluence_rate_limit_rpm` in admin_settings)
- Applied before every API call (fetch, attachment download, streaming download)
- Backpressure: requests queue when rate limit hit (no dropping)
- Initialized from admin_settings at startup

## Test plan
- [x] Token acquisition is immediate when tokens available
- [x] Rate limit configurable and clamped to valid range (1-600)
- [x] Tokens drain correctly under load
- [x] Reset restores full bucket
- [x] TypeScript compiles clean

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)