### PR TITLE
docs: add Mermaid architecture diagrams with maintenance rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ This file provides guidance to AI coding assistants (GitHub Copilot, Cursor, Win
 
 **All project rules, architecture, and conventions are defined in `CLAUDE.md`.** This file exists as a pointer — the rules are identical across all AI tools. Read and follow `CLAUDE.md` completely.
 
+**Architecture diagrams live in `docs/architecture/` (Mermaid).** When you change code that affects system structure — Docker compose, backend domains, ESLint boundaries, migrations that add/rename/drop tables or FKs, auth/sync/RAG/license flows, content conversion — update the affected diagram(s) in the same PR. See `docs/architecture/README.md` for the code-area → diagram mapping.
+
 ## Security (Mandatory)
 
 1. **PAT Encryption** — Confluence PATs are encrypted with AES-256-GCM. Never store plaintext PATs. Never send PATs to the frontend.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code when working with this repository. AG
 
 **Compendiq** — AI-powered knowledge base management web app that integrates with Confluence Data Center (on-premises) and supports multiple LLM providers (Ollama, OpenAI-compatible APIs) for article improvement, generation, summarization, and RAG-powered Q&A. Multi-user: each user configures their own Confluence PAT and space selections. Monorepo: `backend/` (Fastify 5 + PostgreSQL + Redis) and `frontend/` (React 19 + Vite).
 
-See `@docs/ARCHITECTURE-DECISIONS.md` for all ADRs. See `@docs/ACTION-PLAN.md` for the implementation plan.
+See `@docs/ARCHITECTURE-DECISIONS.md` for all ADRs. See `@docs/ACTION-PLAN.md` for the implementation plan. See `@docs/architecture/` for the Mermaid architecture diagrams (system context, containers, domain boundaries, deployment, ERD, auth/sync/RAG/license flows, content pipeline).
 
 ## Mandatory Rules
 
@@ -15,6 +15,7 @@ See `@docs/ARCHITECTURE-DECISIONS.md` for all ADRs. See `@docs/ACTION-PLAN.md` f
 3. **Never commit secrets** — No `.env`, API keys, PATs, passwords, or credentials.
 4. **Ask before assuming** — If ambiguous, ask for clarification before proceeding.
 5. **Follow the ADRs** — All architectural decisions are in `docs/ARCHITECTURE-DECISIONS.md`. Do not deviate without discussion.
+6. **Keep architecture diagrams in sync** — `docs/architecture/*.md` are part of the source of truth. In the same PR as any code change that affects the system structure, update the affected diagram(s). See `docs/architecture/README.md` for the mapping of code areas → diagrams (e.g. Docker compose → `02-container.md` + `05-deployment.md`; new domain/service or ESLint boundary change → `03-backend-domains.md`; new migration that adds/renames/drops a table or FK → `06-data-model.md`; auth/sync/RAG/license flow changes → the matching `07-`/`08-`/`09-`/`10-*.md`; content-converter changes → `11-content-pipeline.md`). If unsure how to update a diagram, flag it in the PR description rather than leaving it stale.
 
 ## Build Commands
 

--- a/backend/src/routes/llm/llm-chat.test.ts
+++ b/backend/src/routes/llm/llm-chat.test.ts
@@ -28,6 +28,7 @@ const mockProviderStreamChat = vi.fn();
 vi.mock('../../domains/llm/services/llm-provider.js', () => ({
   providerStreamChat: (...args: unknown[]) => mockProviderStreamChat(...args),
   providerGenerateEmbedding: vi.fn(),
+  resolveUserProvider: vi.fn().mockResolvedValue({ type: 'ollama' }),
 }));
 
 // --- Mock: circuit-breaker ---

--- a/docs/architecture/01-system-context.md
+++ b/docs/architecture/01-system-context.md
@@ -1,0 +1,45 @@
+# 1. System Context (C4 Level 1)
+
+Shows Compendiq as a single system and the people and external systems it
+interacts with. This is the 10 000-foot view — nothing about containers,
+databases, or code.
+
+```mermaid
+C4Context
+    title System Context — Compendiq CE
+
+    Person(user, "Knowledge User", "Authors and consumes articles; asks RAG-powered questions.")
+    Person(admin, "Administrator", "Configures LLM providers, OIDC, licensing, RBAC.")
+
+    System(compendiq, "Compendiq", "AI knowledge base<br/>management web app.")
+
+    System_Ext(confluence, "Confluence Data Center 9.2", "Source system for synced pages<br/>and attachments. Per-user PAT.")
+    System_Ext(ollama, "Ollama", "Default LLM + embeddings provider<br/>(bge-m3, 1024 dims).")
+    System_Ext(openai, "OpenAI-compatible API", "Optional LLM provider<br/>(OpenAI, Azure OpenAI, vLLM, LM Studio).")
+    System_Ext(oidc, "OIDC Provider", "Enterprise SSO<br/>(EE only — Okta, Entra ID, Keycloak…).")
+    System_Ext(smtp, "SMTP / Email", "Optional — notification delivery.")
+
+    Rel(user, compendiq, "Uses", "HTTPS (browser)")
+    Rel(admin, compendiq, "Administers", "HTTPS (browser)")
+
+    Rel(compendiq, confluence, "Pulls spaces, pages, attachments", "HTTPS + Bearer PAT")
+    Rel(compendiq, ollama, "Chat, embeddings", "HTTP(S) + optional Bearer")
+    Rel(compendiq, openai, "Chat (optional)", "HTTPS + API key")
+    Rel(oidc, compendiq, "OIDC callback (EE)", "HTTPS")
+    Rel(compendiq, smtp, "Sends notifications", "SMTP")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+## Notes
+
+- **Confluence PATs** are stored per-user, AES-256-GCM encrypted with
+  `PAT_ENCRYPTION_KEY`. They never leave the backend to the browser.
+- **LLM provider** is resolved per-user (user setting) with server-wide
+  fallbacks set via `LLM_PROVIDER`, `OLLAMA_BASE_URL`, `OPENAI_BASE_URL`.
+- **OIDC** is an Enterprise Edition feature gated by
+  `ENTERPRISE_FEATURES.OIDC_SSO`. In CE the arrow does not exist.
+- **SMTP** is optional and used by `notification-service`.
+
+No other outbound network calls are made from the backend by default.
+(`searxng` is an internal sidecar — see `02-container.md`.)

--- a/docs/architecture/02-container.md
+++ b/docs/architecture/02-container.md
@@ -1,0 +1,94 @@
+# 2. Container Diagram (C4 Level 2)
+
+Zooms into Compendiq and shows each deployable unit (a "container" in C4
+terms — not strictly a Docker container, though in this project they map
+1-to-1). For the infra view with networks and ports see
+[`05-deployment.md`](./05-deployment.md).
+
+```mermaid
+flowchart TB
+    user(["Browser<br/>(user / admin)"])
+    confluence[("Confluence DC 9.2")]
+    ollama[("Ollama")]
+    openai[("OpenAI-compatible<br/>LLM API")]
+
+    subgraph compendiq["Compendiq"]
+        direction TB
+        fe["<b>frontend</b><br/>React 19 + Vite SPA<br/>TailwindCSS 4, Radix, Zustand,<br/>TanStack Query, TipTap v3"]
+        be["<b>backend</b><br/>Fastify 5 + TypeScript<br/>JWT auth, REST + SSE"]
+
+        subgraph workers["Background workers (in-process)"]
+            direction LR
+            wsync["Sync scheduler"]
+            wemb["Embedding worker"]
+            wqual["Quality worker"]
+            wsum["Summary worker"]
+        end
+
+        pg[("<b>postgres</b><br/>PostgreSQL 17 + pgvector<br/>(HNSW, 1024-dim embeddings)")]
+        redis[("<b>redis</b><br/>Redis 8<br/>cache, queue, locks, rate limit")]
+
+        mcp["<b>mcp-docs</b><br/>Documentation sidecar<br/>(MCP server)"]
+        searx["<b>searxng</b><br/>Meta web-search engine"]
+    end
+
+    user -- "HTTPS" --> fe
+    fe  -- "REST + SSE<br/>/api/*" --> be
+
+    be --> workers
+    be -- "SQL (pg pool)" --> pg
+    be -- "RESP" --> redis
+    be -- "HTTP" --> mcp
+    mcp -- "HTTP" --> searx
+
+    be -. "XHTML pages,<br/>attachments" .-> confluence
+    be -. "chat, embeddings" .-> ollama
+    be -. "chat (optional)" .-> openai
+
+    classDef ext fill:#f5f5f5,stroke:#999,stroke-dasharray: 4 4,color:#333
+    classDef data fill:#eef6ff,stroke:#4a90e2,color:#123
+    classDef app fill:#eefbe8,stroke:#4caf50,color:#123
+    classDef side fill:#fff4e5,stroke:#e5a23c,color:#222
+    class confluence,ollama,openai ext
+    class pg,redis data
+    class fe,be app
+    class mcp,searx,workers side
+```
+
+## Containers at a glance
+
+| Container | Tech | Port (internal) | Image |
+|-----------|------|-----------------|-------|
+| frontend  | React 19 SPA, Vite, Nginx-served | 8081 | `ghcr.io/compendiq/compendiq-ce-frontend` |
+| backend   | Node.js 22, Fastify 5 | 3051 | `ghcr.io/compendiq/compendiq-ce-backend` |
+| postgres  | `pgvector/pgvector:pg17` | 5432 | upstream |
+| redis     | `redis:8-alpine` | 6379 | upstream |
+| mcp-docs  | MCP server (Node) | 3100 | `ghcr.io/compendiq/compendiq-ce-mcp-docs` |
+| searxng   | Python meta search | 8080 | `ghcr.io/compendiq/compendiq-ce-searxng` |
+
+## Background workers
+
+Workers run **inside the backend process** — there is no separate worker
+container. They are started from `backend/src/index.ts` via
+`startQueueWorkers()` (BullMQ) and fall back to interval-based polling when
+`USE_BULLMQ=false`.
+
+- **Sync scheduler** — polls `user_settings`, respects `SYNC_INTERVAL_MIN`,
+  guarded by a Redis lock (`sync:worker:lock`).
+- **Embedding worker** — consumes dirty pages (`pages.embedding_dirty=true`).
+- **Quality worker** — rates page clarity/completeness.
+- **Summary worker** — auto-summarizes pages.
+
+## Shared contracts
+
+`packages/contracts` (published as `@compendiq/contracts`) is imported by
+both frontend and backend and defines Zod schemas / TypeScript types for API
+boundaries. It is a build-time dependency, not a runtime container.
+
+## Enterprise plugin
+
+When `@compendiq/enterprise` is installed, the backend loads it dynamically
+at boot (`core/enterprise/loader.ts`). The frontend image is **identical**
+in CE and EE deployments; enterprise UI is gated at runtime by the
+`/api/admin/license` response. See
+[`10-flow-enterprise-license.md`](./10-flow-enterprise-license.md).

--- a/docs/architecture/03-backend-domains.md
+++ b/docs/architecture/03-backend-domains.md
@@ -1,0 +1,110 @@
+# 3. Backend Domains (C4 Level 3 — Components)
+
+Zooms into the `backend` container. The code is organized by domain with
+imports enforced by `eslint-plugin-boundaries` (see
+`backend/eslint.config.js`).
+
+## Domain map
+
+```mermaid
+flowchart LR
+    subgraph routes["routes/ (HTTP entry points)"]
+        direction TB
+        rF["foundation<br/>health, auth, settings,<br/>admin, rbac, notifications, setup"]
+        rC["confluence<br/>spaces, sync, attachments"]
+        rL["llm<br/>llm-ask (SSE), improve, generate,<br/>summarize, diagram, conversations,<br/>embeddings, models, admin, pdf"]
+        rK["knowledge<br/>pages CRUD, versions, tags,<br/>embeddings, duplicates, pinned,<br/>templates, comments, search,<br/>analytics, requests, export/import"]
+    end
+
+    subgraph domains["domains/"]
+        direction TB
+        dC["<b>confluence</b><br/>confluence-client<br/>sync-service<br/>attachment-handler<br/>subpage-context<br/>sync-overview-service"]
+        dL["<b>llm</b><br/>ollama-service / -provider<br/>openai-service<br/>llm-provider (resolver)<br/>embedding-service<br/>rag-service<br/>llm-cache"]
+        dK["<b>knowledge</b><br/>auto-tagger<br/>quality-worker<br/>summary-worker<br/>version-tracker<br/>duplicate-detector"]
+    end
+
+    subgraph core["core/ (infrastructure)"]
+        direction TB
+        cDB["db/ — pg pool, migrations"]
+        cPlug["plugins/ — auth, correlation-id, redis"]
+        cSvc["services/ — redis-cache, audit,<br/>error-tracker, content-converter,<br/>circuit-breaker, image-references,<br/>rbac, notifications, pdf,<br/>admin-settings, version-snapshot"]
+        cUtil["utils/ — crypto (AES-GCM),<br/>logger (pino), sanitize-llm-input,<br/>ssrf-guard, tls-config, llm-config"]
+        cEnt["enterprise/ — types, noop,<br/>loader, features"]
+    end
+
+    rF --> core
+    rC --> core
+    rC --> dC
+    rL --> core
+    rL --> dL
+    rL --> dC
+    rK --> core
+    rK --> dK
+    rK --> dL
+    rK --> dC
+
+    dC --> core
+    dC --> dL
+    dL --> core
+    dK --> core
+    dK --> dL
+    dK --> dC
+```
+
+## ESLint-enforced boundary rules
+
+Defined in `backend/eslint.config.js` with `eslint-plugin-boundaries`:
+
+```mermaid
+flowchart LR
+    classDef core fill:#eef6ff,stroke:#4a90e2
+    classDef llm fill:#fff4e5,stroke:#e5a23c
+    classDef conf fill:#eefbe8,stroke:#4caf50
+    classDef know fill:#f5eafd,stroke:#9b59b6
+    classDef route fill:#fae8e8,stroke:#c0392b
+
+    core[core]:::core
+    llm[llm]:::llm
+    conf[confluence]:::conf
+    know[knowledge]:::know
+    rF[routes/foundation]:::route
+    rC[routes/confluence]:::route
+    rL[routes/llm]:::route
+    rK[routes/knowledge]:::route
+
+    llm --> core
+    conf --> core
+    conf --> llm
+    know --> core
+    know --> llm
+    know --> conf
+
+    rF --> core
+    rC --> core
+    rC --> conf
+    rL --> core
+    rL --> llm
+    rL --> conf
+    rK --> core
+    rK --> llm
+    rK --> conf
+    rK --> know
+```
+
+**Rules (mnemonic):**
+
+- `core` imports **nothing** from domains/routes. It is pure infrastructure.
+- `confluence` may use `llm` (for sync-time embedding).
+- `llm` is self-contained (core only).
+- `knowledge` is the integrator and may use all three other domains.
+- Each `routes/*` group may import `core` plus the domains it exposes;
+  `routes/knowledge` is the top-level aggregator and may import anything.
+
+Adding a new import across these lines without updating the ESLint config is
+a build failure — update the config *and* this diagram together.
+
+## Background workers
+
+Workers live inside the `domains/*/services/` layer and are started from
+`backend/src/index.ts`. See [`08-flow-sync.md`](./08-flow-sync.md) and
+[`09-flow-rag-chat.md`](./09-flow-rag-chat.md) for the runtime behaviour.

--- a/docs/architecture/04-frontend-structure.md
+++ b/docs/architecture/04-frontend-structure.md
@@ -1,0 +1,102 @@
+# 4. Frontend Structure
+
+Zooms into the `frontend` container. React 19 SPA built with Vite, served
+statically in production.
+
+## Provider & feature layout
+
+```mermaid
+flowchart TB
+    main["main.tsx"]
+
+    subgraph providers["Providers (wrap the app)"]
+        direction TB
+        rp["RouterProvider"]
+        qp["QueryProvider (TanStack Query)"]
+        ap["AuthProvider<br/>(session + token refresh)"]
+        ep["EnterpriseProvider<br/>GET /api/admin/license → isEnterprise"]
+        tp["ThemeProvider"]
+    end
+
+    main --> providers
+    providers --> app["App.tsx<br/>(routes, SetupRoute gating)"]
+
+    subgraph features["features/ (domain UI)"]
+        direction LR
+        fAuth["auth/<br/>LoginPage<br/>OidcCallbackPage (EE route)"]
+        fDash["dashboard/"]
+        fPages["pages/<br/>list · view · new · trash · pinned"]
+        fSpaces["spaces/<br/>settings · new"]
+        fAI["ai/<br/>AiAssistantPage<br/>(ask / improve / generate / summarize)"]
+        fSearch["search/"]
+        fKR["knowledge-requests/"]
+        fTempl["templates/"]
+        fAnalytics["analytics/"]
+        fGraph["graph/"]
+        fSettings["settings/<br/>user + admin"]
+        fAdmin["admin/<br/>LicenseStatusCard<br/>OidcSettingsPage (EE-gated)"]
+    end
+
+    app --> features
+
+    subgraph shared["shared/"]
+        direction LR
+        sEnt["enterprise/<br/>context · loader · types · hook"]
+        sComp["components/<br/>layout · article · diagrams ·<br/>badges · feedback · effects"]
+        sHooks["hooks/<br/>useSessionInit · useTokenRefreshTimer ·<br/>useThemeEffect · useSetupStatus"]
+        sLib["lib/ (api client, utils)"]
+    end
+
+    features --> shared
+
+    subgraph stores["stores/ (Zustand)"]
+        zAuth["auth"]
+        zTheme["theme"]
+        zUI["ui"]
+        zAV["article-view"]
+        zCmd["command-palette"]
+        zKb["keyboard-shortcuts"]
+    end
+
+    features --> stores
+
+    classDef prov fill:#eef6ff,stroke:#4a90e2
+    classDef feat fill:#eefbe8,stroke:#4caf50
+    classDef sh fill:#fff4e5,stroke:#e5a23c
+    classDef st fill:#f5eafd,stroke:#9b59b6
+    class providers,rp,qp,ap,ep,tp prov
+    class features,fAuth,fDash,fPages,fSpaces,fAI,fSearch,fKR,fTempl,fAnalytics,fGraph,fSettings,fAdmin feat
+    class shared,sEnt,sComp,sHooks,sLib sh
+    class stores,zAuth,zTheme,zUI,zAV,zCmd,zKb st
+```
+
+## Enterprise gating
+
+The frontend ships **one image** for both CE and EE. Enterprise UI is gated
+at runtime:
+
+```mermaid
+sequenceDiagram
+    participant UI as React app
+    participant EP as EnterpriseProvider
+    participant API as Backend /api/admin/license
+
+    UI->>EP: mount
+    EP->>API: GET /api/admin/license
+    API-->>EP: { edition, tier, valid, features, canUpdate? }
+    EP->>EP: isEnterprise = (edition !== 'community' && valid)
+    EP-->>UI: context { isEnterprise, features }
+    UI->>UI: useEnterprise() hides/shows EE surfaces<br/>(OIDC settings, license form, etc.)
+```
+
+See [`10-flow-enterprise-license.md`](./10-flow-enterprise-license.md) for
+the backend side.
+
+## Styling
+
+- **TailwindCSS 4** with CSS variables for theming (light/dark/custom).
+- **Glassmorphic** dashboard aesthetic (ADR-010): `bg-card/80 backdrop-blur-md border-white/10`.
+- **Framer Motion** for entrance animations, wrapped in `LazyMotion`;
+  all animations respect `prefers-reduced-motion`.
+- **Radix UI** primitives for all interactive elements (menus, dialogs,
+  tooltips, dropdowns).

--- a/docs/architecture/05-deployment.md
+++ b/docs/architecture/05-deployment.md
@@ -1,0 +1,80 @@
+# 5. Docker Deployment
+
+Physical layout derived from `docker/docker-compose.yml`. The compose file
+defines three networks to keep internal services (`postgres`, `redis`) off
+the public bridge.
+
+## Compose topology
+
+```mermaid
+flowchart LR
+    host(["Host / reverse proxy"])
+
+    subgraph fe_net["frontend-net"]
+        fe["<b>frontend</b><br/>:8081<br/>image: compendiq-ce-frontend"]
+    end
+
+    subgraph be_net["backend-net"]
+        be["<b>backend</b><br/>:3051<br/>image: compendiq-ce-backend<br/>volume: attachments → /app/data"]
+        mcp["<b>mcp-docs</b><br/>:3100<br/>image: compendiq-ce-mcp-docs"]
+        searx["<b>searxng</b><br/>:8080<br/>image: compendiq-ce-searxng"]
+    end
+
+    subgraph data_net["data-net (internal: true)"]
+        pg[("<b>postgres</b><br/>:5432<br/>image: pgvector/pgvector:pg17<br/>volume: postgres-data")]
+        rd[("<b>redis</b><br/>:6379<br/>image: redis:8-alpine")]
+    end
+
+    host -- "FRONTEND_PORT → 8081" --> fe
+    host -- "BACKEND_HOST_PORT → 3051" --> be
+    fe -- "HTTP" --> be
+    be -- "HTTP" --> mcp
+    mcp -- "HTTP" --> searx
+    be -- "SQL" --> pg
+    be -- "RESP" --> rd
+    mcp -- "RESP" --> rd
+
+    classDef ext fill:#fff,stroke:#333
+    classDef net fill:#fafafa,stroke:#bbb,stroke-dasharray: 4 4
+    classDef svc fill:#eefbe8,stroke:#4caf50
+    classDef data fill:#eef6ff,stroke:#4a90e2
+    classDef side fill:#fff4e5,stroke:#e5a23c
+    class host ext
+    class fe,be svc
+    class mcp,searx side
+    class pg,rd data
+```
+
+## Network rules
+
+| Network       | internal | Members                         | Purpose |
+|---------------|----------|---------------------------------|---------|
+| `frontend-net`| no       | frontend, backend               | Browser → frontend, SPA → backend API |
+| `backend-net` | no       | backend, mcp-docs, searxng      | Backend sidecar services |
+| `data-net`    | **yes**  | postgres, redis (+ backend)     | No external exposure; DB/cache only reachable from backend |
+
+`postgres` and `redis` **must not** publish host ports in production.
+Development overrides (`docker/docker-compose.*.yml`) may expose them for
+debugging — never merge that into production.
+
+## Volumes
+
+| Volume          | Mount                                  | Contents |
+|-----------------|----------------------------------------|----------|
+| `postgres-data` | `/var/lib/postgresql/data` (postgres)  | Primary data + embeddings |
+| `attachments`   | `/app/data` (backend)                  | Cached Confluence attachments (images, drawio, PDFs) — also configurable via `ATTACHMENTS_DIR` |
+
+## Additional compose files
+
+- `docker-compose.confluence.yml` — spins up a throwaway Confluence DC for
+  local integration testing.
+- `docker-compose.test.yml` — CI services (Postgres on `:5433`, Redis
+  ephemeral) used by `backend` tests and Playwright E2E.
+
+## Enterprise image
+
+`docker/Dockerfile.enterprise` is a multi-stage template that overlays the
+`@compendiq/enterprise` package onto the backend image. It does **not**
+modify the frontend image — the frontend is identical in CE and EE
+deployments and gates Enterprise UI at runtime (see
+[`04-frontend-structure.md`](./04-frontend-structure.md)).

--- a/docs/architecture/06-data-model.md
+++ b/docs/architecture/06-data-model.md
@@ -1,0 +1,216 @@
+# 6. Data Model (ERD)
+
+Focused ERD of the core tables. Only the most relevant columns are shown;
+auxiliary tables (migrations log, rate-limit buckets, token blacklist,
+per-feature settings) are omitted for readability. See
+`backend/src/core/db/migrations/` for the full schema.
+
+```mermaid
+erDiagram
+    users ||--o| user_settings : "has 1"
+    users ||--o{ pages : "owns"
+    users ||--o{ page_versions : "owns"
+    users ||--o{ page_embeddings : "owns"
+    users ||--o{ llm_conversations : "owns"
+    users ||--o{ notifications : "receives"
+    users ||--o{ audit_log : "generates"
+    users ||--o{ comments : "authors"
+    users ||--o{ knowledge_requests : "requests"
+    users ||--o{ templates : "authors"
+
+    pages ||--o{ page_versions : "versioned as"
+    pages ||--o{ page_embeddings : "chunked into"
+    pages ||--o{ comments : "annotated by"
+    pages ||--o{ page_relationships : "related via"
+    pages ||--o{ knowledge_requests : "fulfils"
+
+    roles ||--o{ group_memberships : "granted via"
+    groups ||--o{ group_memberships : "has"
+    users ||--o{ group_memberships : "member of"
+    groups ||--o{ space_role_assignments : "assigned in"
+    roles ||--o{ space_role_assignments : "used in"
+
+    users {
+        uuid id PK
+        text username UK
+        text password_hash
+        text role "admin | user"
+        text email
+        text display_name
+        text auth_provider "local | oidc"
+        text oidc_sub
+        timestamptz created_at
+    }
+
+    user_settings {
+        uuid user_id PK,FK
+        text confluence_url
+        bytea confluence_pat "AES-256-GCM"
+        text[] selected_spaces
+        text ollama_model
+        text theme
+        int sync_interval_min
+    }
+
+    pages {
+        int id PK
+        uuid user_id FK
+        text confluence_id
+        text space_key
+        text title
+        text body_storage "XHTML"
+        text body_html
+        text body_text
+        int version
+        int parent_id FK
+        text source "confluence | standalone"
+        text visibility "private | shared"
+        uuid created_by_user_id FK
+        bool embedding_dirty
+        timestamptz deleted_at
+    }
+
+    page_versions {
+        uuid id PK
+        uuid user_id FK
+        text confluence_id
+        int version_number
+        text title
+        text body_html
+        text body_text
+        timestamptz synced_at
+    }
+
+    page_embeddings {
+        bigint id PK
+        uuid user_id FK
+        int page_id FK
+        int chunk_index
+        text chunk_text
+        vector embedding "1024 dims (bge-m3)"
+        jsonb metadata
+    }
+
+    page_relationships {
+        bigint id PK
+        uuid user_id FK
+        int page_id_1 FK
+        int page_id_2 FK
+        text relationship_type
+        double score
+    }
+
+    llm_conversations {
+        uuid id PK
+        uuid user_id FK
+        text model
+        text title
+        jsonb messages
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    comments {
+        bigint id PK
+        int page_id FK
+        uuid user_id FK
+        bigint parent_id FK
+        text body
+        bool is_resolved
+        uuid resolved_by FK
+        text anchor_type "selection | block"
+        jsonb anchor_data
+    }
+
+    notifications {
+        bigint id PK
+        uuid user_id FK
+        text type
+        text title
+        text body
+        uuid source_user_id FK
+        int source_page_id FK
+        bool is_read
+    }
+
+    knowledge_requests {
+        bigint id PK
+        text title
+        text description
+        uuid requested_by FK
+        uuid assigned_to FK
+        text space_key
+        text status
+        int fulfilled_by_page_id FK
+    }
+
+    templates {
+        bigint id PK
+        text title
+        text description
+        text category
+        jsonb body_json
+        text body_html
+        uuid created_by FK
+        bool is_global
+        text space_key
+    }
+
+    audit_log {
+        uuid id PK
+        uuid user_id FK
+        text action
+        text resource_type
+        text resource_id
+        jsonb metadata
+        text ip_address
+        timestamptz created_at
+    }
+
+    admin_settings {
+        text key PK
+        text value
+        text type "json | text"
+    }
+
+    roles {
+        bigint id PK
+        text name
+        jsonb permissions
+    }
+
+    groups {
+        bigint id PK
+        text name
+    }
+
+    group_memberships {
+        uuid user_id FK
+        bigint group_id FK
+        bigint role_id FK
+    }
+
+    space_role_assignments {
+        bigint id PK
+        text space_key
+        bigint role_id FK
+        bigint group_id FK
+    }
+```
+
+## Notable conventions
+
+- **User ownership is pervasive.** Almost every table carries `user_id`
+  (UUID, FK → `users.id`) — Compendiq is multi-tenant at the user level.
+- **pgvector.** `page_embeddings.embedding` is `vector(1024)` with an HNSW
+  index (`m=16`, `ef_construction=64`) for cosine similarity. Query-time
+  `ef_search` is set per request.
+- **Encryption at rest.** `user_settings.confluence_pat` is stored as a
+  ciphertext blob (AES-256-GCM, key from `PAT_ENCRYPTION_KEY`). Never
+  log or expose it to the frontend.
+- **`admin_settings`** is a key-value bag used for server-wide config
+  that must survive restarts and be editable at runtime — notably the
+  `license_key` (populated by the EE plugin) and LLM admin overrides.
+- **`audit_log`** captures auth events, license changes, RBAC mutations,
+  and high-value LLM calls (prompt-injection flags, failed sanitization).
+- **Soft delete** on `pages.deleted_at` — the Trash feature filters on this.

--- a/docs/architecture/07-flow-auth.md
+++ b/docs/architecture/07-flow-auth.md
@@ -1,0 +1,109 @@
+# 7. Auth & Login Flow
+
+Compendiq supports two auth modes:
+
+1. **Local credentials** — default in CE. Bcrypt + JWT with refresh tokens.
+2. **OIDC SSO** — Enterprise Edition only, gated by
+   `ENTERPRISE_FEATURES.OIDC_SSO`.
+
+## Local login (CE + EE)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Browser
+    participant FE as Frontend (SPA)
+    participant BE as Backend /api/auth
+    participant DB as Postgres
+    participant RL as Redis (rate-limit)
+
+    B->>FE: submit username / password
+    FE->>BE: POST /api/auth/login
+    BE->>RL: check rate-limit bucket
+    alt over limit
+        RL-->>BE: 429
+        BE-->>FE: 429 Too Many Requests
+    else ok
+        BE->>DB: SELECT password_hash FROM users
+        DB-->>BE: hash
+        BE->>BE: bcrypt.compare()
+        alt mismatch
+            BE-->>FE: 401
+        else match
+            BE->>BE: generateAccessToken() (HS256, 15m)
+            BE->>BE: generateRefreshToken() (7d)
+            BE->>DB: INSERT refresh_tokens
+            BE->>DB: INSERT audit_log (login_success)
+            BE-->>FE: 200 { accessToken }<br/>Set-Cookie: refreshToken (httpOnly)
+        end
+    end
+
+    FE->>FE: store accessToken in memory
+    Note over FE: useTokenRefreshTimer<br/>schedules silent refresh
+    FE->>BE: POST /api/auth/refresh (cookie sent)
+    BE->>DB: validate refresh_tokens row
+    BE-->>FE: 200 { accessToken (new) }
+```
+
+### Registration quirks
+
+- `POST /api/auth/register` is rate-limited (5/min).
+- **The first successful registration creates an admin.** Subsequent
+  registrations create regular users. This transition is atomic
+  (single `INSERT … RETURNING role` guarded by a transaction).
+- Registration may be disabled by an admin setting (`admin_settings`
+  key) once the initial user is created.
+
+### Logout
+
+`POST /api/auth/logout` deletes the refresh token row, clears the cookie,
+and records `audit_log(action='logout')`. The access token is short-lived
+enough that blacklisting is not needed in CE; EE may add it.
+
+## OIDC flow (Enterprise Edition)
+
+Routes registered only when the EE plugin is loaded **and**
+`ENTERPRISE_FEATURES.OIDC_SSO` is enabled in the loaded license.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Browser
+    participant FE as Frontend
+    participant BE as Backend (EE plugin)
+    participant IDP as OIDC Provider
+
+    B->>FE: click "Sign in with SSO"
+    FE->>BE: GET /auth/oidc/start?provider=okta
+    BE->>BE: generate PKCE verifier + state
+    BE-->>B: 302 → IdP /authorize
+    B->>IDP: login (browser-driven)
+    IDP-->>B: 302 → /auth/oidc/callback?code=…&state=…
+    B->>BE: GET /auth/oidc/callback
+    BE->>IDP: POST /token (exchange code)
+    IDP-->>BE: id_token + access_token
+    BE->>BE: verify signature + claims
+    BE->>BE: upsert users (auth_provider='oidc', oidc_sub)
+    BE->>BE: issue short-lived login_code
+    BE-->>B: 302 → /auth/oidc/callback?login_code=…
+    B->>FE: OidcCallbackPage.tsx loads
+    FE->>BE: POST /api/auth/oidc/exchange { login_code }
+    BE-->>FE: 200 { accessToken } + refreshToken cookie
+    FE->>FE: enter app (AuthProvider hydrated)
+```
+
+Why the extra hop via a `login_code`? It keeps tokens out of the URL
+fragment that the browser exposes to history/referer. The callback page
+posts to a JSON endpoint and only then receives the real JWT.
+
+## Where this lives
+
+| Concern | File |
+|---------|------|
+| JWT plugin, decorators | `backend/src/core/plugins/auth.ts` |
+| Routes (register / login / refresh / logout) | `backend/src/routes/foundation/auth.ts` |
+| OIDC routes (EE only) | `@compendiq/enterprise` (loaded via `core/enterprise/loader.ts`) |
+| Frontend session init | `frontend/src/shared/hooks/useSessionInit.ts` |
+| Refresh timer | `frontend/src/shared/hooks/useTokenRefreshTimer.ts` |
+| OIDC callback UI | `frontend/src/features/auth/OidcCallbackPage.tsx` |
+| OIDC admin config UI | `frontend/src/features/admin/OidcSettingsPage.tsx` |

--- a/docs/architecture/08-flow-sync.md
+++ b/docs/architecture/08-flow-sync.md
@@ -1,0 +1,104 @@
+# 8. Confluence Sync Flow
+
+End-to-end flow for pulling a user's selected Confluence spaces into the
+local Postgres + pgvector store. Triggered either manually
+(`POST /api/confluence/sync/:spaceKey`) or automatically by the in-process
+sync scheduler.
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Trigger<br/>(scheduler / API)
+    participant S as sync-service
+    participant R as Redis (lock + status)
+    participant CL as confluence-client
+    participant CF as Confluence DC
+    participant CC as content-converter
+    participant AH as attachment-handler
+    participant DB as Postgres (pages)
+    participant ES as embedding-service
+    participant OL as Ollama (/embed)
+
+    T->>S: syncSpace(userId, spaceKey)
+    S->>R: SETEX NX sync:worker:lock (TTL 600s)
+    alt already locked
+        R-->>S: nil
+        S-->>T: skip (another run in progress)
+    else acquired
+        R-->>S: OK
+        S->>DB: SELECT user_settings (decrypt PAT)
+        S->>CL: getSpaces(pat)
+        CL->>CF: GET /rest/api/space
+        CF-->>CL: spaces
+        CL-->>S: spaces (filtered to selected_spaces)
+
+        loop for each page (recursively, parent-child)
+            S->>CL: getPage(pageId)
+            CL->>CF: GET /rest/api/content/{id}?expand=body.storage,version,children
+            CF-->>CL: XHTML body + metadata
+            CL-->>S: page
+            S->>CC: confluenceToHtml(XHTML)
+            CC-->>S: body_html + body_text
+            S->>AH: downloadAttachments(page)
+            AH->>CF: GET attachments
+            AH->>AH: write to ATTACHMENTS_DIR
+            S->>DB: INSERT/UPDATE pages<br/>SET embedding_dirty = true
+            S->>R: HSET sync:status:{user} progress
+        end
+
+        S->>DB: INSERT/UPDATE page_versions (snapshot)
+        S->>R: DEL sync:worker:lock
+        S-->>T: done
+    end
+
+    Note over ES,OL: Embedding worker (separate loop)
+    ES->>DB: SELECT pages WHERE embedding_dirty = true LIMIT N
+    loop per page
+        ES->>ES: chunk(body_text)
+        ES->>OL: POST /api/embeddings (bge-m3)
+        OL-->>ES: vector[1024]
+        ES->>DB: INSERT page_embeddings
+        ES->>DB: UPDATE pages SET embedding_dirty = false
+    end
+```
+
+## Triggers
+
+| Trigger | Source | Cadence |
+|---------|--------|---------|
+| Manual sync | `POST /api/confluence/sync/:spaceKey` | on demand |
+| Scheduled sync | In-process sync scheduler in `backend/src/index.ts` (`startQueueWorkers`) | every `SYNC_INTERVAL_MIN` (default 15 min) |
+| Webhook (future) | not yet implemented | — |
+
+## Concurrency & safety
+
+- **Redis lock (`sync:worker:lock`)** — single active sync per instance;
+  TTL acts as a dead-man's switch.
+- **Per-user PAT scope** — each sync decrypts the PAT just-in-time, uses it
+  for the duration of the run, and never logs it.
+- **SSRF guard** — `confluence-client` uses the shared SSRF guard from
+  `core/utils/ssrf-guard.ts` to reject URLs pointing at loopback / link-local
+  / metadata IPs.
+- **TLS** — respects `CONFLUENCE_VERIFY_SSL` (default `true`) and
+  `NODE_EXTRA_CA_CERTS` for self-signed internal CAs.
+- **Idempotency** — upsert by `(user_id, confluence_id)`. `version` column
+  is written from Confluence's own version counter; no double-writes.
+- **Circuit breaker** — `core/services/circuit-breaker.ts` protects against
+  runaway failure against a broken Confluence instance.
+
+## Content pipeline hand-off
+
+The `confluenceToHtml()` call produces `body_html` and `body_text`. The
+same page is later converted to Markdown *at query time* when sent to the
+LLM. See [`11-content-pipeline.md`](./11-content-pipeline.md).
+
+## Key files
+
+- `backend/src/domains/confluence/services/sync-service.ts`
+- `backend/src/domains/confluence/services/confluence-client.ts`
+- `backend/src/domains/confluence/services/attachment-handler.ts`
+- `backend/src/domains/confluence/services/sync-overview-service.ts`
+- `backend/src/domains/llm/services/embedding-service.ts`
+- `backend/src/routes/confluence/sync.ts`

--- a/docs/architecture/09-flow-rag-chat.md
+++ b/docs/architecture/09-flow-rag-chat.md
@@ -1,0 +1,136 @@
+# 9. RAG Chat Flow
+
+End-to-end flow for a user's question through the RAG pipeline. Implemented
+in `backend/src/routes/llm/llm-ask.ts` (SSE) with retrieval in
+`backend/src/domains/llm/services/rag-service.ts`.
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant FE as Frontend (AiAssistantPage)
+    participant BE as /api/llm/ask (SSE)
+    participant SAN as sanitize-llm-input
+    participant RAG as rag-service
+    participant OL as Ollama (embed)
+    participant PG as Postgres (pgvector + FTS)
+    participant SP as subpage-context
+    participant CF as Confluence
+    participant MCP as mcp-docs / searxng
+    participant CACHE as llm-cache (Redis)
+    participant PROV as LLM provider<br/>(Ollama / OpenAI)
+    participant CONV as llm_conversations
+
+    FE->>BE: POST /api/llm/ask<br/>{ question, model, conversationId,<br/>  includeSubPages, externalUrls, searchWeb }
+    BE->>SAN: sanitize(question)
+    alt prompt-injection detected
+        SAN-->>BE: flagged
+        BE->>PG: INSERT audit_log (llm_prompt_injection)
+        BE-->>FE: SSE error (blocked)
+    else clean
+        SAN-->>BE: ok
+        BE->>CACHE: getCachedResponse(key)
+        alt cache hit
+            CACHE-->>BE: answer
+            BE-->>FE: SSE { content, done:true, fromCache:true }
+        else miss (stampede lock)
+            CACHE-->>BE: lock acquired
+            BE->>OL: POST /api/embeddings (question)
+            OL-->>BE: q_vector[1024]
+            par vector + keyword
+                BE->>RAG: vectorSearch(q_vector, userId, topK)
+                RAG->>PG: SELECT ... ORDER BY embedding <=> $1<br/>WHERE user_id=$2 AND space in (...)
+                PG-->>RAG: top-K chunks
+            and
+                BE->>RAG: hybridKeyword(question, userId)
+                RAG->>PG: tsvector / BM25 search
+                PG-->>RAG: matches
+            end
+            RAG-->>BE: merged + deduped + ranked
+            opt includeSubPages
+                BE->>SP: assembleSubPageContext(rootPageId)
+                SP->>CF: fetch parent/child tree
+                CF-->>SP: pages
+                SP-->>BE: tree context
+            end
+            opt externalUrls provided
+                BE->>MCP: fetch urls
+                MCP-->>BE: content
+            end
+            opt searchWeb
+                BE->>MCP: search(question)
+                MCP-->>BE: top results
+            end
+            BE->>BE: build system prompt + context<br/>(resolveSystemPrompt, guardrails)
+            BE->>PROV: providerStreamChat(prompt, model)
+            loop chunks
+                PROV-->>BE: delta
+                BE-->>FE: SSE { content: delta }
+            end
+            PROV-->>BE: done
+            BE->>CACHE: setCachedResponse(key, answer)
+            BE->>CONV: upsert message + answer + sources
+            BE->>PG: INSERT audit_log (tokens, latency, doc_ids)
+            BE-->>FE: SSE { done:true, conversationId, sources }
+        end
+    end
+```
+
+## Retrieval details
+
+- **Vector search** uses pgvector's `<=>` cosine distance against an HNSW
+  index on `page_embeddings.embedding`. `ef_search` is set per request for
+  a recall/latency trade-off.
+- **Keyword search** uses the PostgreSQL text-search configuration from
+  `FTS_LANGUAGE` (default `simple`; set `german`, `english`, etc. for
+  language-aware stemming).
+- **Hybrid merge** deduplicates by `page_id`, keeps the best chunk per
+  page, and re-ranks using a weighted blend.
+- **Scope** — results are filtered to pages the requesting user can see
+  (own pages + spaces they have RBAC access to).
+
+## Streaming contract
+
+The SSE frames use JSON events:
+
+```
+data: { "content": "partial token" }
+data: { "content": "more tokens" }
+data: { "done": true, "conversationId": "…", "sources": [ … ] }
+```
+
+On abort (client disconnect) the backend aborts the upstream LLM request —
+see `backend/src/routes/llm/sse-abort.test.ts` for the behaviour we rely on.
+
+## Cache + stampede protection
+
+- **Key** = `hash(userId, model, normalizedQuestion, contextFingerprint)`.
+- Cache hit → answer returned immediately from Redis.
+- Cache miss → a Redis lock is taken; concurrent identical requests wait
+  for the first writer and then read the fresh entry, avoiding duplicate
+  LLM calls.
+- TTL: `LLM_CACHE_TTL` (default `3600`s).
+
+## Related routes
+
+All of these go through the same provider resolver and sanitization layer:
+
+| Route | Purpose |
+|-------|---------|
+| `POST /api/llm/ask` | RAG Q&A (this diagram) |
+| `POST /api/llm/improve` | Improve an existing article |
+| `POST /api/llm/generate` | Generate a new article |
+| `POST /api/llm/summarize` | Summarize a page |
+| `POST /api/llm/diagram` | Generate a Mermaid diagram from prose |
+| `POST /api/llm/pdf/extract` | PDF → text → summary |
+
+## Key files
+
+- `backend/src/routes/llm/llm-ask.ts`
+- `backend/src/domains/llm/services/rag-service.ts`
+- `backend/src/domains/llm/services/embedding-service.ts`
+- `backend/src/domains/llm/services/llm-provider.ts` (Ollama vs OpenAI resolver)
+- `backend/src/domains/llm/services/llm-cache.ts`
+- `backend/src/core/utils/sanitize-llm-input.ts`
+- `backend/src/domains/confluence/services/subpage-context.ts`

--- a/docs/architecture/10-flow-enterprise-license.md
+++ b/docs/architecture/10-flow-enterprise-license.md
@@ -1,0 +1,123 @@
+# 10. Enterprise License Flow (Open-Core)
+
+Compendiq ships as an open-core product. CE (this repo) defines the plugin
+contract, a noop stub, and the UI surfaces for license management. EE is
+published privately as `@compendiq/enterprise` and implements the real
+plugin. See `docs/ENTERPRISE-ARCHITECTURE.md` for the full design.
+
+## Boot-time plugin load
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant I as backend/src/index.ts
+    participant A as app.ts
+    participant L as core/enterprise/loader.ts
+    participant NOOP as noop plugin
+    participant EE as @compendiq/enterprise<br/>(optional)
+    participant F as Fastify
+    participant DB as admin_settings
+    participant ENV as env: COMPENDIQ_LICENSE_KEY
+
+    I->>A: buildApp()
+    A->>L: loadEnterprisePlugin()
+    L->>L: dynamic import('@compendiq/enterprise')
+    alt EE installed
+        L-->>A: EE plugin instance
+        A->>F: decorate license + enterprise
+        A->>EE: registerRoutes(fastify)
+        EE->>DB: SELECT value FROM admin_settings WHERE key='license_key'
+        alt DB row present
+            DB-->>EE: licenseKey
+        else absent
+            EE->>ENV: read COMPENDIQ_LICENSE_KEY (deprecated fallback)
+        end
+        EE->>EE: verify Ed25519 signature<br/>parse tier/seats/expiry/licenseId
+        EE->>F: set app.license = { edition, tier, valid, features, ... }
+        Note over EE: Registers PUT/GET /api/admin/license<br/>and feature-gated routes (OIDC, etc.)
+    else EE not installed
+        L-->>A: noopPlugin
+        A->>F: decorate license = { edition:'community', valid:true, features:[] }
+        A->>F: register CE fallback GET /api/admin/license<br/>(only when version === 'community')
+    end
+    I->>F: listen()
+```
+
+## Runtime license update (EE only)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Admin as Browser (admin UI)
+    participant FE as LicenseStatusCard
+    participant BE as PUT /api/admin/license (EE route)
+    participant DB as admin_settings
+    participant F as app.license (cache)
+
+    Admin->>FE: paste license key
+    FE->>BE: PUT /api/admin/license { key }
+    BE->>BE: verify Ed25519 signature
+    alt invalid
+        BE-->>FE: 400 { valid:false, reason }
+    else valid
+        BE->>DB: UPSERT admin_settings(key='license_key', value=key)
+        BE->>F: refresh in-memory license (no restart)
+        BE-->>FE: 200 { edition, tier, features, displayKey, canUpdate:true }
+        FE->>FE: enter enterprise mode (reload or<br/>re-fetch via EnterpriseProvider)
+    end
+```
+
+## GET /api/admin/license response shape
+
+| Mode | Response |
+|------|----------|
+| **CE (noop)** | `{ edition:'community', tier:'community', valid:true, features:[] }` |
+| **EE valid**  | `{ edition:'enterprise', tier:'business'\|'enterprise', valid:true, features:[...], displayKey, licenseId, canUpdate:true }` |
+| **EE invalid / expired** | `{ edition:'enterprise', valid:false, reason:'expired', canUpdate:true }` |
+
+The frontend uses `canUpdate` to decide whether to render the key-entry
+form; CE omits the flag.
+
+## License key format
+
+```
+ATM-{tier}-{seats}-{expiryYYYYMMDD}-{licenseId}.{ed25519SignatureBase64url}
+```
+
+- **v2** includes `{licenseId}`; **v1** is accepted for backwards compat.
+- Signed with an Ed25519 key pair — the public key is compiled into the
+  EE plugin; the private key is held by the vendor.
+- Persisted in the `admin_settings` table under key `license_key`.
+- The `COMPENDIQ_LICENSE_KEY` env var is a **deprecated bootstrap
+  fallback** — consulted only when the DB row is absent.
+
+## Frontend gating recap
+
+```mermaid
+flowchart LR
+    boot(["App mount"]) --> fetch[["GET /api/admin/license"]]
+    fetch --> decide{edition !== 'community'<br/>AND valid}
+    decide -- yes --> ee["isEnterprise = true<br/>→ show OIDC tab,<br/>license form, EE features"]
+    decide -- no  --> ce["isEnterprise = false<br/>→ CE UI only"]
+```
+
+CE and EE ship the **same frontend image**. There is no IIFE bundle, no
+build-time patch, no separate EE SPA. All gating happens at runtime via
+`useEnterprise()`.
+
+## Key files (CE side)
+
+| File | Purpose |
+|------|---------|
+| `backend/src/core/enterprise/types.ts` | `EnterprisePlugin`, `LicenseInfo`, Fastify augmentation |
+| `backend/src/core/enterprise/features.ts` | `ENTERPRISE_FEATURES` constants |
+| `backend/src/core/enterprise/noop.ts` | Inert CE stub |
+| `backend/src/core/enterprise/loader.ts` | Dynamic import + fallback |
+| `backend/src/core/types/compendiq-enterprise.d.ts` | Type declaration for the optional EE package |
+| `backend/src/routes/foundation/admin.ts` | CE fallback `GET /api/admin/license` |
+| `frontend/src/shared/enterprise/context.tsx` | `EnterpriseProvider` |
+| `frontend/src/shared/enterprise/use-enterprise.ts` | `useEnterprise()` hook |
+| `frontend/src/features/admin/LicenseStatusCard.tsx` | Admin UI for the license |
+| `frontend/src/features/admin/OidcSettingsPage.tsx` | EE-gated OIDC config UI |
+| `frontend/src/features/auth/OidcCallbackPage.tsx` | EE-gated OIDC callback handler |
+| `docker/Dockerfile.enterprise` | Multi-stage Dockerfile template for EE builds |

--- a/docs/architecture/11-content-pipeline.md
+++ b/docs/architecture/11-content-pipeline.md
@@ -1,0 +1,78 @@
+# 11. Content Format Pipeline
+
+Confluence Data Center 9.2 exposes its pages in **XHTML Storage Format**
+only — no ADF, no REST API v2. Compendiq normalizes this into three
+representations that flow through the rest of the system.
+
+## Representations
+
+| Form | Stored in | Consumed by |
+|------|-----------|-------------|
+| **XHTML Storage** | `pages.body_storage` | Round-trip to Confluence (push-back not yet enabled in CE, but retained for fidelity) |
+| **HTML (clean)** | `pages.body_html` | TipTap editor, viewer UI, diff UI |
+| **Plain text** | `pages.body_text` | Embedding input, FTS (`tsvector`) |
+| **Markdown** | not stored — derived per call | LLM prompts (Ollama / OpenAI) |
+
+## Flow
+
+```mermaid
+flowchart LR
+    CF[("Confluence<br/>XHTML Storage")]
+    DB[("Postgres pages<br/>body_storage · body_html · body_text")]
+    LLM[("LLM<br/>Markdown prompts")]
+    ED["Editor (TipTap v3)<br/>HTML"]
+
+    CF -- "confluenceToHtml()" --> DB
+    DB -- "htmlToConfluence()" --> CF
+    DB -- "htmlToMarkdown()" --> LLM
+    LLM -- "markdownToHtml()" --> DB
+    DB <--> ED
+
+    classDef ext fill:#fff,stroke:#333
+    classDef data fill:#eef6ff,stroke:#4a90e2
+    classDef ai fill:#fff4e5,stroke:#e5a23c
+    classDef ui fill:#eefbe8,stroke:#4caf50
+    class CF ext
+    class DB data
+    class LLM ai
+    class ED ui
+```
+
+## Conversion rules
+
+Implemented in `backend/src/core/services/content-converter.ts` using
+`turndown` + `jsdom` + `turndown-plugin-gfm`.
+
+Custom turndown rules handle Confluence-specific macros:
+
+| Confluence macro            | HTML form                        | Markdown form                 |
+|-----------------------------|----------------------------------|-------------------------------|
+| `ac:structured-macro[code]` | `<pre><code class="language-x">` | ` ```x … ``` ` fenced block   |
+| `ac:task-list`              | `<ul data-task-list>`            | `- [ ]` / `- [x]`             |
+| `ac:panel` (info/note/warn) | `<div class="panel panel-…">`    | `> **INFO:** …` block-quote   |
+| `ri:user`                   | `<span class="mention">@user</span>` | `@user` (inline)          |
+| `ri:page`                   | `<a data-page-link>`             | `[title](compendiq://page/ID)` |
+| `ac:structured-macro[drawio]` | `<img data-drawio>`            | `![diagram](attachment-url)`  |
+
+## Why store three forms?
+
+- **`body_storage` (XHTML)** — lossless round-trip with Confluence; any
+  future write-back needs the exact original serialisation.
+- **`body_html`** — what the viewer and TipTap editor consume; already
+  sanitized so we don't run the converter on every render.
+- **`body_text`** — stripped of all tags; the input both to the embedding
+  pipeline and to the PostgreSQL `tsvector` column for hybrid search.
+
+Markdown is regenerated on demand because (a) LLM prompt sizes vary by
+model so partial/windowed serialisation is common, and (b) the conversion
+is cheap compared to the LLM call itself.
+
+## Attachments
+
+Images, drawio diagrams, and PDFs are downloaded during sync to
+`ATTACHMENTS_DIR` (default `data/attachments`) and rewritten to
+Compendiq-local URLs in `body_html`. The original Confluence URLs are
+kept in a sidecar table (`image_references`) for reconciliation.
+
+See [`08-flow-sync.md`](./08-flow-sync.md) for where this hooks into the
+sync pipeline.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,53 @@
+# Architecture Documentation
+
+This folder contains the living architecture diagrams for Compendiq CE.
+All diagrams are written in [Mermaid](https://mermaid.js.org/) so they render
+natively on GitHub and diff cleanly in PRs. Do not add binary diagram exports
+(PNG/SVG) — keep the source of truth in Markdown.
+
+## Index
+
+| # | Diagram | File | View |
+|---|---------|------|------|
+| 1 | System Context (C4 L1) | [`01-system-context.md`](./01-system-context.md) | Users + external systems talking to Compendiq |
+| 2 | Container Diagram (C4 L2) | [`02-container.md`](./02-container.md) | Deployable units (frontend, backend, Postgres, Redis, mcp-docs, searxng) |
+| 3 | Backend Domains (C4 L3) | [`03-backend-domains.md`](./03-backend-domains.md) | Components per domain + ESLint boundary rules |
+| 4 | Frontend Structure | [`04-frontend-structure.md`](./04-frontend-structure.md) | Feature folders, providers, enterprise gating |
+| 5 | Docker Deployment | [`05-deployment.md`](./05-deployment.md) | Compose services, networks, ports, volumes |
+| 6 | Data Model (ERD) | [`06-data-model.md`](./06-data-model.md) | Key PostgreSQL tables and relationships |
+| 7 | Auth & Login Flow | [`07-flow-auth.md`](./07-flow-auth.md) | Local JWT flow + OIDC (EE) |
+| 8 | Confluence Sync Flow | [`08-flow-sync.md`](./08-flow-sync.md) | Scheduler → fetch → convert → persist → embed |
+| 9 | RAG Chat Flow | [`09-flow-rag-chat.md`](./09-flow-rag-chat.md) | Ask pipeline: retrieve → prompt → stream |
+| 10 | Enterprise License Flow | [`10-flow-enterprise-license.md`](./10-flow-enterprise-license.md) | Open-core plugin loading + license persistence |
+| 11 | Content Format Pipeline | [`11-content-pipeline.md`](./11-content-pipeline.md) | Confluence XHTML ↔ HTML ↔ Markdown ↔ Editor |
+
+## Maintenance
+
+**These diagrams are part of the source of truth. When you change the
+architecture in code, you must update the affected diagrams in the same PR.**
+
+Quick reference for what to update when:
+
+| You changed… | Update |
+|--------------|--------|
+| `docker/docker-compose*.yml`, Dockerfiles, service ports/volumes | `02-container.md`, `05-deployment.md` |
+| A new external integration (LLM provider, identity provider, etc.) | `01-system-context.md` |
+| A new backend domain, service in `backend/src/domains/*`, or route group | `03-backend-domains.md` |
+| `backend/eslint.config.js` `boundaries` rules | `03-backend-domains.md` |
+| A new top-level `frontend/src/features/*` folder or provider | `04-frontend-structure.md` |
+| A migration that adds/drops/renames a core table or FK | `06-data-model.md` |
+| Auth routes, JWT/refresh logic, or OIDC wiring | `07-flow-auth.md` |
+| `sync-service.ts`, sync scheduler, attachment handler | `08-flow-sync.md` |
+| `rag-service.ts`, `llm-ask.ts`, prompt-building, caching | `09-flow-rag-chat.md` |
+| Enterprise loader, license route, license persistence | `10-flow-enterprise-license.md` |
+| `content-converter.ts`, XHTML/HTML/Markdown conversion | `11-content-pipeline.md` |
+
+If a change spans multiple areas, update every affected diagram. If a diagram
+becomes stale and you are not sure how to update it, flag it in the PR
+description rather than silently leaving it wrong.
+
+## Rendering locally
+
+GitHub renders Mermaid automatically. For local preview, use any Markdown
+viewer with Mermaid support (VS Code: *Markdown Preview Mermaid Support*
+extension).


### PR DESCRIPTION
## Summary

Add `docs/architecture/` — a living set of Mermaid diagrams that document the system at the usual levels people draw for software documentation, plus a rule that keeps them in sync with code.

### What's in `docs/architecture/`

| # | File | View |
|---|------|------|
| — | `README.md` | Index + **code-area → diagram** maintenance table |
| 1 | `01-system-context.md` | C4 L1 — users + external systems (Confluence, Ollama, OpenAI, OIDC, SMTP) |
| 2 | `02-container.md` | C4 L2 — deployable units (frontend, backend, Postgres, Redis, mcp-docs, searxng) |
| 3 | `03-backend-domains.md` | C4 L3 + ESLint `boundaries` rules (core / confluence / llm / knowledge / routes) |
| 4 | `04-frontend-structure.md` | Providers, features, shared, Zustand stores, EE gating sequence |
| 5 | `05-deployment.md` | Docker compose: networks (`frontend-net` / `backend-net` / internal `data-net`), volumes, ports |
| 6 | `06-data-model.md` | ERD for ~15 core tables (users, pages, page_embeddings, conversations, RBAC, admin_settings, etc.) |
| 7 | `07-flow-auth.md` | Local JWT + refresh, plus OIDC `login_code` handshake (EE) |
| 8 | `08-flow-sync.md` | Sync scheduler → Redis lock → fetch → convert → persist → embed |
| 9 | `09-flow-rag-chat.md` | `/api/llm/ask` SSE: sanitize → cache → hybrid retrieval → stream → persist |
| 10 | `10-flow-enterprise-license.md` | Open-core plugin load + runtime license update via `admin_settings` |
| 11 | `11-content-pipeline.md` | Confluence XHTML ↔ HTML ↔ Markdown ↔ Editor |

All files are Mermaid so they render natively on GitHub and diff cleanly in PRs. No binary exports.

### Maintenance rule

- **`CLAUDE.md`** — new Mandatory Rule #6: diagrams must be updated in the same PR as any structural code change, with a mapping (compose → #2/#5, ESLint boundaries → #3, new migration that adds/renames/drops a table or FK → #6, auth/sync/RAG/license flow changes → #7–10, content-converter changes → #11).
- **`AGENTS.md`** — mirrors the rule so other AI tools see it too.
- **`docs/architecture/README.md`** — canonical code-area → diagram mapping table.

## Test plan

- [ ] Diagrams render correctly in the GitHub PR file viewer (Mermaid blocks).
- [ ] README table links resolve to each diagram file.
- [ ] `CLAUDE.md` renumbered list reads cleanly (no gap at rule #6).
- [ ] `AGENTS.md` pointer to `docs/architecture/` is visible near the top.
- [ ] No code changes — CI should stay green on lint/typecheck/tests.
