### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/frontend/src/stores/auth-store.test.ts
+++ b/frontend/src/stores/auth-store.test.ts
@@ -79,12 +79,13 @@ describe('auth-store', () => {
       },
       version: 0,
     };
-    window.dispatchEvent(
-      new StorageEvent('storage', {
-        key: 'compendiq-auth',
-        newValue: JSON.stringify(newState),
-      }),
-    );
+    const refreshEvent = new Event('storage');
+    Object.defineProperty(refreshEvent, 'key', { value: 'compendiq-auth', configurable: true });
+    Object.defineProperty(refreshEvent, 'newValue', {
+      value: JSON.stringify(newState),
+      configurable: true,
+    });
+    window.dispatchEvent(refreshEvent);
 
     expect(useAuthStore.getState().accessToken).toBe('new-refreshed-token');
     expect(useAuthStore.getState().isAuthenticated).toBe(true);
@@ -106,12 +107,13 @@ describe('auth-store', () => {
       },
       version: 0,
     };
-    window.dispatchEvent(
-      new StorageEvent('storage', {
-        key: 'compendiq-auth',
-        newValue: JSON.stringify(loggedOutState),
-      }),
-    );
+    const logoutEvent = new Event('storage');
+    Object.defineProperty(logoutEvent, 'key', { value: 'compendiq-auth', configurable: true });
+    Object.defineProperty(logoutEvent, 'newValue', {
+      value: JSON.stringify(loggedOutState),
+      configurable: true,
+    });
+    window.dispatchEvent(logoutEvent);
 
     expect(useAuthStore.getState().isAuthenticated).toBe(false);
     expect(useAuthStore.getState().accessToken).toBeNull();
@@ -125,12 +127,10 @@ describe('auth-store', () => {
     });
 
     // Simulate storage event for a different key
-    window.dispatchEvent(
-      new StorageEvent('storage', {
-        key: 'some-other-key',
-        newValue: null,
-      }),
-    );
+    const unrelatedEvent = new Event('storage');
+    Object.defineProperty(unrelatedEvent, 'key', { value: 'some-other-key', configurable: true });
+    Object.defineProperty(unrelatedEvent, 'newValue', { value: null, configurable: true });
+    window.dispatchEvent(unrelatedEvent);
 
     // Should not affect auth state
     expect(useAuthStore.getState().isAuthenticated).toBe(true);
@@ -145,12 +145,13 @@ describe('auth-store', () => {
     });
 
     // Simulate malformed JSON in storage event
-    window.dispatchEvent(
-      new StorageEvent('storage', {
-        key: 'compendiq-auth',
-        newValue: 'not-valid-json{{{',
-      }),
-    );
+    const malformedEvent = new Event('storage');
+    Object.defineProperty(malformedEvent, 'key', { value: 'compendiq-auth', configurable: true });
+    Object.defineProperty(malformedEvent, 'newValue', {
+      value: 'not-valid-json{{{',
+      configurable: true,
+    });
+    window.dispatchEvent(malformedEvent);
 
     // Should not crash or change state
     expect(useAuthStore.getState().isAuthenticated).toBe(true);


### PR DESCRIPTION
Use a plain `Event('storage')` and define `key`/`newValue` via `Object.defineProperty` before dispatching.  
This avoids relying on `StorageEvent` constructor overload support in the test runtime/type model, while preserving test behavior exactly (listeners still receive a `storage` event carrying expected fields).

Best single fix in `frontend/src/stores/auth-store.test.ts`:
- Replace each `new StorageEvent('storage', { ... })` usage with:
  1. `const event = new Event('storage');`
  2. `Object.defineProperty(event, 'key', { value: '...', configurable: true });`
  3. `Object.defineProperty(event, 'newValue', { value: ..., configurable: true });`
  4. `window.dispatchEvent(event);`

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._