### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/frontend/src/stores/auth-store.test.ts
+++ b/frontend/src/stores/auth-store.test.ts
@@ -51,12 +51,10 @@ describe('auth-store', () => {
     expect(useAuthStore.getState().isAuthenticated).toBe(true);
 
     // Simulate another tab clearing localStorage (logout)
-    window.dispatchEvent(
-      new StorageEvent('storage', {
-        key: 'compendiq-auth',
-        newValue: null,
-      }),
-    );
+    const logoutStorageEvent = new Event('storage');
+    Object.defineProperty(logoutStorageEvent, 'key', { value: 'compendiq-auth' });
+    Object.defineProperty(logoutStorageEvent, 'newValue', { value: null });
+    window.dispatchEvent(logoutStorageEvent);
 
     expect(useAuthStore.getState().isAuthenticated).toBe(false);
     expect(useAuthStore.getState().accessToken).toBeNull();
@@ -79,12 +77,12 @@ describe('auth-store', () => {
       },
       version: 0,
     };
-    window.dispatchEvent(
-      new StorageEvent('storage', {
-        key: 'compendiq-auth',
-        newValue: JSON.stringify(newState),
-      }),
-    );
+    const refreshStorageEvent = new Event('storage');
+    Object.defineProperty(refreshStorageEvent, 'key', { value: 'compendiq-auth' });
+    Object.defineProperty(refreshStorageEvent, 'newValue', {
+      value: JSON.stringify(newState),
+    });
+    window.dispatchEvent(refreshStorageEvent);
 
     expect(useAuthStore.getState().accessToken).toBe('new-refreshed-token');
     expect(useAuthStore.getState().isAuthenticated).toBe(true);


### PR DESCRIPTION
To fix this safely without changing test intent, avoid passing the second argument to `StorageEvent` and instead dispatch a regular `Event('storage')` whose `key` and `newValue` properties are defined via `Object.defineProperty`. This keeps the tests focused on store sync behavior while avoiding constructor-signature mismatches that trigger the CodeQL warning.

Best single fix in `frontend/src/stores/auth-store.test.ts`:
- In both storage-event simulations (around lines 54–59 and 82–87), replace `new StorageEvent('storage', { ... })` with:
  1. `const storageEvent = new Event('storage');`
  2. define `key` and `newValue` on that event object
  3. `window.dispatchEvent(storageEvent);`

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._