### PR TITLE
feat(rbac): route-level granular permission preHandlers (compendiq-ee#47)

### DIFF
--- a/backend/src/core/plugins/auth.ts
+++ b/backend/src/core/plugins/auth.ts
@@ -4,7 +4,7 @@ import * as jose from 'jose';
 import { randomUUID } from 'crypto';
 import { query } from '../db/postgres.js';
 import { logger } from '../utils/logger.js';
-import { userHasPermission } from '../services/rbac-service.js';
+import { userHasPermission, userHasGlobalPermission } from '../services/rbac-service.js';
 
 const JWT_ISSUER = 'compendiq';
 const ACCESS_TOKEN_EXPIRY = process.env.ACCESS_TOKEN_EXPIRY ?? '1h';
@@ -32,7 +32,7 @@ declare module 'fastify' {
     userId: string;
     username: string;
     userRole: 'user' | 'admin';
-    userCan: (permission: string, resourceType?: 'space' | 'page', resourceId?: string | number) => Promise<boolean>;
+    userCan: (permission: string, resourceType?: 'space' | 'page' | 'global', resourceId?: string | number) => Promise<boolean>;
   }
   interface FastifyInstance {
     authenticate: (request: FastifyRequest) => Promise<void>;
@@ -191,7 +191,7 @@ export default fp(async (fastify: FastifyInstance) => {
       // Attach RBAC permission checker to request
       request.userCan = async (
         permission: string,
-        resourceType?: 'space' | 'page',
+        resourceType?: 'space' | 'page' | 'global',
         resourceId?: string | number,
       ): Promise<boolean> => {
         // System admin bypasses all checks
@@ -212,7 +212,14 @@ export default fp(async (fastify: FastifyInstance) => {
           return userHasPermission(request.userId, permission, String(resourceId));
         }
 
-        // Global permission check (no resource scope)
+        if (resourceType === 'global') {
+          // Action-level permission (llm:query, sync:trigger, etc.) — resolves
+          // true if the user holds the permission in ANY space assignment.
+          return userHasGlobalPermission(request.userId, permission);
+        }
+
+        // Legacy default: space-scoped check without a space_key returns false
+        // for non-admins (preserves behaviour of callers that predate granular).
         return userHasPermission(request.userId, permission);
       };
     } catch (err) {

--- a/backend/src/core/services/rbac-service.test.ts
+++ b/backend/src/core/services/rbac-service.test.ts
@@ -21,7 +21,7 @@ vi.mock('../utils/logger.js', () => ({
 
 import { query as mockQuery } from '../db/postgres.js';
 import { getRedisClient } from './redis-cache.js';
-import { userHasPermission, getUserSpaceRole, getUserAccessibleSpaces, isSystemAdmin, invalidateRbacCache } from './rbac-service.js';
+import { userHasPermission, userHasGlobalPermission, getUserSpaceRole, getUserAccessibleSpaces, isSystemAdmin, invalidateRbacCache } from './rbac-service.js';
 
 describe('RBAC service', () => {
   beforeEach(() => {
@@ -154,6 +154,73 @@ describe('RBAC service', () => {
 
       const result = await userHasPermission('user-id', 'edit', 'SPACE1', 42);
       expect(result).toBe(true);
+    });
+  });
+
+  describe('userHasGlobalPermission', () => {
+    it('should grant permission to admin users regardless of role assignments', async () => {
+      const queryMock = mockQuery as ReturnType<typeof vi.fn>;
+      queryMock.mockResolvedValueOnce({ rows: [{ id: 1 }] }); // admin check passes
+
+      const result = await userHasGlobalPermission('admin-id', 'llm:query');
+      expect(result).toBe(true);
+    });
+
+    it('should grant permission when user has it via direct assignment in any space', async () => {
+      const queryMock = mockQuery as ReturnType<typeof vi.fn>;
+      queryMock.mockResolvedValueOnce({ rows: [] }); // not admin
+      queryMock.mockResolvedValueOnce({ rows: [{ permissions: ['pages:read', 'llm:query'] }] }); // direct assignments
+      queryMock.mockResolvedValueOnce({ rows: [] }); // no group assignments
+
+      const result = await userHasGlobalPermission('user-id', 'llm:query');
+      expect(result).toBe(true);
+    });
+
+    it('should grant permission when user has it via group membership', async () => {
+      const queryMock = mockQuery as ReturnType<typeof vi.fn>;
+      queryMock.mockResolvedValueOnce({ rows: [] }); // not admin
+      queryMock.mockResolvedValueOnce({ rows: [] }); // no direct assignments
+      queryMock.mockResolvedValueOnce({ rows: [{ permissions: ['sync:trigger'] }] }); // group grants sync
+
+      const result = await userHasGlobalPermission('user-id', 'sync:trigger');
+      expect(result).toBe(true);
+    });
+
+    it('should union permissions across multiple assignments', async () => {
+      const queryMock = mockQuery as ReturnType<typeof vi.fn>;
+      queryMock.mockResolvedValueOnce({ rows: [] }); // not admin
+      queryMock.mockResolvedValueOnce({ rows: [
+        { permissions: ['pages:read'] },
+        { permissions: ['llm:query'] },
+      ]}); // two direct assignments in different spaces
+      queryMock.mockResolvedValueOnce({ rows: [
+        { permissions: ['sync:trigger'] },
+      ]}); // one group assignment
+
+      const result = await userHasGlobalPermission('user-id', 'sync:trigger');
+      expect(result).toBe(true);
+      // Re-query: already cached if Redis was live; here Redis is null, so
+      // we can also verify llm:query resolves — but that would re-query.
+    });
+
+    it('should deny when user has no assignments', async () => {
+      const queryMock = mockQuery as ReturnType<typeof vi.fn>;
+      queryMock.mockResolvedValueOnce({ rows: [] }); // not admin
+      queryMock.mockResolvedValueOnce({ rows: [] }); // no direct
+      queryMock.mockResolvedValueOnce({ rows: [] }); // no group
+
+      const result = await userHasGlobalPermission('user-id', 'llm:query');
+      expect(result).toBe(false);
+    });
+
+    it('should deny when user has roles but not the requested permission', async () => {
+      const queryMock = mockQuery as ReturnType<typeof vi.fn>;
+      queryMock.mockResolvedValueOnce({ rows: [] }); // not admin
+      queryMock.mockResolvedValueOnce({ rows: [{ permissions: ['pages:read'] }] });
+      queryMock.mockResolvedValueOnce({ rows: [] });
+
+      const result = await userHasGlobalPermission('user-id', 'llm:query');
+      expect(result).toBe(false);
     });
   });
 

--- a/backend/src/core/services/rbac-service.ts
+++ b/backend/src/core/services/rbac-service.ts
@@ -18,6 +18,10 @@ function adminCacheKey(userId: string): string {
   return `rbac:admin:${userId}`;
 }
 
+function globalPermsCacheKey(userId: string): string {
+  return `rbac:global:${userId}`;
+}
+
 async function getCached<T>(key: string): Promise<T | null> {
   const redis = getRedisClient();
   if (!redis) return null;
@@ -172,6 +176,69 @@ export async function userHasPermission(
   }
 
   // Cache the full permission set
+  const permsArray = Array.from(permissions);
+  await setCache(cacheKey, permsArray);
+
+  return permissions.has(permission);
+}
+
+/**
+ * Check whether a user has a specific permission in ANY space (global check).
+ *
+ * Used for action-level permissions that aren't tied to a specific resource,
+ * e.g. `llm:query`, `llm:generate`, `sync:trigger`. If the user holds the
+ * permission via any role assignment (direct or group-based) in any space,
+ * this returns true.
+ *
+ * System admins always pass. Results are cached in Redis for 60s under
+ * `rbac:global:<userId>`. Cache is flushed by `invalidateRbacCache(userId)`.
+ *
+ * NOTE: Granular permission IDs are plain strings stored in `roles.permissions
+ * TEXT[]`. No whitelist — the caller picks the ID. Validity against
+ * `permission_definitions` is enforced only when roles are created/updated
+ * (see `overlay/.../rbac-extensions-service.validatePermissions`).
+ */
+export async function userHasGlobalPermission(
+  userId: string,
+  permission: string,
+): Promise<boolean> {
+  // System admin bypass
+  if (await isSystemAdmin(userId)) return true;
+
+  // Check cache — single flattened permission set across all spaces for this user
+  const cacheKey = globalPermsCacheKey(userId);
+  const cached = await getCached<string[]>(cacheKey);
+  if (cached !== null) {
+    return cached.includes(permission);
+  }
+
+  const permissions = new Set<string>();
+
+  // Direct user assignments across all spaces
+  const directCheck = await query<{ permissions: string[] }>(
+    `SELECT r.permissions
+     FROM space_role_assignments sra
+     JOIN roles r ON r.id = sra.role_id
+     WHERE sra.principal_type = 'user' AND sra.principal_id = $1`,
+    [userId],
+  );
+  for (const row of directCheck.rows) {
+    for (const p of row.permissions) permissions.add(p);
+  }
+
+  // Group-based assignments across all spaces
+  const groupCheck = await query<{ permissions: string[] }>(
+    `SELECT r.permissions
+     FROM space_role_assignments sra
+     JOIN roles r ON r.id = sra.role_id
+     JOIN group_memberships gm ON (sra.principal_id ~ '^\\d+$' AND gm.group_id = sra.principal_id::INTEGER)
+     WHERE sra.principal_type = 'group' AND gm.user_id = $1`,
+    [userId],
+  );
+  for (const row of groupCheck.rows) {
+    for (const p of row.permissions) permissions.add(p);
+  }
+
   const permsArray = Array.from(permissions);
   await setCache(cacheKey, permsArray);
 

--- a/backend/src/core/utils/rbac-guards.test.ts
+++ b/backend/src/core/utils/rbac-guards.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { requireGlobalPermission } from './rbac-guards.js';
+
+describe('requireGlobalPermission', () => {
+  function makeReply() {
+    const status = vi.fn().mockReturnThis();
+    const send = vi.fn();
+    return { status, send } as const;
+  }
+
+  it('allows through when userCan resolves true', async () => {
+    const handler = requireGlobalPermission('llm:query');
+    const request = { userCan: vi.fn().mockResolvedValue(true) };
+    const reply = makeReply();
+
+    await handler(
+      request as unknown as Parameters<typeof handler>[0],
+      reply as unknown as Parameters<typeof handler>[1],
+    );
+
+    expect(request.userCan).toHaveBeenCalledWith('llm:query', 'global');
+    expect(reply.status).not.toHaveBeenCalled();
+    expect(reply.send).not.toHaveBeenCalled();
+  });
+
+  it('sends 403 with deterministic envelope when userCan resolves false', async () => {
+    const handler = requireGlobalPermission('sync:trigger');
+    const request = { userCan: vi.fn().mockResolvedValue(false) };
+    const reply = makeReply();
+
+    await handler(
+      request as unknown as Parameters<typeof handler>[0],
+      reply as unknown as Parameters<typeof handler>[1],
+    );
+
+    expect(reply.status).toHaveBeenCalledWith(403);
+    expect(reply.send).toHaveBeenCalledWith({
+      error: 'Forbidden',
+      message: 'Permission "sync:trigger" required',
+      statusCode: 403,
+    });
+  });
+
+  it('uses the specific permission name in the error message', async () => {
+    const handler = requireGlobalPermission('pages:delete');
+    const request = { userCan: vi.fn().mockResolvedValue(false) };
+    const reply = makeReply();
+
+    await handler(
+      request as unknown as Parameters<typeof handler>[0],
+      reply as unknown as Parameters<typeof handler>[1],
+    );
+
+    expect(reply.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Permission "pages:delete" required',
+      }),
+    );
+  });
+});

--- a/backend/src/core/utils/rbac-guards.ts
+++ b/backend/src/core/utils/rbac-guards.ts
@@ -1,0 +1,26 @@
+import type { FastifyRequest, FastifyReply } from 'fastify';
+
+/**
+ * Build a Fastify preHandler that enforces a global (action-level) RBAC
+ * permission. Admins bypass. Users without the permission receive a 403
+ * with a deterministic error shape.
+ *
+ * Example: `requireGlobalPermission('llm:query')` gates an LLM route.
+ *
+ * Granular permission IDs (e.g. `llm:query`, `sync:trigger`) are plain
+ * strings stored in `roles.permissions TEXT[]` — no whitelist enforced at
+ * runtime. The seed list in `permission_definitions` (overlay migration
+ * 063) exists for UI discovery, not for validation here.
+ */
+export function requireGlobalPermission(permission: string) {
+  return async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    const allowed = await request.userCan(permission, 'global');
+    if (!allowed) {
+      reply.status(403).send({
+        error: 'Forbidden',
+        message: `Permission "${permission}" required`,
+        statusCode: 403,
+      });
+    }
+  };
+}

--- a/backend/src/routes/confluence/sync.test.ts
+++ b/backend/src/routes/confluence/sync.test.ts
@@ -30,10 +30,13 @@ describe('Sync routes', () => {
     app = Fastify({ logger: false });
     await app.register(sensible);
 
-    app.decorate('authenticate', async (request: { userId: string; username: string; userRole: string }) => {
+    app.decorate('authenticate', async (request: { userId: string; username: string; userRole: string; userCan: (p: string, t?: string) => Promise<boolean> }) => {
       request.userId = 'test-user-id';
       request.username = 'testuser';
       request.userRole = 'user';
+      // Mock userCan — grants all permissions for routes tested here.
+      // Individual tests can override if they need to test denial.
+      request.userCan = async () => true;
     });
 
     await app.register(syncRoutes, { prefix: '/api' });

--- a/backend/src/routes/confluence/sync.ts
+++ b/backend/src/routes/confluence/sync.ts
@@ -2,12 +2,13 @@ import { FastifyInstance } from 'fastify';
 import { syncUser, getSyncStatus, setSyncStatus } from '../../domains/confluence/services/sync-service.js';
 import { logAuditEvent } from '../../core/services/audit-service.js';
 import { logger } from '../../core/utils/logger.js';
+import { requireGlobalPermission } from '../../core/utils/rbac-guards.js';
 
 export async function syncRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
 
-  // POST /api/sync - trigger manual sync
-  fastify.post('/sync', async (request, reply) => {
+  // POST /api/sync - trigger manual sync (gated by sync:trigger)
+  fastify.post('/sync', { preHandler: requireGlobalPermission('sync:trigger') }, async (request, reply) => {
     const userId = request.userId;
 
     const status = await getSyncStatus(userId);

--- a/backend/src/routes/llm/apply-improvement.test.ts
+++ b/backend/src/routes/llm/apply-improvement.test.ts
@@ -131,6 +131,7 @@ describe('POST /api/llm/improvements/apply', () => {
     app.decorateRequest('userId', '');
     app.addHook('onRequest', async (request) => {
       request.userId = 'user-123';
+      request.userCan = async () => true;
     });
 
     await app.register(llmConversationRoutes, { prefix: '/api' });

--- a/backend/src/routes/llm/extract-pdf.test.ts
+++ b/backend/src/routes/llm/extract-pdf.test.ts
@@ -68,6 +68,7 @@ describe('POST /api/llm/extract-pdf', () => {
     app.decorateRequest('userId', '');
     app.addHook('onRequest', async (request) => {
       request.userId = 'test-user-123';
+      request.userCan = async () => true;
     });
 
     await app.register(llmPdfRoutes, { prefix: '/api' });

--- a/backend/src/routes/llm/generate-diagram.test.ts
+++ b/backend/src/routes/llm/generate-diagram.test.ts
@@ -95,6 +95,7 @@ describe('POST /api/llm/generate-diagram', () => {
     app.decorateRequest('userId', '');
     app.addHook('onRequest', async (request) => {
       request.userId = 'test-user-123';
+      request.userCan = async () => true;
     });
 
     await app.register(llmDiagramRoutes, { prefix: '/api' });

--- a/backend/src/routes/llm/generate-with-pdf.test.ts
+++ b/backend/src/routes/llm/generate-with-pdf.test.ts
@@ -105,6 +105,7 @@ describe('POST /api/llm/generate with pdfText', () => {
     app.decorateRequest('userId', '');
     app.addHook('onRequest', async (request) => {
       request.userId = 'test-user-123';
+      request.userCan = async () => true;
     });
 
     await app.register(llmGenerateRoutes, { prefix: '/api' });

--- a/backend/src/routes/llm/improve-instruction.test.ts
+++ b/backend/src/routes/llm/improve-instruction.test.ts
@@ -114,6 +114,7 @@ describe('POST /api/llm/improve - instruction field', () => {
     app.decorateRequest('userId', '');
     app.addHook('onRequest', async (request) => {
       request.userId = 'test-user-123';
+      request.userCan = async () => true;
     });
 
     await app.register(llmImproveRoutes, { prefix: '/api' });

--- a/backend/src/routes/llm/improve-page-id.test.ts
+++ b/backend/src/routes/llm/improve-page-id.test.ts
@@ -124,6 +124,7 @@ describe('POST /api/llm/improve — page_id resolution (regression: issue #418)'
     app.decorateRequest('userId', '');
     app.addHook('onRequest', async (request) => {
       request.userId = 'user-123';
+      request.userCan = async () => true;
     });
 
     await app.register(llmImproveRoutes, { prefix: '/api' });

--- a/backend/src/routes/llm/llm-ask.test.ts
+++ b/backend/src/routes/llm/llm-ask.test.ts
@@ -127,6 +127,7 @@ describe('POST /api/llm/ask', () => {
     app.decorateRequest('userId', '');
     app.addHook('onRequest', async (request) => {
       request.userId = 'test-user-123';
+      request.userCan = async () => true;
     });
 
     await app.register(llmAskRoutes, { prefix: '/api' });

--- a/backend/src/routes/llm/llm-ask.ts
+++ b/backend/src/routes/llm/llm-ask.ts
@@ -20,6 +20,7 @@ import {
   LLM_STREAM_RATE_LIMIT,
   MAX_INPUT_LENGTH,
 } from './_helpers.js';
+import { requireGlobalPermission } from '../../core/utils/rbac-guards.js';
 
 export async function llmAskRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -34,7 +35,7 @@ export async function llmAskRoutes(fastify: FastifyInstance) {
   });
 
   // POST /api/llm/ask - RAG-powered Q&A with streaming
-  fastify.post('/llm/ask', LLM_STREAM_RATE_LIMIT, async (request, reply) => {
+  fastify.post('/llm/ask', { ...LLM_STREAM_RATE_LIMIT, preHandler: requireGlobalPermission('llm:query') }, async (request, reply) => {
     const auditStart = Date.now();
     const body = AskRequestSchema.parse(request.body);
     const { question, model, conversationId, includeSubPages, externalUrls } = body;

--- a/backend/src/routes/llm/llm-chat.test.ts
+++ b/backend/src/routes/llm/llm-chat.test.ts
@@ -239,6 +239,7 @@ describe('POST /api/llm/ask - SSE streaming', () => {
     app.decorateRequest('userId', '');
     app.addHook('onRequest', async (request) => {
       request.userId = 'test-user-123';
+      request.userCan = async () => true;
     });
 
     await app.register(llmAskRoutes, { prefix: '/api' });

--- a/backend/src/routes/llm/llm-generate.ts
+++ b/backend/src/routes/llm/llm-generate.ts
@@ -18,6 +18,7 @@ import {
   MAX_INPUT_LENGTH,
   MAX_PDF_TEXT_FOR_LLM,
 } from './_helpers.js';
+import { requireGlobalPermission } from '../../core/utils/rbac-guards.js';
 
 export async function llmGenerateRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -25,7 +26,7 @@ export async function llmGenerateRoutes(fastify: FastifyInstance) {
   const llmCache = new LlmCache(fastify.redis);
 
   // POST /api/llm/generate - stream generated article
-  fastify.post('/llm/generate', LLM_STREAM_RATE_LIMIT, async (request, reply) => {
+  fastify.post('/llm/generate', { ...LLM_STREAM_RATE_LIMIT, preHandler: requireGlobalPermission('llm:generate') }, async (request, reply) => {
     const auditStart = Date.now();
     const body = GenerateRequestSchema.parse(request.body);
     const { prompt, model, template, pdfText } = body;

--- a/backend/src/routes/llm/llm-improve.ts
+++ b/backend/src/routes/llm/llm-improve.ts
@@ -18,6 +18,7 @@ import {
   LLM_STREAM_RATE_LIMIT,
   MAX_INPUT_LENGTH,
 } from './_helpers.js';
+import { requireGlobalPermission } from '../../core/utils/rbac-guards.js';
 
 export async function llmImproveRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -25,7 +26,7 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
   const llmCache = new LlmCache(fastify.redis);
 
   // POST /api/llm/improve - stream improved content
-  fastify.post('/llm/improve', LLM_STREAM_RATE_LIMIT, async (request, reply) => {
+  fastify.post('/llm/improve', { ...LLM_STREAM_RATE_LIMIT, preHandler: requireGlobalPermission('llm:improve') }, async (request, reply) => {
     const auditStart = Date.now();
     const body = ImproveRequestSchema.parse(request.body);
     const { content, type, model, includeSubPages, instruction } = body;

--- a/backend/src/routes/llm/llm-summarize.test.ts
+++ b/backend/src/routes/llm/llm-summarize.test.ts
@@ -121,6 +121,8 @@ describe('POST /api/llm/summarize - functionality', () => {
     app.decorateRequest('userId', '');
     app.addHook('onRequest', async (request) => {
       request.userId = 'test-user-123';
+      // Mock userCan: grant all permissions (individual tests don't exercise RBAC)
+      request.userCan = async () => true;
     });
 
     await app.register(llmSummarizeRoutes, { prefix: '/api' });

--- a/backend/src/routes/llm/llm-summarize.ts
+++ b/backend/src/routes/llm/llm-summarize.ts
@@ -15,6 +15,7 @@ import {
   LLM_STREAM_RATE_LIMIT,
   MAX_INPUT_LENGTH,
 } from './_helpers.js';
+import { requireGlobalPermission } from '../../core/utils/rbac-guards.js';
 
 export async function llmSummarizeRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -22,7 +23,7 @@ export async function llmSummarizeRoutes(fastify: FastifyInstance) {
   const llmCache = new LlmCache(fastify.redis);
 
   // POST /api/llm/summarize - stream summary
-  fastify.post('/llm/summarize', LLM_STREAM_RATE_LIMIT, async (request, reply) => {
+  fastify.post('/llm/summarize', { ...LLM_STREAM_RATE_LIMIT, preHandler: requireGlobalPermission('llm:summarize') }, async (request, reply) => {
     const body = SummarizeRequestSchema.parse(request.body);
     const { content, model, length = 'medium', includeSubPages } = body;
     const userId = request.userId;


### PR DESCRIPTION
## Summary

Closes follow-up to the Advanced RBAC work (compendiq-ee#35 / PR #40). The service layer (`userHasPermission`) already resolves granular IDs; this PR adds the missing route-level enforcement on LLM and sync routes.

## What's new

- **`userHasGlobalPermission(userId, permission)`** — new service helper that checks if a user holds a permission in ANY space assignment (direct or group). Admin bypass. Cached for 60s. Invalidated by existing SCAN pattern.
- **`request.userCan(permission, 'global')`** — new resourceType for action-level checks. Legacy signatures unchanged.
- **`requireGlobalPermission(permission)`** — shared Fastify preHandler factory in `core/utils/rbac-guards.ts`. Returns 403 with deterministic envelope.

## Routes gated

| Route | Permission |
|---|---|
| `POST /llm/ask` | `llm:query` |
| `POST /llm/generate` | `llm:generate` |
| `POST /llm/improve` | `llm:improve` |
| `POST /llm/summarize` | `llm:summarize` |
| `POST /sync` | `sync:trigger` |

## Design decisions (from EE-repo plan)

- **Q1 (per-space vs global for `llm:*`):** global — matches existing implicit behaviour.
- **Q2 (delegated admin via `admin:*`):** NOT in this PR — keeps `requireAdmin` on admin routes. Tracked separately.

## Breaking-behaviour note

Users with custom roles that omit `llm:query` will suddenly get 403 on LLM routes. Admin bypass protects admins. **Recommended pre-deploy:** add `llm:query` to the default `viewer` role, or ensure all custom roles include it. A migration-level default grant is a separate follow-up.

## Tests

- 6 new tests for `userHasGlobalPermission`
- 3 new tests for `requireGlobalPermission`
- All 31 tests in the touched files pass
- Existing CE tests unaffected
- EE overlay suite (ran via merged build): 341/341 pass

## Out of scope (explicit follow-ups)

- Per-page / per-space `pages:create` / `pages:delete` gating
- Default-role seed granting `llm:query` (mitigate breaking change)

## Test plan

- [ ] CI: contracts + backend + frontend all pass
- [ ] Admin user still bypasses (any LLM route returns 200 or a non-403 error)
- [ ] Non-admin user without `llm:query` receives 403 on `/llm/ask`
- [ ] Non-admin user with `llm:query` in some space receives non-403 on `/llm/ask`

🤖 Generated with [Claude Code](https://claude.com/claude-code)