### PR TITLE
fix: seed granular LLM/sync permissions into default system roles

### DIFF
--- a/backend/src/core/db/migrations/052_seed_granular_permissions.sql
+++ b/backend/src/core/db/migrations/052_seed_granular_permissions.sql
@@ -1,0 +1,25 @@
+-- Migration 052: Grant granular LLM and sync permissions to default system roles.
+-- Required because CE PR #207 added requireGlobalPermission() preHandlers on
+-- LLM and sync routes, but migration 039 only seeded legacy coarse permissions
+-- (read, comment, edit, delete, manage, admin). Without this seed, non-admin
+-- users with default roles get 403 on all AI features after upgrading to v1.1.
+--
+-- Idempotent: guarded by NOT permissions @> ARRAY[...] so reruns are safe.
+
+-- viewer, commenter, editor all need LLM access
+UPDATE roles
+SET permissions = array_cat(permissions, ARRAY['llm:query', 'llm:generate', 'llm:improve', 'llm:summarize'])
+WHERE name IN ('viewer', 'commenter', 'editor')
+  AND NOT permissions @> ARRAY['llm:query'];
+
+-- editor needs sync trigger (viewers/commenters don't trigger syncs)
+UPDATE roles
+SET permissions = array_cat(permissions, ARRAY['sync:trigger'])
+WHERE name = 'editor'
+  AND NOT permissions @> ARRAY['sync:trigger'];
+
+-- space_admin gets everything editors have plus manage
+UPDATE roles
+SET permissions = array_cat(permissions, ARRAY['llm:query', 'llm:generate', 'llm:improve', 'llm:summarize', 'sync:trigger'])
+WHERE name = 'space_admin'
+  AND NOT permissions @> ARRAY['llm:query'];

--- a/backend/src/core/db/migrations/__tests__/migrations.test.ts
+++ b/backend/src/core/db/migrations/__tests__/migrations.test.ts
@@ -230,4 +230,18 @@ describe.skipIf(!dbAvailable)('Database migrations', () => {
       expect(result.rows).toHaveLength(1);
     });
   });
+
+  describe('granular permissions (migration 052)', () => {
+    it('should have migration 052 applied without error', async () => {
+      // Migration 052 UPDATEs the system roles seeded in 039 to add granular
+      // LLM + sync permissions. The _migrations row existing confirms the SQL
+      // executed without error. Per-role permission assertions are omitted
+      // because other tests in this suite truncate the roles table, so data
+      // isn't reliably present when this describe block runs.
+      const result = await query<{ name: string }>(
+        "SELECT name FROM _migrations WHERE name = '052_seed_granular_permissions.sql'",
+      );
+      expect(result.rows).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
Fixes 403 on AI features for non-admin users after v1.1 upgrade. Migration 052 grants llm:query/generate/improve/summarize to viewer/commenter/editor/space_admin + sync:trigger to editor/space_admin. Idempotent. Closes Compendiq/compendiq-ee#67.