### PR TITLE
feat(admin): ScimSettingsPage — SCIM token management UI

### DIFF
--- a/frontend/src/features/admin/LlmAuditPage.tsx
+++ b/frontend/src/features/admin/LlmAuditPage.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { m } from 'framer-motion';
 import { toast } from 'sonner';
 import {
-  FileText, Loader2, AlertTriangle, Download, ChevronLeft, ChevronRight,
+  FileText, AlertTriangle, Download, ChevronLeft, ChevronRight,
   Filter,
 } from 'lucide-react';
 import { apiFetch } from '../../shared/lib/api';

--- a/frontend/src/features/admin/ScimSettingsPage.test.tsx
+++ b/frontend/src/features/admin/ScimSettingsPage.test.tsx
@@ -1,0 +1,373 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { LazyMotion, domMax } from 'framer-motion';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ScimSettingsPage } from './ScimSettingsPage';
+import { useAuthStore } from '../../stores/auth-store';
+
+// ── Mock useEnterprise ─────────────────────────────────────────────────────────
+
+let mockHasFeature = (_f: string) => true;
+
+vi.mock('../../shared/enterprise/use-enterprise', () => ({
+  useEnterprise: () => ({
+    isEnterprise: true,
+    hasFeature: (f: string) => mockHasFeature(f),
+    ui: null,
+    license: null,
+    isLoading: false,
+  }),
+}));
+
+// ── Mock clipboard ────────────────────────────────────────────────────────────
+
+const mockWriteText = vi.fn().mockResolvedValue(undefined);
+
+Object.assign(navigator, {
+  clipboard: { writeText: mockWriteText },
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LazyMotion features={domMax}>
+            {children}
+          </LazyMotion>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+const mockTokens = [
+  {
+    id: 'tok-1',
+    name: 'Okta SCIM',
+    lastUsedAt: '2026-04-10T12:00:00Z',
+    createdAt: '2026-04-01T09:00:00Z',
+    expiresAt: '2027-04-01T09:00:00Z',
+    createdBy: 'admin',
+  },
+  {
+    id: 'tok-2',
+    name: 'Azure AD',
+    lastUsedAt: null,
+    createdAt: '2026-04-05T14:00:00Z',
+    expiresAt: null,
+    createdBy: 'admin',
+  },
+];
+
+const mockCreateResult = {
+  id: 'tok-3',
+  name: 'New Token',
+  token: 'scim_bEaReR_tOkEn_PlAiNtExT_12345',
+  expiresAt: null,
+};
+
+function mockFetchWithTokens(tokens = mockTokens) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const url = typeof input === 'string' ? input : (input as Request).url;
+    const method = init?.method ?? 'GET';
+
+    if (url.includes('/admin/scim/tokens') && method === 'GET') {
+      return new Response(JSON.stringify(tokens), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('/admin/scim/tokens') && method === 'POST') {
+      return new Response(JSON.stringify(mockCreateResult), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('/admin/scim/tokens/') && method === 'DELETE') {
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify({}), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('ScimSettingsPage', () => {
+  beforeEach(() => {
+    mockHasFeature = () => true;
+    mockWriteText.mockClear();
+    useAuthStore.getState().setAuth('test-token', {
+      id: '1',
+      username: 'admin',
+      role: 'admin',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useAuthStore.getState().clearAuth();
+  });
+
+  // 1. Feature gate
+  it('shows feature-gated banner when scim_provisioning is not enabled', () => {
+    mockHasFeature = () => false;
+    mockFetchWithTokens();
+    render(<ScimSettingsPage />, { wrapper: createWrapper() });
+    expect(screen.getByTestId('scim-gated')).toBeInTheDocument();
+    expect(screen.getByText('Enterprise Feature')).toBeInTheDocument();
+  });
+
+  // 2. Token list renders
+  it('renders token list table when feature is enabled and tokens exist', async () => {
+    mockFetchWithTokens();
+    render(<ScimSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Okta SCIM')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Azure AD')).toBeInTheDocument();
+  });
+
+  // 3. Empty state
+  it('shows empty state when no tokens exist', async () => {
+    mockFetchWithTokens([]);
+    render(<ScimSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('No SCIM tokens')).toBeInTheDocument();
+    });
+  });
+
+  // 4. Create form toggle
+  it('opens create form on Generate Token button click', async () => {
+    mockFetchWithTokens();
+    render(<ScimSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('generate-token-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('generate-token-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scim-create-form')).toBeInTheDocument();
+    });
+  });
+
+  // 5. Create submission
+  it('submits POST with name and expiresInDays on form submit', async () => {
+    const fetchSpy = mockFetchWithTokens();
+    render(<ScimSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('generate-token-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('generate-token-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scim-token-name')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('scim-token-name'), { target: { value: 'New Token' } });
+    fireEvent.change(screen.getByTestId('scim-expires-days'), { target: { value: '90' } });
+    fireEvent.click(screen.getByTestId('scim-create-submit'));
+
+    await waitFor(() => {
+      const postCalls = fetchSpy.mock.calls.filter(
+        ([, opts]) => opts && typeof opts === 'object' && 'method' in opts && (opts as RequestInit).method === 'POST',
+      );
+      expect(postCalls.length).toBeGreaterThanOrEqual(1);
+      const body = JSON.parse((postCalls[0][1] as RequestInit).body as string);
+      expect(body.name).toBe('New Token');
+      expect(body.expiresInDays).toBe(90);
+    });
+  });
+
+  // 6. Plaintext reveal
+  it('shows plaintext reveal overlay after successful creation', async () => {
+    mockFetchWithTokens();
+    render(<ScimSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('generate-token-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('generate-token-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scim-token-name')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('scim-token-name'), { target: { value: 'New Token' } });
+    fireEvent.click(screen.getByTestId('scim-create-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scim-token-reveal')).toBeInTheDocument();
+    });
+    expect(screen.getByDisplayValue('scim_bEaReR_tOkEn_PlAiNtExT_12345')).toBeInTheDocument();
+  });
+
+  // 7. Copy to clipboard
+  it('calls navigator.clipboard.writeText when Copy button is clicked', async () => {
+    mockFetchWithTokens();
+    render(<ScimSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('generate-token-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('generate-token-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scim-token-name')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('scim-token-name'), { target: { value: 'New Token' } });
+    fireEvent.click(screen.getByTestId('scim-create-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scim-copy-token')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('scim-copy-token'));
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith('scim_bEaReR_tOkEn_PlAiNtExT_12345');
+    });
+  });
+
+  // 8. Dismiss disabled until checkbox checked
+  it('disables dismiss button until checkbox is checked', async () => {
+    mockFetchWithTokens();
+    render(<ScimSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('generate-token-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('generate-token-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scim-token-name')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('scim-token-name'), { target: { value: 'New Token' } });
+    fireEvent.click(screen.getByTestId('scim-create-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scim-dismiss-token')).toBeInTheDocument();
+    });
+
+    // Dismiss should be disabled
+    expect(screen.getByTestId('scim-dismiss-token')).toBeDisabled();
+
+    // Check the confirmation checkbox
+    fireEvent.click(screen.getByTestId('scim-copied-confirm'));
+
+    // Dismiss should now be enabled
+    expect(screen.getByTestId('scim-dismiss-token')).not.toBeDisabled();
+  });
+
+  // 9. Dismiss clears plaintext from DOM
+  it('clears revealed token from DOM on dismiss', async () => {
+    mockFetchWithTokens();
+    render(<ScimSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('generate-token-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('generate-token-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scim-token-name')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('scim-token-name'), { target: { value: 'New Token' } });
+    fireEvent.click(screen.getByTestId('scim-create-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scim-token-reveal')).toBeInTheDocument();
+    });
+
+    // Check confirmation and dismiss
+    fireEvent.click(screen.getByTestId('scim-copied-confirm'));
+    fireEvent.click(screen.getByTestId('scim-dismiss-token'));
+
+    // Token plaintext must no longer be in the DOM
+    await waitFor(() => {
+      expect(screen.queryByTestId('scim-token-reveal')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByDisplayValue('scim_bEaReR_tOkEn_PlAiNtExT_12345')).not.toBeInTheDocument();
+  });
+
+  // 10. Revoke
+  it('sends DELETE request when Revoke button is clicked', async () => {
+    const fetchSpy = mockFetchWithTokens();
+    render(<ScimSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('revoke-token-tok-1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('revoke-token-tok-1'));
+
+    await waitFor(() => {
+      const deleteCalls = fetchSpy.mock.calls.filter(
+        ([, opts]) => opts && typeof opts === 'object' && 'method' in opts && (opts as RequestInit).method === 'DELETE',
+      );
+      expect(deleteCalls.length).toBeGreaterThanOrEqual(1);
+      expect(String(deleteCalls[0][0])).toContain('/admin/scim/tokens/tok-1');
+    });
+  });
+
+  // 11. SCIM base URL
+  it('renders SCIM base URL with /scim/v2', async () => {
+    mockFetchWithTokens();
+    render(<ScimSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('/scim/v2')).toBeInTheDocument();
+    });
+  });
+
+  // 12. No expiry option
+  it('omits expiresInDays when the field is empty', async () => {
+    const fetchSpy = mockFetchWithTokens();
+    render(<ScimSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('generate-token-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('generate-token-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scim-token-name')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('scim-token-name'), { target: { value: 'No Expiry' } });
+    // Leave expiresInDays empty
+    fireEvent.click(screen.getByTestId('scim-create-submit'));
+
+    await waitFor(() => {
+      const postCalls = fetchSpy.mock.calls.filter(
+        ([, opts]) => opts && typeof opts === 'object' && 'method' in opts && (opts as RequestInit).method === 'POST',
+      );
+      expect(postCalls.length).toBeGreaterThanOrEqual(1);
+      const body = JSON.parse((postCalls[0][1] as RequestInit).body as string);
+      expect(body.name).toBe('No Expiry');
+      expect(body).not.toHaveProperty('expiresInDays');
+    });
+  });
+});

--- a/frontend/src/features/admin/ScimSettingsPage.tsx
+++ b/frontend/src/features/admin/ScimSettingsPage.tsx
@@ -1,0 +1,394 @@
+import { useState, useCallback } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { m } from 'framer-motion';
+import { toast } from 'sonner';
+import {
+  Key, Plus, Trash2, Copy, CheckCircle2, AlertTriangle, Loader2, Shield,
+} from 'lucide-react';
+import { apiFetch } from '../../shared/lib/api';
+import { cn } from '../../shared/lib/cn';
+import { useEnterprise } from '../../shared/enterprise/use-enterprise';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface ScimToken {
+  id: string;
+  name: string;
+  lastUsedAt: string | null;
+  createdAt: string;
+  expiresAt: string | null;
+  createdBy: string | null;
+}
+
+interface ScimTokenCreateResult {
+  id: string;
+  name: string;
+  token: string;        // plaintext, shown once
+  expiresAt: string | null;
+}
+
+// ── Hooks ──────────────────────────────────────────────────────────────────────
+
+function useScimTokens() {
+  return useQuery<ScimToken[]>({
+    queryKey: ['admin', 'scim-tokens'],
+    queryFn: () => apiFetch('/admin/scim/tokens'),
+    staleTime: 30_000,
+  });
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function formatDate(value: string | null): string {
+  if (!value) return 'Never';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Unknown';
+  return date.toLocaleDateString();
+}
+
+function tokenStatus(expiresAt: string | null): 'active' | 'expiring' | 'expired' {
+  if (!expiresAt) return 'active';
+  const now = Date.now();
+  const exp = new Date(expiresAt).getTime();
+  if (exp <= now) return 'expired';
+  // Expiring soon: within 7 days
+  if (exp - now < 7 * 24 * 60 * 60 * 1000) return 'expiring';
+  return 'active';
+}
+
+const statusDotClass: Record<ReturnType<typeof tokenStatus>, string> = {
+  active: 'bg-emerald-500',
+  expiring: 'bg-amber-500',
+  expired: 'bg-red-500',
+};
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+export function ScimSettingsPage() {
+  const queryClient = useQueryClient();
+  const { hasFeature } = useEnterprise();
+  const { data: tokens, isLoading } = useScimTokens();
+
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [tokenName, setTokenName] = useState('');
+  const [expiresInDays, setExpiresInDays] = useState('');
+  // Security: plaintext token held in state only until explicit dismiss
+  const [revealedToken, setRevealedToken] = useState<ScimTokenCreateResult | null>(null);
+  const [copiedConfirmed, setCopiedConfirmed] = useState(false);
+
+  const featureEnabled = hasFeature('scim_provisioning');
+
+  const createMutation = useMutation({
+    mutationFn: (body: { name: string; expiresInDays?: number }) =>
+      apiFetch<ScimTokenCreateResult>('/admin/scim/tokens', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'scim-tokens'] });
+      setRevealedToken(result);
+      setShowCreateForm(false);
+      setTokenName('');
+      setExpiresInDays('');
+      toast.success('SCIM token generated');
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: (id: string) =>
+      apiFetch(`/admin/scim/tokens/${id}`, { method: 'DELETE' }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'scim-tokens'] });
+      toast.success('Token revoked');
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const handleCreate = useCallback(() => {
+    if (!tokenName.trim()) {
+      toast.error('Token name is required');
+      return;
+    }
+    const body: { name: string; expiresInDays?: number } = { name: tokenName.trim() };
+    if (expiresInDays) {
+      body.expiresInDays = parseInt(expiresInDays, 10);
+    }
+    createMutation.mutate(body);
+  }, [tokenName, expiresInDays, createMutation]);
+
+  const handleCopy = useCallback(async () => {
+    if (!revealedToken) return;
+    try {
+      await navigator.clipboard.writeText(revealedToken.token);
+      toast.success('Copied to clipboard');
+    } catch {
+      toast.error('Copy failed — please select and copy manually');
+    }
+  }, [revealedToken]);
+
+  const handleDismiss = useCallback(() => {
+    // Security: remove plaintext from React state immediately
+    setRevealedToken(null);
+    setCopiedConfirmed(false);
+  }, []);
+
+  // ── Feature gate ────────────────────────────────────────────────────
+
+  if (!featureEnabled) {
+    return (
+      <div className="space-y-6" data-testid="scim-gated">
+        <m.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex items-start gap-3 rounded-lg border border-amber-500/20 bg-amber-500/5 p-4"
+        >
+          <AlertTriangle size={18} className="mt-0.5 shrink-0 text-amber-500" />
+          <div>
+            <div className="text-sm font-medium text-amber-200">Enterprise Feature</div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              SCIM provisioning requires an enterprise license with the SCIM feature enabled.
+            </div>
+          </div>
+        </m.div>
+      </div>
+    );
+  }
+
+  // ── Loading ─────────────────────────────────────────────────────────
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4" data-testid="scim-loading">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-16 animate-pulse rounded-lg bg-foreground/5" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6" data-testid="scim-settings">
+      {/* Header */}
+      <div>
+        <h2 className="text-xl font-bold">SCIM Provisioning</h2>
+        <p className="text-sm text-muted-foreground">
+          Configure SCIM 2.0 bearer tokens for identity provider integration (Okta, Azure AD, etc.)
+        </p>
+      </div>
+
+      {/* SCIM Base URL */}
+      <div className="glass-card p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="flex items-center gap-1.5 text-sm font-medium">
+              <Shield size={14} className="text-muted-foreground" />
+              SCIM Base URL
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Enter this URL in your identity provider's SCIM configuration.
+            </p>
+          </div>
+          <code className="rounded bg-foreground/5 px-3 py-1.5 font-mono text-sm">/scim/v2</code>
+        </div>
+      </div>
+
+      {/* Plaintext reveal overlay — security: shown only once after creation */}
+      {revealedToken && (
+        <m.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="glass-card space-y-4 border border-amber-500/20 p-4"
+          data-testid="scim-token-reveal"
+        >
+          <div className="flex items-start gap-3 rounded-lg bg-amber-500/5 p-3">
+            <AlertTriangle size={18} className="mt-0.5 shrink-0 text-amber-500" />
+            <div className="text-xs text-muted-foreground">
+              <span className="font-medium text-amber-200">Copy this token now.</span>{' '}
+              It will not be shown again. Store it securely in your identity provider.
+            </div>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Token for "{revealedToken.name}"
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                readOnly
+                value={revealedToken.token}
+                className="flex-1 rounded-md bg-foreground/5 px-3 py-2 font-mono text-sm outline-none"
+                data-testid="scim-token-value"
+              />
+              <button
+                onClick={handleCopy}
+                className="flex items-center gap-1.5 rounded-md bg-foreground/5 px-3 py-2 text-sm hover:bg-foreground/10"
+                data-testid="scim-copy-token"
+              >
+                <Copy size={14} />
+                Copy
+              </button>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between border-t border-border/50 pt-3">
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={copiedConfirmed}
+                onChange={(e) => setCopiedConfirmed(e.target.checked)}
+                className="h-4 w-4 rounded border-border accent-primary"
+                data-testid="scim-copied-confirm"
+              />
+              I have copied this token
+            </label>
+            <button
+              onClick={handleDismiss}
+              disabled={!copiedConfirmed}
+              className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              data-testid="scim-dismiss-token"
+            >
+              <CheckCircle2 size={14} />
+              Dismiss
+            </button>
+          </div>
+        </m.div>
+      )}
+
+      {/* Token creation */}
+      {!showCreateForm ? (
+        <button
+          onClick={() => setShowCreateForm(true)}
+          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          data-testid="generate-token-btn"
+        >
+          <Plus size={16} />
+          Generate Token
+        </button>
+      ) : (
+        <m.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="glass-card space-y-3 p-4"
+          data-testid="scim-create-form"
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                Token Name
+              </label>
+              <input
+                type="text"
+                value={tokenName}
+                onChange={(e) => setTokenName(e.target.value)}
+                placeholder="e.g. Okta SCIM"
+                className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary"
+                data-testid="scim-token-name"
+                autoFocus
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                Expires In (days)
+              </label>
+              <input
+                type="number"
+                value={expiresInDays}
+                onChange={(e) => setExpiresInDays(e.target.value)}
+                placeholder="Leave empty for no expiry"
+                min={1}
+                className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary"
+                data-testid="scim-expires-days"
+              />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={handleCreate}
+              disabled={!tokenName.trim() || createMutation.isPending}
+              className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              data-testid="scim-create-submit"
+            >
+              {createMutation.isPending && <Loader2 size={14} className="animate-spin" />}
+              Create
+            </button>
+            <button
+              onClick={() => {
+                setShowCreateForm(false);
+                setTokenName('');
+                setExpiresInDays('');
+              }}
+              className="rounded-md bg-foreground/5 px-3 py-1.5 text-sm hover:bg-foreground/10"
+            >
+              Cancel
+            </button>
+          </div>
+        </m.div>
+      )}
+
+      {/* Token list */}
+      {!tokens?.length ? (
+        <div className="glass-card py-12 text-center text-sm text-muted-foreground">
+          No SCIM tokens
+        </div>
+      ) : (
+        <div className="glass-card overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border/50 text-left text-xs text-muted-foreground">
+                <th className="px-4 py-3 font-medium">Name</th>
+                <th className="px-4 py-3 font-medium">Created</th>
+                <th className="px-4 py-3 font-medium">Last Used</th>
+                <th className="px-4 py-3 font-medium">Expires</th>
+                <th className="w-16 px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/30">
+              {tokens.map((t, i) => {
+                const status = tokenStatus(t.expiresAt);
+                return (
+                  <m.tr
+                    key={t.id}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transition={{ delay: i * 0.03 }}
+                    className="hover:bg-foreground/5"
+                    data-testid={`scim-token-${t.id}`}
+                  >
+                    <td className="px-4 py-2.5">
+                      <div className="flex items-center gap-2">
+                        <div className={cn('h-2 w-2 rounded-full', statusDotClass[status])} />
+                        <span className="font-medium">{t.name}</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-2.5 text-muted-foreground">
+                      {formatDate(t.createdAt)}
+                    </td>
+                    <td className="px-4 py-2.5 text-muted-foreground">
+                      {formatDate(t.lastUsedAt)}
+                    </td>
+                    <td className="px-4 py-2.5 text-muted-foreground">
+                      {t.expiresAt ? formatDate(t.expiresAt) : 'Never'}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <button
+                        onClick={() => revokeMutation.mutate(t.id)}
+                        disabled={revokeMutation.isPending}
+                        className="rounded p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
+                        aria-label={`Revoke token ${t.name}`}
+                        data-testid={`revoke-token-${t.id}`}
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </td>
+                  </m.tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/admin/ScimSettingsPage.tsx
+++ b/frontend/src/features/admin/ScimSettingsPage.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { m } from 'framer-motion';
 import { toast } from 'sonner';
 import {
-  Key, Plus, Trash2, Copy, CheckCircle2, AlertTriangle, Loader2, Shield,
+  Plus, Trash2, Copy, CheckCircle2, AlertTriangle, Loader2, Shield,
 } from 'lucide-react';
 import { apiFetch } from '../../shared/lib/api';
 import { cn } from '../../shared/lib/cn';

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -24,9 +24,10 @@ import { OidcSettingsPage } from '../admin/OidcSettingsPage';
 import { LlmPolicyTab } from '../admin/LlmPolicyTab';
 import { DataRetentionTab } from '../admin/DataRetentionTab';
 import { LlmAuditPage } from '../admin/LlmAuditPage';
+import { ScimSettingsPage } from '../admin/ScimSettingsPage';
 import { useEnterprise } from '../../shared/enterprise/use-enterprise';
 
-type TabId = 'confluence' | 'sync' | 'ollama' | 'ai-prompts' | 'ai-safety' | 'rate-limits' | 'spaces' | 'theme' | 'labels' | 'errors' | 'embedding' | 'workers' | 'mcp-docs' | 'searxng' | 'email' | 'license' | 'sso' | 'llm-policy' | 'retention' | 'llm-audit' | 'system';
+type TabId = 'confluence' | 'sync' | 'ollama' | 'ai-prompts' | 'ai-safety' | 'rate-limits' | 'spaces' | 'theme' | 'labels' | 'errors' | 'embedding' | 'workers' | 'mcp-docs' | 'searxng' | 'email' | 'license' | 'sso' | 'llm-policy' | 'retention' | 'llm-audit' | 'scim' | 'system';
 
 export function SettingsPage() {
   const queryClient = useQueryClient();
@@ -71,6 +72,7 @@ export function SettingsPage() {
     { id: 'llm-policy', label: 'LLM Policy', adminOnly: true, enterpriseOnly: true, requiresFeature: 'org_llm_policy' },
     { id: 'retention', label: 'Data Retention', adminOnly: true, enterpriseOnly: true, requiresFeature: 'data_retention_policies' },
     { id: 'llm-audit', label: 'LLM Audit', adminOnly: true, enterpriseOnly: true, requiresFeature: 'llm_audit_trail' },
+    { id: 'scim', label: 'SCIM', adminOnly: true, enterpriseOnly: true, requiresFeature: 'scim_provisioning' },
     { id: 'system', label: 'System', adminOnly: true },
   ];
 
@@ -109,7 +111,7 @@ export function SettingsPage() {
         </div>
 
         <div className="p-6">
-          {(isLoading || !settings) && activeTab !== 'labels' && activeTab !== 'errors' && activeTab !== 'theme' && activeTab !== 'embedding' && activeTab !== 'sync' && activeTab !== 'workers' && activeTab !== 'mcp-docs' && activeTab !== 'ai-safety' && activeTab !== 'rate-limits' && activeTab !== 'searxng' && activeTab !== 'email' && activeTab !== 'license' && activeTab !== 'sso' && activeTab !== 'llm-policy' && activeTab !== 'retention' && activeTab !== 'llm-audit' ? (
+          {(isLoading || !settings) && activeTab !== 'labels' && activeTab !== 'errors' && activeTab !== 'theme' && activeTab !== 'embedding' && activeTab !== 'sync' && activeTab !== 'workers' && activeTab !== 'mcp-docs' && activeTab !== 'ai-safety' && activeTab !== 'rate-limits' && activeTab !== 'searxng' && activeTab !== 'email' && activeTab !== 'license' && activeTab !== 'sso' && activeTab !== 'llm-policy' && activeTab !== 'retention' && activeTab !== 'llm-audit' && activeTab !== 'scim' ? (
             <SkeletonFormFields />
           ) : activeTab === 'confluence' ? (
             <ConfluenceTab settings={settings!} onSave={(v) => updateSettings.mutate(v)} />
@@ -155,6 +157,8 @@ export function SettingsPage() {
             <DataRetentionTab />
           ) : activeTab === 'llm-audit' && isAdmin ? (
             <LlmAuditPage />
+          ) : activeTab === 'scim' && isAdmin ? (
+            <ScimSettingsPage />
           ) : activeTab === 'system' && isAdmin ? (
             <SystemTab />
           ) : (


### PR DESCRIPTION
## Summary
- Add `ScimSettingsPage.tsx` — admin UI for SCIM 2.0 bearer token lifecycle (generate, view, revoke)
- Token plaintext shown exactly once with copy-once security pattern (checkbox + dismiss gate)
- Wire into SettingsPage as enterprise-only tab gated by `hasFeature('scim_provisioning')`
- SCIM base URL display card for IdP configuration

## Test plan
- [x] 12 unit tests covering feature gate, token CRUD, plaintext reveal, copy-to-clipboard, dismiss security, and empty states
- [x] All 1744 existing frontend tests pass (zero regressions)
- [x] TypeScript type-check passes for all changed files
- [ ] Manual: navigate to Settings > SCIM tab with enterprise license + scim_provisioning feature
- [ ] Manual: generate token, copy, dismiss, verify token appears in list
- [ ] Manual: revoke token, verify removed from list

Closes Compendiq/compendiq-ee#62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>