### PR TITLE
feat(admin): 4 enterprise analytics dashboards with Recharts (#64)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -60,6 +60,11 @@ const SpaceSettingsPage = lazy(() =>
     default: m.SpaceSettingsPage,
   })),
 );
+const AnalyticsPage = lazy(() =>
+  import('./features/admin/analytics/AnalyticsPage').then((m) => ({
+    default: m.AnalyticsPage,
+  })),
+);
 export function PageLoadingFallback() {
   return (
     <div className="flex items-center justify-center h-64">
@@ -139,6 +144,7 @@ export function App() {
                           <Route path="/graph" element={<GraphPage />} />
                           <Route path="/spaces/new" element={<NewSpacePage />} />
                           <Route path="/spaces/:key/settings" element={<SpaceSettingsPage />} />
+                          <Route path="/admin/analytics" element={<AnalyticsPage />} />
                           <Route
                             path="/settings"
                             element={<SettingsPage />}

--- a/frontend/src/features/admin/LlmAuditPage.tsx
+++ b/frontend/src/features/admin/LlmAuditPage.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { m } from 'framer-motion';
 import { toast } from 'sonner';
 import {
-  FileText, Loader2, AlertTriangle, Download, ChevronLeft, ChevronRight,
+  FileText, AlertTriangle, Download, ChevronLeft, ChevronRight,
   Filter,
 } from 'lucide-react';
 import { apiFetch } from '../../shared/lib/api';

--- a/frontend/src/features/admin/analytics/AiUsageDashboard.test.tsx
+++ b/frontend/src/features/admin/analytics/AiUsageDashboard.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EnterpriseContext } from '../../../shared/enterprise/enterprise-context';
+import type { EnterpriseContextValue } from '../../../shared/enterprise/types';
+import { AiUsageDashboard } from './AiUsageDashboard';
+import type { DashboardProps } from './AnalyticsPage';
+
+// ── Mock ChartsBundle ──────────────────────────────────────────────────────────
+
+vi.mock('../../../shared/components/charts/ChartsBundle', () => ({
+  LineChart: ({ children, ...props }: any) => <div data-testid="line-chart" {...props}>{children}</div>,
+  Line: (props: any) => <div {...props} />,
+  BarChart: ({ children, ...props }: any) => <div data-testid="bar-chart" {...props}>{children}</div>,
+  Bar: (props: any) => <div {...props} />,
+  XAxis: (props: any) => <div {...props} />,
+  YAxis: (props: any) => <div {...props} />,
+  Tooltip: () => <div />,
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  CartesianGrid: () => <div />,
+  Legend: () => <div />,
+}));
+
+// ── Mock apiFetch ──────────────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.mock('../../../shared/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockFetch(...args),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function makeEnterpriseValue(features: string[]): EnterpriseContextValue {
+  return {
+    ui: null,
+    license: {
+      edition: 'enterprise' as const,
+      tier: 'enterprise' as const,
+      valid: true,
+      features,
+    },
+    isEnterprise: true,
+    hasFeature: (f: string) => features.includes(f),
+    isLoading: false,
+  };
+}
+
+const defaultDateRange: DashboardProps['dateRange'] = {
+  startDate: '2025-01-01',
+  endDate: '2025-01-31',
+};
+
+const mockData = {
+  available: true,
+  requestsOverTime: [
+    { date: '2025-01-01', requests: 100, errors: 2 },
+    { date: '2025-01-02', requests: 150, errors: 5 },
+  ],
+  tokenConsumption: [
+    { model: 'qwen3:4b', inputTokens: 5000, outputTokens: 3000, totalRequests: 80 },
+    { model: 'llama3.1', inputTokens: 2000, outputTokens: 1500, totalRequests: 40 },
+  ],
+  modelBreakdown: [
+    { model: 'qwen3:4b', action: 'chat', count: 60, avgDurationMs: 1200 },
+    { model: 'llama3.1', action: 'summarize', count: 30, avgDurationMs: 800 },
+  ],
+  errorRate: { total: 250, errors: 7, rate: 2.8 },
+};
+
+function renderDashboard(
+  features: string[] = ['advanced_analytics', 'ai_usage_analytics'],
+  props?: Partial<DashboardProps>,
+) {
+  const queryClient = createQueryClient();
+  const defaultProps: DashboardProps = {
+    dateRange: defaultDateRange,
+    onExportPdf: vi.fn(),
+    onExportExcel: vi.fn(),
+    ...props,
+  };
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <EnterpriseContext.Provider value={makeEnterpriseValue(features)}>
+        <AiUsageDashboard {...defaultProps} />
+      </EnterpriseContext.Provider>
+    </QueryClientProvider>,
+  );
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('AiUsageDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows feature gate banner when ai_usage_analytics is not enabled', () => {
+    renderDashboard(['advanced_analytics']); // missing ai_usage_analytics
+    expect(screen.getByTestId('ai-usage-gate')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /AI Usage Analytics/ })).toBeInTheDocument();
+  });
+
+  it('renders stat cards when data is available', async () => {
+    mockFetch.mockResolvedValue(mockData);
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByTestId('stat-total-requests')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('stat-total-tokens')).toBeInTheDocument();
+    expect(screen.getByTestId('stat-models-used')).toBeInTheDocument();
+    expect(screen.getByTestId('stat-error-rate')).toBeInTheDocument();
+  });
+
+  it('shows "not available" message when available is false', async () => {
+    mockFetch.mockResolvedValue({ available: false, message: 'LLM audit table not found' });
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByTestId('ai-usage-unavailable')).toBeInTheDocument();
+    });
+    expect(screen.getByText('LLM audit table not found')).toBeInTheDocument();
+  });
+
+  it('shows error rate warning when rate > 10%', async () => {
+    mockFetch.mockResolvedValue({
+      ...mockData,
+      errorRate: { total: 100, errors: 15, rate: 15.0 },
+    });
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByTestId('error-rate-warning')).toBeInTheDocument();
+    });
+  });
+
+  it('renders requests-over-time chart container', async () => {
+    mockFetch.mockResolvedValue(mockData);
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByTestId('requests-chart')).toBeInTheDocument();
+    });
+  });
+
+  it('renders model breakdown table when data has entries', async () => {
+    mockFetch.mockResolvedValue(mockData);
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByTestId('model-breakdown-table')).toBeInTheDocument();
+    });
+    expect(screen.getByText('qwen3:4b')).toBeInTheDocument();
+    expect(screen.getByText('chat')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/admin/analytics/AiUsageDashboard.test.tsx
+++ b/frontend/src/features/admin/analytics/AiUsageDashboard.test.tsx
@@ -8,18 +8,15 @@ import type { DashboardProps } from './AnalyticsPage';
 
 // ── Mock ChartsBundle ──────────────────────────────────────────────────────────
 
-vi.mock('../../../shared/components/charts/ChartsBundle', () => ({
-  LineChart: ({ children, ...props }: any) => <div data-testid="line-chart" {...props}>{children}</div>,
-  Line: (props: any) => <div {...props} />,
-  BarChart: ({ children, ...props }: any) => <div data-testid="bar-chart" {...props}>{children}</div>,
-  Bar: (props: any) => <div {...props} />,
-  XAxis: (props: any) => <div {...props} />,
-  YAxis: (props: any) => <div {...props} />,
-  Tooltip: () => <div />,
-  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
-  CartesianGrid: () => <div />,
-  Legend: () => <div />,
-}));
+vi.mock('../../../shared/components/charts/ChartsBundle', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- chart mocks only need to render containers
+  const P = (_: any) => _.children ?? null;
+  return {
+    LineChart: P, Line: P, BarChart: P, Bar: P,
+    XAxis: P, YAxis: P, Tooltip: P, ResponsiveContainer: P,
+    CartesianGrid: P, Legend: P,
+  };
+});
 
 // ── Mock apiFetch ──────────────────────────────────────────────────────────────
 

--- a/frontend/src/features/admin/analytics/AiUsageDashboard.tsx
+++ b/frontend/src/features/admin/analytics/AiUsageDashboard.tsx
@@ -1,0 +1,236 @@
+import { Suspense } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Brain, Download, AlertTriangle, Info } from 'lucide-react';
+import { apiFetch } from '../../../shared/lib/api';
+import { useEnterprise } from '../../../shared/enterprise/use-enterprise';
+import { cn } from '../../../shared/lib/cn';
+import type { DashboardProps } from './AnalyticsPage';
+import {
+  LineChart, Line, BarChart, Bar,
+  XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Legend,
+} from '../../../shared/components/charts/ChartsBundle';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface AiUsageData {
+  available: boolean;
+  message?: string;
+  requestsOverTime: Array<{ date: string; requests: number; errors: number }>;
+  tokenConsumption: Array<{ model: string; inputTokens: number; outputTokens: number; totalRequests: number }>;
+  modelBreakdown: Array<{ model: string; action: string; count: number; avgDurationMs: number }>;
+  errorRate: { total: number; errors: number; rate: number } | null;
+}
+
+// ── Hook ───────────────────────────────────────────────────────────────────────
+
+function useAiUsage(dateRange: DashboardProps['dateRange'], enabled: boolean) {
+  return useQuery<AiUsageData>({
+    queryKey: ['admin', 'analytics', 'ai-usage', dateRange],
+    queryFn: () =>
+      apiFetch(
+        `/admin/analytics/ai-usage?startDate=${dateRange.startDate}&endDate=${dateRange.endDate}`,
+      ),
+    staleTime: 60_000,
+    enabled,
+  });
+}
+
+// ── Chart skeleton ─────────────────────────────────────────────────────────────
+
+function ChartSkeleton() {
+  return <div className="h-64 animate-pulse rounded-lg bg-foreground/5" />;
+}
+
+// ── Stat card ──────────────────────────────────────────────────────────────────
+
+function StatCard({ label, value, warning }: { label: string; value: string | number; warning?: boolean }) {
+  return (
+    <div className={cn('glass-card p-4 text-center', warning && 'border-amber-500/30')} data-testid={`stat-${label.toLowerCase().replace(/\s+/g, '-')}`}>
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      <p className={cn('text-2xl font-semibold', warning && 'text-amber-500')}>{value}</p>
+    </div>
+  );
+}
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+export function AiUsageDashboard({ dateRange, onExportPdf, onExportExcel }: DashboardProps) {
+  const { hasFeature } = useEnterprise();
+  const aiUsageEnabled = hasFeature('ai_usage_analytics');
+
+  const { data, isLoading } = useAiUsage(dateRange, aiUsageEnabled);
+
+  // Feature gate: ai_usage_analytics (separate from outer advanced_analytics)
+  if (!aiUsageEnabled) {
+    return (
+      <div className="glass-card p-8 text-center" data-testid="ai-usage-gate">
+        <Brain className="mx-auto mb-3 h-12 w-12 text-muted-foreground/50" />
+        <h2 className="text-lg font-medium mb-2">AI Usage Analytics</h2>
+        <p className="text-sm text-muted-foreground">
+          AI Usage analytics requires the AI Usage Analytics feature in your Enterprise license.
+        </p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4" data-testid="ai-usage-loading">
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="glass-card h-20 animate-pulse" />
+          ))}
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="glass-card p-4"><ChartSkeleton /></div>
+          <div className="glass-card p-4"><ChartSkeleton /></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="glass-card p-8 text-center text-sm text-muted-foreground" data-testid="ai-usage-empty">
+        No AI usage data available for the selected date range.
+      </div>
+    );
+  }
+
+  // When the llm_audit_log table does not exist
+  if (!data.available) {
+    return (
+      <div className="glass-card p-6 flex items-start gap-3" data-testid="ai-usage-unavailable">
+        <Info className="h-5 w-5 text-blue-400 mt-0.5 shrink-0" />
+        <div>
+          <h3 className="text-sm font-medium mb-1">AI Audit Logging Not Available</h3>
+          <p className="text-sm text-muted-foreground">{data.message ?? 'The AI audit log table has not been initialized.'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Compute stat values
+  const totalRequests = data.requestsOverTime.reduce((sum, d) => sum + d.requests, 0);
+  const totalTokens = data.tokenConsumption.reduce(
+    (sum, d) => sum + d.inputTokens + d.outputTokens,
+    0,
+  );
+  const modelsUsed = new Set(data.tokenConsumption.map((d) => d.model)).size;
+  const errorRate = data.errorRate?.rate ?? 0;
+  const errorRateWarning = errorRate > 10;
+
+  const flatRows: Record<string, unknown>[] = [
+    ...data.requestsOverTime.map((d) => ({ type: 'requests', ...d })),
+    ...data.tokenConsumption.map((d) => ({ type: 'tokens', ...d })),
+    ...data.modelBreakdown.map((d) => ({ type: 'breakdown', ...d })),
+  ];
+
+  return (
+    <div className="space-y-4" data-testid="ai-usage-dashboard">
+      {/* Export row */}
+      <div className="flex justify-end gap-2">
+        <button
+          onClick={() => onExportPdf(flatRows, 'AI Usage')}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          data-testid="ai-export-pdf"
+        >
+          <Download className="h-3.5 w-3.5" /> PDF
+        </button>
+        <button
+          onClick={() => onExportExcel(flatRows, 'AI Usage')}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          data-testid="ai-export-excel"
+        >
+          <Download className="h-3.5 w-3.5" /> Excel
+        </button>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatCard label="Total Requests" value={totalRequests.toLocaleString()} />
+        <StatCard label="Total Tokens" value={totalTokens.toLocaleString()} />
+        <StatCard label="Models Used" value={modelsUsed} />
+        <StatCard label="Error Rate" value={`${errorRate.toFixed(1)}%`} warning={errorRateWarning} />
+      </div>
+
+      {/* Error rate warning */}
+      {errorRateWarning && (
+        <div className="glass-card border-amber-500/30 p-3 flex items-center gap-2 text-sm text-amber-500" data-testid="error-rate-warning">
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          Error rate is above 10% ({errorRate.toFixed(1)}%). Investigate failing requests.
+        </div>
+      )}
+
+      {/* Charts */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Requests Over Time */}
+        <div className="glass-card p-4" data-testid="requests-chart">
+          <h3 className="text-sm font-medium mb-3">Requests Over Time</h3>
+          <Suspense fallback={<ChartSkeleton />}>
+            <ResponsiveContainer width="100%" height={250}>
+              <LineChart data={data.requestsOverTime}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-foreground)" strokeOpacity={0.1} />
+                <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+                <YAxis tick={{ fontSize: 12 }} />
+                <Tooltip />
+                <Legend />
+                <Line type="monotone" dataKey="requests" stroke="#3b82f6" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="errors" stroke="#ef4444" strokeWidth={2} dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </Suspense>
+        </div>
+
+        {/* Token Consumption by Model */}
+        <div className="glass-card p-4" data-testid="tokens-chart">
+          <h3 className="text-sm font-medium mb-3">Token Consumption by Model</h3>
+          <Suspense fallback={<ChartSkeleton />}>
+            <ResponsiveContainer width="100%" height={250}>
+              <BarChart data={data.tokenConsumption}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-foreground)" strokeOpacity={0.1} />
+                <XAxis dataKey="model" tick={{ fontSize: 11 }} />
+                <YAxis tick={{ fontSize: 12 }} />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="inputTokens" name="Input Tokens" fill="#3b82f6" stackId="tokens" radius={[0, 0, 0, 0]} />
+                <Bar dataKey="outputTokens" name="Output Tokens" fill="#10b981" stackId="tokens" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </Suspense>
+        </div>
+      </div>
+
+      {/* Model Breakdown Table */}
+      {data.modelBreakdown.length > 0 && (
+        <div className="glass-card overflow-hidden" data-testid="model-breakdown-table">
+          <div className="p-4 border-b border-foreground/5">
+            <h3 className="text-sm font-medium">Model Breakdown</h3>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-foreground/5">
+                  <th className="text-left px-4 py-2 text-xs text-muted-foreground font-medium">Model</th>
+                  <th className="text-left px-4 py-2 text-xs text-muted-foreground font-medium">Action</th>
+                  <th className="text-right px-4 py-2 text-xs text-muted-foreground font-medium">Count</th>
+                  <th className="text-right px-4 py-2 text-xs text-muted-foreground font-medium">Avg Duration</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.modelBreakdown.map((row, i) => (
+                  <tr key={`${row.model}-${row.action}-${i}`} className="border-b border-foreground/5 last:border-0">
+                    <td className="px-4 py-2 font-mono text-xs">{row.model}</td>
+                    <td className="px-4 py-2">{row.action}</td>
+                    <td className="px-4 py-2 text-right">{row.count.toLocaleString()}</td>
+                    <td className="px-4 py-2 text-right">{row.avgDurationMs.toFixed(0)}ms</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/admin/analytics/AnalyticsPage.test.tsx
+++ b/frontend/src/features/admin/analytics/AnalyticsPage.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EnterpriseContext } from '../../../shared/enterprise/enterprise-context';
+import type { EnterpriseContextValue } from '../../../shared/enterprise/types';
+import { AnalyticsPage } from './AnalyticsPage';
+
+// ── Mock lazy-loaded dashboards ────────────────────────────────────────────────
+
+vi.mock('./KnowledgeHealthDashboard', () => ({
+  KnowledgeHealthDashboard: () => <div data-testid="knowledge-dashboard-mock">Knowledge Health</div>,
+}));
+vi.mock('./AiUsageDashboard', () => ({
+  AiUsageDashboard: () => <div data-testid="ai-usage-dashboard-mock">AI Usage</div>,
+}));
+vi.mock('./SearchEffectivenessDashboard', () => ({
+  SearchEffectivenessDashboard: () => <div data-testid="search-dashboard-mock">Search</div>,
+}));
+vi.mock('./ContentGapsDashboard', () => ({
+  ContentGapsDashboard: () => <div data-testid="content-gaps-dashboard-mock">Content Gaps</div>,
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function makeEnterpriseValue(features: string[]): EnterpriseContextValue {
+  return {
+    ui: null,
+    license: {
+      edition: 'enterprise' as const,
+      tier: 'enterprise' as const,
+      valid: true,
+      features,
+    },
+    isEnterprise: true,
+    hasFeature: (f: string) => features.includes(f),
+    isLoading: false,
+  };
+}
+
+function renderWithProviders(
+  features: string[] = ['advanced_analytics', 'ai_usage_analytics'],
+) {
+  const queryClient = createQueryClient();
+  const enterpriseValue = features.length > 0
+    ? makeEnterpriseValue(features)
+    : {
+        ui: null,
+        license: null,
+        isEnterprise: false,
+        hasFeature: () => false,
+        isLoading: false,
+      };
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <EnterpriseContext.Provider value={enterpriseValue}>
+        <AnalyticsPage />
+      </EnterpriseContext.Provider>
+    </QueryClientProvider>,
+  );
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('AnalyticsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows gate banner when advanced_analytics feature is not enabled', () => {
+    renderWithProviders([]);
+    expect(screen.getByTestId('analytics-gate')).toBeInTheDocument();
+    expect(screen.getByText(/require an Enterprise license/)).toBeInTheDocument();
+  });
+
+  it('renders 4 tab buttons when feature is enabled', () => {
+    renderWithProviders();
+    expect(screen.getByTestId('analytics-tabs')).toBeInTheDocument();
+    expect(screen.getByTestId('tab-knowledge')).toBeInTheDocument();
+    expect(screen.getByTestId('tab-ai-usage')).toBeInTheDocument();
+    expect(screen.getByTestId('tab-search')).toBeInTheDocument();
+    expect(screen.getByTestId('tab-content-gaps')).toBeInTheDocument();
+  });
+
+  it('defaults to Knowledge Health tab', async () => {
+    renderWithProviders();
+    // The knowledge dashboard should be rendered by default
+    expect(await screen.findByTestId('knowledge-dashboard-mock')).toBeInTheDocument();
+  });
+
+  it('switches tabs when clicked', async () => {
+    renderWithProviders();
+    fireEvent.click(screen.getByTestId('tab-search'));
+    expect(await screen.findByTestId('search-dashboard-mock')).toBeInTheDocument();
+  });
+
+  it('renders date range inputs', () => {
+    renderWithProviders();
+    expect(screen.getByTestId('date-start')).toBeInTheDocument();
+    expect(screen.getByTestId('date-end')).toBeInTheDocument();
+  });
+
+  it('updates date range state when inputs change', () => {
+    renderWithProviders();
+    const startInput = screen.getByTestId('date-start') as HTMLInputElement;
+    fireEvent.change(startInput, { target: { value: '2025-01-01' } });
+    expect(startInput.value).toBe('2025-01-01');
+  });
+
+  it('shows AI Usage tab with reduced opacity when ai_usage_analytics is not enabled', () => {
+    renderWithProviders(['advanced_analytics']);
+    const aiTab = screen.getByTestId('tab-ai-usage');
+    // Tab should be rendered but with opacity class
+    expect(aiTab).toBeInTheDocument();
+    expect(aiTab.className).toContain('opacity-50');
+  });
+
+  it('renders export button', () => {
+    renderWithProviders();
+    expect(screen.getByTestId('export-btn')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/admin/analytics/AnalyticsPage.tsx
+++ b/frontend/src/features/admin/analytics/AnalyticsPage.tsx
@@ -1,0 +1,231 @@
+import { lazy, Suspense, useState, useCallback } from 'react';
+import {
+  BarChart3, Brain, Search, AlertTriangle,
+  Download, FileText, FileSpreadsheet,
+} from 'lucide-react';
+import { useEnterprise } from '../../../shared/enterprise/use-enterprise';
+import { cn } from '../../../shared/lib/cn';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export type AnalyticsTab = 'knowledge' | 'ai-usage' | 'search' | 'content-gaps';
+
+export interface DateRange {
+  startDate: string; // YYYY-MM-DD
+  endDate: string;   // YYYY-MM-DD
+}
+
+export interface DashboardProps {
+  dateRange: DateRange;
+  onExportPdf: (rows: Record<string, unknown>[], title: string) => Promise<void>;
+  onExportExcel: (rows: Record<string, unknown>[], title: string) => Promise<void>;
+}
+
+// ── Lazy-loaded dashboards ─────────────────────────────────────────────────────
+
+const KnowledgeHealthDashboard = lazy(() =>
+  import('./KnowledgeHealthDashboard').then((m) => ({ default: m.KnowledgeHealthDashboard })),
+);
+const AiUsageDashboard = lazy(() =>
+  import('./AiUsageDashboard').then((m) => ({ default: m.AiUsageDashboard })),
+);
+const SearchEffectivenessDashboard = lazy(() =>
+  import('./SearchEffectivenessDashboard').then((m) => ({ default: m.SearchEffectivenessDashboard })),
+);
+const ContentGapsDashboard = lazy(() =>
+  import('./ContentGapsDashboard').then((m) => ({ default: m.ContentGapsDashboard })),
+);
+
+// ── Tab config ─────────────────────────────────────────────────────────────────
+
+interface TabDef {
+  id: AnalyticsTab;
+  label: string;
+  icon: typeof BarChart3;
+  requiresFeature?: string;
+}
+
+const TABS: TabDef[] = [
+  { id: 'knowledge', label: 'Knowledge Health', icon: BarChart3 },
+  { id: 'ai-usage', label: 'AI Usage', icon: Brain, requiresFeature: 'ai_usage_analytics' },
+  { id: 'search', label: 'Search', icon: Search },
+  { id: 'content-gaps', label: 'Content Gaps', icon: AlertTriangle },
+];
+
+// ── Loading fallback ───────────────────────────────────────────────────────────
+
+function DashboardSkeleton() {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="glass-card h-64 animate-pulse" />
+      ))}
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────────────
+
+export function AnalyticsPage() {
+  const { hasFeature } = useEnterprise();
+  const analyticsEnabled = hasFeature('advanced_analytics');
+
+  const [activeTab, setActiveTab] = useState<AnalyticsTab>('knowledge');
+  const [dateRange, setDateRange] = useState<DateRange>(() => ({
+    startDate: new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10),
+    endDate: new Date().toISOString().slice(0, 10),
+  }));
+  const [exportOpen, setExportOpen] = useState(false);
+
+  const handleExportPdf = useCallback(
+    async (rows: Record<string, unknown>[], title: string) => {
+      const { exportToPdf } = await import('../../../shared/lib/export-helpers');
+      await exportToPdf(
+        `${title.toLowerCase().replace(/\s+/g, '-')}-${dateRange.startDate}.pdf`,
+        rows,
+        title,
+      );
+    },
+    [dateRange.startDate],
+  );
+
+  const handleExportExcel = useCallback(
+    async (rows: Record<string, unknown>[], title: string) => {
+      const { exportToExcel } = await import('../../../shared/lib/export-helpers');
+      await exportToExcel(
+        `${title.toLowerCase().replace(/\s+/g, '-')}-${dateRange.startDate}.xlsx`,
+        rows,
+        title,
+      );
+    },
+    [dateRange.startDate],
+  );
+
+  // Feature gate: require advanced_analytics
+  if (!analyticsEnabled) {
+    return (
+      <div className="space-y-6" data-testid="analytics-gate">
+        <h1 className="text-2xl font-semibold">Enterprise Analytics</h1>
+        <div className="glass-card p-8 text-center">
+          <BarChart3 className="mx-auto mb-3 h-12 w-12 text-muted-foreground/50" />
+          <h2 className="text-lg font-medium mb-2">Advanced Analytics</h2>
+          <p className="text-sm text-muted-foreground">
+            Analytics dashboards require an Enterprise license with the Advanced Analytics feature.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  const dashboardProps: DashboardProps = {
+    dateRange,
+    onExportPdf: handleExportPdf,
+    onExportExcel: handleExportExcel,
+  };
+
+  return (
+    <div className="space-y-6" data-testid="analytics-page">
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Enterprise Analytics</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Knowledge base health, AI usage, search effectiveness, and content gaps.
+          </p>
+        </div>
+
+        {/* Controls */}
+        <div className="flex items-center gap-3">
+          {/* Date range */}
+          <div className="flex items-center gap-2">
+            <input
+              type="date"
+              value={dateRange.startDate}
+              max={dateRange.endDate}
+              onChange={(e) => setDateRange((prev) => ({ ...prev, startDate: e.target.value }))}
+              className="glass-card px-2 py-1.5 text-xs"
+              data-testid="date-start"
+            />
+            <span className="text-xs text-muted-foreground">to</span>
+            <input
+              type="date"
+              value={dateRange.endDate}
+              min={dateRange.startDate}
+              max={today}
+              onChange={(e) => setDateRange((prev) => ({ ...prev, endDate: e.target.value }))}
+              className="glass-card px-2 py-1.5 text-xs"
+              data-testid="date-end"
+            />
+          </div>
+
+          {/* Export dropdown */}
+          <div className="relative">
+            <button
+              onClick={() => setExportOpen(!exportOpen)}
+              className="glass-card flex items-center gap-1.5 px-3 py-1.5 text-xs hover:bg-foreground/5 transition-colors"
+              data-testid="export-btn"
+            >
+              <Download className="h-3.5 w-3.5" />
+              Export
+            </button>
+            {exportOpen && (
+              <div className="absolute right-0 top-full mt-1 z-10 glass-card p-1 min-w-[140px]">
+                <button
+                  onClick={() => { setExportOpen(false); }}
+                  className="flex w-full items-center gap-2 rounded px-3 py-1.5 text-xs hover:bg-foreground/5 transition-colors"
+                  data-testid="export-pdf"
+                >
+                  <FileText className="h-3.5 w-3.5" />
+                  Export as PDF
+                </button>
+                <button
+                  onClick={() => { setExportOpen(false); }}
+                  className="flex w-full items-center gap-2 rounded px-3 py-1.5 text-xs hover:bg-foreground/5 transition-colors"
+                  data-testid="export-excel"
+                >
+                  <FileSpreadsheet className="h-3.5 w-3.5" />
+                  Export as Excel
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Tab bar */}
+      <div className="glass-card p-1.5 flex gap-1" data-testid="analytics-tabs">
+        {TABS.map((tab) => {
+          const Icon = tab.icon;
+          const isDisabled = tab.requiresFeature ? !hasFeature(tab.requiresFeature) : false;
+          return (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={cn(
+                'flex items-center gap-2 rounded px-3 py-2 text-sm transition-colors',
+                activeTab === tab.id
+                  ? 'bg-foreground/10 font-medium'
+                  : 'hover:bg-foreground/5',
+                isDisabled && activeTab !== tab.id && 'opacity-50',
+              )}
+              data-testid={`tab-${tab.id}`}
+            >
+              <Icon className="h-4 w-4" />
+              <span className="hidden sm:inline">{tab.label}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Tab content */}
+      <Suspense fallback={<DashboardSkeleton />}>
+        {activeTab === 'knowledge' && <KnowledgeHealthDashboard {...dashboardProps} />}
+        {activeTab === 'ai-usage' && <AiUsageDashboard {...dashboardProps} />}
+        {activeTab === 'search' && <SearchEffectivenessDashboard {...dashboardProps} />}
+        {activeTab === 'content-gaps' && <ContentGapsDashboard {...dashboardProps} />}
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/src/features/admin/analytics/ContentGapsDashboard.tsx
+++ b/frontend/src/features/admin/analytics/ContentGapsDashboard.tsx
@@ -1,0 +1,264 @@
+import { Suspense } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Download } from 'lucide-react';
+import { apiFetch } from '../../../shared/lib/api';
+import type { DashboardProps } from './AnalyticsPage';
+import {
+  PieChart, Pie, Cell,
+  Tooltip, ResponsiveContainer, Legend,
+} from '../../../shared/components/charts/ChartsBundle';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface ContentGapsData {
+  gaps: Array<{
+    query: string;
+    occurrences: number;
+    lastSearched: string;
+    avgMaxScore: number | null;
+    avgResultCount: number;
+  }>;
+  duplicateCoverage: Array<{
+    spaceKey: string | null;
+    title: string;
+    pageCount: number;
+  }>;
+  requestBacklog: Array<{
+    status: string;
+    count: number;
+  }>;
+}
+
+// ── Colors ─────────────────────────────────────────────────────────────────────
+
+const BACKLOG_COLORS: Record<string, string> = {
+  open: '#3b82f6',
+  in_progress: '#f59e0b',
+  completed: '#10b981',
+  rejected: '#6b7280',
+};
+
+// ── Hook ───────────────────────────────────────────────────────────────────────
+
+function useContentGaps(dateRange: DashboardProps['dateRange']) {
+  return useQuery<ContentGapsData>({
+    queryKey: ['admin', 'analytics', 'content-gaps', dateRange],
+    queryFn: () =>
+      apiFetch(
+        `/admin/analytics/content-gaps?startDate=${dateRange.startDate}&endDate=${dateRange.endDate}`,
+      ),
+    staleTime: 60_000,
+  });
+}
+
+// ── Chart skeleton ─────────────────────────────────────────────────────────────
+
+function ChartSkeleton() {
+  return <div className="h-48 animate-pulse rounded-lg bg-foreground/5" />;
+}
+
+// ── Stat card ──────────────────────────────────────────────────────────────────
+
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="glass-card p-4 text-center" data-testid={`stat-${label.toLowerCase().replace(/\s+/g, '-')}`}>
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      <p className="text-2xl font-semibold">{value}</p>
+    </div>
+  );
+}
+
+// ── Severity indicator ─────────────────────────────────────────────────────────
+
+function SeverityDot({ score }: { score: number | null }) {
+  const color =
+    score == null ? 'bg-gray-400' :
+    score < 0.2 ? 'bg-red-500' :
+    score < 0.5 ? 'bg-amber-500' : 'bg-green-500';
+  return <span className={`inline-block h-2 w-2 rounded-full ${color}`} />;
+}
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+export function ContentGapsDashboard({ dateRange, onExportPdf, onExportExcel }: DashboardProps) {
+  const { data, isLoading } = useContentGaps(dateRange);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4" data-testid="content-gaps-loading">
+        <div className="grid grid-cols-3 gap-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="glass-card h-20 animate-pulse" />
+          ))}
+        </div>
+        <div className="glass-card p-4"><ChartSkeleton /></div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="glass-card p-8 text-center text-sm text-muted-foreground" data-testid="content-gaps-empty">
+        No content gaps data available for the selected date range.
+      </div>
+    );
+  }
+
+  const totalGaps = data.gaps.length;
+  const totalDuplicates = data.duplicateCoverage.length;
+  const openRequests = data.requestBacklog
+    .filter((r) => r.status === 'open')
+    .reduce((sum, r) => sum + r.count, 0);
+
+  const flatRows: Record<string, unknown>[] = [
+    ...data.gaps.map((d) => ({
+      type: 'gap',
+      query: d.query,
+      occurrences: d.occurrences,
+      lastSearched: d.lastSearched,
+      avgMaxScore: d.avgMaxScore ?? 'N/A',
+      avgResultCount: d.avgResultCount,
+    })),
+    ...data.duplicateCoverage.map((d) => ({
+      type: 'duplicate',
+      spaceKey: d.spaceKey ?? 'unassigned',
+      title: d.title,
+      pageCount: d.pageCount,
+    })),
+    ...data.requestBacklog.map((d) => ({ type: 'backlog', status: d.status, count: d.count })),
+  ];
+
+  return (
+    <div className="space-y-4" data-testid="content-gaps-dashboard">
+      {/* Export row */}
+      <div className="flex justify-end gap-2">
+        <button
+          onClick={() => onExportPdf(flatRows, 'Content Gaps')}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          data-testid="gaps-export-pdf"
+        >
+          <Download className="h-3.5 w-3.5" /> PDF
+        </button>
+        <button
+          onClick={() => onExportExcel(flatRows, 'Content Gaps')}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          data-testid="gaps-export-excel"
+        >
+          <Download className="h-3.5 w-3.5" /> Excel
+        </button>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-3 gap-4">
+        <StatCard label="Content Gaps" value={totalGaps} />
+        <StatCard label="Duplicate Topics" value={totalDuplicates} />
+        <StatCard label="Open Requests" value={openRequests} />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Request Backlog Pie */}
+        <div className="glass-card p-4" data-testid="backlog-chart">
+          <h3 className="text-sm font-medium mb-3">Request Backlog</h3>
+          <Suspense fallback={<ChartSkeleton />}>
+            {data.requestBacklog.length > 0 ? (
+              <ResponsiveContainer width="100%" height={250}>
+                <PieChart>
+                  <Pie
+                    data={data.requestBacklog}
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={80}
+                    dataKey="count"
+                    nameKey="status"
+                    label={({ name, percent }: { name?: string; percent?: number }) =>
+                      `${String(name ?? '').replace(/_/g, ' ')} ${((percent ?? 0) * 100).toFixed(0)}%`
+                    }
+                    labelLine={false}
+                  >
+                    {data.requestBacklog.map((entry) => (
+                      <Cell key={entry.status} fill={BACKLOG_COLORS[entry.status] ?? '#6b7280'} />
+                    ))}
+                  </Pie>
+                  <Tooltip />
+                  <Legend />
+                </PieChart>
+              </ResponsiveContainer>
+            ) : (
+              <div className="flex items-center justify-center h-[250px] text-sm text-muted-foreground">
+                No request backlog data
+              </div>
+            )}
+          </Suspense>
+        </div>
+
+        {/* Content Gaps Table */}
+        <div className="glass-card overflow-hidden" data-testid="gaps-table">
+          <div className="p-4 border-b border-foreground/5">
+            <h3 className="text-sm font-medium">Content Gaps</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">Queries with low or no results, sorted by frequency</p>
+          </div>
+          {data.gaps.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-foreground/5">
+                    <th className="text-left px-4 py-2 text-xs text-muted-foreground font-medium" />
+                    <th className="text-left px-4 py-2 text-xs text-muted-foreground font-medium">Query</th>
+                    <th className="text-right px-4 py-2 text-xs text-muted-foreground font-medium">Occurrences</th>
+                    <th className="text-right px-4 py-2 text-xs text-muted-foreground font-medium">Avg Results</th>
+                    <th className="text-right px-4 py-2 text-xs text-muted-foreground font-medium">Last Searched</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.gaps.map((row) => (
+                    <tr key={row.query} className="border-b border-foreground/5 last:border-0">
+                      <td className="px-4 py-2"><SeverityDot score={row.avgMaxScore} /></td>
+                      <td className="px-4 py-2 font-mono text-xs truncate max-w-[200px]">{row.query}</td>
+                      <td className="px-4 py-2 text-right">{row.occurrences}</td>
+                      <td className="px-4 py-2 text-right">{row.avgResultCount.toFixed(1)}</td>
+                      <td className="px-4 py-2 text-right text-xs text-muted-foreground">
+                        {new Date(row.lastSearched).toLocaleDateString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="p-8 text-center text-sm text-muted-foreground">No content gaps detected</div>
+          )}
+        </div>
+      </div>
+
+      {/* Duplicate Coverage Table */}
+      {data.duplicateCoverage.length > 0 && (
+        <div className="glass-card overflow-hidden" data-testid="duplicates-table">
+          <div className="p-4 border-b border-foreground/5">
+            <h3 className="text-sm font-medium">Duplicate Coverage</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">Topics covered by multiple pages</p>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-foreground/5">
+                  <th className="text-left px-4 py-2 text-xs text-muted-foreground font-medium">Space</th>
+                  <th className="text-left px-4 py-2 text-xs text-muted-foreground font-medium">Title</th>
+                  <th className="text-right px-4 py-2 text-xs text-muted-foreground font-medium">Pages</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.duplicateCoverage.map((row, i) => (
+                  <tr key={`${row.spaceKey}-${row.title}-${i}`} className="border-b border-foreground/5 last:border-0">
+                    <td className="px-4 py-2 font-mono text-xs">{row.spaceKey ?? 'Unassigned'}</td>
+                    <td className="px-4 py-2">{row.title}</td>
+                    <td className="px-4 py-2 text-right">{row.pageCount}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/admin/analytics/KnowledgeHealthDashboard.test.tsx
+++ b/frontend/src/features/admin/analytics/KnowledgeHealthDashboard.test.tsx
@@ -6,20 +6,15 @@ import type { DashboardProps } from './AnalyticsPage';
 
 // ── Mock ChartsBundle ──────────────────────────────────────────────────────────
 
-vi.mock('../../../shared/components/charts/ChartsBundle', () => ({
-  BarChart: ({ children, ...props }: any) => <div data-testid="bar-chart" {...props}>{children}</div>,
-  Bar: (props: any) => <div data-testid="bar" {...props} />,
-  PieChart: ({ children, ...props }: any) => <div data-testid="pie-chart" {...props}>{children}</div>,
-  Pie: ({ children, ...props }: any) => <div data-testid="pie" {...props}>{children}</div>,
-  Cell: (props: any) => <div data-testid="cell" {...props} />,
-  Treemap: (props: any) => <div data-testid="treemap" {...props} />,
-  XAxis: (props: any) => <div {...props} />,
-  YAxis: (props: any) => <div {...props} />,
-  Tooltip: () => <div />,
-  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
-  CartesianGrid: () => <div />,
-  Legend: () => <div />,
-}));
+vi.mock('../../../shared/components/charts/ChartsBundle', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- chart mocks only need to render containers
+  const P = (_: any) => _.children ?? null;
+  return {
+    BarChart: P, Bar: P, PieChart: P, Pie: P, Cell: P, Treemap: P,
+    XAxis: P, YAxis: P, Tooltip: P, ResponsiveContainer: P,
+    CartesianGrid: P, Legend: P,
+  };
+});
 
 // ── Mock apiFetch ──────────────────────────────────────────────────────────────
 

--- a/frontend/src/features/admin/analytics/KnowledgeHealthDashboard.test.tsx
+++ b/frontend/src/features/admin/analytics/KnowledgeHealthDashboard.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { KnowledgeHealthDashboard } from './KnowledgeHealthDashboard';
+import type { DashboardProps } from './AnalyticsPage';
+
+// ── Mock ChartsBundle ──────────────────────────────────────────────────────────
+
+vi.mock('../../../shared/components/charts/ChartsBundle', () => ({
+  BarChart: ({ children, ...props }: any) => <div data-testid="bar-chart" {...props}>{children}</div>,
+  Bar: (props: any) => <div data-testid="bar" {...props} />,
+  PieChart: ({ children, ...props }: any) => <div data-testid="pie-chart" {...props}>{children}</div>,
+  Pie: ({ children, ...props }: any) => <div data-testid="pie" {...props}>{children}</div>,
+  Cell: (props: any) => <div data-testid="cell" {...props} />,
+  Treemap: (props: any) => <div data-testid="treemap" {...props} />,
+  XAxis: (props: any) => <div {...props} />,
+  YAxis: (props: any) => <div {...props} />,
+  Tooltip: () => <div />,
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  CartesianGrid: () => <div />,
+  Legend: () => <div />,
+}));
+
+// ── Mock apiFetch ──────────────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.mock('../../../shared/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockFetch(...args),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+const defaultDateRange: DashboardProps['dateRange'] = {
+  startDate: '2025-01-01',
+  endDate: '2025-01-31',
+};
+
+const mockData = {
+  qualityDistribution: [
+    { bucket: 'excellent', count: 10 },
+    { bucket: 'good', count: 20 },
+    { bucket: 'fair', count: 15 },
+    { bucket: 'poor', count: 5 },
+  ],
+  staleContent: [
+    { bucket: '< 30 days', count: 50 },
+    { bucket: '30-90 days', count: 30 },
+    { bucket: '> 90 days', count: 20 },
+  ],
+  coverageBySpace: [
+    { spaceKey: 'ENG', pageCount: 100, avgQuality: 0.8 },
+    { spaceKey: 'OPS', pageCount: 50, avgQuality: 0.6 },
+  ],
+  verificationStatus: [
+    { status: 'verified_current', count: 40 },
+    { status: 'verified_stale', count: 15 },
+    { status: 'unverified', count: 45 },
+  ],
+};
+
+function renderDashboard(props?: Partial<DashboardProps>) {
+  const queryClient = createQueryClient();
+  const defaultProps: DashboardProps = {
+    dateRange: defaultDateRange,
+    onExportPdf: vi.fn(),
+    onExportExcel: vi.fn(),
+    ...props,
+  };
+  return {
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <KnowledgeHealthDashboard {...defaultProps} />
+      </QueryClientProvider>,
+    ),
+    props: defaultProps,
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('KnowledgeHealthDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading skeleton during fetch', () => {
+    mockFetch.mockReturnValue(new Promise(() => {})); // never resolves
+    renderDashboard();
+    expect(screen.getByTestId('knowledge-loading')).toBeInTheDocument();
+  });
+
+  it('renders chart containers when data is loaded', async () => {
+    mockFetch.mockResolvedValue(mockData);
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByTestId('quality-chart')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('stale-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('coverage-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('verification-chart')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no data is returned', async () => {
+    mockFetch.mockResolvedValue(null);
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByTestId('knowledge-empty')).toBeInTheDocument();
+    });
+  });
+
+  it('calls export handlers when export buttons are clicked', async () => {
+    mockFetch.mockResolvedValue(mockData);
+    const onExportPdf = vi.fn();
+    const onExportExcel = vi.fn();
+    renderDashboard({ onExportPdf, onExportExcel });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('knowledge-export-pdf')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('knowledge-export-pdf'));
+    expect(onExportPdf).toHaveBeenCalledTimes(1);
+    expect(onExportPdf).toHaveBeenCalledWith(expect.any(Array), 'Knowledge Health');
+
+    fireEvent.click(screen.getByTestId('knowledge-export-excel'));
+    expect(onExportExcel).toHaveBeenCalledTimes(1);
+    expect(onExportExcel).toHaveBeenCalledWith(expect.any(Array), 'Knowledge Health');
+  });
+
+  it('renders quality distribution chart heading', async () => {
+    mockFetch.mockResolvedValue(mockData);
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByText('Quality Score Distribution')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/features/admin/analytics/KnowledgeHealthDashboard.tsx
+++ b/frontend/src/features/admin/analytics/KnowledgeHealthDashboard.tsx
@@ -1,0 +1,218 @@
+import { Suspense } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Download } from 'lucide-react';
+import { apiFetch } from '../../../shared/lib/api';
+import type { DashboardProps } from './AnalyticsPage';
+import {
+  BarChart, Bar, PieChart, Pie, Cell, Treemap,
+  XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Legend,
+} from '../../../shared/components/charts/ChartsBundle';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface KnowledgeHealthData {
+  qualityDistribution: Array<{ bucket: string; count: number }>;
+  staleContent: Array<{ bucket: string; count: number }>;
+  coverageBySpace: Array<{ spaceKey: string | null; pageCount: number; avgQuality: number | null }>;
+  verificationStatus: Array<{ status: string; count: number }>;
+}
+
+// ── Colors ─────────────────────────────────────────────────────────────────────
+
+const QUALITY_COLORS: Record<string, string> = {
+  excellent: '#10b981',
+  good: '#3b82f6',
+  fair: '#f59e0b',
+  poor: '#ef4444',
+  unscored: '#6b7280',
+};
+
+const VERIFICATION_COLORS: Record<string, string> = {
+  verified_current: '#10b981',
+  verified_stale: '#f59e0b',
+  unverified: '#6b7280',
+};
+
+const TREEMAP_COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4', '#6b7280'];
+
+// ── Hook ───────────────────────────────────────────────────────────────────────
+
+function useKnowledgeHealth(dateRange: DashboardProps['dateRange']) {
+  return useQuery<KnowledgeHealthData>({
+    queryKey: ['admin', 'analytics', 'knowledge-health', dateRange],
+    queryFn: () =>
+      apiFetch(
+        `/admin/analytics/knowledge-health?startDate=${dateRange.startDate}&endDate=${dateRange.endDate}`,
+      ),
+    staleTime: 60_000,
+  });
+}
+
+// ── Chart skeleton ─────────────────────────────────────────────────────────────
+
+function ChartSkeleton() {
+  return <div className="h-64 animate-pulse rounded-lg bg-foreground/5" />;
+}
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+export function KnowledgeHealthDashboard({ dateRange, onExportPdf, onExportExcel }: DashboardProps) {
+  const { data, isLoading } = useKnowledgeHealth(dateRange);
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4" data-testid="knowledge-loading">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="glass-card p-4">
+            <ChartSkeleton />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="glass-card p-8 text-center text-sm text-muted-foreground" data-testid="knowledge-empty">
+        No knowledge health data available for the selected date range.
+      </div>
+    );
+  }
+
+  const flatRows: Record<string, unknown>[] = [
+    ...data.qualityDistribution.map((d) => ({ type: 'quality', bucket: d.bucket, count: d.count })),
+    ...data.staleContent.map((d) => ({ type: 'stale', bucket: d.bucket, count: d.count })),
+    ...data.coverageBySpace.map((d) => ({
+      type: 'coverage',
+      spaceKey: d.spaceKey ?? 'unassigned',
+      pageCount: d.pageCount,
+      avgQuality: d.avgQuality ?? 'N/A',
+    })),
+    ...data.verificationStatus.map((d) => ({ type: 'verification', status: d.status, count: d.count })),
+  ];
+
+  return (
+    <div className="space-y-4" data-testid="knowledge-dashboard">
+      {/* Export row */}
+      <div className="flex justify-end gap-2">
+        <button
+          onClick={() => onExportPdf(flatRows, 'Knowledge Health')}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          data-testid="knowledge-export-pdf"
+        >
+          <Download className="h-3.5 w-3.5" /> PDF
+        </button>
+        <button
+          onClick={() => onExportExcel(flatRows, 'Knowledge Health')}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          data-testid="knowledge-export-excel"
+        >
+          <Download className="h-3.5 w-3.5" /> Excel
+        </button>
+      </div>
+
+      {/* Charts grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Quality Score Distribution */}
+        <div className="glass-card p-4" data-testid="quality-chart">
+          <h3 className="text-sm font-medium mb-3">Quality Score Distribution</h3>
+          <Suspense fallback={<ChartSkeleton />}>
+            <ResponsiveContainer width="100%" height={250}>
+              <BarChart data={data.qualityDistribution}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-foreground)" strokeOpacity={0.1} />
+                <XAxis dataKey="bucket" tick={{ fontSize: 12 }} />
+                <YAxis tick={{ fontSize: 12 }} />
+                <Tooltip />
+                <Bar dataKey="count" radius={[4, 4, 0, 0]}>
+                  {data.qualityDistribution.map((entry) => (
+                    <Cell key={entry.bucket} fill={QUALITY_COLORS[entry.bucket] ?? '#6b7280'} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </Suspense>
+        </div>
+
+        {/* Stale Content Breakdown */}
+        <div className="glass-card p-4" data-testid="stale-chart">
+          <h3 className="text-sm font-medium mb-3">Stale Content Breakdown</h3>
+          <Suspense fallback={<ChartSkeleton />}>
+            <ResponsiveContainer width="100%" height={250}>
+              <BarChart data={data.staleContent} layout="vertical">
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-foreground)" strokeOpacity={0.1} />
+                <XAxis type="number" tick={{ fontSize: 12 }} />
+                <YAxis dataKey="bucket" type="category" tick={{ fontSize: 12 }} width={100} />
+                <Tooltip />
+                <Bar dataKey="count" fill="#f59e0b" radius={[0, 4, 4, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </Suspense>
+        </div>
+
+        {/* Coverage by Space (Treemap) */}
+        <div className="glass-card p-4" data-testid="coverage-chart">
+          <h3 className="text-sm font-medium mb-3">Coverage by Space</h3>
+          <Suspense fallback={<ChartSkeleton />}>
+            {data.coverageBySpace.length > 0 ? (
+              <ResponsiveContainer width="100%" height={250}>
+                <Treemap
+                  data={data.coverageBySpace.map((d, i) => ({
+                    name: d.spaceKey ?? 'Unassigned',
+                    size: d.pageCount,
+                    fill: TREEMAP_COLORS[i % TREEMAP_COLORS.length],
+                  }))}
+                  dataKey="size"
+                  stroke="var(--color-background)"
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  content={({ x, y, width, height, name, fill }: any) => (
+                    <g>
+                      <rect x={x} y={y} width={width} height={height} fill={fill} rx={4} opacity={0.85} />
+                      {width > 40 && height > 20 && (
+                        <text x={x + width / 2} y={y + height / 2} textAnchor="middle" dominantBaseline="central" fontSize={11} fill="#fff">
+                          {name}
+                        </text>
+                      )}
+                    </g>
+                  )}
+                />
+              </ResponsiveContainer>
+            ) : (
+              <div className="flex items-center justify-center h-[250px] text-sm text-muted-foreground">
+                No space coverage data
+              </div>
+            )}
+          </Suspense>
+        </div>
+
+        {/* Verification Status */}
+        <div className="glass-card p-4" data-testid="verification-chart">
+          <h3 className="text-sm font-medium mb-3">Verification Status</h3>
+          <Suspense fallback={<ChartSkeleton />}>
+            <ResponsiveContainer width="100%" height={250}>
+              <PieChart>
+                <Pie
+                  data={data.verificationStatus}
+                  cx="50%"
+                  cy="50%"
+                  outerRadius={80}
+                  dataKey="count"
+                  nameKey="status"
+                  label={({ name, percent }: { name?: string; percent?: number }) =>
+                    `${String(name ?? '').replace(/_/g, ' ')} ${((percent ?? 0) * 100).toFixed(0)}%`
+                  }
+                  labelLine={false}
+                >
+                  {data.verificationStatus.map((entry) => (
+                    <Cell key={entry.status} fill={VERIFICATION_COLORS[entry.status] ?? '#6b7280'} />
+                  ))}
+                </Pie>
+                <Tooltip />
+                <Legend />
+              </PieChart>
+            </ResponsiveContainer>
+          </Suspense>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/admin/analytics/SearchEffectivenessDashboard.tsx
+++ b/frontend/src/features/admin/analytics/SearchEffectivenessDashboard.tsx
@@ -1,0 +1,223 @@
+import { Suspense } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Download } from 'lucide-react';
+import { apiFetch } from '../../../shared/lib/api';
+import type { DashboardProps } from './AnalyticsPage';
+import {
+  AreaChart, Area, BarChart, Bar, PieChart, Pie, Cell,
+  XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Legend,
+} from '../../../shared/components/charts/ChartsBundle';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface SearchEffectivenessData {
+  zeroResultRate: { total: number; zeroResults: number; rate: number } | null;
+  topQueries: Array<{ query: string; searchCount: number; avgResults: number; avgScore: number | null }>;
+  clickThroughRate: Array<{ searchType: string; withResults: number; total: number; rate: number }>;
+  dailyVolume: Array<{ date: string; totalSearches: number; zeroResultSearches: number }>;
+}
+
+// ── Hook ───────────────────────────────────────────────────────────────────────
+
+function useSearchEffectiveness(dateRange: DashboardProps['dateRange']) {
+  return useQuery<SearchEffectivenessData>({
+    queryKey: ['admin', 'analytics', 'search', dateRange],
+    queryFn: () =>
+      apiFetch(
+        `/admin/analytics/search?startDate=${dateRange.startDate}&endDate=${dateRange.endDate}`,
+      ),
+    staleTime: 60_000,
+  });
+}
+
+// ── Chart skeleton ─────────────────────────────────────────────────────────────
+
+function ChartSkeleton() {
+  return <div className="h-48 animate-pulse rounded-lg bg-foreground/5" />;
+}
+
+// ── Gauge chart (custom half-donut) ────────────────────────────────────────────
+
+function GaugeChart({ value, max, label }: { value: number; max: number; label: string }) {
+  const percentage = max > 0 ? (value / max) * 100 : 0;
+  const gaugeData = [
+    { name: 'value', value: percentage },
+    { name: 'remainder', value: 100 - percentage },
+  ];
+  const color = percentage > 30 ? '#ef4444' : percentage > 15 ? '#f59e0b' : '#10b981';
+
+  return (
+    <div className="relative" data-testid="gauge-chart">
+      <Suspense fallback={<ChartSkeleton />}>
+        <ResponsiveContainer width="100%" height={200}>
+          <PieChart>
+            <Pie
+              data={gaugeData}
+              cx="50%"
+              cy="100%"
+              startAngle={180}
+              endAngle={0}
+              innerRadius={60}
+              outerRadius={90}
+              dataKey="value"
+            >
+              <Cell fill={color} />
+              <Cell fill="var(--color-foreground)" fillOpacity={0.05} />
+            </Pie>
+          </PieChart>
+        </ResponsiveContainer>
+      </Suspense>
+      {/* Center label */}
+      <div className="absolute inset-0 flex flex-col items-center justify-end pb-4">
+        <span className="text-2xl font-semibold" style={{ color }}>{percentage.toFixed(1)}%</span>
+        <span className="text-xs text-muted-foreground">{label}</span>
+      </div>
+    </div>
+  );
+}
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+export function SearchEffectivenessDashboard({ dateRange, onExportPdf, onExportExcel }: DashboardProps) {
+  const { data, isLoading } = useSearchEffectiveness(dateRange);
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4" data-testid="search-loading">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="glass-card p-4"><ChartSkeleton /></div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="glass-card p-8 text-center text-sm text-muted-foreground" data-testid="search-empty">
+        No search data available for the selected date range.
+      </div>
+    );
+  }
+
+  const flatRows: Record<string, unknown>[] = [
+    ...(data.zeroResultRate
+      ? [{ type: 'zeroResultRate', total: data.zeroResultRate.total, zeroResults: data.zeroResultRate.zeroResults, rate: data.zeroResultRate.rate }]
+      : []),
+    ...data.topQueries.map((d) => ({ type: 'topQuery', ...d })),
+    ...data.clickThroughRate.map((d) => ({ type: 'clickThrough', ...d })),
+    ...data.dailyVolume.map((d) => ({ type: 'dailyVolume', ...d })),
+  ];
+
+  return (
+    <div className="space-y-4" data-testid="search-dashboard">
+      {/* Export row */}
+      <div className="flex justify-end gap-2">
+        <button
+          onClick={() => onExportPdf(flatRows, 'Search Effectiveness')}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          data-testid="search-export-pdf"
+        >
+          <Download className="h-3.5 w-3.5" /> PDF
+        </button>
+        <button
+          onClick={() => onExportExcel(flatRows, 'Search Effectiveness')}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          data-testid="search-export-excel"
+        >
+          <Download className="h-3.5 w-3.5" /> Excel
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Zero-Result Rate Gauge */}
+        <div className="glass-card p-4" data-testid="zero-result-gauge">
+          <h3 className="text-sm font-medium mb-3">Zero-Result Rate</h3>
+          {data.zeroResultRate ? (
+            <GaugeChart
+              value={data.zeroResultRate.zeroResults}
+              max={data.zeroResultRate.total}
+              label="of searches return no results"
+            />
+          ) : (
+            <div className="flex items-center justify-center h-[200px] text-sm text-muted-foreground">
+              No search data
+            </div>
+          )}
+        </div>
+
+        {/* Daily Search Volume */}
+        <div className="glass-card p-4" data-testid="daily-volume-chart">
+          <h3 className="text-sm font-medium mb-3">Daily Search Volume</h3>
+          <Suspense fallback={<ChartSkeleton />}>
+            <ResponsiveContainer width="100%" height={250}>
+              <AreaChart data={data.dailyVolume}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-foreground)" strokeOpacity={0.1} />
+                <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+                <YAxis tick={{ fontSize: 12 }} />
+                <Tooltip />
+                <Legend />
+                <Area type="monotone" dataKey="totalSearches" name="Total Searches" stroke="#3b82f6" fill="#3b82f6" fillOpacity={0.15} />
+                <Area type="monotone" dataKey="zeroResultSearches" name="Zero Results" stroke="#ef4444" fill="#ef4444" fillOpacity={0.15} />
+              </AreaChart>
+            </ResponsiveContainer>
+          </Suspense>
+        </div>
+
+        {/* Click-Through Rates */}
+        <div className="glass-card p-4" data-testid="ctr-chart">
+          <h3 className="text-sm font-medium mb-3">Click-Through Rates by Type</h3>
+          <Suspense fallback={<ChartSkeleton />}>
+            {data.clickThroughRate.length > 0 ? (
+              <ResponsiveContainer width="100%" height={250}>
+                <BarChart data={data.clickThroughRate}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--color-foreground)" strokeOpacity={0.1} />
+                  <XAxis dataKey="searchType" tick={{ fontSize: 12 }} />
+                  <YAxis tick={{ fontSize: 12 }} tickFormatter={(v: number) => `${v}%`} />
+                  <Tooltip formatter={(value) => `${Number(value).toFixed(1)}%`} />
+                  <Bar dataKey="rate" fill="#10b981" radius={[4, 4, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            ) : (
+              <div className="flex items-center justify-center h-[250px] text-sm text-muted-foreground">
+                No click-through data
+              </div>
+            )}
+          </Suspense>
+        </div>
+
+        {/* Top Queries Table */}
+        <div className="glass-card overflow-hidden" data-testid="top-queries-table">
+          <div className="p-4 border-b border-foreground/5">
+            <h3 className="text-sm font-medium">Top Queries</h3>
+          </div>
+          {data.topQueries.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-foreground/5">
+                    <th className="text-left px-4 py-2 text-xs text-muted-foreground font-medium">Query</th>
+                    <th className="text-right px-4 py-2 text-xs text-muted-foreground font-medium">Searches</th>
+                    <th className="text-right px-4 py-2 text-xs text-muted-foreground font-medium">Avg Results</th>
+                    <th className="text-right px-4 py-2 text-xs text-muted-foreground font-medium">Avg Score</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.topQueries.map((row) => (
+                    <tr key={row.query} className="border-b border-foreground/5 last:border-0">
+                      <td className="px-4 py-2 font-mono text-xs truncate max-w-[200px]">{row.query}</td>
+                      <td className="px-4 py-2 text-right">{row.searchCount}</td>
+                      <td className="px-4 py-2 text-right">{row.avgResults.toFixed(1)}</td>
+                      <td className="px-4 py-2 text-right">{row.avgScore != null ? row.avgScore.toFixed(2) : '-'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="p-8 text-center text-sm text-muted-foreground">No search queries recorded</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/shared/components/charts/ChartsBundle.tsx
+++ b/frontend/src/shared/components/charts/ChartsBundle.tsx
@@ -12,6 +12,7 @@ export {
   BarChart,
   PieChart,
   AreaChart,
+  Treemap,
   ResponsiveContainer,
   Line,
   Bar,


### PR DESCRIPTION
## Summary

- Add `/admin/analytics` route with 4-tab sub-navigation: Knowledge Health, AI Usage, Search Effectiveness, Content Gaps
- All charts use lazy-loaded `ChartsBundle` (recharts stays in its own chunk, not in main bundle)
- AI Usage dashboard dual-gated: outer `advanced_analytics` + inner `ai_usage_analytics`
- Add `Treemap` export to `ChartsBundle.tsx` (1-line prerequisite)
- Date range filtering (shared state), PDF/Excel export via existing `export-helpers.ts`
- 19 tests covering feature gating, data rendering, loading/empty states, tab switching, export handlers

Closes Compendiq/compendiq-ee#64

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] 19 analytics tests pass
- [x] Full suite: 1777 pass (3 pre-existing RbacPage failures)
- [x] Build succeeds, recharts chunk separate
- [ ] Manual: navigate to `/admin/analytics` with enterprise license

🤖 Generated with [Claude Code](https://claude.com/claude-code)