### PR TITLE
feat(admin): CustomRoleEditor modal for custom role management (#63)

### DIFF
--- a/frontend/src/features/admin/CustomRoleEditor.test.tsx
+++ b/frontend/src/features/admin/CustomRoleEditor.test.tsx
@@ -1,0 +1,376 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { LazyMotion, domAnimation } from 'framer-motion';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CustomRoleEditor } from './CustomRoleEditor';
+import type { CustomRole } from './CustomRoleEditor';
+import { useAuthStore } from '../../stores/auth-store';
+
+// ── Mock useEnterprise ─────────────────────────────────────────────────────────
+
+let mockHasFeature = (_f: string) => true;
+
+vi.mock('../../shared/enterprise/use-enterprise', () => ({
+  useEnterprise: () => ({
+    isEnterprise: true,
+    hasFeature: (f: string) => mockHasFeature(f),
+    ui: null,
+    license: null,
+    isLoading: false,
+  }),
+}));
+
+// ── Mock data ──────────────────────────────────────────────────────────────────
+
+const mockPermissions = [
+  { id: 'pages:read', displayName: 'Read Pages', description: 'View pages and their content', category: 'pages', createdAt: '2024-01-01T00:00:00Z' },
+  { id: 'pages:write', displayName: 'Write Pages', description: 'Edit pages', category: 'pages', createdAt: '2024-01-01T00:00:00Z' },
+  { id: 'llm:query', displayName: 'Query LLM', description: 'Send queries to AI', category: 'llm', createdAt: '2024-01-01T00:00:00Z' },
+  { id: 'admin:settings', displayName: 'Manage Settings', description: 'Admin settings', category: 'admin', createdAt: '2024-01-01T00:00:00Z' },
+];
+
+const mockRole: CustomRole = {
+  id: 10,
+  name: 'content_editor',
+  displayName: 'Content Editor',
+  description: 'Can edit pages',
+  isSystem: false,
+  permissions: ['pages:read', 'pages:write'],
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+const mockAssignments = [
+  { id: 1, spaceKey: 'DEV', principalType: 'user' as const, principalId: 'u1', principalName: 'alice', createdAt: '2024-01-01T00:00:00Z' },
+];
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LazyMotion features={domAnimation}>
+            {children}
+          </LazyMotion>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function mockFetch(overrides?: {
+  permissions?: typeof mockPermissions;
+  assignments?: typeof mockAssignments;
+}) {
+  const perms = overrides?.permissions ?? mockPermissions;
+  const assigns = overrides?.assignments ?? mockAssignments;
+
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const url = typeof input === 'string' ? input : (input as Request).url;
+    const method = init?.method ?? (typeof input !== 'string' ? (input as Request).method : 'GET');
+
+    // POST /admin/roles (create)
+    if (url.includes('/admin/roles') && method === 'POST') {
+      return new Response(JSON.stringify({ id: 99, name: 'new_role' }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // PUT /admin/roles/:id (update)
+    if (url.match(/\/admin\/roles\/\d+$/) && method === 'PUT') {
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // DELETE /admin/roles/:id (delete)
+    if (url.match(/\/admin\/roles\/\d+$/) && method === 'DELETE') {
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // GET /admin/roles/:id/assignments
+    if (url.match(/\/admin\/roles\/\d+\/assignments/)) {
+      return new Response(JSON.stringify(assigns), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // GET /admin/permissions
+    if (url.includes('/admin/permissions')) {
+      return new Response(JSON.stringify(perms), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Fallback for refresh token etc.
+    return new Response(JSON.stringify({}), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('CustomRoleEditor', () => {
+  beforeEach(() => {
+    mockHasFeature = () => true;
+    useAuthStore.getState().setAuth('test-token', {
+      id: '1',
+      username: 'admin',
+      role: 'admin',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useAuthStore.getState().clearAuth();
+  });
+
+  // 1. Create mode renders with empty form
+  it('renders create mode with empty form when editRole is null', async () => {
+    mockFetch();
+    render(
+      <CustomRoleEditor open={true} onOpenChange={() => {}} editRole={null} />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByText('Create Custom Role')).toBeInTheDocument();
+    expect(screen.getByTestId('role-name-input')).toHaveValue('');
+    expect(screen.getByTestId('display-name-input')).toHaveValue('');
+    expect(screen.getByTestId('description-input')).toHaveValue('');
+    expect(screen.getByTestId('submit-role-btn')).toHaveTextContent('Create');
+  });
+
+  // 2. Edit mode renders with pre-populated form
+  it('renders edit mode with pre-populated form when editRole is provided', async () => {
+    mockFetch();
+    render(
+      <CustomRoleEditor open={true} onOpenChange={() => {}} editRole={mockRole} />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByText('Edit Role: Content Editor')).toBeInTheDocument();
+    expect(screen.getByTestId('role-name-input')).toHaveValue('content_editor');
+    expect(screen.getByTestId('role-name-input')).toBeDisabled();
+    expect(screen.getByTestId('display-name-input')).toHaveValue('Content Editor');
+    expect(screen.getByTestId('description-input')).toHaveValue('Can edit pages');
+    expect(screen.getByTestId('submit-role-btn')).toHaveTextContent('Save');
+  });
+
+  // 3. Groups permissions by category
+  it('groups permissions by category with correct headers', async () => {
+    mockFetch();
+    render(
+      <CustomRoleEditor open={true} onOpenChange={() => {}} editRole={null} />,
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('permission-groups')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('permission-group-pages')).toBeInTheDocument();
+    expect(screen.getByTestId('permission-group-llm')).toBeInTheDocument();
+    expect(screen.getByTestId('permission-group-admin')).toBeInTheDocument();
+    expect(screen.getByText('Pages')).toBeInTheDocument();
+    expect(screen.getByText('LLM')).toBeInTheDocument();
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+  });
+
+  // 4. Validates snake_case role name inline
+  it('validates snake_case role name inline', async () => {
+    mockFetch();
+    render(
+      <CustomRoleEditor open={true} onOpenChange={() => {}} editRole={null} />,
+      { wrapper: createWrapper() },
+    );
+
+    const nameInput = screen.getByTestId('role-name-input');
+
+    // Invalid input shows error
+    fireEvent.change(nameInput, { target: { value: 'Content Editor' } });
+    expect(screen.getByTestId('name-error')).toHaveTextContent('Must be lowercase snake_case');
+
+    // Valid input clears error
+    fireEvent.change(nameInput, { target: { value: 'content_editor' } });
+    expect(screen.queryByTestId('name-error')).not.toBeInTheDocument();
+  });
+
+  // 5. Disables Create button when no permissions are selected
+  it('disables Create button when no permissions are selected', () => {
+    mockFetch();
+    render(
+      <CustomRoleEditor open={true} onOpenChange={() => {}} editRole={null} />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByTestId('submit-role-btn')).toBeDisabled();
+  });
+
+  // 6. Submits POST on create
+  it('submits POST with correct body on create', async () => {
+    const fetchSpy = mockFetch();
+    render(
+      <CustomRoleEditor open={true} onOpenChange={() => {}} editRole={null} />,
+      { wrapper: createWrapper() },
+    );
+
+    // Wait for permissions to load
+    await waitFor(() => {
+      expect(screen.getByTestId('permission-groups')).toBeInTheDocument();
+    });
+
+    // Fill form
+    fireEvent.change(screen.getByTestId('role-name-input'), { target: { value: 'test_role' } });
+    fireEvent.change(screen.getByTestId('display-name-input'), { target: { value: 'Test Role' } });
+    fireEvent.change(screen.getByTestId('description-input'), { target: { value: 'A test role' } });
+
+    // Select a permission
+    fireEvent.click(screen.getByTestId('checkbox-pages:read'));
+
+    // Submit
+    fireEvent.click(screen.getByTestId('submit-role-btn'));
+
+    await waitFor(() => {
+      const postCalls = fetchSpy.mock.calls.filter(
+        ([, opts]) => opts && typeof opts === 'object' && 'method' in opts && (opts as RequestInit).method === 'POST',
+      );
+      const adminRolePost = postCalls.find(([url]) =>
+        (typeof url === 'string' ? url : '').includes('/admin/roles'),
+      );
+      expect(adminRolePost).toBeDefined();
+      const body = JSON.parse((adminRolePost![1] as RequestInit).body as string);
+      expect(body.name).toBe('test_role');
+      expect(body.displayName).toBe('Test Role');
+      expect(body.description).toBe('A test role');
+      expect(body.permissions).toEqual(['pages:read']);
+    });
+  });
+
+  // 7. Submits PUT on edit
+  it('submits PUT with correct body on edit', async () => {
+    const fetchSpy = mockFetch();
+    render(
+      <CustomRoleEditor open={true} onOpenChange={() => {}} editRole={mockRole} />,
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('permission-groups')).toBeInTheDocument();
+    });
+
+    // Modify display name
+    fireEvent.change(screen.getByTestId('display-name-input'), { target: { value: 'Updated Editor' } });
+
+    // Submit
+    fireEvent.click(screen.getByTestId('submit-role-btn'));
+
+    await waitFor(() => {
+      const putCalls = fetchSpy.mock.calls.filter(
+        ([, opts]) => opts && typeof opts === 'object' && 'method' in opts && (opts as RequestInit).method === 'PUT',
+      );
+      expect(putCalls.length).toBeGreaterThanOrEqual(1);
+      const body = JSON.parse((putCalls[0][1] as RequestInit).body as string);
+      expect(body.displayName).toBe('Updated Editor');
+      expect(body.permissions).toContain('pages:read');
+      expect(body.permissions).toContain('pages:write');
+      // Name is not in the PUT body (read-only in edit mode)
+      expect(body.name).toBeUndefined();
+    });
+  });
+
+  // 8. Delete button in edit mode, not in create mode
+  it('shows delete button in edit mode but not in create mode', () => {
+    mockFetch();
+    const { unmount } = render(
+      <CustomRoleEditor open={true} onOpenChange={() => {}} editRole={null} />,
+      { wrapper: createWrapper() },
+    );
+    expect(screen.queryByTestId('delete-role-btn')).not.toBeInTheDocument();
+    unmount();
+
+    render(
+      <CustomRoleEditor open={true} onOpenChange={() => {}} editRole={mockRole} />,
+      { wrapper: createWrapper() },
+    );
+    expect(screen.getByTestId('delete-role-btn')).toBeInTheDocument();
+  });
+
+  // 9. DELETE mutation fires on delete confirmation
+  it('fires DELETE mutation on delete confirmation', async () => {
+    const fetchSpy = mockFetch();
+    render(
+      <CustomRoleEditor open={true} onOpenChange={() => {}} editRole={mockRole} />,
+      { wrapper: createWrapper() },
+    );
+
+    // Click delete
+    fireEvent.click(screen.getByTestId('delete-role-btn'));
+
+    // Confirm
+    expect(screen.getByTestId('confirm-delete-btn')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('confirm-delete-btn'));
+
+    await waitFor(() => {
+      const deleteCalls = fetchSpy.mock.calls.filter(
+        ([, opts]) => opts && typeof opts === 'object' && 'method' in opts && (opts as RequestInit).method === 'DELETE',
+      );
+      expect(deleteCalls.length).toBeGreaterThanOrEqual(1);
+      expect(typeof deleteCalls[0][0] === 'string' ? deleteCalls[0][0] : '').toContain('/admin/roles/10');
+    });
+  });
+
+  // 10. Shows assignments tab in edit mode
+  it('shows assignments tab in edit mode', async () => {
+    mockFetch();
+    render(
+      <CustomRoleEditor open={true} onOpenChange={() => {}} editRole={mockRole} />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByTestId('tab-assignments')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('tab-assignments'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assignments-content')).toBeInTheDocument();
+    });
+  });
+
+  // 11. No assignments tab in create mode
+  it('does not show assignments tab in create mode', () => {
+    mockFetch();
+    render(
+      <CustomRoleEditor open={true} onOpenChange={() => {}} editRole={null} />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.queryByTestId('tab-assignments')).not.toBeInTheDocument();
+  });
+
+  // 12. Pre-checks permissions in edit mode
+  it('pre-checks permissions matching the editRole', async () => {
+    mockFetch();
+    render(
+      <CustomRoleEditor open={true} onOpenChange={() => {}} editRole={mockRole} />,
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('permission-groups')).toBeInTheDocument();
+    });
+
+    // pages:read and pages:write should be checked (from mockRole.permissions)
+    expect(screen.getByTestId('checkbox-pages:read')).toBeChecked();
+    expect(screen.getByTestId('checkbox-pages:write')).toBeChecked();
+    // llm:query should not be checked
+    expect(screen.getByTestId('checkbox-llm:query')).not.toBeChecked();
+  });
+});

--- a/frontend/src/features/admin/CustomRoleEditor.tsx
+++ b/frontend/src/features/admin/CustomRoleEditor.tsx
@@ -1,0 +1,501 @@
+import { useState, useMemo, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import * as Dialog from '@radix-ui/react-dialog';
+import {
+  Shield, Trash2, X, Loader2, Check, AlertTriangle,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { apiFetch } from '../../shared/lib/api';
+
+// --- Types ---
+
+export interface PermissionDefinition {
+  id: string;
+  displayName: string;
+  description: string;
+  category: string;
+  createdAt: string;
+}
+
+export interface CustomRole {
+  id: number;
+  name: string;
+  displayName: string;
+  description: string;
+  isSystem: boolean;
+  permissions: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface RoleAssignment {
+  id: number;
+  spaceKey: string;
+  principalType: 'user' | 'group';
+  principalId: string;
+  principalName: string | null;
+  createdAt: string;
+}
+
+export interface CustomRoleEditorProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Existing role to edit; null = create mode */
+  editRole: CustomRole | null;
+}
+
+// --- Hooks ---
+
+function usePermissionDefinitions() {
+  return useQuery<PermissionDefinition[]>({
+    queryKey: ['admin', 'permissions'],
+    queryFn: () => apiFetch('/admin/permissions'),
+    staleTime: 60_000,
+  });
+}
+
+function useRoleAssignments(roleId: number | null) {
+  return useQuery<RoleAssignment[]>({
+    queryKey: ['admin', 'role-assignments', roleId],
+    queryFn: () => apiFetch(`/admin/roles/${roleId}/assignments`),
+    enabled: roleId !== null,
+    staleTime: 30_000,
+  });
+}
+
+// --- Validation ---
+
+const SNAKE_CASE_REGEX = /^[a-z][a-z0-9_]*$/;
+
+function validateRoleName(name: string): string | null {
+  if (!name) return 'Role name is required';
+  if (!SNAKE_CASE_REGEX.test(name)) return 'Must be lowercase snake_case (e.g. content_editor)';
+  if (name.length > 100) return 'Maximum 100 characters';
+  return null;
+}
+
+// --- Category display labels ---
+
+const CATEGORY_LABELS: Record<string, string> = {
+  pages: 'Pages',
+  llm: 'LLM',
+  sync: 'Sync',
+  spaces: 'Spaces',
+  admin: 'Admin',
+};
+
+function getCategoryLabel(category: string): string {
+  return CATEGORY_LABELS[category] ?? category.charAt(0).toUpperCase() + category.slice(1);
+}
+
+// --- Component ---
+
+export function CustomRoleEditor({ open, onOpenChange, editRole }: CustomRoleEditorProps) {
+  const queryClient = useQueryClient();
+  const isEditMode = editRole !== null;
+
+  // --- Form state ---
+  const [roleName, setRoleName] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [description, setDescription] = useState('');
+  const [selectedPermissions, setSelectedPermissions] = useState<Set<string>>(new Set());
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [activeSection, setActiveSection] = useState<'edit' | 'assignments'>('edit');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  // --- Data fetching ---
+  const { data: permissions, isLoading: permissionsLoading } = usePermissionDefinitions();
+  const { data: assignments } = useRoleAssignments(isEditMode ? editRole.id : null);
+
+  // --- Reset form when modal opens or editRole changes ---
+  useEffect(() => {
+    if (open) {
+      if (editRole) {
+        setRoleName(editRole.name);
+        setDisplayName(editRole.displayName);
+        setDescription(editRole.description ?? '');
+        setSelectedPermissions(new Set(editRole.permissions));
+        setActiveSection('edit');
+      } else {
+        setRoleName('');
+        setDisplayName('');
+        setDescription('');
+        setSelectedPermissions(new Set());
+        setActiveSection('edit');
+      }
+      setNameError(null);
+      setShowDeleteConfirm(false);
+    }
+  }, [open, editRole]);
+
+  // --- Permission grouping ---
+  const grouped = useMemo(() => {
+    if (!permissions) return {};
+    const groups: Record<string, PermissionDefinition[]> = {};
+    for (const perm of permissions) {
+      const cat = perm.category || 'other';
+      (groups[cat] ??= []).push(perm);
+    }
+    return groups;
+  }, [permissions]);
+
+  // --- Mutations ---
+
+  const createMutation = useMutation({
+    mutationFn: (body: { name: string; displayName: string; description: string; permissions: string[] }) =>
+      apiFetch('/admin/roles', { method: 'POST', body: JSON.stringify(body) }),
+    onSuccess: () => {
+      // Dual invalidation: CE roles list + EE custom roles list
+      queryClient.invalidateQueries({ queryKey: ['admin', 'roles'] });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'custom-roles'] });
+      toast.success('Custom role created');
+      onOpenChange(false);
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, ...body }: { id: number; displayName: string; description: string; permissions: string[] }) =>
+      apiFetch(`/admin/roles/${id}`, { method: 'PUT', body: JSON.stringify(body) }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'roles'] });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'custom-roles'] });
+      toast.success('Role updated');
+      onOpenChange(false);
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) =>
+      apiFetch(`/admin/roles/${id}`, { method: 'DELETE' }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'roles'] });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'custom-roles'] });
+      toast.success('Role deleted');
+      onOpenChange(false);
+    },
+    onError: (err: Error) => {
+      // Backend returns 409 when role is still assigned to spaces
+      toast.error(
+        err.message.includes('409') || err.message.toLowerCase().includes('assigned')
+          ? 'Role is still assigned to spaces. Remove assignments first.'
+          : err.message,
+      );
+    },
+  });
+
+  // --- Handlers ---
+
+  const handleNameChange = (value: string) => {
+    setRoleName(value);
+    setNameError(validateRoleName(value));
+  };
+
+  const togglePermission = (permId: string) => {
+    setSelectedPermissions((prev) => {
+      const next = new Set(prev);
+      if (next.has(permId)) {
+        next.delete(permId);
+      } else {
+        next.add(permId);
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = () => {
+    if (!isEditMode) {
+      const error = validateRoleName(roleName);
+      if (error) {
+        setNameError(error);
+        return;
+      }
+    }
+    if (selectedPermissions.size === 0) return;
+
+    if (isEditMode) {
+      updateMutation.mutate({
+        id: editRole.id,
+        displayName,
+        description,
+        permissions: [...selectedPermissions],
+      });
+    } else {
+      createMutation.mutate({
+        name: roleName,
+        displayName,
+        description,
+        permissions: [...selectedPermissions],
+      });
+    }
+  };
+
+  const handleDelete = () => {
+    if (!editRole) return;
+    deleteMutation.mutate(editRole.id);
+  };
+
+  const isPending = createMutation.isPending || updateMutation.isPending || deleteMutation.isPending;
+  const canSubmit = selectedPermissions.size > 0 && !isPending && (isEditMode || !nameError);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+          data-testid="custom-role-editor-overlay"
+        />
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border/60 bg-card/90 shadow-2xl backdrop-blur-xl outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] max-h-[85vh] overflow-y-auto"
+          aria-describedby={undefined}
+          data-testid="custom-role-editor"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-border/50 px-5 py-4">
+            <Dialog.Title className="flex items-center gap-2 text-base font-semibold text-foreground">
+              <Shield size={18} className="text-primary" />
+              {isEditMode ? `Edit Role: ${editRole.displayName}` : 'Create Custom Role'}
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button
+                className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
+                aria-label="Close"
+                data-testid="close-editor-btn"
+              >
+                <X size={16} />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          {/* Sub-tabs (edit mode only) */}
+          {isEditMode && (
+            <div className="flex gap-1 border-b border-border/50 px-5 py-2">
+              <button
+                onClick={() => setActiveSection('edit')}
+                className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
+                  activeSection === 'edit'
+                    ? 'bg-primary/15 text-primary font-medium'
+                    : 'text-muted-foreground hover:bg-foreground/5'
+                }`}
+                data-testid="tab-permissions"
+              >
+                Permissions
+              </button>
+              <button
+                onClick={() => setActiveSection('assignments')}
+                className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
+                  activeSection === 'assignments'
+                    ? 'bg-primary/15 text-primary font-medium'
+                    : 'text-muted-foreground hover:bg-foreground/5'
+                }`}
+                data-testid="tab-assignments"
+              >
+                Assignments
+              </button>
+            </div>
+          )}
+
+          {/* Content */}
+          <div className="p-5 space-y-5">
+            {activeSection === 'edit' ? (
+              <>
+                {/* Role name */}
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                    Role Name (snake_case)
+                  </label>
+                  <input
+                    type="text"
+                    value={roleName}
+                    onChange={(e) => handleNameChange(e.target.value)}
+                    placeholder="e.g. content_editor"
+                    disabled={isEditMode}
+                    className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
+                    data-testid="role-name-input"
+                  />
+                  {nameError && (
+                    <p className="mt-1 text-xs text-destructive" data-testid="name-error">
+                      {nameError}
+                    </p>
+                  )}
+                </div>
+
+                {/* Display name */}
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                    Display Name
+                  </label>
+                  <input
+                    type="text"
+                    value={displayName}
+                    onChange={(e) => setDisplayName(e.target.value)}
+                    placeholder="e.g. Content Editor"
+                    className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary"
+                    data-testid="display-name-input"
+                  />
+                </div>
+
+                {/* Description */}
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                    Description
+                  </label>
+                  <textarea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="Optional description for this role"
+                    rows={2}
+                    className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary resize-none"
+                    data-testid="description-input"
+                  />
+                </div>
+
+                {/* Permissions grouped by category */}
+                <div>
+                  <label className="mb-2 block text-xs font-medium text-muted-foreground">
+                    Permissions
+                  </label>
+                  {permissionsLoading ? (
+                    <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+                      <Loader2 size={14} className="animate-spin" />
+                      Loading permissions...
+                    </div>
+                  ) : (
+                    <div className="space-y-4" data-testid="permission-groups">
+                      {Object.entries(grouped).map(([category, perms]) => (
+                        <div key={category} data-testid={`permission-group-${category}`}>
+                          <h4 className="mb-1.5 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+                            {getCategoryLabel(category)}
+                          </h4>
+                          <div className="space-y-1.5">
+                            {perms.map((perm) => (
+                              <label
+                                key={perm.id}
+                                className="flex items-start gap-2.5 rounded-lg px-2.5 py-1.5 transition-colors hover:bg-foreground/3 cursor-pointer"
+                                data-testid={`permission-${perm.id}`}
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={selectedPermissions.has(perm.id)}
+                                  onChange={() => togglePermission(perm.id)}
+                                  className="mt-0.5 h-4 w-4 rounded border-border accent-primary"
+                                  data-testid={`checkbox-${perm.id}`}
+                                />
+                                <div>
+                                  <div className="text-sm font-medium">{perm.displayName}</div>
+                                  <div className="text-xs text-muted-foreground">{perm.description}</div>
+                                </div>
+                              </label>
+                            ))}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </>
+            ) : (
+              /* Assignments tab (edit mode only) */
+              <div data-testid="assignments-content">
+                <p className="mb-3 text-xs text-muted-foreground">
+                  Role assignments are managed via the Space Permissions tab. Below is a read-only view of current assignments for this role.
+                </p>
+                {!assignments?.length ? (
+                  <div className="rounded-lg bg-foreground/5 py-8 text-center text-sm text-muted-foreground">
+                    No assignments for this role
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-border/50 overflow-hidden">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-border/50 text-left text-xs text-muted-foreground">
+                          <th className="px-4 py-2.5 font-medium">Space</th>
+                          <th className="px-4 py-2.5 font-medium">Type</th>
+                          <th className="px-4 py-2.5 font-medium">Principal</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-border/30">
+                        {assignments.map((a) => (
+                          <tr key={a.id} className="hover:bg-foreground/5" data-testid={`assignment-row-${a.id}`}>
+                            <td className="px-4 py-2">{a.spaceKey}</td>
+                            <td className="px-4 py-2">
+                              <span className={`rounded px-2 py-0.5 text-xs font-medium ${
+                                a.principalType === 'group' ? 'bg-primary/10 text-primary' : 'bg-blue-500/10 text-blue-500'
+                              }`}>
+                                {a.principalType === 'group' ? 'Group' : 'User'}
+                              </span>
+                            </td>
+                            <td className="px-4 py-2">{a.principalName ?? a.principalId}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-between border-t border-border/50 px-5 py-4">
+            <div>
+              {isEditMode && !showDeleteConfirm && (
+                <button
+                  onClick={() => setShowDeleteConfirm(true)}
+                  className="flex items-center gap-1.5 rounded-md bg-destructive/10 px-3 py-1.5 text-sm text-destructive hover:bg-destructive/20"
+                  data-testid="delete-role-btn"
+                >
+                  <Trash2 size={14} />
+                  Delete Role
+                </button>
+              )}
+              {isEditMode && showDeleteConfirm && (
+                <div className="flex items-center gap-2">
+                  <span className="flex items-center gap-1 text-xs text-destructive">
+                    <AlertTriangle size={12} />
+                    Delete this role?
+                  </span>
+                  <button
+                    onClick={handleDelete}
+                    disabled={deleteMutation.isPending}
+                    className="flex items-center gap-1 rounded-md bg-destructive px-2.5 py-1 text-xs text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+                    data-testid="confirm-delete-btn"
+                  >
+                    {deleteMutation.isPending ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} />}
+                    Confirm
+                  </button>
+                  <button
+                    onClick={() => setShowDeleteConfirm(false)}
+                    className="rounded-md bg-foreground/5 px-2.5 py-1 text-xs hover:bg-foreground/10"
+                    data-testid="cancel-delete-btn"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <Dialog.Close asChild>
+                <button className="rounded-md bg-foreground/5 px-4 py-2 text-sm hover:bg-foreground/10">
+                  Cancel
+                </button>
+              </Dialog.Close>
+              {activeSection === 'edit' && (
+                <button
+                  onClick={handleSubmit}
+                  disabled={!canSubmit}
+                  className="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                  data-testid="submit-role-btn"
+                >
+                  {isPending && <Loader2 size={14} className="animate-spin" />}
+                  {isEditMode ? 'Save' : 'Create'}
+                </button>
+              )}
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/src/features/admin/RbacPage.test.tsx
+++ b/frontend/src/features/admin/RbacPage.test.tsx
@@ -6,6 +6,20 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RbacPage } from './RbacPage';
 import { useAuthStore } from '../../stores/auth-store';
 
+// ── Mock useEnterprise ─────────────────────────────────────────────────────────
+// eslint-disable-next-line prefer-const
+let mockHasFeature = (_f: string) => false;
+
+vi.mock('../../shared/enterprise/use-enterprise', () => ({
+  useEnterprise: () => ({
+    isEnterprise: false,
+    hasFeature: (f: string) => mockHasFeature(f),
+    ui: null,
+    license: null,
+    isLoading: false,
+  }),
+}));
+
 function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -40,6 +54,23 @@ const mockRoles = [
     permissions: ['read', 'comment', 'edit', 'delete'],
     createdAt: '2024-01-01T00:00:00Z',
   },
+];
+
+const mockRolesWithCustom = [
+  ...mockRoles,
+  {
+    id: 10,
+    name: 'content_editor',
+    displayName: 'Content Editor',
+    isSystem: false,
+    permissions: ['pages:read', 'pages:write'],
+    createdAt: '2024-01-01T00:00:00Z',
+  },
+];
+
+const mockPermissions = [
+  { id: 'pages:read', displayName: 'Read Pages', description: 'View', category: 'pages', createdAt: '2024-01-01T00:00:00Z' },
+  { id: 'pages:write', displayName: 'Write Pages', description: 'Edit', category: 'pages', createdAt: '2024-01-01T00:00:00Z' },
 ];
 
 const mockGroups = [
@@ -83,11 +114,16 @@ const mockSpaceRoles = [
   },
 ];
 
-function mockFetch() {
+function mockFetch(roles = mockRoles) {
   return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
     const url = typeof input === 'string' ? input : (input as Request).url;
+    if (url.includes('/admin/permissions')) {
+      return new Response(JSON.stringify(mockPermissions), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
     if (url.includes('/roles')) {
-      return new Response(JSON.stringify(mockRoles), {
+      return new Response(JSON.stringify(roles), {
         headers: { 'Content-Type': 'application/json' },
       });
     }
@@ -124,6 +160,7 @@ function mockFetch() {
 
 describe('RbacPage', () => {
   beforeEach(() => {
+    mockHasFeature = () => false;
     useAuthStore.getState().setAuth('test-token', {
       id: '1',
       username: 'admin',
@@ -235,5 +272,71 @@ describe('RbacPage', () => {
     mockFetch();
     render(<RbacPage />, { wrapper: createWrapper() });
     expect(screen.queryByText('System Admin')).not.toBeInTheDocument();
+  });
+
+  // ── Custom role editor integration tests ───────────────────────────────────
+
+  it('shows "Create Custom Role" button when advanced_rbac feature is enabled', async () => {
+    mockHasFeature = () => true;
+    mockFetch();
+    render(<RbacPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('roles-list')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('create-custom-role-btn')).toBeInTheDocument();
+  });
+
+  it('hides "Create Custom Role" button when advanced_rbac feature is disabled', async () => {
+    mockHasFeature = () => false;
+    mockFetch();
+    render(<RbacPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('roles-list')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('create-custom-role-btn')).not.toBeInTheDocument();
+  });
+
+  it('shows edit button on non-system roles when feature is enabled', async () => {
+    mockHasFeature = () => true;
+    mockFetch(mockRolesWithCustom);
+    render(<RbacPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role-10')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('edit-role-10')).toBeInTheDocument();
+  });
+
+  it('does not show edit button on system roles', async () => {
+    mockHasFeature = () => true;
+    mockFetch(mockRolesWithCustom);
+    render(<RbacPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role-1')).toBeInTheDocument();
+    });
+    // System roles (id 1, 2) should not have edit buttons
+    expect(screen.queryByTestId('edit-role-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('edit-role-2')).not.toBeInTheDocument();
+  });
+
+  it('opens editor modal when "Create Custom Role" is clicked', async () => {
+    mockHasFeature = () => true;
+    mockFetch();
+    render(<RbacPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-custom-role-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('create-custom-role-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('custom-role-editor')).toBeInTheDocument();
+    });
+    // The modal title and button both contain "Create Custom Role", verify the modal is open via testid
+    expect(screen.getByTestId('role-name-input')).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/admin/RbacPage.tsx
+++ b/frontend/src/features/admin/RbacPage.tsx
@@ -3,11 +3,14 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { m } from 'framer-motion';
 import {
   Shield, Users, FolderOpen, Plus, Trash2,
-  UserPlus, Loader2, Lock, ShieldCheck,
+  UserPlus, Loader2, Lock, ShieldCheck, Pencil,
 } from 'lucide-react';
 import { apiFetch } from '../../shared/lib/api';
 import { cn } from '../../shared/lib/cn';
 import { useAuthStore } from '../../stores/auth-store';
+import { useEnterprise } from '../../shared/enterprise/use-enterprise';
+import { CustomRoleEditor } from './CustomRoleEditor';
+import type { CustomRole } from './CustomRoleEditor';
 
 type RbacTab = 'roles' | 'groups' | 'permissions';
 
@@ -191,6 +194,20 @@ function useUsers() {
 
 function RolesTab() {
   const { data: roles, isLoading } = useRoles();
+  const { hasFeature } = useEnterprise();
+  const advancedRbac = hasFeature('advanced_rbac');
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editRole, setEditRole] = useState<CustomRole | null>(null);
+
+  const handleCreate = () => { setEditRole(null); setEditorOpen(true); };
+  const handleEdit = (role: Role) => {
+    setEditRole({
+      ...role,
+      description: (role as Role & { description?: string }).description ?? '',
+      updatedAt: (role as Role & { updatedAt?: string }).updatedAt ?? role.createdAt,
+    });
+    setEditorOpen(true);
+  };
 
   if (isLoading) {
     return (
@@ -204,14 +221,43 @@ function RolesTab() {
 
   if (!roles?.length) {
     return (
-      <div className="glass-card py-12 text-center text-sm text-muted-foreground">
-        No roles configured
+      <div className="space-y-3">
+        {advancedRbac && (
+          <button
+            onClick={handleCreate}
+            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            data-testid="create-custom-role-btn"
+          >
+            <Plus size={16} />
+            Create Custom Role
+          </button>
+        )}
+        <div className="glass-card py-12 text-center text-sm text-muted-foreground">
+          No roles configured
+        </div>
+        {advancedRbac && (
+          <CustomRoleEditor
+            open={editorOpen}
+            onOpenChange={setEditorOpen}
+            editRole={editRole}
+          />
+        )}
       </div>
     );
   }
 
   return (
     <div className="space-y-3" data-testid="roles-list">
+      {advancedRbac && (
+        <button
+          onClick={handleCreate}
+          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          data-testid="create-custom-role-btn"
+        >
+          <Plus size={16} />
+          Create Custom Role
+        </button>
+      )}
       {roles.map((role, i) => (
         <m.div
           key={role.id}
@@ -229,6 +275,16 @@ function RolesTab() {
                 System
               </span>
             )}
+            {!role.isSystem && advancedRbac && (
+              <button
+                onClick={() => handleEdit(role)}
+                className="rounded p-1 text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+                aria-label={`Edit ${role.displayName}`}
+                data-testid={`edit-role-${role.id}`}
+              >
+                <Pencil size={14} />
+              </button>
+            )}
           </div>
           <div className="mt-2 flex flex-wrap gap-1">
             {role.permissions.map((perm) => (
@@ -242,6 +298,13 @@ function RolesTab() {
           </div>
         </m.div>
       ))}
+      {advancedRbac && (
+        <CustomRoleEditor
+          open={editorOpen}
+          onOpenChange={setEditorOpen}
+          editRole={editRole}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Adds CustomRoleEditor Radix Dialog modal inside RbacPage. Permission checkboxes grouped by category, snake_case validation, CRUD mutations, dual query key invalidation. 17 new tests, all 1768 pass. Ref: Compendiq/compendiq-ee#63