### PR TITLE
fix: remove unused eslint-disable directive in RbacPage.test

### DIFF
--- a/frontend/src/features/admin/RbacPage.test.tsx
+++ b/frontend/src/features/admin/RbacPage.test.tsx
@@ -7,7 +7,6 @@ import { RbacPage } from './RbacPage';
 import { useAuthStore } from '../../stores/auth-store';
 
 // ── Mock useEnterprise ─────────────────────────────────────────────────────────
-// eslint-disable-next-line prefer-const
 let mockHasFeature = (_f: string) => false;
 
 vi.mock('../../shared/enterprise/use-enterprise', () => ({


### PR DESCRIPTION
## Summary

- Remove unused `// eslint-disable-next-line prefer-const` from `RbacPage.test.tsx`
- The directive was unnecessary since `let mockHasFeature` is reassigned in tests
- Fixes `--max-warnings=0` CI gate failure in EE build

## Test plan

- [x] `npx eslint --max-warnings=0 src/features/admin/RbacPage.test.tsx` passes
- [x] No functional change

🤖 Generated with [Claude Code](https://claude.com/claude-code)