### PR TITLE
security(deps): batch-patch 5 Dependabot alerts (#224)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12729,15 +12729,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/exceljs/node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -12889,19 +12880,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/extract-zip": {
@@ -17720,16 +17698,6 @@
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/oxc-parser": {
       "version": "0.121.0",
       "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.121.0.tgz",
@@ -20677,52 +20645,12 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-      "dev": true,
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "license": "MIT",
-      "dependencies": {
-        "rimraf": "^2.6.3"
-      },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tmp/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tmp/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,11 @@
     "zod": "^4.3.6"
   },
   "overrides": {
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "protobufjs": "^7.5.5",
+    "@fastify/static": "^9.1.1",
+    "hono": "^4.12.14",
+    "tmp": "^0.2.4"
   },
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
Closes #220, closes #221, closes #222, closes #223.

Unblocks: epic #224

## Summary

Close 5 open Dependabot alerts in a single surgical PR by extending the existing npm `overrides` block in the root `package.json`. All alerts are transitive; every parent-dependency's declared range (except `tmp`) already accepts the patched version, so no parent bumps are required. The `tmp` override is a forced upgrade across caret boundaries (see ResearchPack §2 / §5/R4 for compatibility evidence).

| Alert | Package | Old | New | Severity |
|-------|---------|-----|-----|----------|
| #51 (→ #220) | `protobufjs` | 7.5.4 | **7.5.5** | critical (prototype pollution) |
| #49 (→ #221) | `@fastify/static` | 9.0.0 | **9.1.1** | medium (CVE-2026-6410) |
| #48 (→ #221) | `@fastify/static` | 9.0.0 | **9.1.1** | medium (CVE-2026-6414) |
| #46 (→ #222) | `hono` | 4.12.12 | **4.12.14** | medium (GHSA-458j-xx4x-4375) |
| #1  (→ #223) | `tmp` | 0.1.0 + 0.0.33 | **0.2.4** (npm resolves 0.2.5; both acceptable per plan §3.2) | low (CVE-2025-54798) |

Source-code changes: **none** (all 4 packages are pure transitives; verified no direct imports in `backend/src`, `frontend/src`, `mcp-docs/src`, or `e2e/`).

## Dependency resolution (§6.1 output)

```
compendiq@0.2.0 /home/simon/Documents/Compendiq/compendiq-ce
├─┬ @lhci/cli@0.15.1
│ ├─┬ inquirer@6.5.2
│ │ └─┬ external-editor@3.1.0
│ │   └── tmp@0.2.5 deduped
│ └── tmp@0.2.5 overridden
├─┬ backend@0.2.0 -> ./backend
│ ├─┬ @fastify/swagger-ui@5.2.5
│ │ └── @fastify/static@9.1.1 overridden
│ ├─┬ @modelcontextprotocol/sdk@1.29.0
│ │ ├─┬ @hono/node-server@1.19.14
│ │ │ └── hono@4.12.14 deduped
│ │ └── hono@4.12.14 overridden
│ └─┬ @opentelemetry/sdk-node@0.213.0
│   └─┬ @opentelemetry/exporter-logs-otlp-grpc@0.213.0
│     ├─┬ @grpc/grpc-js@1.14.3
│     │ └─┬ @grpc/proto-loader@0.8.0
│     │   └── protobufjs@7.5.5 deduped
│     └─┬ @opentelemetry/otlp-transformer@0.213.0
│       └── protobufjs@7.5.5 overridden
└─┬ frontend@0.2.0 -> ./frontend
  └─┬ exceljs@4.4.0
    └── tmp@0.2.5 deduped
```

`npm audit` → **0 vulnerabilities**.

## Verification results

| Step | Status | Notes |
|------|--------|-------|
| §6.1 `npm ls protobufjs @fastify/static hono tmp` | ✅ PASS | all patched versions resolved; `tmp@0.2.5` (accepted range per plan §3.2) |
| §6.2 `npm run typecheck` | ✅ PASS | exit 0, zero TS errors across contracts/backend/frontend |
| §6.3 `npm run lint` | ✅ PASS | exit 0 (boundaries plugin emits a non-fatal legacy-selector warning unrelated to this change) |
| §6.4 `npm run test` (contracts + frontend) | ✅ PASS | frontend: 144 files, 1798 tests all green; contracts has no test files (passes trivially) |
| §6.4 backend tests | ⚠️ SKIPPED | requires Postgres on `localhost:5433`; Docker blocked in implementer's shell (user must re-run post-merge or locally with `docker compose up -d postgres-test`) |
| §6.5 `npm run build` | ✅ PASS | all three workspaces built cleanly (backend, frontend, contracts) |
| §6.6 `docker compose build` | ⚠️ USER ACTION | see below |
| §6.7 `docker compose up + /api/health/ready` | ⚠️ USER ACTION | see below |
| §6.8 Playwright full stack on :8081 | ⚠️ SUBSTITUTED | Docker blocked; substituted with Vite dev server (:8081) + Playwright MCP. SPA bundle loaded successfully, router redirected to `/setup`, zero JS errors from the bundle. All console errors are 500s from the Vite proxy trying to reach non-running backend on :3051 (expected). See `.claude/plans/2026-04-18-dependabot-batch-playwright.md`. |
| §6.9 Swagger-UI dev-mode + path-traversal canary | ✅ PASS (via minimal-Fastify substitute) | full live-backend run blocked by absent Postgres. Ran isolated `@fastify/static` + `@fastify/swagger-ui` registration with path-traversal probes: `/api/docs/` → 200, `/api/docs/static/index.html` → 302, `/api/docs/static/../../../etc/passwd` → **404**, `/api/docs/static/%2e%2e/%2e%2e/%2e%2e/etc/passwd` → **404**. Both CVE probes **denied**, confirming 9.1.1 patches active. |
| §6.10 OTEL collector via `docker run` | ⚠️ USER ACTION | Docker blocked (see below) |
| §6.11 `npm run lighthouse` | ✅ PASS (non-blocking) | `@lhci/cli@0.15.1` loaded and launched Chrome against :8081 (frontend absent; interstitial error returned — expected). `tmp.fileSync({postfix:'.html'})` + `tmp.tmpNameSync({})` APIs (the exact shapes `@lhci/cli/src/open/open.js:47` and `external-editor/main/index.js:131` use) exercised directly against resolved `tmp@0.2.5` with success (create/write/removeCallback). Validates R4 in ResearchPack. |

## User action items (Docker-blocked steps)

These steps require Docker access and could not be executed in the implementer's shell (Docker daemon required sudo). Please run locally before merging, or rely on CI:

### §6.6 — compose build

```bash
cd /home/simon/Documents/Compendiq/compendiq-ce
# Ensure JWT_SECRET and PAT_ENCRYPTION_KEY are set in .env (32+ chars each)
docker compose --env-file .env -f docker/docker-compose.yml build
```

> **Note** on `--env-file`: compose uses the `docker/` directory as project root when invoked with `-f docker/docker-compose.yml`, so the repo-root `.env` isn't auto-loaded — pass it explicitly.

### §6.7 — compose up + health

```bash
docker compose --env-file .env -f docker/docker-compose.yml up -d
for i in {1..30}; do
  if curl -fsS http://localhost:3052/api/health/ready > /dev/null; then
    echo "backend ready"; break
  fi
  sleep 2
done
curl -fsS http://localhost:8081/ | head -5
```

### §6.10 — OTEL smoke

```bash
# Terminal A
docker run --rm -p 4317:4317 -p 4318:4318 otel/opentelemetry-collector:latest

# Terminal B
cd backend
OTEL_ENABLED=true \
OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
OTEL_SERVICE_NAME=compendiq-smoke \
npm run dev
# Watch for "OpenTelemetry initialized" in the log, then curl http://localhost:3051/api/health/ready
```

### §6.4 backend-test rerun

```bash
# Spin up the test Postgres on :5433 (already in compose):
docker compose --env-file .env -f docker/docker-compose.test.yml up -d postgres-test
npm run test -w backend
```

## Source changes (2 files)

- `package.json`: add 4 entries to `overrides` (`protobufjs`, `@fastify/static`, `hono`, `tmp`)
- `package-lock.json`: regenerated via plain `npm install` — net delta is `tmp@0.1.0 + 0.0.33 → 0.2.5` with 5 nested transitives removed (`tmp@0.1.0/glob@7.2.3`, `tmp@0.1.0/rimraf@2.7.1`, `external-editor/tmp@0.0.33`, `os-tmpdir@1.0.2`, duplicate `exceljs/tmp@0.2.5`). Matches reviewer's dry-run shape ("6 added, 5 removed, 1 changed"). The `protobufjs`/`hono`/`@fastify/static` override entries are belt-and-suspenders — they were already naturally resolving to the patched versions on `dev` after #237's lockfile regeneration, but the override now locks them in so a future parent-caret shift can't silently drop them.

`mcp-docs/package-lock.json`: regenerated, diff is empty (no-op — already resolved `hono@4.12.14`).

## Documentation

- Research: `.claude/plans/2026-04-18-dependabot-batch-research.md`
- Plan: `.claude/plans/2026-04-18-dependabot-batch-plan.md`
- Playwright snapshot summary: `.claude/plans/2026-04-18-dependabot-batch-playwright.md`

(All three live under `.claude/` which is gitignored — they are intentionally not committed.)

## Safety / rollback

Plan §8 documents the rollback procedure. Summary: revert the merge commit, rerun `npm install` in root and `mcp-docs/`, re-verify via `npm ls`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
