### PR TITLE
fix(confluence): drop duplicate dot from attachment-handler sanitizer

### DIFF
--- a/backend/src/domains/confluence/services/attachment-handler.test.ts
+++ b/backend/src/domains/confluence/services/attachment-handler.test.ts
@@ -1246,5 +1246,27 @@ describe('attachment-handler', () => {
         cacheAttachment(client, 'user-1', '///', '/download/x.png', 'x.png'),
       ).rejects.toThrow('Invalid page ID');
     });
+
+    it('rejects pageId that is only dots ("...") — was masked by the old duplicate-in-char-class regex', async () => {
+      // Regression for #230: the previous regex /[/\\..]+/g had a duplicate `.`
+      // in the character class. The behaviour was identical (Zod-unrelated
+      // no-op), but leaving the bug in meant anyone editing the pattern later
+      // could misread intent. After the fix to /[/\\.]+/g, "..." still collapses
+      // to a single "_" which then trims to empty → "Invalid page ID".
+      const client = createMockClient();
+      await expect(
+        cacheAttachment(client, 'user-1', '...', '/download/x.png', 'x.png'),
+      ).rejects.toThrow('Invalid page ID');
+    });
+
+    it('preserves pageIds that contain only safe characters (hyphens, digits)', async () => {
+      // Sanity check: common shapes like "page-123" must pass through unchanged.
+      const client = createMockClient();
+      await expect(
+        cacheAttachment(client, 'user-1', 'page-123', '/download/x.png', 'x.png'),
+      ).resolves.toBeDefined();
+      const mkdirCall = vi.mocked(fs.mkdir).mock.calls[0][0] as string;
+      expect(mkdirCall).toContain('page-123');
+    });
   });
 });

--- a/backend/src/domains/confluence/services/attachment-handler.ts
+++ b/backend/src/domains/confluence/services/attachment-handler.ts
@@ -40,7 +40,7 @@ export const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;
  */
 function attachmentDir(_userId: string, pageId: string): string {
   // Sanitize pageId to prevent path traversal (e.g. "../../etc")
-  const safeId = pageId.replace(/[/\\..]+/g, '_').replace(/^_+|_+$/g, '');
+  const safeId = pageId.replace(/[/\\.]+/g, '_').replace(/^_+|_+$/g, '');
   if (!safeId) {
     throw new Error('Invalid page ID');
   }


### PR DESCRIPTION
## Summary

`pageId.replace(/[/\\..]+/g, '_')` has a duplicate `.` inside the character class — CodeQL flags this as `js/regex/duplicate-in-character-class`. Runtime behaviour is unchanged (dup class members are a no-op), but the pattern reads as buggy to anyone editing it later, so fix to `/[/\\.]+/g`.

Added two regression tests in the existing `path traversal prevention` describe block:
- `'...'` → throws `Invalid page ID` (the pure-dot shape that the duplicate `.` was nominally there for).
- `'page-123'` → passes through and the resulting `mkdir` path contains `page-123` (guards against the fix over-sanitising hyphens/digits).

## Test plan

- [x] `cd backend && npx vitest run src/domains/confluence/services/attachment-handler.test.ts` — 86/86 pass (+2 new)
- [x] `npm run lint -w backend` passes
- [x] `npm run typecheck -w backend` passes

Closes #230.
Part of #225.