### PR TITLE
chore(mcp-docs): drop unused logger import in fetch-url.ts

### DIFF
--- a/mcp-docs/src/tools/fetch-url.ts
+++ b/mcp-docs/src/tools/fetch-url.ts
@@ -10,7 +10,6 @@ import { validateUrl } from '../security/ssrf-guard.js';
 import { getDomainConfig, isDomainAllowed } from '../security/domain-filter.js';
 import { logOutboundRequest } from '../security/audit-logger.js';
 import { DocsCache, type CachedDoc } from '../cache/redis-cache.js';
-import { logger } from '../logger.js';
 
 const DEFAULT_MAX_LENGTH = 10_000;
 const ABSOLUTE_MAX_LENGTH = 100_000;


### PR DESCRIPTION
## Summary

`import { logger } from '../logger.js';` at line 13 of `mcp-docs/src/tools/fetch-url.ts` was never referenced in the 158-line file (CodeQL `js/unused-local-variable`). Pure deletion.

Wiring `logger.warn(...)` into the catch paths (timeout, blocked redirect, non-OK status) was called out as a follow-up in #231 and is **deliberately out of scope** for this PR.

## Test plan

- [x] `cd mcp-docs && npm run typecheck` passes (TS would've caught the re-introduction via `noUnusedLocals`)
- [x] `cd mcp-docs && npm test` — 26/26 pass

Note: `mcp-docs` does not currently expose a `lint` script, so no lint step to run.

Closes #231.
Part of #225.