### PR TITLE
test(frontend): tighten RateLimitsTab and RbacPage test assertions

### DIFF
--- a/frontend/src/features/admin/RbacPage.test.tsx
+++ b/frontend/src/features/admin/RbacPage.test.tsx
@@ -7,7 +7,7 @@ import { RbacPage } from './RbacPage';
 import { useAuthStore } from '../../stores/auth-store';
 
 // ── Mock useEnterprise ─────────────────────────────────────────────────────────
-let mockHasFeature = (_f: string) => false;
+let mockHasFeature: (feature: string) => boolean = (_feature) => false;
 
 vi.mock('../../shared/enterprise/use-enterprise', () => ({
   useEnterprise: () => ({
@@ -205,7 +205,7 @@ describe('RbacPage', () => {
       expect(screen.getByTestId('role-1')).toBeInTheDocument();
     });
     // "read" appears in both roles
-    expect(screen.getAllByText('read').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('read')).toHaveLength(2);
     // "admin" only in system_admin role
     const roleR1 = screen.getByTestId('role-1');
     expect(roleR1).toHaveTextContent('admin');
@@ -218,7 +218,9 @@ describe('RbacPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId('role-1')).toBeInTheDocument();
     });
-    expect(screen.getAllByText('System').length).toBeGreaterThanOrEqual(1);
+    // Both `system_admin` and `editor` carry isSystem: true (see mockRoles above),
+    // so exactly two "System" badges should render.
+    expect(screen.getAllByText('System')).toHaveLength(2);
   });
 
   it('switches to groups tab and shows group data', async () => {

--- a/frontend/src/features/settings/RateLimitsTab.test.tsx
+++ b/frontend/src/features/settings/RateLimitsTab.test.tsx
@@ -34,7 +34,7 @@ function mockFetchWith(settings: Record<string, unknown>) {
   return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
     if (url.includes('/admin/settings')) {
-      if ((input as Request)?.method === 'PUT' || (typeof input === 'string' && false)) {
+      if ((input as Request)?.method === 'PUT') {
         return new Response(JSON.stringify({ message: 'Updated' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
       return new Response(JSON.stringify(settings), { status: 200, headers: { 'Content-Type': 'application/json' } });


### PR DESCRIPTION
## Summary

Two frontend-test-only hygiene fixes bundled together — zero production-code impact.

**#232 RateLimitsTab.test.tsx** — drop dead `|| (typeof input === 'string' && false)` short-circuit from the mock-fetch shim. Right operand is always `false`, no test exercises the string-input PUT path (CodeQL `js/trivial-conditional`).

**#234 RbacPage.test.tsx**:
- Rename `_f` → `_feature` and add explicit `(feature: string) => boolean` annotation so reassignments preserve the parameter signature even when the arrow takes no args.
- `.length).toBeGreaterThanOrEqual(2)` → `.toHaveLength(2)` for the "read" permission count (both mock roles carry it).
- `.length).toBeGreaterThanOrEqual(1)` → `.toHaveLength(2)` for the "System" badge count.

### Reviewer note — issue body correction

The issue body for #234 misnames the second System-badged role as `system_user`. Verified by reading the test data at `RbacPage.test.tsx:39-56`: the two `isSystem: true` roles in `mockRoles` are **`system_admin` and `editor`** (not `system_user`). The expected count of **2** is correct; only the rationale needed correcting. Added a comment anchoring the count to the mock data.

The optional "tighten mock-feature assertions" enhancement noted in #234 (e.g. `mockHasFeature = (feature) => feature === 'advanced_rbac';`) is deliberately **not** included — flagged as out-of-scope in the plan.

## Test plan

- [x] `cd frontend && npx vitest run src/features/settings/RateLimitsTab.test.tsx src/features/admin/RbacPage.test.tsx` — 22/22 pass
- [x] `npm run lint -w frontend` passes
- [x] `npm run typecheck -w frontend` passes

Closes #232.
Closes #234.
Part of #225.