### PR TITLE
fix(mcp-docs): cap fetch-url response size + fix slice off-by-one

### DIFF
--- a/mcp-docs/src/tools/fetch-url.test.ts
+++ b/mcp-docs/src/tools/fetch-url.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchUrl } from './fetch-url.js';
+import { DocsCache, type CachedDoc } from '../cache/redis-cache.js';
+import * as auditLogger from '../security/audit-logger.js';
+
+const TEST_URL = 'https://docs.example.com/api';
+
+describe('fetchUrl — slice truncation (cached path)', () => {
+  let getCachedDocSpy: ReturnType<typeof vi.spyOn>;
+  let auditSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    auditSpy = vi.spyOn(auditLogger, 'logOutboundRequest').mockImplementation(() => {});
+    getCachedDocSpy = vi.spyOn(DocsCache.prototype, 'getCachedDoc');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockCachedDoc(doc: Partial<CachedDoc>): void {
+    const cached: CachedDoc = {
+      markdown: doc.markdown ?? '',
+      title: doc.title ?? 'Cached',
+      url: doc.url ?? TEST_URL,
+      fetchedAt: doc.fetchedAt ?? new Date().toISOString(),
+      contentLength: doc.contentLength ?? (doc.markdown?.length ?? 0),
+    };
+    getCachedDocSpy.mockResolvedValue(cached);
+  }
+
+  it('startIndex past the end returns empty markdown with truncated=false', async () => {
+    mockCachedDoc({ markdown: 'a'.repeat(1000), contentLength: 1000 });
+
+    const result = await fetchUrl(TEST_URL, null, { maxLength: 100, startIndex: 999_999 });
+
+    expect(result.markdown).toBe('');
+    expect(result.truncated).toBe(false);
+    expect(result.contentLength).toBe(1000);
+    expect(result.cached).toBe(true);
+  });
+
+  it('startIndex exactly at contentLength returns empty with truncated=false', async () => {
+    mockCachedDoc({ markdown: 'a'.repeat(500), contentLength: 500 });
+
+    const result = await fetchUrl(TEST_URL, null, { maxLength: 100, startIndex: 500 });
+
+    expect(result.markdown).toBe('');
+    expect(result.truncated).toBe(false);
+  });
+
+  it('negative startIndex is clamped to 0', async () => {
+    mockCachedDoc({ markdown: 'abcdefghij', contentLength: 10 });
+
+    const result = await fetchUrl(TEST_URL, null, { maxLength: 5, startIndex: -50 });
+
+    expect(result.markdown).toBe('abcde');
+    expect(result.truncated).toBe(true);
+  });
+
+  it('partial slice (start + maxLength below contentLength) marks truncated=true', async () => {
+    mockCachedDoc({ markdown: 'a'.repeat(1000), contentLength: 1000 });
+
+    const result = await fetchUrl(TEST_URL, null, { maxLength: 100, startIndex: 0 });
+
+    expect(result.markdown.length).toBe(100);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('reading the tail (start + maxLength === contentLength) marks truncated=false', async () => {
+    mockCachedDoc({ markdown: 'a'.repeat(1000), contentLength: 1000 });
+
+    const result = await fetchUrl(TEST_URL, null, { maxLength: 100, startIndex: 900 });
+
+    expect(result.markdown.length).toBe(100);
+    expect(result.truncated).toBe(false);
+  });
+});
+
+describe('fetchUrl — response body size cap (uncached path)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let auditSpy: ReturnType<typeof vi.spyOn>;
+  let getCachedDocSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+    auditSpy = vi.spyOn(auditLogger, 'logOutboundRequest').mockImplementation(() => {});
+    // Force cache miss so the fetch path runs
+    getCachedDocSpy = vi.spyOn(DocsCache.prototype, 'getCachedDoc').mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects when declared Content-Length exceeds the cap', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response('ignored', {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/html',
+          'Content-Length': String(10 * 1024 * 1024), // 10 MB > 5 MB cap
+        },
+      }),
+    );
+
+    await expect(fetchUrl(TEST_URL, null, {})).rejects.toThrow(/Response too large: 10485760 bytes exceeds/);
+
+    // Audit log fired even on rejection — security-visible event must be observable
+    expect(auditSpy).toHaveBeenCalledTimes(1);
+    expect(auditSpy.mock.calls[0]![0]).toMatchObject({
+      tool: 'fetch_url',
+      url: TEST_URL,
+      cached: false,
+      statusCode: 200,
+    });
+  });
+
+  it('rejects when actual body exceeds the cap (no Content-Length header)', async () => {
+    // Build a body whose decoded byte length exceeds 5 MB. ASCII char === 1 byte.
+    const oversized = 'a'.repeat(5 * 1024 * 1024 + 1);
+    fetchSpy.mockResolvedValue(
+      new Response(oversized, {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      }),
+    );
+
+    await expect(fetchUrl(TEST_URL, null, {})).rejects.toThrow(/Response too large: 5242881 bytes exceeds/);
+
+    expect(auditSpy).toHaveBeenCalledTimes(1);
+    expect(auditSpy.mock.calls[0]![0]).toMatchObject({
+      tool: 'fetch_url',
+      url: TEST_URL,
+      cached: false,
+    });
+  });
+
+  it('succeeds when body is under the cap', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response('<html><title>OK</title><body><main>hello world</main></body></html>', {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    );
+
+    const result = await fetchUrl(TEST_URL, null, {});
+
+    expect(result.markdown).toContain('hello world');
+    expect(result.title).toBe('OK');
+    expect(result.cached).toBe(false);
+  });
+
+  it('succeeds when declared Content-Length is exactly at the cap', async () => {
+    const body = 'short body';
+    fetchSpy.mockResolvedValue(
+      new Response(body, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/plain',
+          'Content-Length': String(5 * 1024 * 1024), // == cap, must not throw on header check
+        },
+      }),
+    );
+
+    const result = await fetchUrl(TEST_URL, null, {});
+    expect(result.markdown).toBe(body);
+  });
+});

--- a/mcp-docs/src/tools/fetch-url.ts
+++ b/mcp-docs/src/tools/fetch-url.ts
@@ -14,6 +14,10 @@ import { DocsCache, type CachedDoc } from '../cache/redis-cache.js';
 const DEFAULT_MAX_LENGTH = 10_000;
 const ABSOLUTE_MAX_LENGTH = 100_000;
 const FETCH_TIMEOUT_MS = 30_000;
+// Hard ceiling on bytes pulled into memory before HTML→Markdown conversion.
+// The MCP spec doesn't pin a number; 5 MB matches the request body limit used
+// by other Compendiq services and bounds heap usage by an obvious factor.
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
 
 // Reusable turndown instance
 const turndown = new TurndownService({
@@ -59,14 +63,16 @@ export async function fetchUrl(
       contentLength: cached.contentLength, timestamp: new Date().toISOString(),
     });
 
-    const content = cached.markdown.slice(startIndex, startIndex + maxLength);
+    const safeStartIndex = Math.min(Math.max(startIndex, 0), cached.contentLength);
+    const endIndex = Math.min(safeStartIndex + maxLength, cached.contentLength);
+    const content = cached.markdown.slice(safeStartIndex, endIndex);
     return {
       markdown: content,
       title: cached.title,
       url: cached.url,
       cached: true,
       contentLength: cached.contentLength,
-      truncated: startIndex + maxLength < cached.contentLength,
+      truncated: endIndex < cached.contentLength,
     };
   }
 
@@ -100,7 +106,30 @@ export async function fetchUrl(
   }
 
   const contentType = response.headers.get('content-type') ?? '';
-  const body = await response.text();
+
+  // Bound in-memory body size: a hostile or misconfigured allowed-domain server
+  // could otherwise exhaust the heap. Check the declared Content-Length first,
+  // then verify the actual byte count once the body has been read.
+  const contentLengthHeader = response.headers.get('content-length');
+  if (contentLengthHeader) {
+    const declaredLength = Number(contentLengthHeader);
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_RESPONSE_BYTES) {
+      logOutboundRequest({
+        tool: 'fetch_url', url, userId: options.userId, cached: false,
+        statusCode: response.status, timestamp: new Date().toISOString(),
+      });
+      throw new Error(`Response too large: ${declaredLength} bytes exceeds ${MAX_RESPONSE_BYTES}`);
+    }
+  }
+  const bodyBuffer = await response.arrayBuffer();
+  if (bodyBuffer.byteLength > MAX_RESPONSE_BYTES) {
+    logOutboundRequest({
+      tool: 'fetch_url', url, userId: options.userId, cached: false,
+      statusCode: response.status, timestamp: new Date().toISOString(),
+    });
+    throw new Error(`Response too large: ${bodyBuffer.byteLength} bytes exceeds ${MAX_RESPONSE_BYTES}`);
+  }
+  const body = new TextDecoder().decode(bodyBuffer);
 
   // 5. Convert to markdown
   let markdown: string;
@@ -144,13 +173,15 @@ export async function fetchUrl(
   });
 
   // 8. Return truncated content
-  const content = markdown.slice(startIndex, startIndex + maxLength);
+  const safeStartIndex = Math.min(Math.max(startIndex, 0), fullLength);
+  const endIndex = Math.min(safeStartIndex + maxLength, fullLength);
+  const content = markdown.slice(safeStartIndex, endIndex);
   return {
     markdown: content,
     title,
     url,
     cached: false,
     contentLength: fullLength,
-    truncated: startIndex + maxLength < fullLength,
+    truncated: endIndex < fullLength,
   };
 }


### PR DESCRIPTION
## Summary

Two related real bugs in `mcp-docs/src/tools/fetch-url.ts`, shipped together:

- **Security (priority:high)**: the uncached path loaded the entire HTTP response into memory before applying any size guard. A misconfigured or hostile allowed-domain server could exhaust the process heap. Add `MAX_RESPONSE_BYTES = 5 * 1024 * 1024` (5 MB), check the declared `Content-Length` first, then verify the actual byte count after `arrayBuffer()`. Both branches throw and emit an audit log entry on reject.
- **Correctness**: `slice(startIndex, startIndex + maxLength)` returned `""` when `startIndex >= contentLength`, but `truncated` still reported `false`. Clamp `startIndex` to `[0, contentLength]`, compute `endIndex` explicitly, and base `truncated` on `endIndex < contentLength`. Applied at both call sites (cached path L62, uncached path L148).

### Why 5 MB

The MCP spec doesn't pin a number for tool response sizes — it's per-implementation. 5 MB matches Compendiq's existing request body limits and is a generous defensive default for in-memory text processing on a process serving multiple MCP tool calls. Open to adjustment if a real-world doc page hits this.

### Audit log on reject

A blocked request is still a security-visible event, so `logOutboundRequest(...)` fires before throwing in both the header pre-check and post-read paths. Tests assert this.

## Test plan

- [x] New `mcp-docs/src/tools/fetch-url.test.ts` — 9 tests across slice clamping (5) and size cap (4)
- [x] `cd mcp-docs && npm test` — 35/35 passing (existing 26 + new 9)
- [x] Sanity-checked: with the patch reverted, the 3 new regression tests fail as expected
- [x] `cd mcp-docs && npm run typecheck` clean
- [x] Repo-wide `npm run lint` clean

Closes #246