### PR TITLE
test(settings): RateLimitsTab name says 6 but asserts 5

### DIFF
--- a/frontend/src/features/settings/RateLimitsTab.test.tsx
+++ b/frontend/src/features/settings/RateLimitsTab.test.tsx
@@ -60,7 +60,7 @@ describe('RateLimitsTab', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders all 6 rate limit categories', async () => {
+  it('renders all 5 rate limit categories', async () => {
     mockFetchWith(defaultSettings);
     render(<RateLimitsTab />, { wrapper: createWrapper() });
 


### PR DESCRIPTION
## Summary

One-line fix: `RateLimitsTab.test.tsx` had a test named "renders all 6 rate limit categories" while only asserting on 5 labels. The schema in `packages/contracts/src/schemas/admin.ts` defines exactly 5 (`Global`, `Auth`, `Admin`, `LlmStream`, `LlmEmbedding`), so the assertions are correct and the name was wrong.

The optional `cleanup`-import removal noted in the issue is intentionally NOT bundled here — it's tracked separately in the cleanup epic #248.

## Test plan

- [x] `cd frontend && npx vitest run src/features/settings/RateLimitsTab.test.tsx` — 7/7 passing
- [x] `npm run lint -w frontend` clean

Closes #247