### PR TITLE
chore(code-quality): apply 5 nice-to-haves from April 2026 rerun

### DIFF
--- a/backend/src/domains/confluence/services/attachment-handler.ts
+++ b/backend/src/domains/confluence/services/attachment-handler.ts
@@ -34,11 +34,12 @@ export const STREAM_THRESHOLD_BYTES = 5 * 1024 * 1024;
 export const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;
 
 /**
- * Attachments are now stored in a shared directory keyed only by pageId.
- * The userId parameter is kept in public-facing functions for backward
- * compatibility with callers, but is no longer used in the path.
+ * Attachments are stored in a shared directory keyed only by pageId.
+ * The public-facing functions still accept a `userId` argument for
+ * backward compatibility / observability, but the on-disk path no longer
+ * depends on it.
  */
-function attachmentDir(_userId: string, pageId: string): string {
+function attachmentDir(pageId: string): string {
   // Sanitize pageId to prevent path traversal (e.g. "../../etc")
   const safeId = pageId.replace(/[/\\.]+/g, '_').replace(/^_+|_+$/g, '');
   if (!safeId) {
@@ -52,10 +53,10 @@ function attachmentDir(_userId: string, pageId: string): string {
   return dir;
 }
 
-function attachmentPath(userId: string, pageId: string, filename: string): string {
+function attachmentPath(_userId: string, pageId: string, filename: string): string {
   // Sanitize filename to prevent path traversal
   const safe = path.basename(filename);
-  return path.join(attachmentDir(userId, pageId), safe);
+  return path.join(attachmentDir(pageId), safe);
 }
 
 /**
@@ -74,7 +75,7 @@ export async function cacheAttachment(
   filename: string,
   fileSizeHint?: number,
 ): Promise<string> {
-  const dir = attachmentDir(userId, pageId);
+  const dir = attachmentDir(pageId);
   await fs.mkdir(dir, { recursive: true });
 
   const filePath = attachmentPath(userId, pageId, filename);
@@ -121,7 +122,7 @@ export async function readAttachment(userId: string, pageId: string, filename: s
 
   // Search for .xref- variants: "foo.jpg" matches "foo.xref-{hash}.jpg"
   const safe = path.basename(filename);
-  const dir = attachmentDir('', pageId);
+  const dir = attachmentDir(pageId);
   const ext = path.extname(safe);
   const stem = ext ? safe.slice(0, -ext.length) : safe;
   const prefix = `${stem}.xref-`;
@@ -403,7 +404,7 @@ async function cacheExternalImage(
   filename: string,
   url: string,
 ): Promise<string> {
-  const dir = attachmentDir(userId, pageId);
+  const dir = attachmentDir(pageId);
   await fs.mkdir(dir, { recursive: true });
 
   const filePath = attachmentPath(userId, pageId, filename);
@@ -416,7 +417,7 @@ async function downloadExternalImage(url: string): Promise<ExternalImageDownload
   validateUrl(url);
 
   const { statusCode, headers, body } = await request(url, {
-    signal: AbortSignal.timeout(60_000),
+    signal: AbortSignal.timeout(15_000),
   });
 
   if (statusCode !== 200) {
@@ -506,7 +507,7 @@ export async function fetchAndCacheAttachment(
   const fileSize = attachment.extensions?.fileSize;
   const useStreaming = fileSize !== undefined && fileSize > STREAM_THRESHOLD_BYTES;
 
-  const dir = attachmentDir(userId, pageId);
+  const dir = attachmentDir(pageId);
   await fs.mkdir(dir, { recursive: true });
   const filePath = attachmentPath(userId, pageId, safe);
 
@@ -609,7 +610,7 @@ export async function writeAttachmentCache(
   filename: string,
   data: Buffer,
 ): Promise<string> {
-  const dir = attachmentDir(userId, pageId);
+  const dir = attachmentDir(pageId);
   await fs.mkdir(dir, { recursive: true });
   const filePath = attachmentPath(userId, pageId, filename);
   await fs.writeFile(filePath, data);
@@ -622,8 +623,8 @@ export async function writeAttachmentCache(
  * Used by sync-service to decide whether to retry attachment downloads
  * for pages whose content version hasn't changed.
  */
-export async function hasLocalAttachments(userId: string, pageId: string): Promise<boolean> {
-  const dir = attachmentDir(userId, pageId);
+export async function hasLocalAttachments(_userId: string, pageId: string): Promise<boolean> {
+  const dir = attachmentDir(pageId);
   try {
     const entries = await fs.readdir(dir);
     return entries.length > 0;
@@ -672,8 +673,8 @@ export async function getMissingAttachments(
  * Clean up all attachments for a page.
  * Also clears any Redis failure counters so re-synced attachments get a fresh start.
  */
-export async function cleanPageAttachments(userId: string, pageId: string): Promise<void> {
-  const dir = attachmentDir(userId, pageId);
+export async function cleanPageAttachments(_userId: string, pageId: string): Promise<void> {
+  const dir = attachmentDir(pageId);
   try {
     await fs.rm(dir, { recursive: true, force: true });
   } catch {

--- a/frontend/src/features/settings/RateLimitsTab.test.tsx
+++ b/frontend/src/features/settings/RateLimitsTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { RateLimitsTab } from './RateLimitsTab';
@@ -56,7 +56,6 @@ function createWrapper() {
 
 describe('RateLimitsTab', () => {
   afterEach(() => {
-    cleanup();
     vi.restoreAllMocks();
   });
 

--- a/packages/contracts/src/schemas/admin.test.ts
+++ b/packages/contracts/src/schemas/admin.test.ts
@@ -1,28 +1,48 @@
 import { describe, it, expect } from 'vitest';
 import { UpdateAdminSettingsSchema, AdminSettingsSchema } from './admin.js';
 
+const validReadPayload = {
+  llmProvider: 'ollama',
+  ollamaModel: 'qwen3.5',
+  openaiBaseUrl: null,
+  hasOpenaiApiKey: false,
+  openaiModel: null,
+  embeddingModel: 'bge-m3',
+  embeddingDimensions: 1024,
+  ftsLanguage: 'simple',
+  embeddingChunkSize: 500,
+  embeddingChunkOverlap: 50,
+  drawioEmbedUrl: null,
+  usecaseAssignments: {
+    chat: { provider: null, model: null },
+    summary: { provider: null, model: null },
+    quality: { provider: null, model: null },
+    auto_tag: { provider: null, model: null },
+  },
+} as const;
+
 describe('AdminSettingsSchema (read)', () => {
   it('accepts explicit null for drawioEmbedUrl (backend returns null when unset)', () => {
-    const parsed = AdminSettingsSchema.parse({
-      llmProvider: 'ollama',
-      ollamaModel: 'qwen3.5',
-      openaiBaseUrl: null,
-      hasOpenaiApiKey: false,
-      openaiModel: null,
-      embeddingModel: 'bge-m3',
-      embeddingDimensions: 1024,
-      ftsLanguage: 'simple',
-      embeddingChunkSize: 500,
-      embeddingChunkOverlap: 50,
-      drawioEmbedUrl: null,
-      usecaseAssignments: {
-        chat: { provider: null, model: null },
-        summary: { provider: null, model: null },
-        quality: { provider: null, model: null },
-        auto_tag: { provider: null, model: null },
-      },
-    });
+    const parsed = AdminSettingsSchema.parse(validReadPayload);
     expect(parsed.drawioEmbedUrl).toBeNull();
+  });
+
+  it('rejects empty ollamaModel — guards against a backend bug returning ""', () => {
+    expect(() =>
+      AdminSettingsSchema.parse({ ...validReadPayload, ollamaModel: '' }),
+    ).toThrow();
+  });
+
+  it('rejects empty embeddingModel', () => {
+    expect(() =>
+      AdminSettingsSchema.parse({ ...validReadPayload, embeddingModel: '' }),
+    ).toThrow();
+  });
+
+  it('rejects empty ftsLanguage', () => {
+    expect(() =>
+      AdminSettingsSchema.parse({ ...validReadPayload, ftsLanguage: '' }),
+    ).toThrow();
   });
 });
 

--- a/packages/contracts/src/schemas/admin.ts
+++ b/packages/contracts/src/schemas/admin.ts
@@ -61,13 +61,15 @@ export type UpdateUsecaseAssignmentsInput = z.infer<typeof UpdateUsecaseAssignme
 
 export const AdminSettingsSchema = z.object({
   llmProvider: LlmProviderSchema,
-  ollamaModel: z.string(),
+  ollamaModel: z.string().min(1),
   openaiBaseUrl: z.string().url().nullable(),
   hasOpenaiApiKey: z.boolean(),
-  openaiModel: z.string().nullable(),
-  embeddingModel: z.string(),
+  openaiModel: z.string().min(1).nullable(),
+  embeddingModel: z.string().min(1),
+  // Derived from the active embedding model; read-only in GET /admin/settings
+  // and intentionally not accepted by UpdateAdminSettingsSchema.
   embeddingDimensions: z.number().int().min(128).max(4096),
-  ftsLanguage: z.string(),
+  ftsLanguage: z.string().min(1),
   embeddingChunkSize: z.number().int().min(128).max(2048),
   embeddingChunkOverlap: z.number().int().min(0).max(512),
   /**


### PR DESCRIPTION
Closes #248

## Summary

Applies all 5 nice-to-have items from epic #248 (cosmetic / defensive / doc improvements surfaced during the rerun after epic #225 merged). No bug fixes, no behaviour changes other than the slightly shorter external-image download timeout.

## Changes per item

- **attachment-handler.ts — drop unused `_userId` from `attachmentDir`.** Verified the function is module-private (no `export`), so dropped the parameter entirely and updated all 7 internal call sites. Renamed the unused `userId` arg on the public `hasLocalAttachments` and `cleanPageAttachments` exports to `_userId` (signatures kept stable for backward compat — picked up by ESLint's `argsIgnorePattern: '^_'`). The in-file comment was updated to reflect the new shape.
- **attachment-handler.ts — 60s → 15s timeout.** External-image download `AbortSignal.timeout` reduced from `60_000` to `15_000`. `MAX_ATTACHMENT_BYTES` already caps payload size, so this is a pure responsiveness win.
- **RateLimitsTab.test.tsx — drop redundant `cleanup`.** Removed the `cleanup` import and the `cleanup()` call inside `afterEach`. Kept `afterEach` in the vitest import (still needed for `vi.restoreAllMocks()`).
- **AdminSettingsSchema — add `.min(1)` to string read fields.** Applied to `ollamaModel`, `embeddingModel`, `openaiModel`, and `ftsLanguage`, matching the update schema and rejecting `""` at parse time. Conservative call: `.min(1)` is **inside** the `.nullable()` chain on `openaiModel` (i.e. `null` still allowed, empty string not).
- **AdminSettingsSchema — document `embeddingDimensions` as read-only.** One-line comment added above the field.

## Test plan

- [x] `attachment-handler.ts` — drop unused `_userId` from `attachmentDir`, update all 7 call sites — `npx vitest run src/domains/confluence/services/attachment-handler.test.ts` → 86/86 pass
- [x] `attachment-handler.ts` — 60s → 15s timeout for external image downloads — covered by existing tests; verified diff `60_000` → `15_000`
- [x] `RateLimitsTab.test.tsx` — drop `cleanup` import + `cleanup()` call — `npx vitest run src/features/settings/RateLimitsTab.test.tsx` → 7/7 pass
- [x] `AdminSettingsSchema` — `.min(1)` added to `ollamaModel`, `embeddingModel`, `ftsLanguage`, `openaiModel` — added 3 parse-rejection tests in `admin.test.ts` (covering `ollamaModel`, `embeddingModel`, `ftsLanguage`); `npx vitest run src/schemas/admin.test.ts` → 16/16 pass. Skipped a separate test for `openaiModel` (one-line schema change, low marginal value).
- [x] `AdminSettingsSchema` — `embeddingDimensions` documented as read-only — comment added above the field

## Verification

```
npm run lint        # clean
npm run typecheck   # clean
npm test            # backend 1752 / frontend 1811 / contracts 16 pass
```