### PR TITLE
chore(code-quality): apply 3 AI findings from Apr 19 rerun

### DIFF
--- a/frontend/src/features/settings/panels/LlmTab.tsx
+++ b/frontend/src/features/settings/panels/LlmTab.tsx
@@ -14,6 +14,8 @@ interface LlmStatusResponse {
   embeddingModel: string;
 }
 
+type LlmModelOption = { name: string };
+
 export function LlmTab({ settings }: { settings: SettingsResponse }) {
   const queryClient = useQueryClient();
   const { data: adminSettings, isLoading: adminSettingsLoading } = useQuery<AdminSettings>({
@@ -286,10 +288,10 @@ export function LlmTab({ settings }: { settings: SettingsResponse }) {
             onChange={(e) => setEmbeddingModel(e.target.value)}
             className="glass-select"
           >
-            {!models.some((m: { name: string }) => m.name === embeddingModel) && embeddingModel && (
+            {!models.some((m: LlmModelOption) => m.name === embeddingModel) && embeddingModel && (
               <option value={embeddingModel}>{embeddingModel}</option>
             )}
-            {models.map((m: { name: string }) => (
+            {models.map((m: LlmModelOption) => (
               <option key={m.name} value={m.name}>{m.name}</option>
             ))}
           </select>
@@ -385,7 +387,7 @@ function UsecaseAssignmentsSection({
       <div className="space-y-2">
         {USECASES_ORDERED.map((usecase) => {
           const row = assignments[usecase];
-          const effectiveProvider = row.provider ?? row.resolved?.provider;
+          const effectiveProvider = row.provider ?? row.resolved?.provider ?? 'ollama';
           const models = effectiveProvider === 'openai' ? openaiModels : ollamaModels;
           return (
             <div key={usecase} className="grid grid-cols-1 gap-2 sm:grid-cols-[140px_180px_1fr_auto] sm:items-center">

--- a/frontend/src/features/settings/panels/LlmTab.tsx
+++ b/frontend/src/features/settings/panels/LlmTab.tsx
@@ -367,8 +367,8 @@ function UsecaseAssignmentsSection({
 }: {
   assignments: UsecaseAssignments;
   onChange: (next: UsecaseAssignments) => void;
-  ollamaModels: Array<{ name: string }>;
-  openaiModels: Array<{ name: string }>;
+  ollamaModels: LlmModelOption[];
+  openaiModels: LlmModelOption[];
 }) {
   function update(usecase: LlmUsecase, patch: Partial<UsecaseAssignments[LlmUsecase]>) {
     onChange({ ...assignments, [usecase]: { ...assignments[usecase], ...patch } });

--- a/packages/contracts/src/schemas/admin.test.ts
+++ b/packages/contracts/src/schemas/admin.test.ts
@@ -44,6 +44,23 @@ describe('AdminSettingsSchema (read)', () => {
       AdminSettingsSchema.parse({ ...validReadPayload, ftsLanguage: '' }),
     ).toThrow();
   });
+
+  it('rejects aiGuardrailNoFabrication > 5000 chars — symmetric with update schema', () => {
+    expect(() =>
+      AdminSettingsSchema.parse({
+        ...validReadPayload,
+        aiGuardrailNoFabrication: 'x'.repeat(5001),
+      }),
+    ).toThrow();
+  });
+
+  it('accepts aiGuardrailNoFabrication at 5000 chars', () => {
+    const parsed = AdminSettingsSchema.parse({
+      ...validReadPayload,
+      aiGuardrailNoFabrication: 'x'.repeat(5000),
+    });
+    expect(parsed.aiGuardrailNoFabrication).toHaveLength(5000);
+  });
 });
 
 describe('UpdateAdminSettingsSchema tri-state semantics', () => {

--- a/packages/contracts/src/schemas/admin.ts
+++ b/packages/contracts/src/schemas/admin.ts
@@ -81,7 +81,7 @@ export const AdminSettingsSchema = z.object({
    */
   drawioEmbedUrl: z.string().url().nullable(),
   // AI Safety settings
-  aiGuardrailNoFabrication: z.string().optional(),
+  aiGuardrailNoFabrication: z.string().max(5000).optional(),
   aiGuardrailNoFabricationEnabled: z.boolean().optional(),
   aiOutputRuleStripReferences: z.boolean().optional(),
   aiOutputRuleReferenceAction: ReferenceActionSchema.optional(),


### PR DESCRIPTION
## Summary

Applies 3 of 6 AI Code Quality findings surfaced at `/security/quality/ai-findings` on 2026-04-19. The other 3 are false positives and will be dismissed in the UI.

## Applied

- **LlmTab.tsx** — extract `type LlmModelOption = { name: string }` so the embedding-model `<select>` stops re-declaring the inline shape on lines 289 / 292.
- **LlmTab.tsx** — add `?? 'ollama'` fallback to `effectiveProvider` in `UsecaseAssignmentsSection`. Behaviour was already a silent default-to-ollama via the ternary, but the explicit fallback makes intent clear and future-proofs if a third provider lands.
- **packages/contracts/src/schemas/admin.ts** — add `.max(5000)` to `aiGuardrailNoFabrication` in `AdminSettingsSchema` to match the existing constraint on `UpdateAdminSettingsSchema` (line 125). Closes a read/update asymmetry; same pattern as the `.min(1)` symmetry fixes in #254.

## Dismissed as false positives (not in this PR)

- **F1** — `setOpenaiApiKey('')` on mount. `handleSave()` line 127 uses `if (openaiApiKey) updates.openaiApiKey = openaiApiKey;` — empty string is guarded out of the PUT body, so the existing key is preserved on the backend.
- **F4** — `Buffer.concat` → `Uint8Array`. `mcp-docs` is a Node-only CLI; edge/Deno compatibility is out of scope.
- **F5** — `contentType.includes('application/xhtml')` "should be `application/xhtml+xml`". `.includes()` does substring matching and already catches `application/xhtml+xml`. Same false flag noted in epic #248.

## Test plan

- [x] `packages/contracts` — added 2 tests for the new `.max(5000)` boundary on `aiGuardrailNoFabrication`. 18/18 pass.
- [x] `frontend` — full suite 1811/1811 pass (type-alias refactor is behaviour-neutral; assignments coverage already exercises `effectiveProvider`).
- [x] `backend` admin route tests — 26/26 pass.
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)