### PR TITLE
docs: sync top-level docs to multi-LLM-provider (#259 follow-up)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,8 +44,7 @@ BACKEND_PORT=3051
 # All env vars in this section are DEPRECATED: seed-only; consulted on first
 # boot when `llm_providers` is empty. Configure providers in Settings → LLM.
 
-# DEPRECATED: seed-only; consulted on first boot when llm_providers is empty. Configure providers in Settings → LLM.
-# LLM_PROVIDER=ollama          # "ollama" or "openai" — selects which seed row to insert on first boot
+# (Removed) LLM_PROVIDER was the legacy two-slot {ollama, openai} toggle. Replaced by the `llm_providers` table + per-use-case assignments. Configure providers in Settings → LLM.
 
 # DEPRECATED: seed-only; consulted on first boot when llm_providers is empty. Configure providers in Settings → LLM.
 OLLAMA_BASE_URL=http://localhost:11434

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,11 @@ compendiq/
 │   ├── domains/
 │   │   ├── confluence/services/     # confluence-client, sync-service, attachment-handler,
 │   │   │                            #   subpage-context, sync-overview-service, confluence-rate-limiter
-│   │   ├── llm/services/            # ollama-service, ollama-provider, openai-service,
-│   │   │                            #   llm-provider, embedding-service, rag-service, llm-cache,
-│   │   │                            #   llm-audit-hook, llm-queue
+│   │   ├── llm/services/            # openai-compatible-client (unified; queue + per-provider breakers),
+│   │   │                            #   llm-provider-service (CRUD), llm-provider-resolver (resolveUsecase),
+│   │   │                            #   llm-provider-bootstrap (env seed on fresh install), cache-bus,
+│   │   │                            #   embedding-service, rag-service, llm-cache, llm-audit-hook,
+│   │   │                            #   llm-queue, prompts
 │   │   └── knowledge/services/      # auto-tagger, quality-worker, summary-worker,
 │   │                                #   version-tracker, duplicate-detector
 │   ├── routes/
@@ -96,7 +98,7 @@ Import restrictions enforced by `eslint-plugin-boundaries`:
 ## Tech Stack
 
 - **Backend**: Fastify 5, TypeScript, PostgreSQL 17 (pgvector), Redis 8, `ollama` npm package, `jose` (JWT), `bcrypt`, `pg`, `undici`, `zod`, `pino`, `bullmq`, `nodemailer`
-- **LLM providers**: Ollama (default) + OpenAI-compatible APIs (via `undici`) — configurable per-user or server-wide via `LLM_PROVIDER`
+- **LLM providers**: N named `openai-compatible` endpoints configured in Settings → LLM. Ollama is reached via its `/v1` shim — no separate protocol. Each use case (chat/summary/quality/auto_tag/embedding) either inherits a default provider or picks an explicit provider+model. Queue + per-provider circuit breakers wrap every outbound call inside `openai-compatible-client.ts`
 - **Frontend**: React 19, Vite, TailwindCSS 4, Radix UI, Zustand, TanStack Query, Framer Motion, TipTap v3, Sonner
 - **Content conversion**: `turndown` + `jsdom` + `turndown-plugin-gfm` (Confluence XHTML → Markdown), `marked` (Markdown → HTML)
 - **PDF**: `pdf-lib` for PDF export/import processing
@@ -237,8 +239,8 @@ Copy `.env.example` to `.env`. Key vars:
 - `PAT_ENCRYPTION_KEY` (32+ chars, required)
 - `POSTGRES_URL` (default: `postgresql://kb_user:changeme-postgres@localhost:5432/kb_creator`)
 - `REDIS_URL` (default: `redis://:changeme-redis@localhost:6379`)
-- `OLLAMA_BASE_URL` (default: `http://localhost:11434`)
-- `LLM_PROVIDER` (optional, `ollama` or `openai`, default: `ollama`)
+- `OLLAMA_BASE_URL` (**deprecated — seed-only**; consulted once on fresh install to seed the first `llm_providers` row. After that, configure providers in Settings → LLM.)
+- `LLM_PROVIDER` (**removed** — was the two-slot toggle. Replaced by the `llm_providers` table + per-use-case assignments.)
 - `LLM_BEARER_TOKEN` (optional, Bearer token for authenticated Ollama/LLM proxies)
 - `LLM_AUTH_TYPE` (optional, `bearer` or `none`, default: `bearer`)
 - `LLM_VERIFY_SSL` (optional, set to `false` to disable TLS verification for LLM connections)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ Copy `.env.example` to `.env`. Key vars:
 - `REDIS_URL` (default: `redis://:changeme-redis@localhost:6379`)
 - `OLLAMA_BASE_URL` (**deprecated — seed-only**; consulted once on fresh install to seed the first `llm_providers` row. After that, configure providers in Settings → LLM.)
 - `LLM_PROVIDER` (**removed** — was the two-slot toggle. Replaced by the `llm_providers` table + per-use-case assignments.)
-- `LLM_BEARER_TOKEN` (optional, Bearer token for authenticated Ollama/LLM proxies)
+- `LLM_BEARER_TOKEN` (**deprecated — seed-only**; Bearer token on the seeded Ollama row, consulted once on fresh install. After that, configure per-provider API keys in Settings → LLM.)
 - `LLM_AUTH_TYPE` (optional, `bearer` or `none`, default: `bearer`)
 - `LLM_VERIFY_SSL` (optional, set to `false` to disable TLS verification for LLM connections)
 - `LLM_STREAM_TIMEOUT_MS` (optional, streaming timeout in ms, default: `300000`)

--- a/README.md
+++ b/README.md
@@ -256,11 +256,9 @@ All configuration is via environment variables. Key settings:
 |----------|:---:|-------------|
 | `JWT_SECRET` | Yes | JWT signing secret (32+ characters) |
 | `PAT_ENCRYPTION_KEY` | Yes | AES-256-GCM key for Confluence PATs (32+ characters) |
-| `OLLAMA_BASE_URL` | -- | Ollama server URL (default: `http://localhost:11434`) |
-| `EMBEDDING_MODEL` | -- | Embedding model (default: `bge-m3`) |
-| `LLM_PROVIDER` | -- | `ollama` (default) or `openai` |
-| `OPENAI_BASE_URL` | -- | OpenAI-compatible API URL (for Azure, LM Studio, vLLM, etc.) |
-| `OPENAI_API_KEY` | -- | API key when using OpenAI provider |
+| `OLLAMA_BASE_URL` | -- | **Deprecated — seed-only.** Used on fresh install to create the first `llm_providers` row. Configure providers in Settings → LLM after first login. |
+| `OPENAI_BASE_URL` | -- | **Deprecated — seed-only.** Same as above for an OpenAI-compatible endpoint. |
+| `OPENAI_API_KEY` | -- | **Deprecated — seed-only.** API key for the seeded OpenAI row. |
 | `POSTGRES_URL` | -- | PostgreSQL connection string |
 | `REDIS_URL` | -- | Redis connection string |
 
@@ -277,10 +275,9 @@ All configuration is via environment variables. Key settings:
 | `POSTGRES_URL` | `postgresql://kb_user:changeme-postgres@localhost:5432/kb_creator` | Full connection string |
 | `REDIS_PASSWORD` | `changeme-redis` | Redis password |
 | `REDIS_URL` | `redis://:changeme-redis@localhost:6379` | Full Redis connection string |
-| `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server URL |
-| `EMBEDDING_MODEL` | `bge-m3` | Server-wide embedding model (1024 dimensions) |
-| `LLM_PROVIDER` | `ollama` | LLM provider: `ollama` or `openai` |
-| `LLM_BEARER_TOKEN` | -- | Bearer token for authenticated Ollama/LLM proxies |
+| `OLLAMA_BASE_URL` | `http://localhost:11434` | **Deprecated — seed-only.** Consulted once on fresh install to create the first `llm_providers` row; ignored afterwards. Configure providers via Settings → LLM. |
+| `LLM_PROVIDER` | — | **Removed.** The two-slot `{ollama, openai}` toggle was replaced by the `llm_providers` table + per-use-case assignments. |
+| `LLM_BEARER_TOKEN` | -- | **Deprecated — seed-only.** Bearer token on the seeded Ollama row. |
 | `LLM_VERIFY_SSL` | `true` | Set to `false` for self-signed LLM certs |
 | `LLM_STREAM_TIMEOUT_MS` | `300000` | Streaming request timeout (ms) |
 | `LLM_CACHE_TTL` | `3600` | Redis TTL for LLM cache (seconds) |

--- a/docs/architecture/09-flow-rag-chat.md
+++ b/docs/architecture/09-flow-rag-chat.md
@@ -13,13 +13,13 @@ sequenceDiagram
     participant BE as /api/llm/ask (SSE)
     participant SAN as sanitize-llm-input
     participant RAG as rag-service
-    participant OL as Ollama (embed)
+    participant EMB as embedding provider<br/>(resolveUsecase('embedding'))
     participant PG as Postgres (pgvector + FTS)
     participant SP as subpage-context
     participant CF as Confluence
     participant MCP as mcp-docs / searxng
     participant CACHE as llm-cache (Redis)
-    participant PROV as LLM provider<br/>(Ollama / OpenAI)
+    participant PROV as chat provider<br/>(resolveUsecase('chat'))
     participant CONV as llm_conversations
 
     FE->>BE: POST /api/llm/ask<br/>{ question, model, conversationId,<br/>  includeSubPages, externalUrls, searchWeb }
@@ -36,8 +36,8 @@ sequenceDiagram
             BE-->>FE: SSE { content, done:true, fromCache:true }
         else miss (stampede lock)
             CACHE-->>BE: lock acquired
-            BE->>OL: POST /api/embeddings (question)
-            OL-->>BE: q_vector[1024]
+            BE->>EMB: POST /v1/embeddings (question)
+            EMB-->>BE: q_vector[N]
             par vector + keyword
                 BE->>RAG: vectorSearch(q_vector, userId, topK)
                 RAG->>PG: SELECT ... ORDER BY embedding <=> $1<br/>WHERE user_id=$2 AND space in (...)
@@ -135,7 +135,8 @@ All of these go through the same provider resolver and sanitization layer:
 - `backend/src/routes/llm/llm-ask.ts`
 - `backend/src/domains/llm/services/rag-service.ts`
 - `backend/src/domains/llm/services/embedding-service.ts`
-- `backend/src/domains/llm/services/llm-provider.ts` (Ollama vs OpenAI resolver)
+- `backend/src/domains/llm/services/llm-provider-resolver.ts` (per-use-case provider + model resolver)
+- `backend/src/domains/llm/services/openai-compatible-client.ts` (unified client — `chat` / `streamChat` / `generateEmbedding` with queue + per-provider circuit breakers)
 - `backend/src/domains/llm/services/llm-cache.ts`
 - `backend/src/core/utils/sanitize-llm-input.ts`
 - `backend/src/domains/confluence/services/subpage-context.ts`


### PR DESCRIPTION
## Summary

Doc sweep after PR #259 landed. Brings CLAUDE.md, README, and the RAG-flow architecture diagram in line with the new provider model (N named `openai-compatible` endpoints + per-use-case assignment, queue + per-provider breakers inside the client).

## Scope

- \`CLAUDE.md\` — service tree (ollama-service/openai-service/llm-provider → openai-compatible-client/llm-provider-service/llm-provider-resolver/cache-bus), LLM-providers blurb, env-var table
- \`README.md\` — env-var quick-reference table + full reference both marked \`OLLAMA_BASE_URL\` / \`OPENAI_BASE_URL\` / \`OPENAI_API_KEY\` / \`LLM_BEARER_TOKEN\` as "deprecated — seed-only" and \`LLM_PROVIDER\` as removed
- \`docs/architecture/09-flow-rag-chat.md\` — sequence diagram participants renamed and "Key files" pointer updated

Historical snapshots (MODULARIZATION-PLAN, CONSISTENCY-ANALYSIS-REPORT, IMPLEMENTATION-PLAN, docs/plans/214-*.md) left untouched.

## Test plan
- [ ] No code touched; CI should be green on docs-only PR.
- [ ] Mermaid renders in GitHub preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)