### PR TITLE
feat(#257): wire BullMQ re-embed-all worker + lock visibility

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -17,6 +17,7 @@ import { healthRoutes } from './routes/foundation/health.js';
 import { authRoutes } from './routes/foundation/auth.js';
 import { settingsRoutes } from './routes/foundation/settings.js';
 import { adminRoutes } from './routes/foundation/admin.js';
+import { adminEmbeddingLocksRoutes } from './routes/foundation/admin-embedding-locks.js';
 import { rbacRoutes } from './routes/foundation/rbac.js';
 // Confluence routes
 import { spacesRoutes } from './routes/confluence/spaces.js';
@@ -225,6 +226,7 @@ export async function buildApp() {
   await app.register(authRoutes, { prefix: '/api/auth' });
   await app.register(settingsRoutes, { prefix: '/api' });
   await app.register(adminRoutes, { prefix: '/api' });
+  await app.register(adminEmbeddingLocksRoutes, { prefix: '/api' });
   await app.register(rbacRoutes, { prefix: '/api' });
 
   // Community-mode license endpoint fallback.

--- a/backend/src/core/db/migrations/055_admin_settings_reembed_retention.sql
+++ b/backend/src/core/db/migrations/055_admin_settings_reembed_retention.sql
@@ -1,0 +1,18 @@
+-- Migration 055: admin-configurable reembed-all job history retention (#257)
+--
+-- Introduces the `reembed_history_retention` admin setting (integer stored as
+-- text). Controls how many completed / failed re-embed-all BullMQ job records
+-- are retained in Redis before the oldest get swept.
+--
+-- Additive + idempotent:
+--   - No schema DDL.
+--   - No column or table changes.
+--   - Uses ON CONFLICT DO NOTHING so existing deployments that already set an
+--     explicit value (via a manual UPDATE before this migration ran) keep it.
+--
+-- Default: 150. Valid range (enforced by Zod at the API boundary +
+-- `getReembedHistoryRetention` clamp inside `admin-settings-service.ts`):
+-- [10, 10000].
+INSERT INTO admin_settings (setting_key, setting_value, updated_at)
+VALUES ('reembed_history_retention', '150', NOW())
+ON CONFLICT (setting_key) DO NOTHING;

--- a/backend/src/core/services/admin-settings-service.ts
+++ b/backend/src/core/services/admin-settings-service.ts
@@ -20,3 +20,22 @@ export async function getEmbeddingDimensions(): Promise<number> {
   }
   return parseInt(process.env.EMBEDDING_DIMENSIONS ?? '1024', 10);
 }
+
+/**
+ * Issue #257 — returns the configured re-embed-all job history retention
+ * (how many completed/failed BullMQ job records are kept in Redis before
+ * the oldest get swept). Default 150, clamped to [10, 10000].
+ *
+ * Read per-enqueue inside `enqueueReembedAll` so runtime changes take
+ * effect on the next run. Also consumed by the admin GET/PUT
+ * `/api/admin/settings` surface.
+ */
+export async function getReembedHistoryRetention(): Promise<number> {
+  const r = await query<{ setting_value: string }>(
+    `SELECT setting_value FROM admin_settings WHERE setting_key='reembed_history_retention'`,
+  );
+  const raw = r.rows[0]?.setting_value;
+  const n = raw ? parseInt(raw, 10) : NaN;
+  if (!Number.isFinite(n)) return 150;
+  return Math.max(10, Math.min(10_000, n));
+}

--- a/backend/src/core/services/queue-service.test.ts
+++ b/backend/src/core/services/queue-service.test.ts
@@ -1,25 +1,76 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock BullMQ before importing the module
-const mockQueue = {
-  upsertJobScheduler: vi.fn().mockResolvedValue(undefined),
-  close: vi.fn().mockResolvedValue(undefined),
-  getWaitingCount: vi.fn().mockResolvedValue(5),
-  getActiveCount: vi.fn().mockResolvedValue(2),
-  getCompletedCount: vi.fn().mockResolvedValue(100),
-  getFailedCount: vi.fn().mockResolvedValue(3),
-};
+// ─── BullMQ mock wiring ──────────────────────────────────────────────────
+// Each test needs fine-grained control over Job methods (getState, remove).
+// We route every `new Queue(...)` to a per-name stub held in `queueStubs` so
+// tests can assert against `queueStubs.get('reembed-all')!.add` etc.
 
-const mockWorker = {
-  on: vi.fn(),
-  close: vi.fn().mockResolvedValue(undefined),
-};
+interface JobStub {
+  id: string;
+  name: string;
+  data: unknown;
+  progress: number | object;
+  returnvalue: unknown;
+  failedReason?: string;
+  getState: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+}
+
+interface QueueStub {
+  add: ReturnType<typeof vi.fn>;
+  getJob: ReturnType<typeof vi.fn>;
+  upsertJobScheduler: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  getWaitingCount: ReturnType<typeof vi.fn>;
+  getActiveCount: ReturnType<typeof vi.fn>;
+  getCompletedCount: ReturnType<typeof vi.fn>;
+  getFailedCount: ReturnType<typeof vi.fn>;
+}
+
+const queueStubs = new Map<string, QueueStub>();
+
+function createQueueStub(): QueueStub {
+  return {
+    add: vi.fn(),
+    getJob: vi.fn(),
+    upsertJobScheduler: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    getWaitingCount: vi.fn().mockResolvedValue(5),
+    getActiveCount: vi.fn().mockResolvedValue(2),
+    getCompletedCount: vi.fn().mockResolvedValue(100),
+    getFailedCount: vi.fn().mockResolvedValue(3),
+  };
+}
+
+function createJobStub(overrides: Partial<JobStub> & { id: string }): JobStub {
+  return {
+    name: 'reembed-all',
+    data: {},
+    progress: 0,
+    returnvalue: undefined,
+    getState: vi.fn().mockResolvedValue('waiting'),
+    remove: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
 
 vi.mock('bullmq', () => ({
-  Queue: vi.fn().mockImplementation(() => ({ ...mockQueue })),
-  Worker: vi.fn().mockImplementation((_name: string, _processor: unknown, _opts: unknown) => ({
-    ...mockWorker,
-  })),
+  // Use a real constructor function so `new Queue(...)` returns the stub
+  // (arrow functions / vi.fn implementations are not constructible).
+  Queue: function (this: QueueStub, name: string) {
+    let stub = queueStubs.get(name);
+    if (!stub) {
+      stub = createQueueStub();
+      queueStubs.set(name, stub);
+    }
+    // Copy stub properties onto `this` — returning a non-object from a
+    // constructor is ignored, so mutation is the cleanest approach.
+    Object.assign(this, stub);
+  },
+  Worker: function (this: Record<string, unknown>) {
+    this.on = vi.fn();
+    this.close = vi.fn().mockResolvedValue(undefined);
+  },
 }));
 
 vi.mock('../db/postgres.js', () => ({
@@ -38,6 +89,12 @@ vi.mock('../utils/logger.js', () => ({
 describe('queue-service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Fresh stubs per test — prevents state leaking between cases.
+    queueStubs.clear();
+    // Reset the module-level `queues`/`workerDefs` maps inside queue-service.
+    // Without this, an internal queue reference from the previous test would
+    // shadow the fresh stub we set up, making vi.fn()s unreachable.
+    vi.resetModules();
   });
 
   it('isBullMQEnabled returns true by default', async () => {
@@ -51,5 +108,162 @@ describe('queue-service', () => {
     const metrics = await getQueueMetrics();
     // Before any queues are created, metrics should be an object
     expect(typeof metrics).toBe('object');
+  });
+
+  // ─── RED #5 (plan §4.2, Q3 core) ─────────────────────────────────────
+  describe('enqueueJob — idempotent re-enqueue semantics', () => {
+    it('removes the previous completed job before re-adding so a fresh run can start', async () => {
+      const { enqueueJob } = await import('./queue-service.js');
+      const completedJob = createJobStub({
+        id: 'reembed-all',
+        getState: vi.fn().mockResolvedValue('completed'),
+      });
+      // First call returns the stale completed job; subsequent `add` resolves normally.
+      const stub = createQueueStub();
+      stub.getJob.mockResolvedValueOnce(completedJob);
+      stub.add.mockResolvedValueOnce({ id: 'reembed-all' });
+      queueStubs.set('reembed-all', stub);
+
+      const id = await enqueueJob(
+        'reembed-all',
+        { triggeredAt: 't' },
+        { jobId: 'reembed-all', removeOnComplete: 150, removeOnFail: 150 },
+      );
+
+      expect(completedJob.remove).toHaveBeenCalledOnce();
+      expect(stub.add).toHaveBeenCalledOnce();
+      expect(id).toBe('reembed-all');
+    });
+
+    it('also removes a previous failed job before re-adding', async () => {
+      const { enqueueJob } = await import('./queue-service.js');
+      const failedJob = createJobStub({
+        id: 'reembed-all',
+        getState: vi.fn().mockResolvedValue('failed'),
+      });
+      const stub = createQueueStub();
+      stub.getJob.mockResolvedValueOnce(failedJob);
+      stub.add.mockResolvedValueOnce({ id: 'reembed-all' });
+      queueStubs.set('reembed-all', stub);
+
+      await enqueueJob(
+        'reembed-all',
+        {},
+        { jobId: 'reembed-all' },
+      );
+
+      expect(failedJob.remove).toHaveBeenCalledOnce();
+      expect(stub.add).toHaveBeenCalledOnce();
+    });
+
+    it('does NOT remove a previous waiting/active job (collapse-concurrent semantic)', async () => {
+      const { enqueueJob } = await import('./queue-service.js');
+      const activeJob = createJobStub({
+        id: 'reembed-all',
+        getState: vi.fn().mockResolvedValue('active'),
+      });
+      const stub = createQueueStub();
+      stub.getJob.mockResolvedValueOnce(activeJob);
+      // When the job is already in-flight, BullMQ add() with the same jobId is
+      // a silent no-op — it still resolves to the existing job record.
+      stub.add.mockResolvedValueOnce({ id: 'reembed-all' });
+      queueStubs.set('reembed-all', stub);
+
+      const id = await enqueueJob(
+        'reembed-all',
+        {},
+        { jobId: 'reembed-all' },
+      );
+
+      expect(activeJob.remove).not.toHaveBeenCalled();
+      expect(id).toBe('reembed-all');
+    });
+
+    it('forwards removeOnComplete / removeOnFail counts into BullMQ add opts', async () => {
+      const { enqueueJob } = await import('./queue-service.js');
+      const stub = createQueueStub();
+      stub.getJob.mockResolvedValueOnce(null);
+      stub.add.mockResolvedValueOnce({ id: 'reembed-all' });
+      queueStubs.set('reembed-all', stub);
+
+      await enqueueJob(
+        'reembed-all',
+        {},
+        { jobId: 'reembed-all', removeOnComplete: 250, removeOnFail: 250 },
+      );
+
+      const addCall = stub.add.mock.calls[0];
+      // add(name, data, opts)
+      expect(addCall[2]).toMatchObject({
+        jobId: 'reembed-all',
+        removeOnComplete: { count: 250 },
+        removeOnFail: { count: 250 },
+      });
+    });
+
+    it('swallows a race error from existing.remove()', async () => {
+      const { enqueueJob } = await import('./queue-service.js');
+      const completedJob = createJobStub({
+        id: 'reembed-all',
+        getState: vi.fn().mockResolvedValue('completed'),
+        remove: vi.fn().mockRejectedValue(new Error('already removed')),
+      });
+      const stub = createQueueStub();
+      stub.getJob.mockResolvedValueOnce(completedJob);
+      stub.add.mockResolvedValueOnce({ id: 'reembed-all' });
+      queueStubs.set('reembed-all', stub);
+
+      await expect(
+        enqueueJob('reembed-all', {}, { jobId: 'reembed-all' }),
+      ).resolves.toBe('reembed-all');
+    });
+  });
+
+  // ─── RED #6 (plan §4.2) ───────────────────────────────────────────────
+  describe('getJobStatus', () => {
+    it('returns null for an unknown job id', async () => {
+      const { getJobStatus } = await import('./queue-service.js');
+      const stub = createQueueStub();
+      stub.getJob.mockResolvedValueOnce(null);
+      queueStubs.set('reembed-all', stub);
+
+      const status = await getJobStatus('reembed-all', 'unknown-id');
+      expect(status).toBeNull();
+    });
+
+    it('returns { state, progress, returnvalue, failedReason } when the job exists', async () => {
+      const { getJobStatus } = await import('./queue-service.js');
+      const job = createJobStub({
+        id: 'reembed-all',
+        progress: { phase: 'embedding', processed: 42 },
+        returnvalue: 'processed=42 failed=0 total=42',
+        getState: vi.fn().mockResolvedValue('completed'),
+      });
+      const stub = createQueueStub();
+      stub.getJob.mockResolvedValueOnce(job);
+      queueStubs.set('reembed-all', stub);
+
+      const status = await getJobStatus('reembed-all', 'reembed-all');
+      expect(status).toEqual({
+        state: 'completed',
+        progress: { phase: 'embedding', processed: 42 },
+        returnvalue: 'processed=42 failed=0 total=42',
+        failedReason: undefined,
+      });
+    });
+  });
+
+  // ─── Queue registration — reembed-all must be registerable (plan §2.2) ──
+  describe('reembed-all queue wiring', () => {
+    it('getJobStatus transparently creates the reembed-all queue if no enqueue happened first', async () => {
+      const { getJobStatus } = await import('./queue-service.js');
+
+      // No pre-seeded stub — trigger the lazy getOrCreateQueue path.
+      const status = await getJobStatus('reembed-all', 'any-id');
+      expect(status).toBeNull(); // getJob returns undefined on an empty fresh stub by default
+
+      // Stub got created lazily
+      expect(queueStubs.has('reembed-all')).toBe(true);
+    });
   });
 });

--- a/backend/src/core/services/queue-service.ts
+++ b/backend/src/core/services/queue-service.ts
@@ -211,6 +211,103 @@ export async function stopQueueWorkers(): Promise<void> {
 }
 
 /**
+ * Enqueue a one-off job onto a named queue. Returns the resolved job id.
+ *
+ * Idempotency model (issue #257):
+ *   - When `opts.jobId` is passed and a previous job with that id is in a
+ *     *terminal* state (`completed` / `failed`), we explicitly `.remove()` it
+ *     before calling `queue.add()`. BullMQ's auto-removal is lazy — it only
+ *     runs when the NEXT job finishes — so without this sweep the second
+ *     enqueue would silently dedupe against the stale record.
+ *   - When the previous job is still `waiting` / `active` / `delayed` we do
+ *     NOT remove it — the duplicate `add()` is ignored by BullMQ (emitting a
+ *     `duplicated` event) and the second caller observes the same jobId.
+ *     That's the "collapse concurrent POSTs" semantic.
+ *
+ * When BullMQ is disabled (`USE_BULLMQ=false`) this runs the queue's
+ * registered processor inline synchronously (legacy fallback behaviour).
+ */
+export async function enqueueJob(
+  queueName: string,
+  data: Record<string, unknown>,
+  opts?: { jobId?: string; removeOnComplete?: number; removeOnFail?: number },
+): Promise<string> {
+  if (!USE_BULLMQ) {
+    const fakeId = opts?.jobId ?? `${queueName}-${Date.now()}`;
+    const def = workerDefs.find((d) => d.queueName === queueName);
+    if (def) {
+      // Fire-and-forget inline execution. We don't await so the caller
+      // observes the same "enqueue returns before processing finishes"
+      // contract as the BullMQ path.
+      void def.processor({
+        id: fakeId,
+        name: queueName,
+        data,
+        updateProgress: async () => {},
+        remove: async () => {},
+      } as unknown as Job);
+    }
+    return fakeId;
+  }
+
+  const q = getOrCreateQueue(queueName);
+
+  // Explicitly sweep terminal stale jobs — see jsdoc above.
+  if (opts?.jobId) {
+    const existing = await q.getJob(opts.jobId);
+    if (existing) {
+      const state = await existing.getState();
+      if (state === 'completed' || state === 'failed') {
+        await existing.remove().catch(() => {
+          /* race-tolerant: another process may have removed it first */
+        });
+      }
+    }
+  }
+
+  const addOpts: Record<string, unknown> = {};
+  if (opts?.jobId) addOpts.jobId = opts.jobId;
+  if (opts?.removeOnComplete !== undefined) {
+    addOpts.removeOnComplete = { count: opts.removeOnComplete };
+  }
+  if (opts?.removeOnFail !== undefined) {
+    addOpts.removeOnFail = { count: opts.removeOnFail };
+  }
+
+  const job = await q.add(queueName, data, addOpts);
+  return job.id ?? opts?.jobId ?? `${queueName}-${Date.now()}`;
+}
+
+/**
+ * Fetch a job's current status + progress. Returns null when the job is not
+ * found (includes unknown queue / unknown id). Returns null when BullMQ is
+ * disabled (legacy fallback has no observable job state).
+ */
+export async function getJobStatus(
+  queueName: string,
+  jobId: string,
+): Promise<
+  | {
+      state: string;
+      progress: number | object;
+      returnvalue: unknown;
+      failedReason?: string;
+    }
+  | null
+> {
+  if (!USE_BULLMQ) return null;
+  const q = queues.get(queueName) ?? getOrCreateQueue(queueName);
+  const job = await q.getJob(jobId);
+  if (!job) return null;
+  return {
+    state: await job.getState(),
+    progress: (job.progress ?? 0) as number | object,
+    returnvalue: job.returnvalue,
+    failedReason: job.failedReason,
+  };
+}
+
+/**
  * Get metrics for all queues (for health endpoint).
  */
 export async function getQueueMetrics(): Promise<
@@ -316,6 +413,19 @@ async function registerAllWorkers(): Promise<void> {
     { every: retentionHours * 60 * 60 * 1000 },
     { name: 'data-retention' },
   );
+
+  // Re-embed-all worker (issue #257) — NO repeatPattern: triggered on-demand
+  // by `enqueueReembedAll` via `POST /api/admin/embedding/reembed`.
+  // Concurrency 1 so a global re-embed is a true exclusive operation.
+  registerWorkerDef({
+    queueName: 'reembed-all',
+    concurrency: 1,
+    processor: async (job: Job) => {
+      // eslint-disable-next-line boundaries/dependencies -- orchestrator needs cross-domain access
+      const { runReembedAllJob } = await import('../../domains/llm/services/embedding-service.js');
+      return runReembedAllJob(job);
+    },
+  });
 }
 
 // ─── Legacy setInterval fallback ─────────────────────────────────────────────

--- a/backend/src/core/services/redis-cache.test.ts
+++ b/backend/src/core/services/redis-cache.test.ts
@@ -11,6 +11,8 @@ import {
   acquireEmbeddingLock,
   releaseEmbeddingLock,
   isEmbeddingLocked,
+  listActiveEmbeddingLocks,
+  forceReleaseEmbeddingLock,
   recordAttachmentFailure,
   getAttachmentFailureCount,
   clearAttachmentFailures,
@@ -35,6 +37,7 @@ function createMockRedisClient() {
     ping: vi.fn(),
     incr: vi.fn(),
     expire: vi.fn(),
+    pTTL: vi.fn(),
   };
 }
 
@@ -201,6 +204,145 @@ describe('redis-cache embedding lock', () => {
       const locked = await isEmbeddingLocked('user-1');
 
       expect(locked).toBe(false);
+    });
+  });
+
+  // ─── RED #7 (plan §2.1, §4.3) ─────────────────────────────────────────────
+  describe('listActiveEmbeddingLocks', () => {
+    it('returns empty array when Redis client is not available', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setRedisClient(null as any);
+      const locks = await listActiveEmbeddingLocks();
+      expect(locks).toEqual([]);
+    });
+
+    it('returns empty array when no locks are held (SCAN returns no keys)', async () => {
+      mockRedis.scan.mockResolvedValueOnce({ cursor: '0', keys: [] });
+      const locks = await listActiveEmbeddingLocks();
+      expect(locks).toEqual([]);
+      expect(mockRedis.scan).toHaveBeenCalledWith('0', {
+        MATCH: 'embedding:lock:*',
+        COUNT: 100,
+      });
+    });
+
+    it('returns EmbeddingLockSnapshot[] for each active lock (userId, holderEpoch, ttlRemainingMs)', async () => {
+      mockRedis.scan.mockResolvedValueOnce({
+        cursor: '0',
+        keys: ['embedding:lock:alice', 'embedding:lock:bob'],
+      });
+      mockRedis.get.mockImplementation(async (key: string) => {
+        if (key === 'embedding:lock:alice') return 'uuid-alice';
+        if (key === 'embedding:lock:bob') return 'uuid-bob';
+        return null;
+      });
+      mockRedis.pTTL.mockImplementation(async (key: string) => {
+        if (key === 'embedding:lock:alice') return 3_000_000;
+        if (key === 'embedding:lock:bob') return 2_500_000;
+        return -2;
+      });
+
+      const locks = await listActiveEmbeddingLocks();
+
+      expect(locks).toEqual(
+        expect.arrayContaining([
+          { userId: 'alice', holderEpoch: 'uuid-alice', ttlRemainingMs: 3_000_000 },
+          { userId: 'bob', holderEpoch: 'uuid-bob', ttlRemainingMs: 2_500_000 },
+        ]),
+      );
+      expect(locks).toHaveLength(2);
+    });
+
+    it('handles paginated SCAN results (multi-page cursor loop)', async () => {
+      mockRedis.scan
+        .mockResolvedValueOnce({ cursor: '5', keys: ['embedding:lock:alice'] })
+        .mockResolvedValueOnce({ cursor: '0', keys: ['embedding:lock:bob'] });
+      mockRedis.get.mockResolvedValue('uuid');
+      mockRedis.pTTL.mockResolvedValue(1000);
+
+      const locks = await listActiveEmbeddingLocks();
+
+      expect(mockRedis.scan).toHaveBeenCalledTimes(2);
+      expect(locks).toHaveLength(2);
+    });
+
+    it('skips malformed keys with empty userId suffix', async () => {
+      mockRedis.scan.mockResolvedValueOnce({
+        cursor: '0',
+        keys: ['embedding:lock:'], // malformed — trailing colon, no user id
+      });
+      mockRedis.get.mockResolvedValue('uuid');
+      mockRedis.pTTL.mockResolvedValue(1000);
+
+      const locks = await listActiveEmbeddingLocks();
+      expect(locks).toEqual([]);
+    });
+
+    it('coerces null holderEpoch to empty string', async () => {
+      mockRedis.scan.mockResolvedValueOnce({
+        cursor: '0',
+        keys: ['embedding:lock:alice'],
+      });
+      mockRedis.get.mockResolvedValue(null); // lock key raced-away between SCAN and GET
+      mockRedis.pTTL.mockResolvedValue(-2);
+
+      const locks = await listActiveEmbeddingLocks();
+      expect(locks).toEqual([
+        { userId: 'alice', holderEpoch: '', ttlRemainingMs: -2 },
+      ]);
+    });
+
+    it('returns empty array when SCAN throws', async () => {
+      mockRedis.scan.mockRejectedValue(new Error('Redis down'));
+      const locks = await listActiveEmbeddingLocks();
+      expect(locks).toEqual([]);
+    });
+  });
+
+  // ─── RED #7b (plan §2.1, §4.3) ────────────────────────────────────────────
+  describe('forceReleaseEmbeddingLock', () => {
+    it('returns { released: false, previousHolderEpoch: null } when Redis is unavailable', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setRedisClient(null as any);
+      const result = await forceReleaseEmbeddingLock('alice');
+      expect(result).toEqual({ released: false, previousHolderEpoch: null });
+    });
+
+    it('returns { released: true, previousHolderEpoch: "<uuid>" } when the key existed', async () => {
+      mockRedis.get.mockResolvedValueOnce('uuid-alice');
+      mockRedis.del.mockResolvedValueOnce(1);
+
+      const result = await forceReleaseEmbeddingLock('alice');
+
+      expect(result).toEqual({ released: true, previousHolderEpoch: 'uuid-alice' });
+      expect(mockRedis.get).toHaveBeenCalledWith('embedding:lock:alice');
+      expect(mockRedis.del).toHaveBeenCalledWith('embedding:lock:alice');
+    });
+
+    it('returns { released: false, previousHolderEpoch: null } when the key was already gone (idempotent)', async () => {
+      mockRedis.get.mockResolvedValueOnce(null);
+      mockRedis.del.mockResolvedValueOnce(0);
+
+      const result = await forceReleaseEmbeddingLock('alice');
+
+      expect(result).toEqual({ released: false, previousHolderEpoch: null });
+    });
+
+    it('returns { released: false, previousHolderEpoch: null } when Redis throws', async () => {
+      mockRedis.get.mockRejectedValueOnce(new Error('Redis down'));
+
+      const result = await forceReleaseEmbeddingLock('alice');
+
+      expect(result).toEqual({ released: false, previousHolderEpoch: null });
+    });
+
+    it('uses the embedding:lock:<userId> key pattern', async () => {
+      mockRedis.get.mockResolvedValueOnce('uuid');
+      mockRedis.del.mockResolvedValueOnce(1);
+
+      await forceReleaseEmbeddingLock('user-with-hyphens');
+
+      expect(mockRedis.del).toHaveBeenCalledWith('embedding:lock:user-with-hyphens');
     });
   });
 

--- a/backend/src/core/services/redis-cache.ts
+++ b/backend/src/core/services/redis-cache.ts
@@ -109,6 +109,108 @@ export async function isEmbeddingLocked(userId: string): Promise<boolean> {
   }
 }
 
+// ── Embedding lock visibility + admin escape hatch (plan §2.1) ───────────
+
+/** Snapshot of a single active per-user embedding lock (issue #257). */
+export interface EmbeddingLockSnapshot {
+  userId: string;
+  /** Lock identity token (random UUID written by `acquireEmbeddingLock`).
+   *  Exposed so the worker can verify, before each write, that the lock it
+   *  originally acquired is still the one in Redis (holder-epoch guard). */
+  holderEpoch: string;
+  /** Remaining TTL in milliseconds. `-2` means key does not exist; `-1` means
+   *  the key has no TTL (should not happen — `acquireEmbeddingLock` always
+   *  sets one). */
+  ttlRemainingMs: number;
+}
+
+/**
+ * List all per-user embedding locks currently held.
+ *
+ * Uses Redis SCAN (NOT KEYS) to avoid blocking Redis on large keyspaces.
+ * Returns `[]` when Redis is unavailable or SCAN fails.
+ *
+ * Consumers:
+ *   1. Admin UI (`GET /api/admin/embedding/locks`) — renders "alice, bob".
+ *   2. `runReembedAllJob` wait-on-locks loop (worker back-pressure).
+ */
+export async function listActiveEmbeddingLocks(): Promise<EmbeddingLockSnapshot[]> {
+  if (!_redisClient) return [];
+  const out: EmbeddingLockSnapshot[] = [];
+  try {
+    // Existing modules (e.g. `clearAttachmentFailures`, `RedisCache.scanAndDelete`)
+    // use the string-cursor form. Stay consistent with that idiom.
+    let cursor = '0';
+    do {
+      const reply = await _redisClient.scan(cursor, {
+        MATCH: 'embedding:lock:*',
+        COUNT: 100,
+      });
+      cursor = String(reply.cursor);
+      for (const key of reply.keys) {
+        const userId = key.slice('embedding:lock:'.length);
+        if (!userId) continue; // defend against malformed trailing-colon keys
+        // Two round-trips per key is fine for the expected keyspace size
+        // (typically << 100 entries) and the 5-second admin poll cadence.
+        const [holderEpoch, pttl] = await Promise.all([
+          _redisClient.get(key),
+          _redisClient.pTTL(key),
+        ]);
+        out.push({
+          userId,
+          holderEpoch: holderEpoch ?? '',
+          ttlRemainingMs: typeof pttl === 'number' ? pttl : -2,
+        });
+      }
+    } while (cursor !== '0');
+    return out;
+  } catch (err) {
+    logger.error({ err }, 'Failed to list active embedding locks');
+    return [];
+  }
+}
+
+/**
+ * Admin escape hatch — force-delete a per-user embedding lock regardless of
+ * holder. Unlike `releaseEmbeddingLock(userId, lockId)` (which refuses to
+ * delete unless the caller's lockId matches the stored value via Lua), this
+ * one unconditionally DELs the key. Use ONLY from admin-authenticated routes;
+ * log to the audit trail on every call.
+ *
+ * Returns:
+ *   - `{ released: true,  previousHolderEpoch: '<uuid>' }` when the key existed.
+ *   - `{ released: false, previousHolderEpoch: null     }` when the key was
+ *     already gone (idempotent — no 404) or when Redis is unavailable.
+ *
+ * Safety contract (documented for operators):
+ *   If the user's embedding worker is still genuinely running when this is
+ *   called, the worker's next `embedPage` transaction will still commit (it
+ *   doesn't re-check the lock between every row). A racing second acquirer of
+ *   the same userId's lock would see a fresh `holderEpoch`; the original
+ *   worker's write-guard (§2.10 holder-epoch guard) detects this and aborts
+ *   the loop. Duplicate rows in `page_embeddings` are prevented by the
+ *   DELETE/INSERT transaction inside `embedPage`.
+ */
+export async function forceReleaseEmbeddingLock(
+  userId: string,
+): Promise<{ released: boolean; previousHolderEpoch: string | null }> {
+  if (!_redisClient) {
+    return { released: false, previousHolderEpoch: null };
+  }
+  try {
+    const key = embeddingLockKey(userId);
+    const previous = await _redisClient.get(key);
+    const deleted = await _redisClient.del(key);
+    return {
+      released: deleted === 1,
+      previousHolderEpoch: previous,
+    };
+  } catch (err) {
+    logger.error({ err, userId }, 'Failed to force-release embedding lock');
+    return { released: false, previousHolderEpoch: null };
+  }
+}
+
 // ── Generic worker lock (distributed via Redis) ──────────────────────────
 // Provides a simple distributed lock for background workers (quality, summary,
 // token-cleanup) so that only one process runs a given worker at a time.

--- a/backend/src/core/services/redis-cache.ts
+++ b/backend/src/core/services/redis-cache.ts
@@ -1,5 +1,6 @@
 import type { RedisClientType } from 'redis';
 import { randomUUID } from 'node:crypto';
+import { EMBEDDING_LOCK_TTL_MS } from '@compendiq/contracts';
 import { logger } from '../utils/logger.js';
 
 // Module-level reference for services that need cache invalidation without Fastify context
@@ -39,7 +40,13 @@ export async function invalidateGraphCache(userId: string): Promise<void> {
 // Replaces in-memory Set<string> to work correctly in multi-process deployments.
 // Uses SET NX EX for atomic lock acquisition with a safety TTL.
 
-const EMBEDDING_LOCK_TTL = 3600; // 1 hour safety TTL prevents permanent lock on crash
+/**
+ * Safety TTL on embedding lock keys (seconds). Derived from the shared
+ * `EMBEDDING_LOCK_TTL_MS` contract constant so the frontend banner can
+ * compute "held for" without hardcoding the value. 1 hour default —
+ * prevents permanent locks on crash.
+ */
+export const EMBEDDING_LOCK_TTL = Math.floor(EMBEDDING_LOCK_TTL_MS / 1000);
 
 function embeddingLockKey(userId: string): string {
   return `embedding:lock:${userId}`;

--- a/backend/src/domains/llm/services/embedding-service-reembed-all.integration.test.ts
+++ b/backend/src/domains/llm/services/embedding-service-reembed-all.integration.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Integration test for issue #257 / PR #261 — real Redis + real Postgres.
+ *
+ * Guards against a regression of the CRITICAL bug:
+ *   runReembedAllJob acquires the `__reembed_all__` embedding lock, then
+ *   calls processDirtyPages(REEMBED_ALL_LOCK_USER, ...). Before the fix,
+ *   processDirtyPages re-ran `acquireEmbeddingLock` against the same key,
+ *   Redis SET NX EX refused, and processDirtyPages short-circuited with
+ *   `alreadyProcessing: true`. The wrapper had already marked every
+ *   eligible page dirty — so on any non-empty DB, the outer return string
+ *   was `processed=0 failed=0 total=N`.
+ *
+ * This test seeds one dirty page, mocks ONLY the external embedding
+ * provider (`generateEmbedding`) so no LLM call is made, and asserts that
+ * `runReembedAllJob` returns `processed=1 failed=0 total=1`. Against the
+ * pre-fix code it would have returned `processed=0`.
+ *
+ * Skipped automatically when the test PG / Redis instances aren't
+ * reachable (CI uses docker-compose; local `docker compose up` covers it).
+ */
+
+import { beforeAll, afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createClient, type RedisClientType } from 'redis';
+
+// Mock ONLY the external embedding provider to avoid real LLM calls.
+// Everything else (Postgres, Redis, chunking, DB transactions) runs for real.
+vi.mock('./openai-compatible-client.js', async () => {
+  const actual = await vi.importActual<typeof import('./openai-compatible-client.js')>(
+    './openai-compatible-client.js',
+  );
+  return {
+    ...actual,
+    // Return a 1024-dim vector per input text. Dimensions must match the
+    // default embedding column (vector(1024)) — otherwise pgvector rejects
+    // the insert and the test would fail for an unrelated reason.
+    generateEmbedding: vi.fn(async (_cfg: unknown, _model: string, texts: string[] | string) => {
+      const arr = Array.isArray(texts) ? texts : [texts];
+      return arr.map(() => new Array(1024).fill(0.1));
+    }),
+  };
+});
+
+// Provider resolver: skip the real DB lookup — the openai-compatible-client
+// mock ignores the config anyway, and bootstrapping llm_providers rows would
+// require extra seed work that's out of scope for this test.
+vi.mock('./llm-provider-resolver.js', async () => {
+  const actual = await vi.importActual<typeof import('./llm-provider-resolver.js')>(
+    './llm-provider-resolver.js',
+  );
+  return {
+    ...actual,
+    resolveUsecase: vi.fn(async () => ({
+      config: {
+        providerId: 'test-provider',
+        id: 'test-provider',
+        name: 'Test',
+        baseUrl: 'http://localhost:0/v1',
+        apiKey: null,
+        authType: 'none' as const,
+        verifySsl: false,
+        defaultModel: 'bge-m3',
+      },
+      model: 'bge-m3',
+    })),
+  };
+});
+
+import { setupTestDb, teardownTestDb, truncateAllTables, isDbAvailable } from '../../../test-db-helper.js';
+import { query } from '../../../core/db/postgres.js';
+import {
+  setRedisClient,
+  forceReleaseEmbeddingLock,
+} from '../../../core/services/redis-cache.js';
+import { runReembedAllJob } from './embedding-service.js';
+
+const dbAvailable = await isDbAvailable();
+
+async function checkRedisReachable(): Promise<boolean> {
+  const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
+  const probe = createClient({ url });
+  try {
+    probe.on('error', () => {
+      /* swallow — we only care whether connect works */
+    });
+    await probe.connect();
+    await probe.ping();
+    await probe.quit();
+    return true;
+  } catch {
+    try {
+      await probe.quit();
+    } catch {
+      /* best effort */
+    }
+    return false;
+  }
+}
+
+const redisAvailable = dbAvailable ? await checkRedisReachable() : false;
+const canRun = dbAvailable && redisAvailable;
+
+let redis: RedisClientType | null = null;
+
+type FakeJob = {
+  id: string;
+  name: string;
+  data: unknown;
+  updateProgress: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+};
+
+function makeFakeJob(): FakeJob {
+  return {
+    id: 'reembed-all',
+    name: 'reembed-all',
+    data: {},
+    updateProgress: vi.fn(async () => undefined),
+    remove: vi.fn(async () => undefined),
+  };
+}
+
+beforeAll(async () => {
+  if (!canRun) return;
+  await setupTestDb();
+  const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
+  redis = createClient({ url }) as RedisClientType;
+  redis.on('error', () => {
+    /* connection errors surface via the test runner */
+  });
+  await redis.connect();
+  setRedisClient(redis);
+}, 30_000);
+
+afterAll(async () => {
+  if (!canRun) return;
+  if (redis) {
+    try {
+      await redis.quit();
+    } catch {
+      /* best effort */
+    }
+  }
+  await teardownTestDb();
+});
+
+beforeEach(async () => {
+  if (!canRun) return;
+  await truncateAllTables();
+  // Drop any lingering lock keys from prior runs (different test file may
+  // have written them).
+  await forceReleaseEmbeddingLock('__reembed_all__');
+});
+
+describe.skipIf(!canRun)('runReembedAllJob integration (#257)', () => {
+  it('embeds a dirty page end-to-end and returns processed=1 (regression guard for double-acquire bug)', async () => {
+    // Seed one page that matches processDirtyPages' WHERE filter:
+    //   embedding_dirty = TRUE, body_html IS NOT NULL, deleted_at IS NULL,
+    //   COALESCE(page_type, 'page') != 'folder'.
+    const seeded = await query<{ id: number }>(
+      `INSERT INTO pages
+        (confluence_id, space_key, title, body_html, body_text, last_modified_at,
+         embedding_dirty, embedding_status, deleted_at, page_type)
+       VALUES
+        ('reembed-int-1', 'DEV', 'Re-embed Regression Page',
+         '<p>Content substantial enough that the chunker will keep it after filtering.</p>',
+         'Content substantial enough that the chunker will keep it after filtering.',
+         NOW(), TRUE, 'not_embedded', NULL, 'page')
+       RETURNING id`,
+    );
+    expect(seeded.rows).toHaveLength(1);
+    const pageId = seeded.rows[0]!.id;
+
+    const job = makeFakeJob();
+    const result = await runReembedAllJob(job as unknown as Parameters<typeof runReembedAllJob>[0]);
+
+    // Pre-fix behaviour on any non-empty DB: `processed=0`. Post-fix: at
+    // least one page must have been embedded.
+    expect(result).toMatch(/^processed=([1-9]\d*) /);
+    expect(result).toContain('failed=0');
+
+    // Verify the embedding actually landed in page_embeddings — the
+    // string-assertion above would pass if processDirtyPages cheated, but
+    // the row count is ground truth.
+    const chunks = await query<{ c: string }>(
+      `SELECT COUNT(*)::text AS c FROM page_embeddings WHERE page_id = $1`,
+      [pageId],
+    );
+    expect(parseInt(chunks.rows[0]!.c, 10)).toBeGreaterThanOrEqual(1);
+
+    // And the page is no longer dirty.
+    const pageRow = await query<{ embedding_dirty: boolean; embedding_status: string }>(
+      `SELECT embedding_dirty, embedding_status FROM pages WHERE id = $1`,
+      [pageId],
+    );
+    expect(pageRow.rows[0]!.embedding_dirty).toBe(false);
+    expect(pageRow.rows[0]!.embedding_status).toBe('embedded');
+
+    // And the system lock got released.
+    const stillLocked = await redis!.exists('embedding:lock:__reembed_all__');
+    expect(stillLocked).toBe(0);
+  }, 30_000);
+});
+
+// When the test environment is missing PG or Redis we still want the file
+// to report *something* rather than silently producing zero tests — vitest
+// treats an empty suite as success, which would quietly hide a broken CI.
+describe.skipIf(canRun)('runReembedAllJob integration (#257) [SKIPPED]', () => {
+  it.skip(
+    `Requires real Postgres (${dbAvailable ? 'OK' : 'MISSING'}) and Redis (${redisAvailable ? 'OK' : 'MISSING'})`,
+    () => {
+      /* placeholder */
+    },
+  );
+});

--- a/backend/src/domains/llm/services/embedding-service.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.test.ts
@@ -27,7 +27,14 @@ const mocks = vi.hoisted(() => ({
   acquireEmbeddingLock: vi.fn().mockResolvedValue('fake-lock-id-for-tests'),
   releaseEmbeddingLock: vi.fn().mockResolvedValue(undefined),
   isEmbeddingLocked: vi.fn().mockResolvedValue(false),
+  listActiveEmbeddingLocks: vi.fn().mockResolvedValue([]),
+  forceReleaseEmbeddingLock: vi.fn().mockResolvedValue({ released: true, previousHolderEpoch: null }),
   invalidateGraphCache: vi.fn().mockResolvedValue(undefined),
+  // Mock Redis client used by the holder-epoch guard (plan §2.10):
+  // `processDirtyPages` reads back the lock key every 20 pages via
+  // `getRedisClient().get(embeddingLockKey(userId))`.
+  redisGet: vi.fn().mockResolvedValue(null),
+  enqueueJob: vi.fn().mockResolvedValue('reembed-all'),
 }));
 
 vi.mock('../../../core/db/postgres.js', () => ({
@@ -69,8 +76,19 @@ vi.mock('../../../core/services/redis-cache.js', () => ({
   acquireEmbeddingLock: (...args: unknown[]) => mocks.acquireEmbeddingLock(...args),
   releaseEmbeddingLock: (...args: unknown[]) => mocks.releaseEmbeddingLock(...args),
   isEmbeddingLocked: (...args: unknown[]) => mocks.isEmbeddingLocked(...args),
+  listActiveEmbeddingLocks: (...args: unknown[]) => mocks.listActiveEmbeddingLocks(...args),
+  forceReleaseEmbeddingLock: (...args: unknown[]) => mocks.forceReleaseEmbeddingLock(...args),
   invalidateGraphCache: (...args: unknown[]) => mocks.invalidateGraphCache(...args),
-  getRedisClient: () => null,
+  // The holder-epoch guard in processDirtyPages calls getRedisClient().get(...)
+  // every 20 pages. Return a minimal stub that exposes `.get` wired to `redisGet`.
+  getRedisClient: () => ({ get: mocks.redisGet }),
+}));
+
+// Mock queue-service so tests can observe `enqueueJob` without BullMQ booting.
+vi.mock('../../../core/services/queue-service.js', () => ({
+  enqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
+  getJobStatus: vi.fn().mockResolvedValue(null),
+  isBullMQEnabled: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock('../../../core/services/rbac-service.js', () => ({
@@ -102,6 +120,8 @@ import {
   isContextLengthError,
   splitByWords,
   getEmbedBreakerNextRetryTime,
+  enqueueReembedAll,
+  runReembedAllJob,
   CHUNK_HARD_LIMIT,
   DIRTY_PAGE_BATCH_SIZE,
   type EmbeddingProgressEvent,
@@ -134,7 +154,18 @@ describe('embedding-service', () => {
     mocks.acquireEmbeddingLock.mockResolvedValue(FAKE_LOCK_ID);
     mocks.releaseEmbeddingLock.mockResolvedValue(undefined);
     mocks.isEmbeddingLocked.mockResolvedValue(false);
+    mocks.listActiveEmbeddingLocks.mockResolvedValue([]);
+    mocks.forceReleaseEmbeddingLock.mockResolvedValue({ released: true, previousHolderEpoch: null });
     mocks.invalidateGraphCache.mockResolvedValue(undefined);
+    // Holder-epoch guard: by default the Redis GET returns the lock we just
+    // acquired for `embedding:lock:*` keys so the guard does not fire (it
+    // only aborts on mismatch/null). Other keys (e.g. embedding:last_run_at)
+    // must return null to avoid polluting unrelated tests.
+    mocks.redisGet.mockImplementation(async (key: string) => {
+      if (typeof key === 'string' && key.startsWith('embedding:lock:')) return FAKE_LOCK_ID;
+      return null;
+    });
+    mocks.enqueueJob.mockResolvedValue('reembed-all');
     // Default: htmlToText returns non-trivial text so embedPage proceeds
     mocks.htmlToText.mockReturnValue('Some substantial page content for embedding that is long enough');
     // Default: getSharedLlmSettings returns standard Ollama settings
@@ -289,6 +320,19 @@ describe('embedding-service', () => {
       mocks.isEmbeddingLocked.mockResolvedValue(true);
       expect(await isProcessingUser('busy-user')).toBe(true);
       expect(mocks.isEmbeddingLocked).toHaveBeenCalledWith('busy-user');
+    });
+
+    // Plan §2.4 — bidirectional gating for reembed-all.
+    it('returns true when the reembed-all system lock is held, even if the user has no lock', async () => {
+      mocks.isEmbeddingLocked.mockImplementation(async (id: string) => id === '__reembed_all__');
+      expect(await isProcessingUser('some-user')).toBe(true);
+      expect(mocks.isEmbeddingLocked).toHaveBeenCalledWith('some-user');
+      expect(mocks.isEmbeddingLocked).toHaveBeenCalledWith('__reembed_all__');
+    });
+
+    it('returns false when neither the user nor reembed-all lock is held', async () => {
+      mocks.isEmbeddingLocked.mockResolvedValue(false);
+      expect(await isProcessingUser('some-user')).toBe(false);
     });
   });
 
@@ -1434,6 +1478,351 @@ describe('chunkText', () => {
     it('returns null when no embedding provider can be resolved', async () => {
       mocks.resolveUsecase.mockRejectedValueOnce(new Error('No default provider configured'));
       expect(await getEmbedBreakerNextRetryTime()).toBeNull();
+    });
+  });
+
+  // ─── Plan §2.3 / §4.1 — enqueueReembedAll returns fixed jobId + retention ──
+  describe('enqueueReembedAll', () => {
+    beforeEach(() => {
+      // The top-level describe('chunkText') has no beforeEach, so reset
+      // locally to prevent mockResolvedValueOnce queues from leaking.
+      vi.resetAllMocks();
+      mocks.listActiveEmbeddingLocks.mockResolvedValue([]);
+      mocks.enqueueJob.mockResolvedValue('reembed-all');
+    });
+
+    it('returns the fixed "reembed-all" jobId (collapse-concurrent semantic)', async () => {
+      // Retention query returns the default seed.
+      mocks.query.mockResolvedValueOnce({ rows: [{ setting_value: '150' }] });
+
+      const id = await enqueueReembedAll();
+
+      expect(id).toBe('reembed-all');
+      expect(mocks.enqueueJob).toHaveBeenCalledOnce();
+      const [queueName, data, opts] = mocks.enqueueJob.mock.calls[0];
+      expect(queueName).toBe('reembed-all');
+      expect(data).toMatchObject({ heldBy: [] });
+      expect(opts).toMatchObject({
+        jobId: 'reembed-all',
+        removeOnComplete: 150,
+        removeOnFail: 150,
+      });
+    });
+
+    // RED #4 (plan §4.1): retention read from admin_settings.
+    it('reads reembed_history_retention from admin_settings and passes it as removeOnComplete/removeOnFail', async () => {
+      mocks.query.mockResolvedValueOnce({ rows: [{ setting_value: '250' }] });
+
+      await enqueueReembedAll();
+
+      const opts = mocks.enqueueJob.mock.calls[0][2];
+      expect(opts).toMatchObject({ removeOnComplete: 250, removeOnFail: 250 });
+    });
+
+    it('falls back to 150 when the retention setting is missing', async () => {
+      mocks.query.mockResolvedValueOnce({ rows: [] });
+
+      await enqueueReembedAll();
+
+      const opts = mocks.enqueueJob.mock.calls[0][2];
+      expect(opts).toMatchObject({ removeOnComplete: 150, removeOnFail: 150 });
+    });
+
+    it('clamps retention below the minimum (10) up to 10', async () => {
+      mocks.query.mockResolvedValueOnce({ rows: [{ setting_value: '1' }] });
+      await enqueueReembedAll();
+      const opts = mocks.enqueueJob.mock.calls[0][2];
+      expect(opts).toMatchObject({ removeOnComplete: 10, removeOnFail: 10 });
+    });
+
+    it('clamps retention above the maximum (10000) down to 10000', async () => {
+      mocks.query.mockResolvedValueOnce({ rows: [{ setting_value: '999999' }] });
+      await enqueueReembedAll();
+      const opts = mocks.enqueueJob.mock.calls[0][2];
+      expect(opts).toMatchObject({ removeOnComplete: 10_000, removeOnFail: 10_000 });
+    });
+
+    it('includes the currently-held per-user lock userIds in the job data (heldBy)', async () => {
+      mocks.query.mockResolvedValueOnce({ rows: [{ setting_value: '150' }] });
+      mocks.listActiveEmbeddingLocks.mockResolvedValueOnce([
+        { userId: 'alice', holderEpoch: 'uuid-a', ttlRemainingMs: 1000 },
+        { userId: 'bob', holderEpoch: 'uuid-b', ttlRemainingMs: 2000 },
+      ]);
+
+      await enqueueReembedAll();
+
+      const data = mocks.enqueueJob.mock.calls[0][1];
+      expect(data).toMatchObject({ heldBy: ['alice', 'bob'] });
+    });
+  });
+
+  // ─── Plan §2.3 / §4.1 — runReembedAllJob ────────────────────────────────
+  describe('runReembedAllJob', () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+      mocks.toSql.mockReturnValue('[0.1,0.2]');
+      mocks.acquireEmbeddingLock.mockResolvedValue(FAKE_LOCK_ID);
+      mocks.releaseEmbeddingLock.mockResolvedValue(undefined);
+      mocks.isEmbeddingLocked.mockResolvedValue(false);
+      mocks.listActiveEmbeddingLocks.mockResolvedValue([]);
+      mocks.forceReleaseEmbeddingLock.mockResolvedValue({ released: true, previousHolderEpoch: null });
+      mocks.invalidateGraphCache.mockResolvedValue(undefined);
+      mocks.htmlToText.mockReturnValue('Some substantial page content for embedding that is long enough');
+      vi.mocked(getSharedLlmSettings).mockResolvedValue({
+        llmProvider: 'ollama',
+        ollamaModel: 'qwen3.5',
+        openaiBaseUrl: null,
+        hasOpenaiApiKey: false,
+        openaiModel: null,
+        embeddingModel: 'bge-m3',
+        embeddingDimensions: 1024,
+        ftsLanguage: 'simple',
+      });
+      mocks.providerGenerateEmbedding.mockImplementation((_u: string, t: string[]) =>
+        Promise.resolve(t.map(() => new Array(1024).fill(0.1))),
+      );
+      mocks.resolveUsecase.mockResolvedValue({
+        config: {
+          providerId: 'p1', id: 'p1', name: 'X',
+          baseUrl: 'http://x/v1', apiKey: null,
+          authType: 'none', verifySsl: true, defaultModel: 'bge-m3',
+        },
+        model: 'bge-m3',
+      });
+      mockClient.query.mockResolvedValue({ rows: [], rowCount: 0 });
+      mockClient.release.mockResolvedValue(undefined);
+      mocks.getPool.mockReturnValue({ connect: async () => mockClient });
+      mocks.redisGet.mockImplementation(async (key: string) => {
+        if (typeof key === 'string' && key.startsWith('embedding:lock:')) return FAKE_LOCK_ID;
+        return null;
+      });
+      mocks.enqueueJob.mockResolvedValue('reembed-all');
+    });
+
+    type FakeJob = {
+      id: string;
+      name: string;
+      data: unknown;
+      updateProgress: ReturnType<typeof vi.fn>;
+      remove: ReturnType<typeof vi.fn>;
+    };
+
+    function makeFakeJob(): FakeJob {
+      return {
+        id: 'reembed-all',
+        name: 'reembed-all',
+        data: {},
+        updateProgress: vi.fn().mockResolvedValue(undefined),
+        remove: vi.fn().mockResolvedValue(undefined),
+      };
+    }
+
+    // RED #1 (plan §4.1): happy path. Uses a query dispatcher keyed on SQL
+    // fragments so the response order doesn't matter — the order of the
+    // real code path (getAdminChunkSettings → outer COUNT → inner COUNT →
+    // batch SELECT → batch UPDATE → embedPage → recompute relationships) is
+    // easily bypassed by matching the first few words of each query.
+    it('marks all non-folder pages dirty, runs processDirtyPages, returns processed/failed summary', async () => {
+      const pages = [makePage('c1', 1), makePage('c2', 2)];
+      mocks.query.mockImplementation(async (sql: string, _args?: unknown[]) => {
+        if (sql.includes('UPDATE pages') && sql.includes('embedding_dirty = TRUE')) {
+          return { rowCount: 2, rows: [] };
+        }
+        if (sql.includes('admin_settings') && sql.includes('embedding_chunk_size')) {
+          return { rows: [] };
+        }
+        if (sql.includes('COUNT(*)') && sql.includes('embedding_dirty')) {
+          // Worker's outer COUNT returns `{ c: '…' }` while processDirtyPages'
+          // inner COUNT returns `{ count: '…' }`. Return both aliases.
+          return { rows: [{ c: '2', count: '2' }] };
+        }
+        if (sql.includes('SELECT id, confluence_id')) {
+          return { rows: pages };
+        }
+        if (sql.includes("embedding_status = 'embedding'")) {
+          return { rowCount: 2, rows: [] };
+        }
+        // Any computePageRelationships / UPDATE-dirty-false calls.
+        return { rows: [], rowCount: 0 };
+      });
+
+      const job = makeFakeJob();
+      const result = await runReembedAllJob(job as unknown as Parameters<typeof runReembedAllJob>[0]);
+
+      expect(result).toMatch(/^processed=\d+ failed=\d+ total=\d+$/);
+      const finalProgress = job.updateProgress.mock.calls
+        .map((c: unknown[]) => c[0])
+        .reverse()
+        .find((p: unknown) => typeof p === 'object' && p !== null && (p as { phase?: string }).phase === 'complete');
+      expect(finalProgress).toBeTruthy();
+      expect(mocks.acquireEmbeddingLock).toHaveBeenCalledWith('__reembed_all__');
+      expect(mocks.releaseEmbeddingLock).toHaveBeenCalledWith('__reembed_all__', FAKE_LOCK_ID);
+    });
+
+    // RED #2 (plan §4.1, Q2): wait-on-locks loop.
+    it('emits { phase: "waiting-on-user-locks", heldBy: [...] } progress and waits until locks clear', async () => {
+      // Collapse setTimeout inside the wait loop so 3s polls fire immediately.
+      vi.useFakeTimers();
+      try {
+        // First two poll cycles: alice still holds a lock. Third: clear.
+        mocks.listActiveEmbeddingLocks
+          .mockResolvedValueOnce([
+            { userId: 'alice', holderEpoch: 'u1', ttlRemainingMs: 5000 },
+          ])
+          .mockResolvedValueOnce([
+            { userId: 'alice', holderEpoch: 'u1', ttlRemainingMs: 4000 },
+          ])
+          .mockResolvedValue([]);
+
+        // Zero-dirty-pages dispatcher — just enough to let processDirtyPages
+        // return quickly once the wait loop clears.
+        mocks.query.mockImplementation(async (sql: string) => {
+          if (sql.includes('UPDATE pages') && sql.includes('embedding_dirty = TRUE')) {
+            return { rowCount: 0, rows: [] };
+          }
+          if (sql.includes('admin_settings')) return { rows: [] };
+          if (sql.includes('COUNT(*)')) return { rows: [{ c: '0', count: '0' }] };
+          return { rows: [], rowCount: 0 };
+        });
+
+        const job = makeFakeJob();
+        const pending = runReembedAllJob(job as unknown as Parameters<typeof runReembedAllJob>[0]);
+
+        // Advance timers until the wait loop resolves (3s poll interval).
+        await vi.advanceTimersByTimeAsync(10_000);
+        await pending;
+
+        const waitingProgressCalls = job.updateProgress.mock.calls
+          .map((c: unknown[]) => c[0])
+          .filter((p: unknown): p is { phase: string; heldBy?: string[] } =>
+            typeof p === 'object' && p !== null && (p as { phase?: string }).phase === 'waiting-on-user-locks',
+          );
+        expect(waitingProgressCalls.length).toBeGreaterThan(0);
+        expect(waitingProgressCalls[0].heldBy).toEqual(['alice']);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    // RED #3 (plan §4.1, Q2 timeout).
+    it('aborts with a clear error when per-user locks remain beyond REEMBED_WAIT_LOCKS_MS', async () => {
+      const originalTimeout = process.env.REEMBED_WAIT_LOCKS_MS;
+      process.env.REEMBED_WAIT_LOCKS_MS = '10'; // immediate timeout
+
+      try {
+        mocks.listActiveEmbeddingLocks.mockResolvedValue([
+          { userId: 'alice', holderEpoch: 'u1', ttlRemainingMs: 5000 },
+          { userId: 'bob', holderEpoch: 'u2', ttlRemainingMs: 5000 },
+        ]);
+
+        const job = makeFakeJob();
+        await expect(
+          runReembedAllJob(job as unknown as Parameters<typeof runReembedAllJob>[0]),
+        ).rejects.toThrow(/reembed-all aborted.*alice.*bob/);
+
+        // Did NOT proceed to acquire the system lock.
+        expect(mocks.acquireEmbeddingLock).not.toHaveBeenCalledWith('__reembed_all__');
+      } finally {
+        if (originalTimeout === undefined) delete process.env.REEMBED_WAIT_LOCKS_MS;
+        else process.env.REEMBED_WAIT_LOCKS_MS = originalTimeout;
+      }
+    });
+
+    it('excludes the __reembed_all__ lock itself from the held-locks list', async () => {
+      mocks.listActiveEmbeddingLocks.mockResolvedValueOnce([
+        { userId: '__reembed_all__', holderEpoch: 'self', ttlRemainingMs: 3_600_000 },
+      ]);
+      mocks.query.mockImplementation(async (sql: string) => {
+        if (sql.includes('UPDATE pages') && sql.includes('embedding_dirty = TRUE')) {
+          return { rowCount: 0, rows: [] };
+        }
+        if (sql.includes('admin_settings')) return { rows: [] };
+        if (sql.includes('COUNT(*)')) return { rows: [{ c: '0', count: '0' }] };
+        return { rows: [], rowCount: 0 };
+      });
+
+      const job = makeFakeJob();
+      // Should NOT block / timeout — the system-lock entry is filtered out.
+      await expect(
+        runReembedAllJob(job as unknown as Parameters<typeof runReembedAllJob>[0]),
+      ).resolves.toMatch(/^processed=/);
+    });
+  });
+
+  // ─── Plan §2.10 / §4.7 — RED #11g: holder-epoch worker guard ────────────
+  describe('processDirtyPages holder-epoch guard', () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+      mocks.toSql.mockReturnValue('[0.1,0.2]');
+      mocks.acquireEmbeddingLock.mockResolvedValue(FAKE_LOCK_ID);
+      mocks.releaseEmbeddingLock.mockResolvedValue(undefined);
+      mocks.isEmbeddingLocked.mockResolvedValue(false);
+      mocks.invalidateGraphCache.mockResolvedValue(undefined);
+      mocks.htmlToText.mockReturnValue('Some substantial page content for embedding that is long enough');
+      vi.mocked(getSharedLlmSettings).mockResolvedValue({
+        llmProvider: 'ollama',
+        ollamaModel: 'qwen3.5',
+        openaiBaseUrl: null,
+        hasOpenaiApiKey: false,
+        openaiModel: null,
+        embeddingModel: 'bge-m3',
+        embeddingDimensions: 1024,
+        ftsLanguage: 'simple',
+      });
+      mocks.providerGenerateEmbedding.mockImplementation((_u: string, t: string[]) =>
+        Promise.resolve(t.map(() => new Array(1024).fill(0.1))),
+      );
+      mocks.resolveUsecase.mockResolvedValue({
+        config: {
+          providerId: 'p1', id: 'p1', name: 'X',
+          baseUrl: 'http://x/v1', apiKey: null,
+          authType: 'none', verifySsl: true, defaultModel: 'bge-m3',
+        },
+        model: 'bge-m3',
+      });
+      mockClient.query.mockResolvedValue({ rows: [], rowCount: 0 });
+      mockClient.release.mockResolvedValue(undefined);
+      mocks.getPool.mockReturnValue({ connect: async () => mockClient });
+    });
+
+    it('aborts the batch loop within its 20-page guard window when the lock is force-released', async () => {
+      mocks.acquireEmbeddingLock.mockResolvedValue(FAKE_LOCK_ID);
+      const pages = Array.from({ length: 25 }, (_, i) => makePage(`c${i}`, i + 1));
+
+      mocks.query.mockImplementation(async (sql: string) => {
+        if (sql.includes('admin_settings') && sql.includes('embedding_chunk_size')) {
+          return { rows: [] };
+        }
+        if (sql.includes('COUNT(*)') && sql.includes('embedding_dirty')) {
+          return { rows: [{ count: '25' }] };
+        }
+        if (sql.includes('SELECT id, confluence_id')) {
+          return { rows: pages };
+        }
+        if (sql.includes("embedding_status = 'embedding'")) {
+          return { rowCount: 25, rows: [] };
+        }
+        // Defaults (no rows returned) for any additional queries.
+        return { rows: [], rowCount: 0 };
+      });
+
+      mocks.getPool.mockReturnValue({ connect: async () => mockClient });
+      mockClient.query.mockResolvedValue({ rows: [], rowCount: 1 });
+
+      // Holder-epoch guard: every redisGet returns null → the VERY FIRST
+      // guard check (after page 20) detects the mismatch and aborts. We
+      // expect ≤ 20 processed because the inner loop breaks immediately on
+      // page 21 before any more embedPage calls.
+      mocks.redisGet.mockImplementation(async () => null);
+
+      const { processed, errors } = await processDirtyPages('alice');
+
+      // Guard fires on page 21; we processed exactly 20 pages.
+      expect(processed).toBeLessThanOrEqual(20);
+      expect(errors).toBe(0);
+      expect(mocks.releaseEmbeddingLock).toHaveBeenCalledWith('alice', FAKE_LOCK_ID);
+      // Guard check was actually invoked.
+      expect(mocks.redisGet).toHaveBeenCalledWith('embedding:lock:alice');
     });
   });
 });

--- a/backend/src/domains/llm/services/embedding-service.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.test.ts
@@ -106,6 +106,18 @@ vi.mock('../../../core/services/admin-settings-service.js', () => ({
     embeddingDimensions: 1024,
     ftsLanguage: 'simple',
   }),
+  // Issue #257 — retention read during enqueueReembedAll. We delegate to
+  // mocks.query so existing `mockResolvedValueOnce({ rows: [...] })` seeding
+  // in enqueueReembedAll retention tests keeps working.
+  getReembedHistoryRetention: vi.fn(async () => {
+    const r = await mocks.query(
+      "SELECT setting_value FROM admin_settings WHERE setting_key='reembed_history_retention'",
+    );
+    const raw = r?.rows?.[0]?.setting_value;
+    const n = raw ? parseInt(raw, 10) : NaN;
+    if (!Number.isFinite(n)) return 150;
+    return Math.max(10, Math.min(10_000, n));
+  }),
 }));
 
 import {

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -1,3 +1,4 @@
+import type { Job } from 'bullmq';
 import { query, getPool } from '../../../core/db/postgres.js';
 import { resolveUsecase } from './llm-provider-resolver.js';
 import { generateEmbedding } from './openai-compatible-client.js';
@@ -948,4 +949,24 @@ export async function enqueueReembedAll(
     }
   }
   return jobId;
+}
+
+/**
+ * BullMQ worker entry point for the `reembed-all` queue (issue #257).
+ *
+ * Phase 1 placeholder — wired up so the queue can be registered against a
+ * real function (typecheck passes, worker boots cleanly). The lock-aware
+ * wait-on-locks loop, progress throttling, and
+ * `processDirtyPages('__reembed_all__', …)` delegation arrive in Phase 2
+ * (§2.3 of `docs/issues/257-implementation-plan.md`).
+ *
+ * The `_job` parameter is deliberately unused in this stub — Phase 2 will
+ * use `job.updateProgress` for real progress reporting.
+ */
+export async function runReembedAllJob(_job: Job): Promise<string> {
+  // Phase 2 replaces this body with the real worker per plan §2.3.
+  // For now the legacy in-process reEmbedAll is invoked so the queue
+  // registration has a real callable target.
+  await reEmbedAll();
+  return 'phase-1-stub';
 }

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -983,21 +983,6 @@ export async function reEmbedAll(): Promise<void> {
 }
 
 /**
- * Read the admin-configurable job-history retention setting.
- * Default 150, clamped to [10, 10000]. See plan §2.6/§2.8 for schema +
- * migration. Exported for unit-level clamping tests.
- */
-async function getReembedHistoryRetention(): Promise<number> {
-  const r = await query<{ setting_value: string }>(
-    `SELECT setting_value FROM admin_settings WHERE setting_key='reembed_history_retention'`,
-  );
-  const raw = r.rows[0]?.setting_value;
-  const n = raw ? parseInt(raw, 10) : NaN;
-  if (!Number.isFinite(n)) return 150;
-  return Math.max(10, Math.min(10_000, n));
-}
-
-/**
  * Enqueue a re-embed job for all pages. When `newDimensions` is supplied it
  * atomically TRUNCATEs `page_embeddings`, rewrites the pgvector column type,
  * updates the `embedding_dimensions` admin setting, and rebuilds the HNSW
@@ -1059,6 +1044,7 @@ export async function enqueueReembedAll(
 
   // Plan §2.3 Q4 — retention read per-enqueue so runtime admin changes take
   // effect on the next run (existing queued jobs carry the old retention).
+  const { getReembedHistoryRetention } = await import('../../../core/services/admin-settings-service.js');
   const retention = await getReembedHistoryRetention();
 
   const { enqueueJob } = await import('../../../core/services/queue-service.js');

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -443,6 +443,23 @@ export async function isProcessingUser(userId: string): Promise<boolean> {
 }
 
 /**
+ * Options for {@link processDirtyPages}.
+ */
+export interface ProcessDirtyPagesOpts {
+  /**
+   * When set, the caller has already acquired `embedding:lock:${userId}` and
+   * owns its lifecycle. In that case this function must NOT attempt a second
+   * `acquireEmbeddingLock(userId)` (Redis SET NX EX would fail because the
+   * key is held — see issue #257 / #261: `runReembedAllJob` acquires the
+   * `__reembed_all__` lock before calling this function; without this flag,
+   * the inner acquire short-circuits and every eligible page stays dirty),
+   * and must NOT release the lock in the `finally` — the outer caller keeps
+   * ownership and releases after post-embed hooks complete.
+   */
+  lockAlreadyHeld?: boolean;
+}
+
+/**
  * Process all dirty pages in batches with circuit breaker resilience.
  *
  * Pages are fetched in batches of DIRTY_PAGE_BATCH_SIZE using LIMIT/OFFSET.
@@ -456,11 +473,25 @@ export async function isProcessingUser(userId: string): Promise<boolean> {
 export async function processDirtyPages(
   userId: string,
   onProgress?: (event: EmbeddingProgressEvent) => void,
+  opts: ProcessDirtyPagesOpts = {},
 ): Promise<{ processed: number; errors: number; alreadyProcessing?: boolean }> {
-  const lockId = await acquireEmbeddingLock(userId);
-  if (!lockId) {
-    logger.warn({ userId }, 'Embedding processing already in progress for user');
-    return { processed: 0, errors: 0, alreadyProcessing: true };
+  // When the caller already holds the lock (e.g. runReembedAllJob for the
+  // `__reembed_all__` system lock), skip re-acquire / release. The inner
+  // SET NX EX would fail and we'd short-circuit without doing any work.
+  // In that case, snapshot the already-stored lockId from Redis so the
+  // holder-epoch guard (plan §2.10) can still detect a force-release or
+  // re-acquire, and skip `releaseEmbeddingLock` in the `finally` block so
+  // the outer caller keeps ownership.
+  let lockId: string | null;
+  if (opts.lockAlreadyHeld) {
+    const redis = getRedisClient();
+    lockId = redis ? await redis.get(`embedding:lock:${userId}`) : null;
+  } else {
+    lockId = await acquireEmbeddingLock(userId);
+    if (!lockId) {
+      logger.warn({ userId }, 'Embedding processing already in progress for user');
+      return { processed: 0, errors: 0, alreadyProcessing: true };
+    }
   }
 
   await setLastEmbeddingRunAt(new Date());
@@ -762,7 +793,13 @@ export async function processDirtyPages(
       });
     }
   } finally {
-    await releaseEmbeddingLock(userId, lockId);
+    // Only release when we acquired the lock ourselves. When
+    // `opts.lockAlreadyHeld` is set, the outer caller (e.g.
+    // `runReembedAllJob`) owns the lock's lifecycle and will release after
+    // post-embed hooks complete.
+    if (!opts.lockAlreadyHeld && lockId) {
+      await releaseEmbeddingLock(userId, lockId);
+    }
   }
 
   // Post-embed hook: recompute nearest-neighbor relationships (incremental)
@@ -1138,16 +1175,24 @@ export async function runReembedAllJob(job: Job): Promise<string> {
 
     let processed = 0;
     let failed = 0;
-    await processDirtyPages(REEMBED_ALL_LOCK_USER, (evt) => {
-      if (evt.type === 'progress') {
-        processed = evt.completed;
-        failed = evt.failed;
-        // Throttle: every 100 (processed + failed) pages, or on 100%.
-        if ((processed + failed) % 100 === 0 || evt.percentage === 100) {
-          void job.updateProgress({ total, processed, failed, phase: 'embedding' });
+    // `lockAlreadyHeld: true` — we already own the `__reembed_all__` lock
+    // above. Without this, `processDirtyPages`'s inner `acquireEmbeddingLock`
+    // would SET NX against the held key, fail, and short-circuit with
+    // `alreadyProcessing: true`, marking every page dirty but embedding none.
+    await processDirtyPages(
+      REEMBED_ALL_LOCK_USER,
+      (evt) => {
+        if (evt.type === 'progress') {
+          processed = evt.completed;
+          failed = evt.failed;
+          // Throttle: every 100 (processed + failed) pages, or on 100%.
+          if ((processed + failed) % 100 === 0 || evt.percentage === 100) {
+            void job.updateProgress({ total, processed, failed, phase: 'embedding' });
+          }
         }
-      }
-    });
+      },
+      { lockAlreadyHeld: true },
+    );
 
     await job.updateProgress({ total, processed, failed, phase: 'complete' });
     return `processed=${processed} failed=${failed} total=${total}`;

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -416,11 +416,30 @@ export async function embedPage(
 export const DIRTY_PAGE_BATCH_SIZE = 100;
 
 /**
+ * System lock userId used by the reembed-all worker (plan §2.3/§2.4).
+ * Not a real user — acts as a second distinct key in Redis so the same
+ * locking primitive can coordinate BOTH per-user triggers and the global
+ * reembed-all run, preventing overlap in either direction.
+ */
+const REEMBED_ALL_LOCK_USER = '__reembed_all__';
+
+/**
  * Check if embedding processing is already running for a user.
- * Uses Redis distributed lock instead of in-memory Set.
+ *
+ * Plan §2.4 — bidirectional gate: returns `true` whenever EITHER
+ *   1. the user's own embedding lock is held, OR
+ *   2. the reembed-all system lock is held.
+ *
+ * Route handlers (`/embeddings/process`, `/embeddings/retry-failed`) throw
+ * 409 when this returns true — updating the 409 body text to mention the
+ * global reembed is a one-liner in those handlers, not this predicate.
  */
 export async function isProcessingUser(userId: string): Promise<boolean> {
-  return isEmbeddingLocked(userId);
+  const [mine, reembedAll] = await Promise.all([
+    isEmbeddingLocked(userId),
+    isEmbeddingLocked(REEMBED_ALL_LOCK_USER),
+  ]);
+  return mine || reembedAll;
 }
 
 /**
@@ -475,8 +494,41 @@ export async function processDirtyPages(
     let offset = 0;
     let batchAborted = false;
 
+    // Plan §2.10 — holder-epoch write-guard: every GUARD_CHECK_EVERY pages
+    // re-read the Redis lock key and compare against the lockId we originally
+    // acquired. If it's missing (force-released or expired) or mismatched
+    // (re-acquired by another process), break the outer loop cleanly. The
+    // `finally` block's `releaseEmbeddingLock` Lua is a no-op on mismatch, so
+    // no duplicate/destructive release happens.
+    const GUARD_CHECK_EVERY = 20;
+    let pagesProcessedSinceGuardCheck = 0;
+    const guardLockKey = `embedding:lock:${userId}`;
+
     for (;;) {
       if (batchAborted) break;
+
+      // Guard check — evaluated at the top of each batch iteration so it
+      // always runs before the next DB query block, and in the inner page
+      // loop once GUARD_CHECK_EVERY is exceeded.
+      if (pagesProcessedSinceGuardCheck >= GUARD_CHECK_EVERY) {
+        const redis = getRedisClient();
+        if (redis) {
+          try {
+            const stillMine = await redis.get(guardLockKey);
+            if (stillMine !== lockId) {
+              logger.warn(
+                { userId, expected: lockId, actual: stillMine },
+                'Embedding lock was force-released or expired — aborting worker loop',
+              );
+              batchAborted = true;
+              break;
+            }
+          } catch (err) {
+            logger.error({ err, userId }, 'Holder-epoch guard GET failed — continuing');
+          }
+        }
+        pagesProcessedSinceGuardCheck = 0;
+      }
 
       const batch = await query<{
         id: number;
@@ -507,10 +559,35 @@ export async function processDirtyPages(
       );
 
       for (const page of batch.rows) {
+        // Holder-epoch guard (plan §2.10): re-read the lock key every
+        // GUARD_CHECK_EVERY pages from inside the per-page loop too, so a
+        // force-release mid-batch aborts quickly rather than after the
+        // whole batch completes.
+        if (pagesProcessedSinceGuardCheck >= GUARD_CHECK_EVERY) {
+          const redis = getRedisClient();
+          if (redis) {
+            try {
+              const stillMine = await redis.get(guardLockKey);
+              if (stillMine !== lockId) {
+                logger.warn(
+                  { userId, expected: lockId, actual: stillMine },
+                  'Embedding lock was force-released or expired — aborting worker loop',
+                );
+                batchAborted = true;
+                break; // exits the inner per-page loop
+              }
+            } catch (err) {
+              logger.error({ err, userId }, 'Holder-epoch guard GET failed — continuing');
+            }
+          }
+          pagesProcessedSinceGuardCheck = 0;
+        }
+
         try {
 
           await embedPage(userId, page.id, page.title, page.space_key, page.body_html, chunkOpts);
           totalProcessed++;
+          pagesProcessedSinceGuardCheck++;
           processedPageIds.push(page.id);
           consecutiveFailures = 0; // Reset on success
 
@@ -564,6 +641,7 @@ export async function processDirtyPages(
               try {
                 await embedPage(userId, page.id, page.title, page.space_key, page.body_html, chunkOpts);
                 totalProcessed++;
+                pagesProcessedSinceGuardCheck++;
                 processedPageIds.push(page.id);
                 consecutiveFailures = 0;
                 cbSuccess = true;
@@ -623,6 +701,7 @@ export async function processDirtyPages(
           ).catch((updateErr) => logger.error({ err: updateErr }, 'Failed to update embedding_status to failed'));
           totalErrors++;
           batchErrors++;
+          pagesProcessedSinceGuardCheck++;
           consecutiveFailures++;
           errorList.push(`${page.title}: ${errorMessage.slice(0, 200)}`);
 
@@ -904,16 +983,37 @@ export async function reEmbedAll(): Promise<void> {
 }
 
 /**
+ * Read the admin-configurable job-history retention setting.
+ * Default 150, clamped to [10, 10000]. See plan §2.6/§2.8 for schema +
+ * migration. Exported for unit-level clamping tests.
+ */
+async function getReembedHistoryRetention(): Promise<number> {
+  const r = await query<{ setting_value: string }>(
+    `SELECT setting_value FROM admin_settings WHERE setting_key='reembed_history_retention'`,
+  );
+  const raw = r.rows[0]?.setting_value;
+  const n = raw ? parseInt(raw, 10) : NaN;
+  if (!Number.isFinite(n)) return 150;
+  return Math.max(10, Math.min(10_000, n));
+}
+
+/**
  * Enqueue a re-embed job for all pages. When `newDimensions` is supplied it
  * atomically TRUNCATEs `page_embeddings`, rewrites the pgvector column type,
  * updates the `embedding_dimensions` admin setting, and rebuilds the HNSW
- * index before returning the job id. The worker run that iterates the pages
- * and calls `embedText()` per page is tracked in issue #257.
+ * index before returning the job id.
+ *
+ * Plan §2.3: the BullMQ worker registered under the `reembed-all` queue
+ * actually runs the embedding loop. Fixed `jobId='reembed-all'` + our
+ * `enqueueJob` lazy-removal workaround gives "collapse concurrent POSTs,
+ * re-run cleanly after completion" (issue #257 Q3).
  */
 export async function enqueueReembedAll(
   opts: { newDimensions?: number } = {},
 ): Promise<string> {
-  const jobId = `reembed-${Date.now()}`;
+  // Fixed id — concurrent POSTs collapse onto the same BullMQ record.
+  const jobId = 'reembed-all';
+
   if (opts.newDimensions !== undefined) {
     // pgvector type args must be literal — validate strictly before interpolation.
     const n = Math.floor(opts.newDimensions);
@@ -948,25 +1048,124 @@ export async function enqueueReembedAll(
       client.release();
     }
   }
+
+  // Plan §2.3 Q2 — include currently-held per-user lock userIds as hints
+  // in the job payload so the worker can surface them in its initial
+  // "waiting-on-user-locks" progress event without a second Redis round-trip.
+  const { listActiveEmbeddingLocks } = await import('../../../core/services/redis-cache.js');
+  const heldBy = (await listActiveEmbeddingLocks())
+    .map((l) => l.userId)
+    .filter((id) => id !== REEMBED_ALL_LOCK_USER);
+
+  // Plan §2.3 Q4 — retention read per-enqueue so runtime admin changes take
+  // effect on the next run (existing queued jobs carry the old retention).
+  const retention = await getReembedHistoryRetention();
+
+  const { enqueueJob } = await import('../../../core/services/queue-service.js');
+  await enqueueJob(
+    'reembed-all',
+    { triggeredAt: new Date().toISOString(), heldBy },
+    { jobId, removeOnComplete: retention, removeOnFail: retention },
+  );
   return jobId;
 }
 
 /**
- * BullMQ worker entry point for the `reembed-all` queue (issue #257).
+ * BullMQ worker entry point — registered in `core/services/queue-service.ts`
+ * (plan §2.2). Runs a global re-embed of every non-folder, non-deleted page.
  *
- * Phase 1 placeholder — wired up so the queue can be registered against a
- * real function (typecheck passes, worker boots cleanly). The lock-aware
- * wait-on-locks loop, progress throttling, and
- * `processDirtyPages('__reembed_all__', …)` delegation arrive in Phase 2
- * (§2.3 of `docs/issues/257-implementation-plan.md`).
+ * Coordination (plan §2.3 Q2):
+ *   - Before starting, polls `listActiveEmbeddingLocks()` and waits (up to
+ *     `REEMBED_WAIT_LOCKS_MS`, default 10 min) until no per-user locks are
+ *     held. Emits `{ phase: 'waiting-on-user-locks', heldBy }` progress
+ *     events so the admin UI can show who we're blocked on.
+ *   - Acquires the system lock `embedding:lock:__reembed_all__`. While held,
+ *     `isProcessingUser` returns true for ALL users — per-user triggers
+ *     (`/embeddings/process`) see a 409 until the run completes.
  *
- * The `_job` parameter is deliberately unused in this stub — Phase 2 will
- * use `job.updateProgress` for real progress reporting.
+ * Idempotency (plan §2.3 Q3):
+ *   - `enqueueReembedAll` uses the fixed jobId `reembed-all` +
+ *     `enqueueJob`'s lazy-removal workaround so concurrent POSTs collapse
+ *     and post-completion POSTs start a fresh run.
+ *
+ * Progress throttling (plan §2.3 / §6 acceptance):
+ *   - The per-page `processDirtyPages` callback updates BullMQ progress
+ *     every 100 pages (or on 100%).
  */
-export async function runReembedAllJob(_job: Job): Promise<string> {
-  // Phase 2 replaces this body with the real worker per plan §2.3.
-  // For now the legacy in-process reEmbedAll is invoked so the queue
-  // registration has a real callable target.
-  await reEmbedAll();
-  return 'phase-1-stub';
+export async function runReembedAllJob(job: Job): Promise<string> {
+  const { listActiveEmbeddingLocks } = await import('../../../core/services/redis-cache.js');
+
+  const WAIT_LOCKS_TIMEOUT_MS = parseInt(
+    process.env.REEMBED_WAIT_LOCKS_MS ?? '600000',
+    10,
+  );
+  const POLL_INTERVAL_MS = 3_000;
+
+  // Wait-on-locks loop — exit when no per-user lock (other than our own
+  // system lock) remains, or timeout.
+  const waitStart = Date.now();
+  for (;;) {
+    const held = (await listActiveEmbeddingLocks())
+      .filter((l) => l.userId !== REEMBED_ALL_LOCK_USER)
+      .map((l) => l.userId);
+    if (held.length === 0) break;
+    if (Date.now() - waitStart > WAIT_LOCKS_TIMEOUT_MS) {
+      throw new Error(
+        `reembed-all aborted: per-user embedding locks still held after ` +
+        `${Math.round(WAIT_LOCKS_TIMEOUT_MS / 60_000)}m by: ${held.join(', ')}`,
+      );
+    }
+    await job.updateProgress({
+      phase: 'waiting-on-user-locks',
+      heldBy: held,
+      waitedMs: Date.now() - waitStart,
+    });
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+
+  const lockId = await acquireEmbeddingLock(REEMBED_ALL_LOCK_USER);
+  if (!lockId) {
+    // Lost the race between the wait-loop and acquire — another worker is
+    // already running this job. Return a sentinel the admin UI can render.
+    return 'already-running';
+  }
+
+  try {
+    // Mark every eligible page dirty (matches processDirtyPages' filter).
+    await query(
+      `UPDATE pages
+          SET embedding_dirty = TRUE,
+              embedding_status = 'not_embedded',
+              embedded_at = NULL,
+              embedding_error = NULL
+        WHERE deleted_at IS NULL
+          AND COALESCE(page_type, 'page') != 'folder'`,
+    );
+
+    const countRow = await query<{ c: string }>(
+      `SELECT COUNT(*)::text AS c FROM pages
+        WHERE embedding_dirty = TRUE AND deleted_at IS NULL
+          AND COALESCE(page_type, 'page') != 'folder'`,
+    );
+    const total = parseInt(countRow.rows[0]?.c ?? '0', 10);
+    await job.updateProgress({ total, processed: 0, failed: 0, phase: 'started' });
+
+    let processed = 0;
+    let failed = 0;
+    await processDirtyPages(REEMBED_ALL_LOCK_USER, (evt) => {
+      if (evt.type === 'progress') {
+        processed = evt.completed;
+        failed = evt.failed;
+        // Throttle: every 100 (processed + failed) pages, or on 100%.
+        if ((processed + failed) % 100 === 0 || evt.percentage === 100) {
+          void job.updateProgress({ total, processed, failed, phase: 'embedding' });
+        }
+      }
+    });
+
+    await job.updateProgress({ total, processed, failed, phase: 'complete' });
+    return `processed=${processed} failed=${failed} total=${total}`;
+  } finally {
+    await releaseEmbeddingLock(REEMBED_ALL_LOCK_USER, lockId);
+  }
 }

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -1153,6 +1153,26 @@ export async function runReembedAllJob(job: Job): Promise<string> {
     return 'already-running';
   }
 
+  // Close the TOCTOU window between the wait-loop and the acquire above:
+  // a user could have called `processDirtyPages` (taking their own
+  // `embedding:lock:${userId}`) in the milliseconds between the loop's
+  // final `held.length === 0` check and our `acquireEmbeddingLock`. If so,
+  // two writers would now scan `pages WHERE embedding_dirty = TRUE` in
+  // parallel. Release our system lock and return a sentinel so BullMQ's
+  // retry policy (or a manual re-trigger) can re-enter the wait-loop
+  // cleanly rather than running concurrently.
+  const postAcquire = (await listActiveEmbeddingLocks()).filter(
+    (l) => l.userId !== REEMBED_ALL_LOCK_USER,
+  );
+  if (postAcquire.length > 0) {
+    await releaseEmbeddingLock(REEMBED_ALL_LOCK_USER, lockId);
+    logger.warn(
+      { heldBy: postAcquire.map((l) => l.userId) },
+      'reembed-all: per-user lock appeared between wait-loop and acquire — releasing system lock and backing off',
+    );
+    return 'already-running';
+  }
+
   try {
     // Mark every eligible page dirty (matches processDirtyPages' filter).
     await query(

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -4,9 +4,11 @@ import { resolveUsecase } from './llm-provider-resolver.js';
 import { generateEmbedding } from './openai-compatible-client.js';
 import { htmlToText } from '../../../core/services/content-converter.js';
 import { logger } from '../../../core/utils/logger.js';
-import { invalidateGraphCache, acquireEmbeddingLock, releaseEmbeddingLock, isEmbeddingLocked, getRedisClient } from '../../../core/services/redis-cache.js';
+import { invalidateGraphCache, acquireEmbeddingLock, releaseEmbeddingLock, isEmbeddingLocked, getRedisClient, listActiveEmbeddingLocks } from '../../../core/services/redis-cache.js';
 import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
 import { CircuitBreakerOpenError, getProviderBreaker } from '../../../core/services/circuit-breaker.js';
+import { getReembedHistoryRetention } from '../../../core/services/admin-settings-service.js';
+import { enqueueJob } from '../../../core/services/queue-service.js';
 import pgvector from 'pgvector';
 
 const CHUNK_SIZE = 500;          // ~500 tokens target
@@ -1074,17 +1076,14 @@ export async function enqueueReembedAll(
   // Plan §2.3 Q2 — include currently-held per-user lock userIds as hints
   // in the job payload so the worker can surface them in its initial
   // "waiting-on-user-locks" progress event without a second Redis round-trip.
-  const { listActiveEmbeddingLocks } = await import('../../../core/services/redis-cache.js');
   const heldBy = (await listActiveEmbeddingLocks())
     .map((l) => l.userId)
     .filter((id) => id !== REEMBED_ALL_LOCK_USER);
 
   // Plan §2.3 Q4 — retention read per-enqueue so runtime admin changes take
   // effect on the next run (existing queued jobs carry the old retention).
-  const { getReembedHistoryRetention } = await import('../../../core/services/admin-settings-service.js');
   const retention = await getReembedHistoryRetention();
 
-  const { enqueueJob } = await import('../../../core/services/queue-service.js');
   await enqueueJob(
     'reembed-all',
     { triggeredAt: new Date().toISOString(), heldBy },
@@ -1116,8 +1115,6 @@ export async function enqueueReembedAll(
  *     every 100 pages (or on 100%).
  */
 export async function runReembedAllJob(job: Job): Promise<string> {
-  const { listActiveEmbeddingLocks } = await import('../../../core/services/redis-cache.js');
-
   const WAIT_LOCKS_TIMEOUT_MS = parseInt(
     process.env.REEMBED_WAIT_LOCKS_MS ?? '600000',
     10,

--- a/backend/src/routes/foundation/admin-embedding-locks.test.ts
+++ b/backend/src/routes/foundation/admin-embedding-locks.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// Short-circuit DNS lookups performed by the SSRF guard.
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async () => {
+    const err = new Error('getaddrinfo ENOTFOUND (mocked)') as NodeJS.ErrnoException;
+    err.code = 'ENOTFOUND';
+    throw err;
+  }),
+}));
+
+import { setupTestDb, truncateAllTables, teardownTestDb, isDbAvailable } from '../../test-db-helper.js';
+import { query } from '../../core/db/postgres.js';
+import { buildApp } from '../../app.js';
+import { generateAccessToken } from '../../core/plugins/auth.js';
+import {
+  acquireEmbeddingLock,
+  releaseEmbeddingLock,
+  forceReleaseEmbeddingLock,
+} from '../../core/services/redis-cache.js';
+
+async function createAdminAndLogin(username: string): Promise<{ token: string; userId: string }> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO users (username, password_hash, role)
+     VALUES ($1, 'fakehash', 'admin') RETURNING id`,
+    [username],
+  );
+  const userId = result.rows[0]!.id;
+  await query('INSERT INTO user_settings (user_id) VALUES ($1)', [userId]);
+  const token = await generateAccessToken({ sub: userId, username, role: 'admin' });
+  return { token, userId };
+}
+
+async function createMemberAndLogin(username: string): Promise<{ token: string; userId: string }> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO users (username, password_hash, role)
+     VALUES ($1, 'fakehash', 'member') RETURNING id`,
+    [username],
+  );
+  const userId = result.rows[0]!.id;
+  await query('INSERT INTO user_settings (user_id) VALUES ($1)', [userId]);
+  const token = await generateAccessToken({ sub: userId, username, role: 'member' });
+  return { token, userId };
+}
+
+const dbAvailable = await isDbAvailable();
+
+let app: FastifyInstance;
+let adminToken: string;
+let adminUserId: string;
+
+beforeAll(async () => {
+  if (!dbAvailable) return;
+  await setupTestDb();
+  app = await buildApp();
+  await app.ready();
+}, 30_000);
+
+afterAll(async () => {
+  if (!dbAvailable) return;
+  await app?.close();
+  await teardownTestDb();
+});
+
+beforeEach(async () => {
+  if (!dbAvailable) return;
+  await truncateAllTables();
+  // Clear any Redis state that may linger between cases (lock keys live there,
+  // not in Postgres).
+  await forceReleaseEmbeddingLock('alice');
+  await forceReleaseEmbeddingLock('bob');
+  await forceReleaseEmbeddingLock('__reembed_all__');
+  ({ token: adminToken, userId: adminUserId } = await createAdminAndLogin('locks_admin'));
+});
+
+describe.skipIf(!dbAvailable)('GET /api/admin/embedding/locks', () => {
+  // RED #11a (plan §4.6)
+  it('returns an EmbeddingLockSnapshot[] for each currently-held per-user lock', async () => {
+    const aliceLockId = await acquireEmbeddingLock('alice');
+    expect(aliceLockId).toBeTruthy();
+
+    try {
+      const r = await app.inject({
+        method: 'GET',
+        url: '/api/admin/embedding/locks',
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+      expect(r.statusCode).toBe(200);
+      const body = r.json();
+      expect(Array.isArray(body.locks)).toBe(true);
+      const alice = body.locks.find((l: { userId: string }) => l.userId === 'alice');
+      expect(alice).toBeTruthy();
+      expect(alice.holderEpoch).toBe(aliceLockId);
+      expect(typeof alice.ttlRemainingMs).toBe('number');
+      expect(alice.ttlRemainingMs).toBeGreaterThan(0);
+    } finally {
+      await releaseEmbeddingLock('alice', aliceLockId!);
+    }
+  });
+
+  // RED #11b
+  it('filters out the synthetic __reembed_all__ system lock', async () => {
+    const reembedLockId = await acquireEmbeddingLock('__reembed_all__');
+    try {
+      const r = await app.inject({
+        method: 'GET',
+        url: '/api/admin/embedding/locks',
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+      expect(r.statusCode).toBe(200);
+      const body = r.json();
+      const systemLock = body.locks.find((l: { userId: string }) => l.userId === '__reembed_all__');
+      expect(systemLock).toBeUndefined();
+    } finally {
+      await releaseEmbeddingLock('__reembed_all__', reembedLockId!);
+    }
+  });
+
+  it('returns { locks: [] } when no per-user locks are held', async () => {
+    const r = await app.inject({
+      method: 'GET',
+      url: '/api/admin/embedding/locks',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(r.statusCode).toBe(200);
+    expect(r.json().locks).toEqual([]);
+  });
+
+  // RED #11e (non-admin forbidden)
+  it('returns 403 for non-admin callers', async () => {
+    const { token: memberToken } = await createMemberAndLogin('locks_member');
+    const r = await app.inject({
+      method: 'GET',
+      url: '/api/admin/embedding/locks',
+      headers: { authorization: `Bearer ${memberToken}` },
+    });
+    expect(r.statusCode).toBe(403);
+  });
+
+  it('returns 401 without auth', async () => {
+    const r = await app.inject({
+      method: 'GET',
+      url: '/api/admin/embedding/locks',
+    });
+    expect(r.statusCode).toBe(401);
+  });
+});
+
+describe.skipIf(!dbAvailable)('POST /api/admin/embedding/locks/:userId/release', () => {
+  // RED #11c — force-release happy path + audit log
+  it('releases an existing lock and writes an ADMIN_ACTION audit row', async () => {
+    const aliceLockId = await acquireEmbeddingLock('alice');
+    expect(aliceLockId).toBeTruthy();
+
+    const r = await app.inject({
+      method: 'POST',
+      url: '/api/admin/embedding/locks/alice/release',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(r.statusCode).toBe(200);
+    expect(r.json()).toEqual({ released: true, userId: 'alice' });
+
+    // Audit row present
+    const { rows } = await query<{
+      user_id: string;
+      action: string;
+      resource_type: string;
+      resource_id: string;
+      metadata: Record<string, unknown>;
+    }>(
+      `SELECT user_id, action, resource_type, resource_id, metadata::jsonb AS metadata
+         FROM audit_log
+        WHERE action = 'ADMIN_ACTION'
+          AND resource_type = 'embedding_lock'
+        ORDER BY created_at DESC
+        LIMIT 1`,
+    );
+    expect(rows).toHaveLength(1);
+    const audit = rows[0]!;
+    expect(audit.user_id).toBe(adminUserId);
+    expect(audit.resource_id).toBe('alice');
+    expect(audit.metadata).toMatchObject({
+      action: 'force_release_embedding_lock',
+      targetUserId: 'alice',
+      released: true,
+    });
+  });
+
+  // RED #11d — idempotent on non-existent
+  it('returns 200 { released: false } when the lock was already gone', async () => {
+    const r = await app.inject({
+      method: 'POST',
+      url: '/api/admin/embedding/locks/ghost-user/release',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(r.statusCode).toBe(200);
+    expect(r.json()).toEqual({ released: false, userId: 'ghost-user' });
+
+    // Still writes an audit row so deliberate no-ops are observable.
+    const { rows } = await query<{ metadata: Record<string, unknown> }>(
+      `SELECT metadata::jsonb AS metadata FROM audit_log
+        WHERE action = 'ADMIN_ACTION'
+          AND resource_id = 'ghost-user'
+        ORDER BY created_at DESC LIMIT 1`,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.metadata).toMatchObject({
+      action: 'force_release_embedding_lock',
+      released: false,
+    });
+  });
+
+  // RED #11e — non-admin forbidden (no audit row)
+  it('returns 403 for non-admin callers and writes no audit row', async () => {
+    const { token: memberToken } = await createMemberAndLogin('locks_member_release');
+    const r = await app.inject({
+      method: 'POST',
+      url: '/api/admin/embedding/locks/alice/release',
+      headers: { authorization: `Bearer ${memberToken}` },
+    });
+    expect(r.statusCode).toBe(403);
+
+    const { rows } = await query<{ c: string }>(
+      `SELECT COUNT(*)::text AS c FROM audit_log
+        WHERE action = 'ADMIN_ACTION'
+          AND resource_type = 'embedding_lock'`,
+    );
+    expect(rows[0]!.c).toBe('0');
+  });
+
+  it('returns 401 without auth', async () => {
+    const r = await app.inject({
+      method: 'POST',
+      url: '/api/admin/embedding/locks/alice/release',
+    });
+    expect(r.statusCode).toBe(401);
+  });
+
+  // userId param validation
+  it('rejects empty userId (router match on trailing slash)', async () => {
+    // Fastify's router will 404 a truly empty path param.
+    const r = await app.inject({
+      method: 'POST',
+      url: '/api/admin/embedding/locks//release',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect([400, 404]).toContain(r.statusCode);
+  });
+});

--- a/backend/src/routes/foundation/admin-embedding-locks.ts
+++ b/backend/src/routes/foundation/admin-embedding-locks.ts
@@ -1,0 +1,85 @@
+/**
+ * Admin-only visibility + escape-hatch routes for per-user embedding locks.
+ * Scope: issue #257, plan §2.10.
+ *
+ * Endpoints:
+ *   - `GET  /api/admin/embedding/locks`              — list all active locks
+ *   - `POST /api/admin/embedding/locks/:userId/release` — force-release (audited)
+ *
+ * Both are admin-only (`fastify.requireAdmin`) and rate-limited with the
+ * shared admin bucket. The list endpoint is polled by the admin UI every
+ * 5 s; the release endpoint is behind a confirm modal on the frontend.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import {
+  listActiveEmbeddingLocks,
+  forceReleaseEmbeddingLock,
+} from '../../core/services/redis-cache.js';
+import { logAuditEvent } from '../../core/services/audit-service.js';
+import { getRateLimits } from '../../core/services/rate-limit-service.js';
+
+const ADMIN_RATE_LIMIT = {
+  config: {
+    rateLimit: {
+      max: async () => (await getRateLimits()).admin.max,
+      timeWindow: '1 minute',
+    },
+  },
+};
+
+const UserIdParam = z.object({ userId: z.string().min(1).max(256) });
+
+/**
+ * The synthetic `__reembed_all__` lock is held by the reembed-all worker
+ * (plan §2.3). It is NOT a real user and is hidden from the admin UI, which
+ * learns about the global run via the reembed job-status endpoint instead.
+ */
+const REEMBED_SYSTEM_LOCK_USER = '__reembed_all__';
+
+export async function adminEmbeddingLocksRoutes(fastify: FastifyInstance) {
+  fastify.addHook('onRequest', fastify.authenticate);
+
+  // GET — list all per-user locks. Admin-only.
+  fastify.get(
+    '/admin/embedding/locks',
+    { preHandler: fastify.requireAdmin, ...ADMIN_RATE_LIMIT },
+    async () => {
+      const locks = (await listActiveEmbeddingLocks()).filter(
+        (l) => l.userId !== REEMBED_SYSTEM_LOCK_USER,
+      );
+      return { locks };
+    },
+  );
+
+  // POST — admin escape hatch. Audit-logged on every call, including
+  // idempotent no-ops so deliberate releases on already-gone locks are
+  // observable in the audit trail.
+  fastify.post(
+    '/admin/embedding/locks/:userId/release',
+    { preHandler: fastify.requireAdmin, ...ADMIN_RATE_LIMIT },
+    async (request) => {
+      const { userId } = UserIdParam.parse(request.params);
+
+      const result = await forceReleaseEmbeddingLock(userId);
+
+      await logAuditEvent(
+        request.userId,
+        'ADMIN_ACTION',
+        'embedding_lock',
+        userId,
+        {
+          action: 'force_release_embedding_lock',
+          targetUserId: userId,
+          released: result.released,
+          previousHolderEpoch: result.previousHolderEpoch,
+        },
+        request,
+      );
+
+      // Idempotent — 200 with released:false when the lock was already gone.
+      return { released: result.released, userId };
+    },
+  );
+}

--- a/backend/src/routes/foundation/admin.test.ts
+++ b/backend/src/routes/foundation/admin.test.ts
@@ -424,6 +424,84 @@ describe('Admin routes', () => {
       expect(embeddingDirtyCall).toBeDefined();
     });
   });
+
+  // ─── Plan §2.7 / §4.5 RED #11 — reembedHistoryRetention wiring ──────────
+  describe('reembedHistoryRetention (issue #257)', () => {
+    it('GET /api/admin/settings returns 150 when no row is stored (default)', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValue({
+        rows: [
+          { setting_key: 'embedding_chunk_size', setting_value: '500' },
+          { setting_key: 'embedding_chunk_overlap', setting_value: '50' },
+        ],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/admin/settings',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.reembedHistoryRetention).toBe(150);
+    });
+
+    it('GET /api/admin/settings reflects the persisted admin_settings row', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValue({
+        rows: [
+          { setting_key: 'embedding_chunk_size', setting_value: '500' },
+          { setting_key: 'embedding_chunk_overlap', setting_value: '50' },
+          { setting_key: 'reembed_history_retention', setting_value: '500' },
+        ],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/admin/settings',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body).reembedHistoryRetention).toBe(500);
+    });
+
+    it('PUT /api/admin/settings persists reembedHistoryRetention via UPSERT', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/settings',
+        payload: { reembedHistoryRetention: 500 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const calls = (mockQuery as ReturnType<typeof vi.fn>).mock.calls as Array<[string, ...unknown[]]>;
+      const upsert = calls.find(([sql, args]) =>
+        typeof sql === 'string' &&
+        sql.includes('INSERT INTO admin_settings') &&
+        Array.isArray(args) &&
+        args[0] === 'reembed_history_retention',
+      );
+      expect(upsert).toBeTruthy();
+      // Persisted as text — the value is stringified.
+      expect((upsert![1] as unknown[])[1]).toBe('500');
+    });
+
+    it('PUT rejects values below 10 with 400 (validated by Zod)', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/settings',
+        payload: { reembedHistoryRetention: 5 },
+      });
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('PUT rejects values above 10000 with 400', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/settings',
+        payload: { reembedHistoryRetention: 10_001 },
+      });
+      expect(response.statusCode).toBe(400);
+    });
+  });
 });
 
 describe('Admin routes - non-admin access guard', () => {

--- a/backend/src/routes/foundation/admin.ts
+++ b/backend/src/routes/foundation/admin.ts
@@ -234,7 +234,7 @@ export async function adminRoutes(fastify: FastifyInstance) {
     ]);
     const result = await query<{ setting_key: string; setting_value: string }>(
       `SELECT setting_key, setting_value FROM admin_settings
-       WHERE setting_key IN ('embedding_chunk_size', 'embedding_chunk_overlap', 'drawio_embed_url', 'fts_language')`,
+       WHERE setting_key IN ('embedding_chunk_size', 'embedding_chunk_overlap', 'drawio_embed_url', 'fts_language', 'reembed_history_retention')`,
     );
 
     const map: Record<string, string> = {};
@@ -248,6 +248,8 @@ export async function adminRoutes(fastify: FastifyInstance) {
       embeddingChunkSize: parseInt(map['embedding_chunk_size'] ?? '500', 10),
       embeddingChunkOverlap: parseInt(map['embedding_chunk_overlap'] ?? '50', 10),
       drawioEmbedUrl: map['drawio_embed_url'] ?? null,
+      // Issue #257 — re-embed-all job history retention (default 150, [10, 10000]).
+      reembedHistoryRetention: parseInt(map['reembed_history_retention'] ?? '150', 10),
       // AI Safety
       aiGuardrailNoFabrication: guardrails.noFabricationInstruction,
       aiGuardrailNoFabricationEnabled: guardrails.noFabricationEnabled,
@@ -337,6 +339,15 @@ export async function adminRoutes(fastify: FastifyInstance) {
       } else {
         updates.push({ key: 'drawio_embed_url', value: body.drawioEmbedUrl });
       }
+    }
+
+    // Issue #257 — reembed-all job history retention. Zod already enforced
+    // the [10, 10000] integer range at the boundary.
+    if (body.reembedHistoryRetention !== undefined) {
+      updates.push({
+        key: 'reembed_history_retention',
+        value: String(body.reembedHistoryRetention),
+      });
     }
 
     for (const { key, value } of updates) {

--- a/backend/src/routes/llm/llm-embedding-reembed.test.ts
+++ b/backend/src/routes/llm/llm-embedding-reembed.test.ts
@@ -189,4 +189,81 @@ describe.skipIf(!dbAvailable)('POST /api/admin/embedding/reembed', () => {
     });
     expect(r.statusCode).toBe(403);
   });
+
+  // ─── Plan §2.5 / §4.4 RED #8 + #9 + #10 ─────────────────────────────────
+  it('returns the fixed jobId="reembed-all" (idempotent across repeated POSTs)', async () => {
+    const r1 = await app.inject({
+      method: 'POST',
+      url: '/api/admin/embedding/reembed',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(r1.statusCode).toBe(200);
+    const b1 = r1.json();
+    expect(b1.jobId).toBe('reembed-all');
+
+    // Second POST returns the same fixed jobId (collapse-concurrent).
+    const r2 = await app.inject({
+      method: 'POST',
+      url: '/api/admin/embedding/reembed',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(r2.statusCode).toBe(200);
+    expect(r2.json().jobId).toBe('reembed-all');
+  });
+
+  it('returns a heldBy string[] (empty when no per-user locks are held)', async () => {
+    const r = await app.inject({
+      method: 'POST',
+      url: '/api/admin/embedding/reembed',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(Array.isArray(body.heldBy)).toBe(true);
+    expect(body.heldBy).toEqual([]);
+  });
+});
+
+describe.skipIf(!dbAvailable)('GET /api/admin/embedding/reembed/:jobId', () => {
+  it('returns 401 without auth', async () => {
+    const r = await app.inject({
+      method: 'GET',
+      url: '/api/admin/embedding/reembed/reembed-all',
+    });
+    expect(r.statusCode).toBe(401);
+  });
+
+  it('returns 403 for non-admin users', async () => {
+    const userResult = await query<{ id: string }>(
+      `INSERT INTO users (username, password_hash, role)
+       VALUES ('reembed_getter_member', 'fakehash', 'member') RETURNING id`,
+    );
+    const memberId = userResult.rows[0]!.id;
+    await query('INSERT INTO user_settings (user_id) VALUES ($1)', [memberId]);
+    const memberToken = await generateAccessToken({
+      sub: memberId,
+      username: 'reembed_getter_member',
+      role: 'member',
+    });
+    const r = await app.inject({
+      method: 'GET',
+      url: '/api/admin/embedding/reembed/reembed-all',
+      headers: { authorization: `Bearer ${memberToken}` },
+    });
+    expect(r.statusCode).toBe(403);
+  });
+
+  it('returns { jobId, state: "unknown", progress: null, heldBy: [] } for an unknown job id', async () => {
+    const r = await app.inject({
+      method: 'GET',
+      url: '/api/admin/embedding/reembed/does-not-exist',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.jobId).toBe('does-not-exist');
+    expect(body.state).toBe('unknown');
+    expect(body.progress).toBeNull();
+    expect(Array.isArray(body.heldBy)).toBe(true);
+  });
 });

--- a/backend/src/routes/llm/llm-embedding-reembed.ts
+++ b/backend/src/routes/llm/llm-embedding-reembed.ts
@@ -2,6 +2,8 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { query } from '../../core/db/postgres.js';
 import { enqueueReembedAll } from '../../domains/llm/services/embedding-service.js';
+import { listActiveEmbeddingLocks } from '../../core/services/redis-cache.js';
+import { getJobStatus } from '../../core/services/queue-service.js';
 import { getRateLimits } from '../../core/services/rate-limit-service.js';
 
 const ADMIN_RATE_LIMIT = {
@@ -16,6 +18,17 @@ const ReembedBodySchema = z.object({
   newDimensions: z.number().int().min(1).max(8192).optional(),
 });
 
+const ReembedJobParamsSchema = z.object({
+  jobId: z.string().min(1).max(256),
+});
+
+/**
+ * The synthetic `__reembed_all__` lock is held by the re-embed worker while
+ * it runs. It is NOT a real user and must be filtered out of any list we
+ * hand to the UI (plan §2.5 / §2.10).
+ */
+const REEMBED_SYSTEM_LOCK_USER = '__reembed_all__';
+
 export async function llmEmbeddingReembedRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
 
@@ -27,7 +40,29 @@ export async function llmEmbeddingReembedRoutes(fastify: FastifyInstance) {
       const { rows } = await query<{ c: string }>(`SELECT COUNT(*)::text AS c FROM pages`);
       const pageCount = parseInt(rows[0]!.c, 10);
       const jobId = await enqueueReembedAll(newDimensions !== undefined ? { newDimensions } : {});
-      return { jobId, pageCount };
+
+      // Plan §2.5 — surface currently-held per-user lock userIds in the
+      // initial POST response so the UI can render "waiting for alice, bob
+      // to finish" without a second round-trip.
+      const heldBy = (await listActiveEmbeddingLocks())
+        .filter((l) => l.userId !== REEMBED_SYSTEM_LOCK_USER)
+        .map((l) => l.userId);
+      return { jobId, pageCount, heldBy };
+    },
+  );
+
+  // Plan §2.5 — progress-polling endpoint for the admin UI.
+  fastify.get(
+    '/admin/embedding/reembed/:jobId',
+    { preHandler: fastify.requireAdmin, ...ADMIN_RATE_LIMIT },
+    async (request) => {
+      const { jobId } = ReembedJobParamsSchema.parse(request.params);
+      const status = await getJobStatus('reembed-all', jobId);
+      const heldBy = (await listActiveEmbeddingLocks())
+        .filter((l) => l.userId !== REEMBED_SYSTEM_LOCK_USER)
+        .map((l) => l.userId);
+      if (!status) return { jobId, state: 'unknown', progress: null, heldBy };
+      return { jobId, ...status, heldBy };
     },
   );
 }

--- a/backend/src/routes/llm/llm-embeddings.ts
+++ b/backend/src/routes/llm/llm-embeddings.ts
@@ -3,11 +3,25 @@ import { query } from '../../core/db/postgres.js';
 import { confluenceToHtml } from '../../core/services/content-converter.js';
 import { getEmbeddingStatus, processDirtyPages, reEmbedAll, isProcessingUser, embedPage, resetFailedEmbeddings } from '../../domains/llm/services/embedding-service.js';
 import type { EmbeddingProgressEvent } from '../../domains/llm/services/embedding-service.js';
+import { isEmbeddingLocked } from '../../core/services/redis-cache.js';
 import { getClientForUser } from '../../domains/confluence/services/sync-service.js';
 import { ForceEmbedTreeRequestSchema } from '@compendiq/contracts';
 import { logger } from '../../core/utils/logger.js';
 import { EMBEDDING_RATE_LIMIT } from './_helpers.js';
 import { getRateLimits } from '../../core/services/rate-limit-service.js';
+
+/**
+ * Pick the right 409 body depending on which lock is responsible.
+ * Plan §2.4: differentiate "your own in-flight run" from "global re-embed".
+ * Caller already knows `isProcessingUser(userId)` is true; we only re-check
+ * the system lock here to pick the wording.
+ */
+async function conflictMessage(): Promise<string> {
+  if (await isEmbeddingLocked('__reembed_all__')) {
+    return 'A global re-embed is in progress — per-user triggers are temporarily disabled. Try again in a few minutes.';
+  }
+  return 'Embedding processing is already in progress for this user';
+}
 
 export async function llmEmbeddingRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -22,8 +36,9 @@ export async function llmEmbeddingRoutes(fastify: FastifyInstance) {
     const userId = request.userId;
 
     // Return 409 if embedding is already in progress for this user
+    // (either their own lock, or the global reembed-all system lock).
     if (await isProcessingUser(userId)) {
-      throw fastify.httpErrors.conflict('Embedding processing is already in progress for this user');
+      throw fastify.httpErrors.conflict(await conflictMessage());
     }
 
     // Set up SSE response
@@ -68,8 +83,9 @@ export async function llmEmbeddingRoutes(fastify: FastifyInstance) {
     const userId = request.userId;
 
     // Return 409 if embedding is already in progress for this user
+    // (either their own lock, or the global reembed-all system lock).
     if (await isProcessingUser(userId)) {
-      throw fastify.httpErrors.conflict('Embedding processing is already in progress for this user');
+      throw fastify.httpErrors.conflict(await conflictMessage());
     }
 
     // Reset all failed pages back to 'not_embedded'

--- a/docs/ADMIN-GUIDE.md
+++ b/docs/ADMIN-GUIDE.md
@@ -167,7 +167,7 @@ curl http://localhost:3051/api/health
 
 ### Background Job Queue (BullMQ)
 
-Compendiq uses BullMQ (Redis-backed) for reliable background job processing. Five worker types run as BullMQ queues:
+Compendiq uses BullMQ (Redis-backed) for reliable background job processing. Six worker types run as BullMQ queues:
 
 | Queue | Purpose | Default Interval |
 |-------|---------|-----------------|
@@ -176,12 +176,19 @@ Compendiq uses BullMQ (Redis-backed) for reliable background job processing. Fiv
 | `summary` | Auto-summary generation (LLM) | 60 min |
 | `maintenance` | Expired token cleanup | 24 hours |
 | `maintenance` | Data retention cleanup | 24 hours |
+| `reembed-all` | Global re-embed of every non-folder page (issue #257) | On-demand |
 
 **Configuration:**
 - `USE_BULLMQ=true` (default) -- set to `false` to fall back to legacy `setInterval` workers
 - Redis `maxmemory-policy` must be `noeviction` (default in the provided Docker config)
 - Job history is stored in the `job_history` PostgreSQL table for observability
 - Queue metrics are exposed via `GET /api/health` under the `queues` key
+- `REEMBED_WAIT_LOCKS_MS=600000` (default 10 min): how long the `reembed-all`
+  worker waits for in-flight per-user embedding runs to finish before
+  aborting the job. Visible in the admin UI via `GET /api/admin/embedding/locks`.
+- `reembed_history_retention` (admin setting, default 150): how many
+  completed/failed `reembed-all` job records BullMQ keeps in Redis before
+  sweeping the oldest. Range [10, 10000]. Takes effect on the next run.
 
 **Monitoring:** The health endpoint returns per-queue counts (waiting, active, completed, failed):
 ```bash

--- a/docs/ARCHITECTURE-DECISIONS.md
+++ b/docs/ARCHITECTURE-DECISIONS.md
@@ -867,6 +867,7 @@ setInterval(async () => {
 |--------|----------|------------|---------------|-------------|
 | Sync | `SYNC_INTERVAL_MINUTES` (15) | All changed pages | N/A | N/A |
 | Embedding | After sync | All dirty pages | `EMBEDDING_MODEL` | N/A |
+| Re-embed-all (#257) | On-demand via `POST /api/admin/embedding/reembed` | All non-folder pages | `EMBEDDING_MODEL` | No automatic retry (fixed `jobId='reembed-all'` collapses concurrent POSTs; admin can re-trigger after completion) |
 | Quality Analysis | `QUALITY_CHECK_INTERVAL_MINUTES` (60) | `QUALITY_BATCH_SIZE` (5) | `QUALITY_MODEL` → `DEFAULT_LLM_MODEL` → `qwen3:4b` | 3 (`quality_retry_count`) |
 | Summary | `SUMMARY_CHECK_INTERVAL_MINUTES` (60) | `SUMMARY_BATCH_SIZE` (5) | `SUMMARY_MODEL` → `DEFAULT_LLM_MODEL` | 3 (`summary_retry_count`) |
 

--- a/docs/issues/257-implementation-plan.md
+++ b/docs/issues/257-implementation-plan.md
@@ -1,0 +1,1070 @@
+# Implementation Plan — Issue #257: wire BullMQ re-embed-all worker (v3)
+
+> Follow-up to #256 (merged via PR #259 on 2026-04-21). Target branch: `dev`.
+> Scope: replace the `TODO(#257)` stub in `enqueueReembedAll` with a real
+> BullMQ-backed worker, add a progress-readable job endpoint, gate the
+> worker on per-user embedding locks (with admin visibility + force-release
+> escape hatch), and make job-history retention admin-configurable.
+>
+> **v3 changes from v2:** dedicated `GET /api/admin/embedding/locks`
+> endpoint (not an extension of `/api/embeddings/status`); new
+> `POST /api/admin/embedding/locks/:userId/release` force-release with
+> audit logging + holder-epoch write-guard; SCAN-based
+> `listActiveEmbeddingLocks` kept as-is with an upgrade-path note. See §9
+> for the full v2→v3 changelog.
+>
+> CLAUDE.md compliance: tests required on every change (§4), branch
+> `feature/257-reembed-worker` targets `dev` (never `main`), migration
+> `055` additive + idempotent, no architecture-diagram area affected (no
+> new domain boundary, no new container, no table schema change — only a
+> new `admin_settings` row).
+
+---
+
+## 1. ResearchPack — files touched / read
+
+All paths relative to repo root `compendiq-ce/`. Line numbers verified against
+tip of `feature/docs-multi-llm-provider-sync` (commit `040d10f`) on
+2026-04-21.
+
+| File | Current role | Key lines |
+|---|---|---|
+| `backend/src/domains/llm/services/embedding-service.ts` | Stub `enqueueReembedAll` (line 912) returns `reembed-${Date.now()}`. Working `reEmbedAll()` (line 891) + `processDirtyPages(userId, onProgress)` (line 436) — both **sync / in-process**. | 891–951, 436–700 |
+| `backend/src/routes/llm/llm-embedding-reembed.ts` | Admin route — validates `newDimensions`, returns `{ jobId, pageCount }`. Already wired to `fastify.requireAdmin` + admin rate limit. | 1–33 |
+| `backend/src/routes/llm/llm-embedding-reembed.test.ts` | Vitest + real Postgres. Asserts `jobId` starts with `reembed-`, validates `newDimensions=768` rewrites column & truncates. | 70–192 |
+| `backend/src/core/services/queue-service.ts` | BullMQ wrapper. Registers `sync`, `quality`, `summary`, `maintenance`, stub `analytics-aggregation`. Exports `startQueueWorkers`, `stopQueueWorkers`, `getQueueMetrics`, `isBullMQEnabled`. **No `enqueueJob` API today.** Writes `job_history` rows (lines 63–81, migration 050). | 11–50, 94–183, 240–319 |
+| `backend/src/core/db/migrations/050_job_history.sql` | Existing `job_history` table reused for outcome persistence. | full file |
+| `backend/src/core/services/redis-cache.ts` | `acquireEmbeddingLock(userId) / releaseEmbeddingLock / isEmbeddingLocked`. Lock key pattern: `embedding:lock:${userId}` (line 45). 1-hour TTL safety cap. No listing helper today — we need to add `listActiveEmbeddingLocks()`. | 40–110 |
+| `backend/src/core/services/admin-settings-service.ts` | `getEmbeddingDimensions()`. The admin_settings table is the canonical key/value store. | 1–23 |
+| `backend/src/routes/foundation/admin.ts` | `GET/PUT /api/admin/settings` — surface for all existing tunables. The new `reembed_history_retention` key plugs in here. | 228–329 |
+| `packages/contracts/src/schemas/admin.ts` | `AdminSettingsSchema` (line 18) + `UpdateAdminSettingsSchema` (line 44). Zod validators for admin settings API; frontend consumes typed shape. | full file |
+| `backend/src/domains/llm/services/llm-provider-resolver.ts` | `resolveUsecase('embedding')` returns `{ config, model }`. Worker inherits it via `embedPage`. | 45–102 |
+| `frontend/src/features/settings/panels/EmbeddingReembedBanner.tsx` | UI that triggers reembed. Today shows a "worker not implemented" warning (line 76). | full file |
+| `frontend/src/features/settings/panels/EmbeddingTab.tsx` | Admin UI embedding settings panel. Host for the new retention-control field + lock-visibility banner. | around lines 48–129 |
+| `backend/src/index.ts` | Boot order: `initLlmQueue()` → `buildApp()` → `startQueueWorkers()`. | 1–85 |
+| `e2e/llm-providers.spec.ts` | Playwright E2E — chat-only today. | full file |
+
+External ResearchPack (BullMQ v5, via Ref MCP — verified 2026-04-21):
+
+- **Custom `jobId` = idempotency primitive.** `queue.add()` with an existing
+  `jobId` is a no-op — BullMQ ignores it and (optionally) emits a
+  `duplicated` event. Source:
+  `taskforcesh/bullmq` `docs/gitbook/guide/jobs/job-ids.md`.
+- **Reusability after completion.** From
+  `docs/gitbook/guide/queues/auto-removal-of-jobs.md §"What about idempotence?"`:
+  > "When you add a job with an id that exists already in the queue, the
+  > new job is ignored and a **duplicated** event is triggered. … a job
+  > that has been removed will not be considered part of the queue
+  > anymore, and will not affect any future jobs that could have the
+  > same Id."
+  → Exactly the Q3 semantic we want: removed == reusable id. §2.2
+  pins `removeOnComplete`/`removeOnFail` to make this happen.
+- **Lazy removal caveat.** Same doc: "The auto removal of jobs works
+  lazily. … jobs are not removed unless a new job completes or fails".
+  → First post-completion `POST` may still collide if the previous
+  completed job wasn't swept yet. §2.2 mitigates via an explicit
+  `job.remove()` on the old record before enqueue (see Q3 mechanism).
+- **`job.updateProgress(n | {…})`** official progress API. Listeners via
+  `Worker.on('progress')` / `QueueEvents.on('progress')`. Source:
+  `docs/gitbook/guide/workers/README.md#progress`.
+
+---
+
+## 2. Plan — surgical edits, file by file
+
+### 2.1 `backend/src/core/services/redis-cache.ts` — list + force-release helpers
+
+Needed for Q2 visibility (list) and Q2-follow-up (admin force-release). Add
+after `isEmbeddingLocked` (~line 110):
+
+```typescript
+export interface EmbeddingLockSnapshot {
+  userId: string;
+  /** Lock identity token (random UUID written by acquireEmbeddingLock).
+   *  Exposed so the worker can verify, before each write, that the lock it
+   *  originally acquired is still the one in Redis (holder-epoch guard). */
+  holderEpoch: string;
+  /** Remaining TTL in ms. -1 means "no TTL" (shouldn't happen — SET NX EX
+   *  always sets one; -2 means key doesn't exist). */
+  ttlRemainingMs: number;
+}
+
+/**
+ * List all per-user embedding locks currently held. Used by:
+ *   1. Admin UI (`GET /api/admin/embedding/locks`) — render "alice, bob".
+ *   2. `runReembedAllJob` wait-on-locks loop.
+ *
+ * Uses Redis SCAN (NOT KEYS) to avoid blocking Redis on large keyspaces.
+ * See §7 open-Q3 for the future optimisation path if SCAN latency grows.
+ * Returns `[]` when Redis is unavailable.
+ */
+export async function listActiveEmbeddingLocks(): Promise<EmbeddingLockSnapshot[]> {
+  if (!_redisClient) return [];
+  const out: EmbeddingLockSnapshot[] = [];
+  try {
+    let cursor = 0;
+    do {
+      const reply = await _redisClient.scan(cursor, {
+        MATCH: 'embedding:lock:*',
+        COUNT: 100,
+      });
+      cursor = Number(reply.cursor);
+      for (const key of reply.keys) {
+        const userId = key.slice('embedding:lock:'.length);
+        if (!userId) continue;
+        // Pipeline would be nicer but keyspaces are small (< 100 entries
+        // typical). Two round-trips per key is fine for 5-sec polling.
+        const [holderEpoch, pttl] = await Promise.all([
+          _redisClient.get(key),
+          _redisClient.pTTL(key),
+        ]);
+        out.push({
+          userId,
+          holderEpoch: holderEpoch ?? '',
+          ttlRemainingMs: typeof pttl === 'number' ? pttl : -2,
+        });
+      }
+    } while (cursor !== 0);
+    return out;
+  } catch (err) {
+    logger.error({ err }, 'Failed to list active embedding locks');
+    return [];
+  }
+}
+
+/**
+ * Admin escape hatch — force-delete a per-user embedding lock regardless of
+ * holder. Unlike `releaseEmbeddingLock(userId, lockId)` (which refuses to
+ * delete unless the caller's lockId matches the stored value via Lua), this
+ * one unconditionally DELs the key. Use ONLY from admin-authenticated
+ * routes; log to the audit trail on every call.
+ *
+ * Returns:
+ *   - { released: true,  previousHolderEpoch: '<uuid>' } when the key existed.
+ *   - { released: false, previousHolderEpoch: null     } when the key was
+ *     already gone (idempotent — no 404).
+ *
+ * Safety contract (documented for operators):
+ *   If the user's embedding worker is still genuinely running when this is
+ *   called, the worker's next `embedPage` transaction will still commit (it
+ *   doesn't re-check the lock between every row). A racing second acquirer
+ *   of the same userId's lock would see a fresh `holderEpoch`; the original
+ *   worker's write-guard (see §2.3 "Holder-epoch guard") detects this and
+ *   aborts the loop. Duplicate rows in `page_embeddings` are prevented by
+ *   the DELETE/INSERT transaction inside `embedPage` (see lines 370–409).
+ */
+export async function forceReleaseEmbeddingLock(
+  userId: string,
+): Promise<{ released: boolean; previousHolderEpoch: string | null }> {
+  if (!_redisClient) {
+    return { released: false, previousHolderEpoch: null };
+  }
+  try {
+    const key = embeddingLockKey(userId);
+    const previous = await _redisClient.get(key);
+    const deleted = await _redisClient.del(key);
+    return {
+      released: deleted === 1,
+      previousHolderEpoch: previous,
+    };
+  } catch (err) {
+    logger.error({ err, userId }, 'Failed to force-release embedding lock');
+    return { released: false, previousHolderEpoch: null };
+  }
+}
+```
+
+### 2.2 `backend/src/core/services/queue-service.ts` — enqueueJob + reembed-all worker
+
+Add thin `enqueueJob` + `getJobStatus`. Register the `reembed-all` queue.
+
+```diff
++/**
++ * Enqueue a one-off job onto a named queue. Returns the resolved job id.
++ *
++ * Idempotency: when the caller passes a `jobId`, BullMQ ignores the add if a
++ * job with that id is already in waiting/active/delayed. Removed jobs
++ * (completed/failed that have been swept via `removeOnComplete`/`removeOnFail`)
++ * do **not** block re-adds — which is exactly the "collapse concurrent, allow
++ * re-run after finish" semantic we want (see Q3 in plan §6).
++ */
++export async function enqueueJob(
++  queueName: string,
++  data: Record<string, unknown>,
++  opts?: { jobId?: string; removeOnComplete?: number; removeOnFail?: number },
++): Promise<string> {
++  if (!USE_BULLMQ) {
++    const fakeId = opts?.jobId ?? `${queueName}-${Date.now()}`;
++    const def = workerDefs.find((d) => d.queueName === queueName);
++    if (def) {
++      void def.processor({ id: fakeId, name: queueName, data,
++        updateProgress: async () => {}, remove: async () => {} } as unknown as Job);
++    }
++    return fakeId;
++  }
++  const q = getOrCreateQueue(queueName);
++
++  // Q3 mechanism: if a previous job with this id exists in a *terminal* state
++  // (completed / failed) we must explicitly remove it before re-adding,
++  // because BullMQ's auto-removal is lazy — it does not happen until the
++  // NEXT job finishes. Without this sweep, the second POST after a clean
++  // run would silently dedupe against the stale completed record.
++  //
++  // When the previous job is still waiting/active/delayed, DO NOT remove
++  // it: let the duplicate add be ignored so the second caller observes
++  // the same jobId (collapse-concurrent semantic).
++  if (opts?.jobId) {
++    const existing = await q.getJob(opts.jobId);
++    if (existing) {
++      const state = await existing.getState();
++      if (state === 'completed' || state === 'failed') {
++        await existing.remove().catch(() => { /* race-tolerant */ });
++      }
++    }
++  }
++
++  const addOpts: Record<string, unknown> = {};
++  if (opts?.jobId) addOpts.jobId = opts.jobId;
++  if (opts?.removeOnComplete !== undefined) addOpts.removeOnComplete = { count: opts.removeOnComplete };
++  if (opts?.removeOnFail !== undefined) addOpts.removeOnFail = { count: opts.removeOnFail };
++
++  const job = await q.add(queueName, data, addOpts);
++  return job.id ?? opts?.jobId ?? `${queueName}-${Date.now()}`;
++}
++
++/** Fetch a job's current status + progress. Returns null when unknown. */
++export async function getJobStatus(
++  queueName: string,
++  jobId: string,
++): Promise<
++  | {
++      state: string;
++      progress: number | object;
++      returnvalue: unknown;
++      failedReason?: string;
++    }
++  | null
++> {
++  if (!USE_BULLMQ) return null;
++  const q = queues.get(queueName) ?? getOrCreateQueue(queueName);
++  const job = await q.getJob(jobId);
++  if (!job) return null;
++  return {
++    state: await job.getState(),
++    progress: (job.progress ?? 0) as number | object,
++    returnvalue: job.returnvalue,
++    failedReason: job.failedReason,
++  };
++}
+```
+
+In `registerAllWorkers()`, add after `maintenance`:
+
+```typescript
+registerWorkerDef({
+  queueName: 'reembed-all',
+  concurrency: 1,
+  processor: async (job: Job) => {
+    const { runReembedAllJob } = await import(
+      // eslint-disable-next-line boundaries/dependencies -- orchestrator
+      '../../domains/llm/services/embedding-service.js'
+    );
+    return runReembedAllJob(job);
+  },
+});
+```
+
+### 2.3 `backend/src/domains/llm/services/embedding-service.ts`
+
+Replace stub (lines 891–951 keep the dim-change transaction; only return path changes) + add worker entry point. Integrates **Q2** (per-user lock
+coordination) and **Q4** (configurable retention).
+
+```diff
+ export async function enqueueReembedAll(
+   opts: { newDimensions?: number } = {},
+ ): Promise<string> {
+-  const jobId = `reembed-${Date.now()}`;
++  // Fixed id → concurrent POSTs collapse (Q3).
++  const jobId = `reembed-all`;
+   if (opts.newDimensions !== undefined) {
+-    // … existing heavy dim-change transaction, unchanged …
++    // … existing heavy dim-change transaction, unchanged (lines 916–949) …
+   }
+-  return jobId;
++
++  // Q2: if per-user embedding locks are currently held, DO NOT start the
++  // worker yet — enqueue it with a short delay and include the offender
++  // list in the job data. The worker re-checks on start and keeps
++  // back-pressuring until locks clear. Surfaces to the UI via
++  // `GET /admin/embedding/reembed/:jobId`.
++  const { listActiveEmbeddingLocks } = await import('../../../core/services/redis-cache.js');
++  // v3: `listActiveEmbeddingLocks` now returns
++  //   Array<{ userId, holderEpoch, ttlRemainingMs }>.
++  // We pass only userIds into the BullMQ job data (the rest is UI-only,
++  // fetched fresh by the GET endpoint).
++  const heldBy = (await listActiveEmbeddingLocks()).map((l) => l.userId);
++
++  // Q4: read retention from admin_settings (default 150, range 10–10000).
++  const retention = await getReembedHistoryRetention();
++
++  const { enqueueJob } = await import('../../../core/services/queue-service.js');
++  await enqueueJob(
++    'reembed-all',
++    { triggeredAt: new Date().toISOString(), heldBy },
++    { jobId, removeOnComplete: retention, removeOnFail: retention },
++  );
++  return jobId;
++}
++
++/**
++ * Read the admin-configurable job-history retention setting.
++ * Default 150, clamped to [10, 10000]. See plan §2.6 for schema.
++ */
++async function getReembedHistoryRetention(): Promise<number> {
++  const r = await query<{ setting_value: string }>(
++    `SELECT setting_value FROM admin_settings WHERE setting_key='reembed_history_retention'`,
++  );
++  const raw = r.rows[0]?.setting_value;
++  const n = raw ? parseInt(raw, 10) : NaN;
++  if (!Number.isFinite(n)) return 150;
++  return Math.max(10, Math.min(10_000, n));
++}
++
++/**
++ * BullMQ worker entry point — registered in `queue-service.ts`.
++ *
++ * Q2 lock coordination:
++ *   Before the cursor loop, the worker polls `listActiveEmbeddingLocks()`
++ *   up to `REEMBED_WAIT_LOCKS_MS` (default 10 min). While it waits, it
++ *   emits `{ phase: 'waiting-on-user-locks', heldBy: string[] }` progress
++ *   events so the admin UI can show "waiting for alice, bob to finish".
++ *   If locks do not clear within the window, the job fails with a clear
++ *   message. The admin can retry or force-cancel user locks.
++ *
++ *   While the re-embed worker runs, its own Redis lock is held at the
++ *   special key `embedding:lock:__reembed_all__`. Per-user triggers
++ *   (`POST /embeddings/process`) already no-op via `isProcessingUser`
++ *   — we extend that check to also consider the reembed-all lock
++ *   (see §2.4 below). Net effect: only ONE embedding loop ever runs.
++ *
++ * Idempotency: the fixed `jobId='reembed-all'` + removeOnComplete
++ * together give "collapse concurrent, allow re-run after finish" (Q3).
++ */
++export async function runReembedAllJob(job: Job): Promise<string> {
++  const REEMBED_LOCK_USER = '__reembed_all__';
++  const WAIT_LOCKS_TIMEOUT_MS = parseInt(
++    process.env.REEMBED_WAIT_LOCKS_MS ?? '600000', 10,  // 10 min default
++  );
++  const POLL_INTERVAL_MS = 3_000;
++
++  const { listActiveEmbeddingLocks } = await import('../../../core/services/redis-cache.js');
++
++  // Wait-on-locks loop.
++  const waitStart = Date.now();
++  while (true) {
++    const held = (await listActiveEmbeddingLocks())
++      .filter((l) => l.userId !== REEMBED_LOCK_USER)
++      .map((l) => l.userId);
++    if (held.length === 0) break;
++    if (Date.now() - waitStart > WAIT_LOCKS_TIMEOUT_MS) {
++      throw new Error(
++        `reembed-all aborted: per-user embedding locks still held after ` +
++        `${Math.round(WAIT_LOCKS_TIMEOUT_MS / 60_000)}m by: ${held.join(', ')}`,
++      );
++    }
++    await job.updateProgress({
++      phase: 'waiting-on-user-locks',
++      heldBy: held,
++      waitedMs: Date.now() - waitStart,
++    });
++    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
++  }
++
++  const lockId = await acquireEmbeddingLock(REEMBED_LOCK_USER);
++  if (!lockId) {
++    // Lock appeared between the wait loop and here — treat as already running.
++    return 'already-running';
++  }
++
++  try {
++    // Mark every eligible page dirty (excludes folders + soft-deleted).
++    await query(
++      `UPDATE pages
++          SET embedding_dirty = TRUE,
++              embedding_status = 'not_embedded',
++              embedded_at = NULL,
++              embedding_error = NULL
++        WHERE deleted_at IS NULL
++          AND COALESCE(page_type, 'page') != 'folder'`,
++    );
++
++    const countRow = await query<{ c: string }>(
++      `SELECT COUNT(*)::text AS c FROM pages
++        WHERE embedding_dirty = TRUE AND deleted_at IS NULL
++          AND COALESCE(page_type, 'page') != 'folder'`,
++    );
++    const total = parseInt(countRow.rows[0]?.c ?? '0', 10);
++    await job.updateProgress({ total, processed: 0, failed: 0, phase: 'started' });
++
++    let processed = 0;
++    let failed = 0;
++    await processDirtyPages(REEMBED_LOCK_USER, (evt) => {
++      if (evt.type === 'progress') {
++        processed = evt.completed;
++        failed = evt.failed;
++        if ((processed + failed) % 100 === 0 || evt.percentage === 100) {
++          void job.updateProgress({ total, processed, failed, phase: 'embedding' });
++        }
++      }
++    });
++
++    await job.updateProgress({ total, processed, failed, phase: 'complete' });
++    return `processed=${processed} failed=${failed} total=${total}`;
++  } finally {
++    await releaseEmbeddingLock(REEMBED_LOCK_USER, lockId);
++  }
++}
+```
+
+Add `import type { Job } from 'bullmq';` at the top.
+
+### 2.4 `backend/src/domains/llm/services/embedding-service.ts` — extend `isProcessingUser` check
+
+Q2 bidirectional gating: per-user `POST /embeddings/process` must refuse
+while the reembed-all worker holds `embedding:lock:__reembed_all__`.
+
+```diff
+ export async function isProcessingUser(userId: string): Promise<boolean> {
+-  return isEmbeddingLocked(userId);
++  // Q2: block per-user triggers whenever ANY of these is held:
++  //   1. This user's own lock (existing behaviour).
++  //   2. The reembed-all system lock.
++  //
++  // Route handlers (`/embeddings/process`, `/embeddings/retry-failed`)
++  // already throw 409 when this returns true — so the reembed-all
++  // coordination is invisible to the user except for the 409 body
++  // (updated to mention "global re-embed in progress").
++  const [mine, reembedAll] = await Promise.all([
++    isEmbeddingLocked(userId),
++    isEmbeddingLocked('__reembed_all__'),
++  ]);
++  return mine || reembedAll;
++}
+```
+
+Companion: update the 409 body in `routes/llm/llm-embeddings.ts` to
+differentiate: "Embedding processing is already in progress for this user"
+vs "A global re-embed is in progress — per-user triggers are temporarily
+disabled. Try again in a few minutes."
+
+### 2.5 `backend/src/routes/llm/llm-embedding-reembed.ts` — add GET + locks in response
+
+```diff
+ fastify.post(
+   '/admin/embedding/reembed',
+   …
+-  async (request) => {
++  async (request) => {
+     const { newDimensions } = ReembedBodySchema.parse(request.body ?? {});
+     const { rows } = await query<{ c: string }>(`SELECT COUNT(*)::text AS c FROM pages`);
+     const pageCount = parseInt(rows[0]!.c, 10);
+     const jobId = await enqueueReembedAll(newDimensions !== undefined ? { newDimensions } : {});
+-    return { jobId, pageCount };
++
++    // Q2 (v3): surface per-user lock userIds so the UI can render
++    // "Embedding in progress: alice, bob — re-embed-all will start after
++    //  these complete." without a second round-trip. The richer
++    // `EmbeddingLockSnapshot[]` (with `holderEpoch` + `ttlRemainingMs`) is
++    // only exposed via `GET /api/admin/embedding/locks` (§2.10).
++    const { listActiveEmbeddingLocks } = await import(
++      '../../core/services/redis-cache.js'
++    );
++    const heldBy = (await listActiveEmbeddingLocks())
++      .filter((l) => l.userId !== '__reembed_all__')
++      .map((l) => l.userId);
++    return { jobId, pageCount, heldBy };
+   },
+ );
++
++fastify.get(
++  '/admin/embedding/reembed/:jobId',
++  { preHandler: fastify.requireAdmin },
++  async (request) => {
++    const { jobId } = request.params as { jobId: string };
++    const { getJobStatus } = await import('../../core/services/queue-service.js');
++    const { listActiveEmbeddingLocks } = await import(
++      '../../core/services/redis-cache.js'
++    );
++    const status = await getJobStatus('reembed-all', jobId);
++    const heldBy = (await listActiveEmbeddingLocks())
++      .filter((l) => l.userId !== '__reembed_all__')
++      .map((l) => l.userId);
++    if (!status) return { jobId, state: 'unknown', progress: null, heldBy };
++    return { jobId, ...status, heldBy };
++  },
++);
+```
+
+### 2.6 `packages/contracts/src/schemas/admin.ts` — new retention setting
+
+Q4. Add one field to both read + write schemas:
+
+```diff
+ export const AdminSettingsSchema = z.object({
+   embeddingDimensions: z.number().int().min(128).max(4096),
+   …
++  reembedHistoryRetention: z.number().int().min(10).max(10_000),
+ });
+
+ export const UpdateAdminSettingsSchema = z.object({
+   …
++  reembedHistoryRetention: z.number().int().min(10).max(10_000).optional(),
+ });
+```
+
+### 2.7 `backend/src/routes/foundation/admin.ts` — wire the setting
+
+```diff
+ const result = await query<{ setting_key: string; setting_value: string }>(
+   `SELECT setting_key, setting_value FROM admin_settings
+-   WHERE setting_key IN ('embedding_chunk_size', 'embedding_chunk_overlap', 'drawio_embed_url', 'fts_language')`,
++   WHERE setting_key IN ('embedding_chunk_size', 'embedding_chunk_overlap', 'drawio_embed_url', 'fts_language', 'reembed_history_retention')`,
+ );
+ …
+ return {
+   embeddingDimensions,
+   …
++  reembedHistoryRetention: parseInt(map['reembed_history_retention'] ?? '150', 10),
+ };
+```
+
+And in the PUT handler, alongside `embeddingChunkSize` upsert:
+
+```diff
++if (body.reembedHistoryRetention !== undefined) {
++  updates.push({
++    key: 'reembed_history_retention',
++    value: String(body.reembedHistoryRetention),
++  });
++}
+```
+
+### 2.8 Migration `055_reembed_history_retention.sql`
+
+```sql
+-- Migration 055: admin-configurable reembed-all job history retention (#257)
+INSERT INTO admin_settings (setting_key, setting_value, updated_at)
+VALUES ('reembed_history_retention', '150', NOW())
+ON CONFLICT (setting_key) DO NOTHING;
+```
+
+Additive, idempotent. Existing installs inherit default 150; explicit
+override is honoured.
+
+### 2.9 Frontend — `EmbeddingReembedBanner.tsx` + `EmbeddingTab.tsx` + new `ActiveEmbeddingLocksBanner.tsx`
+
+**New component** `frontend/src/features/settings/panels/ActiveEmbeddingLocksBanner.tsx`:
+
+- Polls `GET /api/embeddings/status` (or a new `GET /api/admin/embedding/locks` — see §6 open-Q) every 5 s.
+- Renders when `heldBy.length > 0`.
+- Displays "Embedding in progress: alice, bob — per-user triggers and
+  re-embed-all will queue until these complete."
+- Mounted above `EmbeddingReembedBanner` inside `EmbeddingTab.tsx`.
+- Unmounts when `heldBy` is empty.
+
+**`EmbeddingReembedBanner.tsx` updates** (drops v1 warning, adds polling):
+
+1. Remove the "worker not yet implemented" warning block (v1 lines 72–95).
+2. After a successful `POST /admin/embedding/reembed`, start a `setInterval`
+   polling `GET /admin/embedding/reembed/:jobId` every 2 s.
+3. Surface the `progress.phase`:
+   - `'waiting-on-user-locks'` → "Waiting for alice, bob to finish
+     (${waitedMs / 1000}s elapsed)"
+   - `'embedding'` → "${processed}/${total} pages"
+   - `'complete'` → green toast, stop polling.
+4. Cancel polling on component unmount or after 30 min.
+
+**`EmbeddingTab.tsx` updates** — add one new field in the embedding
+settings section:
+
+```tsx
+<label>Re-embed job history retention
+  <input
+    type="number" min={10} max={10000} step={1}
+    value={reembedHistoryRetention}
+    onChange={(e) => setField('reembedHistoryRetention', parseInt(e.target.value, 10))}
+  />
+  <span className="help">
+    Maximum completed/failed re-embed jobs retained in Redis before the
+    oldest get swept. Takes effect on the next re-embed run.
+  </span>
+</label>
+```
+
+**`ActiveEmbeddingLocksBanner.tsx` — v3 additions (force-release UI).**
+
+Per-lock row now renders a **"Force release"** button gated behind a
+confirm modal. The banner consumes `EmbeddingLockSnapshot[]` from the
+dedicated admin endpoint (§2.10, §3.2).
+
+```tsx
+// Pseudocode sketch — real implementation follows existing banner style.
+{locks.map((lock) => (
+  <li key={lock.userId} className="flex items-center justify-between gap-2">
+    <span>
+      {lock.userId} — holding for{' '}
+      {Math.max(0, Math.round((EMBEDDING_LOCK_TTL_MS - lock.ttlRemainingMs) / 1000))}s
+    </span>
+    <button
+      className="glass-button-danger text-xs"
+      onClick={() => openConfirm({
+        title: 'Force release embedding lock?',
+        body: `This will abandon any in-flight embedding for user "${lock.userId}". `
+            + `Their worker may continue writing a few rows before detecting the `
+            + `release; no duplicate embeddings will be produced. Continue?`,
+        confirmLabel: 'Force release',
+        danger: true,
+        onConfirm: () => postForceRelease(lock.userId),
+      })}
+    >
+      Force release
+    </button>
+  </li>
+))}
+```
+
+Confirm modal: reuse the existing `ConfirmDialog` / `AlertDialog` component
+already used by `BulkOperations.tsx` and the delete-page flow (whichever
+already exists in `frontend/src/shared/components/` — audit at implementation
+time). Do not introduce a new modal primitive.
+
+Polling cadence: 5 s (unchanged from v2).
+
+### 2.10 New admin-only routes — `/api/admin/embedding/locks` (GET + force-release POST)
+
+**File:** new `backend/src/routes/foundation/admin-embedding-locks.ts`
+(or extend `admin.ts` — place alongside `admin_settings` routes since both
+are foundation-scope admin).
+
+```typescript
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import {
+  listActiveEmbeddingLocks,
+  forceReleaseEmbeddingLock,
+} from '../../core/services/redis-cache.js';
+import { logAuditEvent } from '../../core/services/audit-service.js';
+import { getRateLimits } from '../../core/services/rate-limit-service.js';
+
+const ADMIN_RATE_LIMIT = {
+  config: {
+    rateLimit: {
+      max: async () => (await getRateLimits()).admin.max,
+      timeWindow: '1 minute',
+    },
+  },
+};
+
+const UserIdParam = z.object({ userId: z.string().min(1).max(256) });
+
+export async function adminEmbeddingLocksRoutes(fastify: FastifyInstance) {
+  fastify.addHook('onRequest', fastify.authenticate);
+
+  // GET /api/admin/embedding/locks — list ALL active per-user embedding locks.
+  // Admin-only. Polled by `ActiveEmbeddingLocksBanner` every 5s.
+  fastify.get(
+    '/admin/embedding/locks',
+    { preHandler: fastify.requireAdmin, ...ADMIN_RATE_LIMIT },
+    async () => {
+      // Filter out the synthetic `__reembed_all__` system lock — the UI
+      // handles that one via the reembed-job GET, not the lock banner.
+      const locks = (await listActiveEmbeddingLocks()).filter(
+        (l) => l.userId !== '__reembed_all__',
+      );
+      return { locks };
+    },
+  );
+
+  // POST /api/admin/embedding/locks/:userId/release — admin escape hatch.
+  // Audit-logged on every call.
+  fastify.post(
+    '/admin/embedding/locks/:userId/release',
+    { preHandler: fastify.requireAdmin, ...ADMIN_RATE_LIMIT },
+    async (request) => {
+      const { userId } = UserIdParam.parse(request.params);
+
+      const result = await forceReleaseEmbeddingLock(userId);
+
+      await logAuditEvent(
+        request.userId,
+        'ADMIN_ACTION',
+        'embedding_lock',
+        userId,
+        {
+          action: 'force_release_embedding_lock',
+          targetUserId: userId,
+          released: result.released,
+          previousHolderEpoch: result.previousHolderEpoch,
+        },
+        request,
+      );
+
+      // Idempotent: return 200 with `released: false` when the lock was
+      // already gone, NOT 404. Avoids races where the lock releases
+      // naturally between the banner-poll and the admin click.
+      return { released: result.released, userId };
+    },
+  );
+}
+```
+
+Register in `app.ts` alongside the other foundation routes (next to
+`adminRoutes`).
+
+**Holder-epoch guard — `embedPage` worker-side check** (small follow-up in
+`backend/src/domains/llm/services/embedding-service.ts`):
+
+The `acquireEmbeddingLock` call already returns a random UUID (the
+"lockId") that is only used for the safe-release Lua script today. For v3
+we also use it as the **holder-epoch** so a force-released worker can
+detect it lost its lock and abort cleanly:
+
+```typescript
+// Inside processDirtyPages, between embedPage() calls:
+//   Every 20 pages, re-read the lock key and compare.
+//   If it's missing or mismatched, break the loop and log.
+if (pagesProcessedSinceGuardCheck >= 20) {
+  const stillMine = await redis.get(embeddingLockKey(userId));
+  if (stillMine !== lockId) {
+    logger.warn(
+      { userId, expected: lockId, actual: stillMine },
+      'Embedding lock was force-released or expired — aborting worker loop',
+    );
+    break; // exits the outer page-batch loop; finally block releases nothing
+           // (already gone) via the safe-release Lua (no-op when mismatched).
+  }
+  pagesProcessedSinceGuardCheck = 0;
+}
+```
+
+This is the minimum-intrusive change that gives the "release abort"
+safety documented in `forceReleaseEmbeddingLock`. Check frequency every
+20 pages matches the existing inter-page delay pattern; tune if test
+coverage shows a tighter bound is worth the extra Redis round-trip.
+
+**Important:** the `releaseEmbeddingLock` Lua script in the existing
+codebase (redis-cache.ts:76) already does `get+compare+del`, so the
+worker's `finally` block continues to work unchanged — it just no-ops
+when the lock no longer matches, which is exactly what we want.
+
+---
+
+## 3. Admin settings, API endpoints, frontend surface — inventory
+
+### 3.1 New `admin_settings` keys
+
+| key | type | default | range | validation | migration |
+|---|---|---|---|---|---|
+| `reembed_history_retention` | integer (stored as text) | `150` | `[10, 10000]` | Zod int + server-side clamp in `getReembedHistoryRetention()` | `055_reembed_history_retention.sql` |
+
+### 3.2 New / changed API endpoints
+
+| method | path | auth | request | response | behaviour change |
+|---|---|---|---|---|---|
+| POST | `/api/admin/embedding/reembed` | `requireAdmin` + admin rate-limit | `{ newDimensions?: number }` | **changed**: `{ jobId, pageCount, heldBy: string[] }` | Adds `heldBy` userIds. Worker now actually runs. |
+| **GET** (new) | `/api/admin/embedding/reembed/:jobId` | `requireAdmin` | path param | `{ jobId, state, progress, returnvalue?, failedReason?, heldBy: string[] }` | Progress polling. |
+| **GET** (new, v3) | `/api/admin/embedding/locks` | `requireAdmin` + admin rate-limit | — | `{ locks: EmbeddingLockSnapshot[] }` where `EmbeddingLockSnapshot = { userId, holderEpoch, ttlRemainingMs }` | Q1: dedicated endpoint — does NOT extend `/api/embeddings/status`. Excludes the synthetic `__reembed_all__` system lock. |
+| **POST** (new, v3) | `/api/admin/embedding/locks/:userId/release` | `requireAdmin` + admin rate-limit | path param: userId | `{ released: boolean, userId }` (200 on both; idempotent) | Q2-follow-up: admin escape-hatch. Audit-logged as `ADMIN_ACTION` / `embedding_lock` / `force_release_embedding_lock`. |
+| GET | `/api/admin/settings` | `requireAdmin` | — | **changed**: adds `reembedHistoryRetention: number` | Additive. |
+| PUT | `/api/admin/settings` | `requireAdmin` | **changed**: accepts `reembedHistoryRetention?` | `{ message }` | Additive. |
+| GET | `/api/embeddings/status` | `authenticate` | — | unchanged | v3: NOT extended — dedicated admin endpoint instead. |
+
+Rate limits: admin routes share `ADMIN_RATE_LIMIT` (existing decorator).
+`retry-failed` / `process` route semantics unchanged (still 409 when
+`isProcessingUser` true); only the 409 body text is updated to differentiate
+"user's own lock" vs "global re-embed in progress".
+
+### 3.3 New / changed frontend components
+
+| component | status | consumes | purpose |
+|---|---|---|---|
+| `ActiveEmbeddingLocksBanner.tsx` | **new** | `GET /api/admin/embedding/locks` → `{ locks: EmbeddingLockSnapshot[] }` (polled every 5 s) | Shows "Embedding in progress: alice, bob" when any per-user lock is held, with a per-row **Force release** button (v3) gated behind a confirm modal. |
+| `EmbeddingReembedBanner.tsx` | **changed** | `/admin/embedding/reembed/:jobId` | Drops v1 warning, polls progress, surfaces `waiting-on-user-locks` + `embedding` + `complete` phases. |
+| `EmbeddingTab.tsx` | **changed** | `AdminSettingsSchema.reembedHistoryRetention` + admin-only surface | Adds the retention-number input and mounts `ActiveEmbeddingLocksBanner` above `EmbeddingReembedBanner`. |
+| existing `ConfirmDialog` / `AlertDialog` | **reused** | — | Confirm modal for force-release. No new primitive. |
+
+**Type export:** add `EmbeddingLockSnapshot` to `packages/contracts/src/schemas/admin.ts`
+(or a new `…/schemas/embedding-locks.ts` if reviewer prefers a dedicated
+module) so the frontend imports the type instead of redeclaring. Zod
+shape:
+
+```ts
+export const EmbeddingLockSnapshotSchema = z.object({
+  userId: z.string(),
+  holderEpoch: z.string(),
+  ttlRemainingMs: z.number().int(),
+});
+export type EmbeddingLockSnapshot = z.infer<typeof EmbeddingLockSnapshotSchema>;
+
+export const AdminEmbeddingLocksResponseSchema = z.object({
+  locks: z.array(EmbeddingLockSnapshotSchema),
+});
+
+export const ForceReleaseLockResponseSchema = z.object({
+  released: z.boolean(),
+  userId: z.string(),
+});
+```
+
+No new prop shapes on existing components besides the changes above.
+
+---
+
+## 4. New tests (TDD — RED first)
+
+### 4.1 Unit: `backend/src/domains/llm/services/embedding-service.test.ts`
+
+- **RED #1**: `runReembedAllJob` on 2 pages + 1 folder → `processed === 2`, `job.updateProgress` called with `phase: 'complete'`.
+- **RED #2** (Q2): With `acquireEmbeddingLock('alice')` held, worker emits `{ phase: 'waiting-on-user-locks', heldBy: ['alice'] }` and waits. Release lock → worker proceeds to `'embedding'` phase. Use a short `REEMBED_WAIT_LOCKS_MS` env override.
+- **RED #3** (Q2 timeout): With lock held for longer than `REEMBED_WAIT_LOCKS_MS`, worker throws `reembed-all aborted: per-user embedding locks still held …`.
+- **RED #4** (Q4): Custom `reembed_history_retention='250'` in admin_settings → `enqueueJob` called with `removeOnComplete: 250`. Default path (unset) → `150`.
+
+### 4.2 Unit: `backend/src/core/services/queue-service.test.ts`
+
+- **RED #5** (Q3 core): `enqueueJob('reembed-all', {}, { jobId: 'x' })` while a previous 'x' is in `completed` state → old record removed before new add, second add succeeds, third add (while new one is `active`) no-ops (returns same id, no new `Queue.add` call).
+- **RED #6**: `getJobStatus` returns `null` for unknown queue.
+
+### 4.3 Unit: `backend/src/core/services/redis-cache.test.ts`
+
+- **RED #7** (v3 signature): `listActiveEmbeddingLocks()` returns
+  `EmbeddingLockSnapshot[]` with `{ userId, holderEpoch, ttlRemainingMs }`
+  for each `SET NX`-acquired lock. After `releaseEmbeddingLock` on the
+  same user → returns `[]`. Assert `holderEpoch` matches the lockId
+  returned by `acquireEmbeddingLock`. Assert `ttlRemainingMs` is > 0 and
+  ≤ `EMBEDDING_LOCK_TTL * 1000`. Uses real Redis.
+- **RED #7b** (v3 new): `forceReleaseEmbeddingLock('alice')` when alice
+  holds a lock → returns `{ released: true, previousHolderEpoch: '<uuid>' }`
+  and key is gone from Redis. Calling it a second time (idempotent) →
+  `{ released: false, previousHolderEpoch: null }`. Calling it when Redis
+  is unavailable → `{ released: false, previousHolderEpoch: null }`
+  (no throw).
+
+### 4.4 Route test: `backend/src/routes/llm/llm-embedding-reembed.test.ts`
+
+- **RED #8**: `POST /admin/embedding/reembed` twice in flight → identical `jobId` both times.
+- **RED #9** (Q3): After first run completes, second `POST` returns the **same** `jobId='reembed-all'` but enqueues a NEW BullMQ job (verified via `GET /admin/embedding/reembed/:jobId` showing fresh `state='waiting'|'active'`).
+- **RED #10** (Q2 surface): `POST` returns `heldBy: ['alice']` when alice's lock is held. `GET /admin/embedding/reembed/:jobId` returns the same `heldBy` field (string[], filtered to exclude `__reembed_all__`).
+
+### 4.5 Route test: `backend/src/routes/foundation/admin.test.ts`
+
+- **RED #11** (Q4): `PUT /api/admin/settings` with `reembedHistoryRetention: 500` persists. GET reflects it. Out-of-range value (e.g. `5`) returns 400.
+
+### 4.6 Route test: `backend/src/routes/foundation/admin-embedding-locks.test.ts` (new)
+
+- **RED #11a** (v3, GET): `GET /api/admin/embedding/locks` with admin token → returns `{ locks: [{ userId: 'alice', holderEpoch: '…', ttlRemainingMs: <positive> }] }` when alice holds a lock.
+- **RED #11b** (v3, GET excludes system): The synthetic `__reembed_all__` lock acquired by the worker is filtered out of the GET response.
+- **RED #11c** (v3, force-release happy path): `POST /api/admin/embedding/locks/alice/release` with admin token → 200, `{ released: true, userId: 'alice' }`. Lock key gone from Redis. `audit_log` contains an `ADMIN_ACTION` / `embedding_lock` / `force_release_embedding_lock` row with `targetUserId: 'alice'`.
+- **RED #11d** (v3, force-release idempotent / non-existent): `POST .../:userId/release` when no lock exists → 200, `{ released: false, userId }`. Still writes an audit row (so deliberate no-ops are observable).
+- **RED #11e** (v3, non-admin forbidden): Member token on either GET or POST → 403. No audit row created on the forbidden request.
+- **RED #11f** (v3, rate-limited): Excessive POSTs hit `ADMIN_RATE_LIMIT` → 429.
+
+### 4.7 Unit: holder-epoch worker guard (extend `embedding-service.test.ts`)
+
+- **RED #11g** (v3): Acquire a lock as user 'alice', start `processDirtyPages('alice', …)` with fake pages. After N pages, call `forceReleaseEmbeddingLock('alice')` from the test. Assert: the worker's loop exits within its next 20-page guard-check window; no `throw`; `finally` block's `releaseEmbeddingLock` is a safe no-op (Lua mismatch path). Remaining pages left in their pre-worker state (embedding_dirty = TRUE still).
+
+### 4.8 Contract test: `packages/contracts/src/schemas/admin.test.ts`
+
+- **RED #12**: `AdminSettingsSchema.parse` accepts valid retention. `UpdateAdminSettingsSchema.parse({ reembedHistoryRetention: 100 })` valid; `= 9` rejected; `= 10001` rejected.
+- **RED #12a** (v3): `EmbeddingLockSnapshotSchema` / `AdminEmbeddingLocksResponseSchema` / `ForceReleaseLockResponseSchema` round-trip through `parse` with sample payloads.
+
+### 4.9 E2E: `e2e/llm-providers.spec.ts`
+
+Extend with: admin triggers re-embed, polls, asserts
+`state === 'completed'` within 60 s. Mirrors v1 §3.4.
+
+### 4.10 Frontend: component tests (Vitest + jsdom)
+
+- **RED #13** (v3 updated): `ActiveEmbeddingLocksBanner` given `locks = [{ userId: 'alice', holderEpoch: 'uuid', ttlRemainingMs: 500_000 }]` renders "alice" row with a visible **Force release** button. Given `locks = []`, component renders nothing.
+- **RED #14**: `EmbeddingReembedBanner` surfaces `waiting-on-user-locks` message when the polled job payload has that phase.
+- **RED #14a** (v3 new): Clicking "Force release" on a lock row opens the confirm modal; clicking cancel closes it without any fetch; clicking confirm fires `POST /api/admin/embedding/locks/alice/release`. After the POST resolves `{ released: true }`, the row disappears on the next poll (mock the fetcher to return empty `locks`).
+- **RED #14b** (v3 new): When the force-release POST returns a non-2xx (403/500), the modal surfaces an error toast and leaves the lock row in place.
+
+---
+
+## 5. Rollback procedure
+
+1. `git revert <range>` reverts all of:
+   - `backend/src/core/services/queue-service.ts` (additive `enqueueJob` + worker def).
+   - `backend/src/core/services/redis-cache.ts` (additive `listActiveEmbeddingLocks`).
+   - `backend/src/domains/llm/services/embedding-service.ts` (stub + new helpers).
+   - `backend/src/routes/llm/llm-embedding-reembed.ts` (GET route).
+   - `backend/src/routes/foundation/admin.ts` (setting wiring).
+   - `packages/contracts/src/schemas/admin.ts` (Zod field).
+   - Frontend components + banner.
+2. Migration `055_reembed_history_retention.sql` is idempotent & additive;
+   the `admin_settings` row can remain (no harm) or be manually deleted:
+   `DELETE FROM admin_settings WHERE setting_key='reembed_history_retention';`.
+   No schema DDL to revert.
+3. Partial rollback: setting `USE_BULLMQ=false` restores inline-execution
+   fallback for the enqueue path.
+
+---
+
+## 6. Acceptance-criteria checklist
+
+- [ ] `POST /api/admin/embedding/reembed` enqueues & runs a BullMQ worker.
+      (§2.2, §2.3)
+- [ ] Worker cursors all pages, calls `embedText` via the existing client.
+      (§2.3 reuses `processDirtyPages`)
+- [ ] Progress emitted every 100 pages. (§2.3 throttle)
+- [ ] Frontend banner polls progress. (§2.9 + §3.2)
+- [ ] Concurrent POSTs collapse to same `jobId`. (Q3 — §2.2, §4.2 RED #5, §4.4 RED #8)
+- [ ] Post-completion POST enqueues a fresh run. (Q3 — §2.2 explicit remove, §4.4 RED #9)
+- [ ] E2E completion within 60s. (§4.9)
+- [ ] Worker waits for / respects per-user locks. (Q2 — §2.3, §4.1 RED #2/#3)
+- [ ] Per-user triggers gated while reembed-all runs. (Q2 — §2.4)
+- [ ] Admin UI shows active-lock list via **dedicated** `/api/admin/embedding/locks`. (v3-Q1 — §2.10, §4.6 RED #11a, §4.10 RED #13)
+- [ ] Admin can force-release a user lock; action is audit-logged; idempotent on non-existent. (v3-Q2 — §2.10, §4.6 RED #11c/#11d, §4.10 RED #14a)
+- [ ] Force-released worker aborts cleanly (no dup rows, no throw). (v3-Q2 write-guard — §2.10 holder-epoch guard, §4.7 RED #11g)
+- [ ] Retention configurable from admin settings. (Q4 — §2.6–§2.8, §4.5 RED #11)
+
+---
+
+## 7. Risks + open questions
+
+### 7.1 Resolved in v3 (noted for reviewer traceability)
+
+- **(resolved, v3-Q1) Lock-listing endpoint placement.** Dedicated
+  `GET /api/admin/embedding/locks` — NOT an extension of
+  `/api/embeddings/status`. §2.10, §3.2.
+- **(resolved, v3-Q2) Admin force-release.** In scope.
+  `POST /api/admin/embedding/locks/:userId/release` with audit logging +
+  holder-epoch write-guard on the embedding worker. §2.1
+  (`forceReleaseEmbeddingLock`), §2.10 (routes + worker guard), §4.6,
+  §4.7.
+
+### 7.2 Remaining risks
+
+1. **SCAN cost on Redis (accepted as-is, v3-Q3).** `listActiveEmbeddingLocks`
+   uses SCAN `MATCH embedding:lock:* COUNT 100`. O(N) across the whole
+   keyspace; fine today (admin poll cadence 5 s, expected ≤ 100 locks).
+   **Upgrade path if this ever hurts:** maintain a dedicated
+   `SADD embedding:locks:active <userId>` set alongside each `SET NX`
+   lock write (with matching `SREM` on release + a reconciling sweep on
+   boot to handle crashes). Switch `listActiveEmbeddingLocks` to
+   `SMEMBERS` + per-key `GET` / `PTTL`. **Revisit heuristic:** if the
+   `/api/admin/embedding/locks` P99 latency exceeds **50 ms** in
+   production or the SCAN `COUNT` tuning becomes load-bearing.
+2. **Force-release race (documented trade-off).** `forceReleaseEmbeddingLock`
+   unconditionally DELs the Redis key. If the victim worker is
+   mid-`embedPage` when the key is deleted, it still finishes the
+   in-flight page transaction (the DELETE/INSERT inside `embedPage`
+   already prevents duplicate `page_embeddings` rows). The holder-epoch
+   guard (§2.10) catches the release within at most 20 pages, aborting
+   the loop. Worst-case: ≤ 20 pages get their embeddings rewritten by a
+   soon-to-abort worker. Acceptable for an admin escape-hatch. UI
+   confirm-modal body text explicitly calls this out.
+3. **BullMQ lazy-removal edge case.** The explicit `existing.remove()` in
+   `enqueueJob` races against the next job's auto-removal sweep. Both
+   operations are idempotent (`del` vs `del`) and the `.catch(() => {})`
+   swallows the race. Verified safe per BullMQ docs; call out in review.
+4. **Setting change timing.** Retention changes take effect on the
+   **next** enqueue (reads `admin_settings` inside `enqueueReembedAll`,
+   §2.3). Existing queued jobs carry the old retention until they
+   complete — documented in the field's help-text.
+5. **Multi-instance deployment.** BullMQ handles this natively (Redis
+   coordination). `listActiveEmbeddingLocks` /
+   `forceReleaseEmbeddingLock` are Redis-native.
+   `acquireEmbeddingLock(__reembed_all__)` is atomic via `SET NX`. No
+   single-instance assumption. Flag: make sure CI runs Redis.
+6. **`page_type='folder'` exclusion.** Current code uses
+   `COALESCE(page_type, 'page') != 'folder'`. Worker uses same filter —
+   consistency preserved.
+7. **Job removal after explicit failure.** If `runReembedAllJob` throws,
+   BullMQ retries per queue config (default: no retries). The first POST
+   after that keeps the same `jobId` and collapses into the failed record
+   unless we remove it. `enqueueJob` §2.2 handles both `completed` and
+   `failed` — correct.
+8. **Audit log on forbidden attempts (§4.6 RED #11e).** Non-admin POSTs
+   to the force-release route get a 403 from `requireAdmin` *before* the
+   handler runs → no audit row. If auditing denied attempts is desired,
+   wire it at the `requireAdmin` decorator level (cross-cutting, out of
+   scope for #257). Called out for reviewer.
+
+---
+
+## 8. Dependency on #258
+
+See #258's §7 for the reverse summary. Short version:
+
+- **#257 lands first.** Unblocks the dimension-change banner. Reuses the
+  `openai-compatible-client.ts` queue+breaker wrapping that #256 already
+  shipped.
+- **#258 is mostly tests + cleanup** around the same wrapping —
+  non-breaking relative to #257.
+- **Shared scaffolding:** the local-HTTP stub pattern from
+  `openai-compatible-client.test.ts` is reused across both plans; keep
+  it inline in each test for now and extract if a 3rd consumer appears.
+
+---
+
+## 9. Changelog
+
+### v1 → v2
+
+- **Q2 integrated** (§2.1 new `listActiveEmbeddingLocks`, §2.3 worker
+  wait-on-locks loop, §2.4 bidirectional `isProcessingUser`, §2.5 `heldBy`
+  in API response, §2.9 new `ActiveEmbeddingLocksBanner` component).
+- **Q3 integrated** (§2.2 explicit completed/failed job removal before
+  re-add; research citation of BullMQ "lazy removal" doc; RED #5 + RED #9
+  cover the post-completion re-run path).
+- **Q4 integrated** (new `reembed_history_retention` admin setting;
+  §2.6 Zod, §2.7 route wiring, §2.8 migration, §2.9 UI field; default 150,
+  range [10, 10000]; read per-enqueue so changes take effect on next run).
+- New §3 inventory table (admin settings / endpoints / components) per
+  user ask.
+- Test list expanded from 6 → 14 RED cases.
+- Two new open questions (lock-listing endpoint placement; admin force-release).
+
+### v2 → v3
+
+- **v3-Q1 resolved, dedicated endpoint.** `GET /api/admin/embedding/locks`
+  is a new admin-only route (§2.10). `/api/embeddings/status` is NOT
+  extended — the §3.2 "TBD" row is resolved. Response is
+  `{ locks: EmbeddingLockSnapshot[] }` where each snapshot carries
+  `userId` + `holderEpoch` + `ttlRemainingMs`.
+- **v3-Q2 resolved, folded into #257.** New admin-only
+  `POST /api/admin/embedding/locks/:userId/release` with audit logging
+  (`ADMIN_ACTION` / `embedding_lock` / `force_release_embedding_lock`).
+  §2.1 adds `forceReleaseEmbeddingLock` helper. §2.10 adds the route file
+  + worker-side **holder-epoch guard** (re-reads the lock every 20 pages
+  inside `processDirtyPages` and breaks the loop on mismatch) so a
+  force-released worker aborts without throwing and without duplicate
+  writes. UI: per-row "Force release" button in
+  `ActiveEmbeddingLocksBanner` gated by existing `ConfirmDialog`
+  primitive.
+- **v3-Q3 noted, no code change.** SCAN-based `listActiveEmbeddingLocks`
+  kept. §7.2 Risk #1 adds the upgrade-path note (dedicated
+  `embedding:locks:active` set) with the 50 ms P99 revisit heuristic.
+- **Type exports added** to `packages/contracts/src/schemas/admin.ts`:
+  `EmbeddingLockSnapshotSchema`, `AdminEmbeddingLocksResponseSchema`,
+  `ForceReleaseLockResponseSchema`. §3.3 + §4.8 RED #12a.
+- **§1 ResearchPack** line for `redis-cache.ts` updated to note the
+  `SET NX EX` + Lua safe-release pattern already in place (line 76)
+  is what makes the holder-epoch guard cheap to add.
+- **§2.1 signature breaking change** inside this PR:
+  `listActiveEmbeddingLocks` returns `EmbeddingLockSnapshot[]` instead
+  of `string[]`. Call-sites in §2.3 (worker wait loop) and §2.5 (POST
+  + GET reembed routes) updated in the diff to `.map((l) => l.userId)`.
+- **Tests:** 14 REDs → 20 REDs. New:
+  #7b (`forceReleaseEmbeddingLock` unit), #11a–#11f (new route-test file
+  `admin-embedding-locks.test.ts`), #11g (worker holder-epoch guard),
+  #12a (contract schema), #14a / #14b (frontend confirm modal +
+  error-toast).
+- **§6 acceptance checklist** expanded with three new bullets (dedicated
+  endpoint, force-release + audit, worker abort safety).
+- **§7 open questions** reorganised: §7.1 resolved items pinned for
+  reviewer traceability; §7.2 renumbered remaining risks; new risk #2
+  (force-release race trade-off, documented); new risk #8 (forbidden
+  attempts not audit-logged — cross-cutting, flagged).
+- No schema changes — migration `055` unchanged.

--- a/e2e/llm-providers.spec.ts
+++ b/e2e/llm-providers.spec.ts
@@ -82,4 +82,48 @@ test.describe('Multi-LLM-provider flow', () => {
     await page.getByRole('button', { name: /send/i }).click();
     await expect(page.locator('.message-assistant')).toBeVisible({ timeout: 30_000 });
   });
+
+  // Issue #257 §4.9 RED #20 — end-to-end completion of reembed-all.
+  // Triggers the admin endpoint and polls the GET until `state === 'completed'`
+  // within 60 s. The BullMQ worker acquires the `__reembed_all__` lock, marks
+  // every non-folder page dirty, runs processDirtyPages, and reports progress.
+  // Empty-DB deployments complete near-instantly (processDirtyPages skips the
+  // batch loop when nothing is dirty); populated DBs need the upstream
+  // embedding endpoint to be reachable.
+  test('admin can trigger reembed-all and the worker completes within 60s', async ({
+    page,
+  }) => {
+    const headers = await page.evaluate(() => {
+      const raw = localStorage.getItem('compendiq-auth');
+      if (!raw) return {};
+      const token = (JSON.parse(raw) as { state: { accessToken: string } }).state.accessToken;
+      return { authorization: `Bearer ${token}` };
+    });
+
+    const enqueue = await page.request.post('/api/admin/embedding/reembed', {
+      headers: { ...headers, 'content-type': 'application/json' },
+      data: {},
+    });
+    expect(enqueue.ok()).toBe(true);
+    const body = await enqueue.json();
+    expect(body.jobId).toBe('reembed-all');
+
+    // Poll GET until state transitions to completed (or fail hard after 60s).
+    const deadline = Date.now() + 60_000;
+    let lastState = 'unknown';
+    while (Date.now() < deadline) {
+      const poll = await page.request.get(`/api/admin/embedding/reembed/${body.jobId}`, {
+        headers,
+      });
+      expect(poll.ok()).toBe(true);
+      const status = await poll.json();
+      lastState = status.state ?? 'unknown';
+      if (lastState === 'completed') return;
+      if (lastState === 'failed') {
+        throw new Error(`reembed-all failed: ${status.failedReason ?? 'unknown'}`);
+      }
+      await new Promise((r) => setTimeout(r, 1_000));
+    }
+    throw new Error(`reembed-all did not complete within 60s (last state: ${lastState})`);
+  });
 });

--- a/frontend/src/features/settings/panels/ActiveEmbeddingLocksBanner.test.tsx
+++ b/frontend/src/features/settings/panels/ActiveEmbeddingLocksBanner.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ActiveEmbeddingLocksBanner } from './ActiveEmbeddingLocksBanner';
+import { useAuthStore } from '../../../stores/auth-store';
+
+function createWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('ActiveEmbeddingLocksBanner', () => {
+  beforeEach(() => {
+    useAuthStore.getState().setAuth('test-token', {
+      id: '1',
+      username: 'admin',
+      role: 'admin',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useAuthStore.getState().clearAuth();
+  });
+
+  // RED #13 (plan §4.10) — empty state: render nothing.
+  it('renders nothing when no locks are held', async () => {
+    const Wrapper = createWrapper();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      return new Response(JSON.stringify({ locks: [] }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const { container } = render(<ActiveEmbeddingLocksBanner />, { wrapper: Wrapper });
+
+    // Wait for the initial poll to settle.
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  // RED #13 — populated state: render per-user rows + Force release button.
+  it('renders one row per active lock with a Force release button', async () => {
+    const Wrapper = createWrapper();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({
+          locks: [
+            { userId: 'alice', holderEpoch: 'uuid-a', ttlRemainingMs: 1_200_000 },
+            { userId: 'bob', holderEpoch: 'uuid-b', ttlRemainingMs: 2_400_000 },
+          ],
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+
+    render(<ActiveEmbeddingLocksBanner />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('embedding-lock-row-alice')).toBeTruthy();
+      expect(screen.getByTestId('embedding-lock-row-bob')).toBeTruthy();
+    });
+    const buttons = await screen.findAllByRole('button', { name: /force release/i });
+    expect(buttons).toHaveLength(2);
+  });
+
+  // RED #14a — confirm flow: cancel does NOT fire the release call.
+  it('cancel on confirm-inline does not fire a release call', async () => {
+    const Wrapper = createWrapper();
+    const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.includes('/admin/embedding/locks') && !url.includes('/release')) {
+        return new Response(
+          JSON.stringify({
+            locks: [{ userId: 'alice', holderEpoch: 'uuid-a', ttlRemainingMs: 1_000_000 }],
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response('{}', { headers: { 'Content-Type': 'application/json' } });
+    });
+
+    render(<ActiveEmbeddingLocksBanner />, { wrapper: Wrapper });
+    const releaseBtn = await screen.findByRole('button', { name: /force release/i });
+    fireEvent.click(releaseBtn);
+    const cancelBtn = await screen.findByRole('button', { name: /cancel/i });
+    fireEvent.click(cancelBtn);
+
+    // No POST went out.
+    const releaseCalls = spy.mock.calls.filter(([input]) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      return url.includes('/release');
+    });
+    expect(releaseCalls).toHaveLength(0);
+  });
+
+  // RED #14a — confirm flow happy path: confirm fires POST.
+  it('confirm on inline-confirm fires POST /admin/embedding/locks/:userId/release', async () => {
+    const Wrapper = createWrapper();
+    let postFired = false;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.endsWith('/admin/embedding/locks/alice/release') && init?.method === 'POST') {
+        postFired = true;
+        return new Response(JSON.stringify({ released: true, userId: 'alice' }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/admin/embedding/locks')) {
+        return new Response(
+          JSON.stringify({
+            locks: postFired
+              ? []
+              : [{ userId: 'alice', holderEpoch: 'uuid-a', ttlRemainingMs: 1_000_000 }],
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response('{}', { headers: { 'Content-Type': 'application/json' } });
+    });
+
+    render(<ActiveEmbeddingLocksBanner />, { wrapper: Wrapper });
+    const releaseBtn = await screen.findByRole('button', { name: /force release/i });
+    fireEvent.click(releaseBtn);
+    const confirmBtn = await screen.findByRole('button', { name: /^confirm$/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(postFired).toBe(true);
+    });
+  });
+
+  // RED #14b — error path: non-2xx response surfaces without removing the row.
+  it('keeps the row in place when the release POST returns a non-2xx', async () => {
+    const Wrapper = createWrapper();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.endsWith('/release') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ error: 'forbidden' }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/admin/embedding/locks')) {
+        return new Response(
+          JSON.stringify({
+            locks: [{ userId: 'alice', holderEpoch: 'uuid-a', ttlRemainingMs: 1_000_000 }],
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response('{}', { headers: { 'Content-Type': 'application/json' } });
+    });
+
+    render(<ActiveEmbeddingLocksBanner />, { wrapper: Wrapper });
+    const releaseBtn = await screen.findByRole('button', { name: /force release/i });
+    fireEvent.click(releaseBtn);
+    const confirmBtn = await screen.findByRole('button', { name: /^confirm$/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    // Row still visible after the failed POST — user can retry or cancel.
+    await waitFor(() => {
+      expect(screen.getByTestId('embedding-lock-row-alice')).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/features/settings/panels/ActiveEmbeddingLocksBanner.tsx
+++ b/frontend/src/features/settings/panels/ActiveEmbeddingLocksBanner.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import type { AdminEmbeddingLocksResponse, EmbeddingLockSnapshot } from '@compendiq/contracts';
+import { apiFetch } from '../../../shared/lib/api';
+
+/**
+ * ActiveEmbeddingLocksBanner — admin-only panel component (issue #257 plan
+ * §2.9 / §2.10 / §3.3).
+ *
+ * Polls `GET /api/admin/embedding/locks` every 5 seconds. When one or more
+ * locks are held (the synthetic `__reembed_all__` system lock is already
+ * filtered server-side) it renders a per-user row with a "Force release"
+ * button, behind an inline confirm — matching the pattern used by
+ * `BulkOperations.tsx` delete rather than introducing a new modal primitive.
+ *
+ * On successful force-release the next 5-second poll drops the row; on a
+ * non-2xx response a toast surfaces the error and the row remains in place.
+ */
+export function ActiveEmbeddingLocksBanner() {
+  const queryClient = useQueryClient();
+  const [confirming, setConfirming] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['admin-embedding-locks'],
+    queryFn: () => apiFetch<AdminEmbeddingLocksResponse>('/admin/embedding/locks'),
+    refetchInterval: 5_000,
+  });
+
+  const forceRelease = useMutation({
+    mutationFn: (userId: string) =>
+      apiFetch<{ released: boolean; userId: string }>(
+        `/admin/embedding/locks/${encodeURIComponent(userId)}/release`,
+        { method: 'POST' },
+      ),
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: ['admin-embedding-locks'] });
+      if (res.released) {
+        toast.success(`Released embedding lock for "${res.userId}"`);
+      } else {
+        toast.message(`Lock for "${res.userId}" was already gone`);
+      }
+      setConfirming(null);
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : 'Failed to release lock');
+      // Keep confirming-state so the row stays visible with the inline confirm
+      // open, giving the admin a chance to retry or cancel.
+    },
+  });
+
+  if (isLoading) return null;
+  const locks = data?.locks ?? [];
+  if (locks.length === 0) return null;
+
+  const userList = locks.map((l) => l.userId).join(', ');
+
+  return (
+    <div
+      className="glass-card border-yellow-500/30 p-3 text-sm"
+      data-testid="active-embedding-locks-banner"
+    >
+      <p className="mb-2 text-yellow-300">
+        <b>Embedding in progress:</b> {userList} — per-user triggers and
+        re-embed-all will queue until these complete.
+      </p>
+      <ul className="space-y-1">
+        {locks.map((lock: EmbeddingLockSnapshot) => {
+          // Approximate "held for" = TTL_cap - remaining. EMBEDDING_LOCK_TTL
+          // is 1 hour per redis-cache.ts, i.e. 3_600_000 ms.
+          const heldSecs = Math.max(
+            0,
+            Math.round((3_600_000 - lock.ttlRemainingMs) / 1000),
+          );
+          const isConfirming = confirming === lock.userId;
+          return (
+            <li
+              key={lock.userId}
+              className="flex items-center justify-between gap-2"
+              data-testid={`embedding-lock-row-${lock.userId}`}
+            >
+              <span className="text-xs text-muted-foreground">
+                {lock.userId} — holding for {heldSecs}s
+              </span>
+              {isConfirming ? (
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-destructive">
+                    Force release &quot;{lock.userId}&quot;?
+                  </span>
+                  <button
+                    onClick={() => forceRelease.mutate(lock.userId)}
+                    disabled={forceRelease.isPending}
+                    className="rounded-md bg-destructive px-2 py-1 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+                    data-testid={`force-release-confirm-${lock.userId}`}
+                  >
+                    Confirm
+                  </button>
+                  <button
+                    onClick={() => setConfirming(null)}
+                    className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+                    data-testid={`force-release-cancel-${lock.userId}`}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setConfirming(lock.userId)}
+                  className="rounded-md px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
+                  data-testid={`force-release-btn-${lock.userId}`}
+                >
+                  Force release
+                </button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+      <p className="mt-2 text-xs text-muted-foreground/70">
+        Force-release abandons any in-flight embedding for the user. Their
+        worker may continue writing a few more rows before detecting the
+        release (holder-epoch guard checks every 20 pages). No duplicate
+        embeddings will be produced — safe for stuck workers.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/features/settings/panels/ActiveEmbeddingLocksBanner.tsx
+++ b/frontend/src/features/settings/panels/ActiveEmbeddingLocksBanner.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import type { AdminEmbeddingLocksResponse, EmbeddingLockSnapshot } from '@compendiq/contracts';
+import { EMBEDDING_LOCK_TTL_MS } from '@compendiq/contracts';
 import { apiFetch } from '../../../shared/lib/api';
 
 /**
@@ -66,11 +67,12 @@ export function ActiveEmbeddingLocksBanner() {
       </p>
       <ul className="space-y-1">
         {locks.map((lock: EmbeddingLockSnapshot) => {
-          // Approximate "held for" = TTL_cap - remaining. EMBEDDING_LOCK_TTL
-          // is 1 hour per redis-cache.ts, i.e. 3_600_000 ms.
+          // Approximate "held for" = TTL_cap - remaining. EMBEDDING_LOCK_TTL_MS
+          // is the shared contract constant (see packages/contracts), kept in
+          // sync with the backend's SET NX EX.
           const heldSecs = Math.max(
             0,
-            Math.round((3_600_000 - lock.ttlRemainingMs) / 1000),
+            Math.round((EMBEDDING_LOCK_TTL_MS - lock.ttlRemainingMs) / 1000),
           );
           const isConfirming = confirming === lock.userId;
           return (

--- a/frontend/src/features/settings/panels/EmbeddingReembedBanner.test.tsx
+++ b/frontend/src/features/settings/panels/EmbeddingReembedBanner.test.tsx
@@ -91,7 +91,10 @@ describe('EmbeddingReembedBanner', () => {
     expect(screen.getByText(/1024 → 768/)).toBeTruthy();
   });
 
-  it('heavy-warning dialog explicitly warns that the re-embed worker is not implemented yet and links to #257', async () => {
+  // Plan §2.9 — the "worker not yet implemented" warning block was dropped
+  // by Phase 5 of #257 now that the BullMQ worker actually runs. The dialog
+  // should now contain neither the old warning text nor a link to #257.
+  it('heavy-warning dialog no longer carries the "worker not implemented" alert', async () => {
     const Wrapper = createWrapper();
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
       const url = typeof input === 'string' ? input : (input as URL).toString();
@@ -110,15 +113,10 @@ describe('EmbeddingReembedBanner', () => {
       { wrapper: Wrapper },
     );
     fireEvent.click(screen.getByRole('button', { name: /probe/i }));
+    await screen.findByText(/delete all existing embeddings/i);
 
-    // ARIA-role alert banner must appear
-    const alert = await screen.findByRole('alert');
-    expect(alert).toBeTruthy();
-    expect(alert.textContent ?? '').toMatch(/re-embed worker not yet implemented/i);
-
-    // Link to issue #257 must be present
-    const link = screen.getByRole('link', { name: /issue #257/i });
-    expect(link.getAttribute('href')).toBe('https://github.com/Compendiq/compendiq-ce/issues/257');
+    expect(screen.queryByText(/re-embed worker not yet implemented/i)).toBeNull();
+    expect(screen.queryByRole('link', { name: /issue #257/i })).toBeNull();
   });
 
   it('on confirm with heavy change, POSTs reembed with newDimensions', async () => {
@@ -193,5 +191,62 @@ describe('EmbeddingReembedBanner', () => {
       expect(reembedCall).toBeTruthy();
       expect(JSON.parse((reembedCall![1] as RequestInit).body as string)).toEqual({});
     });
+  });
+
+  // RED #14 (plan §4.10) — surfaces the waiting-on-user-locks phase.
+  it('surfaces the waiting-on-user-locks progress phase when the GET polls return it', async () => {
+    const Wrapper = createWrapper();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.includes('/admin/embedding/probe')) {
+        return new Response(JSON.stringify({ dimensions: 1024 }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/admin/embedding/reembed')) {
+        return new Response(
+          JSON.stringify({ jobId: 'reembed-all', pageCount: 5, heldBy: ['alice'] }),
+          { headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (url.includes('/admin/embedding/reembed/reembed-all')) {
+        return new Response(
+          JSON.stringify({
+            jobId: 'reembed-all',
+            state: 'active',
+            progress: {
+              phase: 'waiting-on-user-locks',
+              heldBy: ['alice'],
+              waitedMs: 4000,
+            },
+            heldBy: ['alice'],
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response('{}', { headers: { 'Content-Type': 'application/json' } });
+    });
+
+    render(
+      <EmbeddingReembedBanner
+        currentDimensions={1024}
+        pending={{ providerId: 'p1', model: 'bge-m3-instruct' }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /probe/i }));
+    await screen.findByText(/inconsistent until re-embedded/i);
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    // Wait for the 2-second poll interval to fire at least once and the
+    // progress phase to hit the DOM.
+    const banner = await waitFor(
+      () => screen.getByTestId('reembed-progress-banner'),
+      { timeout: 5000 },
+    );
+    await waitFor(() => {
+      expect(banner.textContent ?? '').toMatch(/waiting for alice/i);
+    }, { timeout: 5000 });
   });
 });

--- a/frontend/src/features/settings/panels/EmbeddingReembedBanner.tsx
+++ b/frontend/src/features/settings/panels/EmbeddingReembedBanner.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { apiFetch } from '../../../shared/lib/api';
 
@@ -14,9 +14,76 @@ interface Props {
 
 type Stage = 'idle' | 'probing' | 'confirm' | 'running';
 
+/**
+ * Shape of the BullMQ job-status payload returned by
+ * `GET /api/admin/embedding/reembed/:jobId` (plan §2.5, §3.2).
+ */
+interface ReembedJobStatus {
+  jobId: string;
+  state?: string;
+  progress?:
+    | number
+    | {
+        phase?: 'waiting-on-user-locks' | 'started' | 'embedding' | 'complete';
+        heldBy?: string[];
+        total?: number;
+        processed?: number;
+        failed?: number;
+        waitedMs?: number;
+      };
+  heldBy?: string[];
+  returnvalue?: unknown;
+  failedReason?: string;
+}
+
 export function EmbeddingReembedBanner({ currentDimensions, pending }: Props) {
   const [stage, setStage] = useState<Stage>('idle');
   const [newDims, setNewDims] = useState<number | null>(null);
+  const [jobStatus, setJobStatus] = useState<ReembedJobStatus | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Issue #257 — clean up the polling interval on unmount.
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  function stopPolling() {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }
+
+  function startPolling(jobId: string) {
+    stopPolling();
+    const startedAt = Date.now();
+    const MAX_POLL_MS = 30 * 60 * 1_000; // 30 min safety cap
+    pollRef.current = setInterval(async () => {
+      try {
+        const s = await apiFetch<ReembedJobStatus>(`/admin/embedding/reembed/${jobId}`);
+        setJobStatus(s);
+        const phase =
+          typeof s.progress === 'object' && s.progress !== null
+            ? (s.progress as { phase?: string }).phase
+            : undefined;
+        if (s.state === 'completed' || phase === 'complete') {
+          toast.success('Re-embed complete');
+          stopPolling();
+          setStage('idle');
+        } else if (s.state === 'failed') {
+          toast.error(`Re-embed failed: ${s.failedReason ?? 'unknown error'}`);
+          stopPolling();
+          setStage('idle');
+        } else if (Date.now() - startedAt > MAX_POLL_MS) {
+          stopPolling();
+        }
+      } catch {
+        // network blips — keep polling until the safety cap.
+      }
+    }, 2_000);
+  }
 
   if (!pending) return null;
 
@@ -46,14 +113,22 @@ export function EmbeddingReembedBanner({ currentDimensions, pending }: Props) {
     try {
       const heavy = newDims !== null && newDims !== currentDimensions;
       const body = heavy ? { newDimensions: newDims } : {};
-      const r = await apiFetch<{ jobId: string; pageCount: number }>(
+      const r = await apiFetch<{ jobId: string; pageCount: number; heldBy?: string[] }>(
         '/admin/embedding/reembed',
         { method: 'POST', body: JSON.stringify(body) },
       );
-      toast.success(`Re-embed queued (${r.pageCount} pages, ${r.jobId})`);
+      if (r.heldBy && r.heldBy.length > 0) {
+        toast.info(
+          `Re-embed queued (${r.pageCount} pages). Waiting for ${r.heldBy.join(', ')} to finish.`,
+        );
+      } else {
+        toast.success(`Re-embed queued (${r.pageCount} pages, ${r.jobId})`);
+      }
+      // Seed an initial status so the progress line renders immediately.
+      setJobStatus({ jobId: r.jobId, heldBy: r.heldBy });
+      startPolling(r.jobId);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'failed');
-    } finally {
       setStage('idle');
     }
   }
@@ -63,37 +138,11 @@ export function EmbeddingReembedBanner({ currentDimensions, pending }: Props) {
     return (
       <div className="glass-card border-red-500/30 p-3 text-sm">
         {heavy ? (
-          <>
-            <p>
-              ⚠ Dimension change: <b>{currentDimensions} → {newDims}</b>. This will{' '}
-              <b>delete all existing embeddings</b>, rewrite the column type, and rebuild the
-              HNSW index. Continue?
-            </p>
-            <div
-              role="alert"
-              className="mt-2 rounded border border-red-500/40 bg-red-500/10 p-2 text-red-200"
-            >
-              <p className="font-semibold">⚠ Warning: re-embed worker not yet implemented.</p>
-              <p className="mt-1">
-                Confirming will <b>truncate every existing embedding row</b>, but the worker
-                loop that re-embeds all pages against the new model/dimension is tracked as a
-                follow-up and has not shipped yet. Until it does, RAG / semantic search will
-                return <b>no results</b> for any page.
-              </p>
-              <p className="mt-1">
-                See{' '}
-                <a
-                  href="https://github.com/Compendiq/compendiq-ce/issues/257"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  className="underline"
-                >
-                  issue #257
-                </a>{' '}
-                for progress.
-              </p>
-            </div>
-          </>
+          <p>
+            ⚠ Dimension change: <b>{currentDimensions} → {newDims}</b>. This will{' '}
+            <b>delete all existing embeddings</b>, rewrite the column type, and rebuild the
+            HNSW index. Continue?
+          </p>
         ) : (
           <p>
             ⚠ Embedding model changed (dimension stays at {currentDimensions}). Existing
@@ -108,6 +157,38 @@ export function EmbeddingReembedBanner({ currentDimensions, pending }: Props) {
             Confirm + re-embed
           </button>
         </div>
+      </div>
+    );
+  }
+
+  // While a job is in flight, surface its current phase so the admin can see
+  // progress (plan §2.9). The banner keeps rendering until polling ends.
+  if (stage === 'running' && jobStatus) {
+    const progress =
+      typeof jobStatus.progress === 'object' && jobStatus.progress !== null
+        ? jobStatus.progress
+        : undefined;
+    const phase = progress?.phase;
+    let status = 'Queued…';
+    if (phase === 'waiting-on-user-locks') {
+      const heldBy = progress?.heldBy?.join(', ') ?? '';
+      const waitedSec = Math.round((progress?.waitedMs ?? 0) / 1000);
+      status = `Waiting for ${heldBy} to finish (${waitedSec}s elapsed)`;
+    } else if (phase === 'embedding') {
+      status = `${progress?.processed ?? 0}/${progress?.total ?? 0} pages`;
+    } else if (phase === 'started') {
+      status = `Starting (${progress?.total ?? 0} pages)…`;
+    } else if (phase === 'complete') {
+      status = 'Complete';
+    }
+    return (
+      <div
+        className="glass-card border-blue-500/30 flex items-center justify-between p-3 text-sm"
+        data-testid="reembed-progress-banner"
+      >
+        <span>
+          Re-embed in progress: <b>{status}</b>
+        </span>
       </div>
     );
   }

--- a/frontend/src/features/settings/panels/EmbeddingReembedBanner.tsx
+++ b/frontend/src/features/settings/panels/EmbeddingReembedBanner.tsx
@@ -85,7 +85,14 @@ export function EmbeddingReembedBanner({ currentDimensions, pending }: Props) {
     }, 2_000);
   }
 
-  if (!pending) return null;
+  // Issue #257 / PR #261: after a successful re-embed POST, the parent
+  // (LlmTab) recomputes `embeddingPending` from refetched saved assignments
+  // and hands us `pending === null`. The banner must still render the
+  // running-state UI below so the admin keeps seeing phase / heldBy /
+  // progress while polling continues — only collapse to null when we're
+  // NOT actively tracking a job.
+  const hasRunningJob = stage === 'running' && jobStatus !== null;
+  if (!pending && !hasRunningJob) return null;
 
   async function start() {
     if (!pending) return;

--- a/frontend/src/features/settings/panels/EmbeddingTab.tsx
+++ b/frontend/src/features/settings/panels/EmbeddingTab.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import type { AdminSettings } from '@compendiq/contracts';
 import { apiFetch } from '../../../shared/lib/api';
 import { SkeletonFormFields } from '../../../shared/components/feedback/Skeleton';
+import { ActiveEmbeddingLocksBanner } from './ActiveEmbeddingLocksBanner';
 
 export function EmbeddingTab() {
   const queryClient = useQueryClient();
@@ -16,22 +17,29 @@ export function EmbeddingTab() {
   const [chunkSize, setChunkSize] = useState<number | undefined>(undefined);
   const [chunkOverlap, setChunkOverlap] = useState<number | undefined>(undefined);
   const [drawioEmbedUrl, setDrawioEmbedUrl] = useState<string | undefined>(undefined);
+  // Issue #257 — admin-configurable BullMQ job-history retention.
+  const [reembedHistoryRetention, setReembedHistoryRetention] = useState<number | undefined>(undefined);
 
   // Initialise local state once data loads
   const effectiveChunkSize = chunkSize ?? adminSettings?.embeddingChunkSize ?? 500;
   const effectiveChunkOverlap = chunkOverlap ?? adminSettings?.embeddingChunkOverlap ?? 50;
   const effectiveDrawioUrl = drawioEmbedUrl ?? adminSettings?.drawioEmbedUrl ?? '';
+  const effectiveRetention =
+    reembedHistoryRetention ?? adminSettings?.reembedHistoryRetention ?? 150;
 
   const savedChunkSize = adminSettings?.embeddingChunkSize ?? 500;
   const savedChunkOverlap = adminSettings?.embeddingChunkOverlap ?? 50;
   const savedDrawioUrl = adminSettings?.drawioEmbedUrl ?? '';
+  const savedRetention = adminSettings?.reembedHistoryRetention ?? 150;
 
   const hasChunkChanges =
     (chunkSize !== undefined && chunkSize !== savedChunkSize) ||
     (chunkOverlap !== undefined && chunkOverlap !== savedChunkOverlap);
   const hasDrawioChanges =
     drawioEmbedUrl !== undefined && drawioEmbedUrl !== savedDrawioUrl;
-  const hasChanges = hasChunkChanges || hasDrawioChanges;
+  const hasRetentionChanges =
+    reembedHistoryRetention !== undefined && reembedHistoryRetention !== savedRetention;
+  const hasChanges = hasChunkChanges || hasDrawioChanges || hasRetentionChanges;
 
   const updateAdminSettings = useMutation({
     mutationFn: (body: Record<string, unknown>) =>
@@ -43,11 +51,12 @@ export function EmbeddingTab() {
       setChunkSize(undefined);
       setChunkOverlap(undefined);
       setDrawioEmbedUrl(undefined);
+      setReembedHistoryRetention(undefined);
       const hasChunk = variables.embeddingChunkSize !== undefined || variables.embeddingChunkOverlap !== undefined;
       if (hasChunk) {
         toast.success('Embedding settings saved. All pages queued for re-embedding.');
       } else {
-        toast.success('Draw.io settings saved.');
+        toast.success('Settings saved.');
       }
     },
     onError: (err) => toast.error(err.message),
@@ -63,6 +72,9 @@ export function EmbeddingTab() {
       const trimmed = drawioEmbedUrl.trim();
       updates.drawioEmbedUrl = trimmed === '' ? null : trimmed;
     }
+    if (reembedHistoryRetention !== undefined) {
+      updates.reembedHistoryRetention = reembedHistoryRetention;
+    }
     if (Object.keys(updates).length > 0) {
       updateAdminSettings.mutate(updates);
     }
@@ -74,6 +86,9 @@ export function EmbeddingTab() {
 
   return (
     <div className="space-y-6">
+      {/* Issue #257 — admin visibility for in-flight per-user embedding locks. */}
+      <ActiveEmbeddingLocksBanner />
+
       <div className="glass-card border-yellow-500/30 p-3 text-sm text-yellow-400">
         These settings are shared across all users. Changing chunk settings will trigger re-embedding of all pages, which may take several minutes.
       </div>
@@ -156,6 +171,30 @@ export function EmbeddingTab() {
           onChange={(e) => setDrawioEmbedUrl(e.target.value)}
           className="glass-input w-full max-w-md"
           data-testid="admin-drawio-url-input"
+        />
+      </div>
+
+      <hr className="border-border/40" />
+
+      <div>
+        <label className="mb-1.5 block text-sm font-medium" htmlFor="admin-reembed-retention-input">
+          Re-embed Job History Retention
+        </label>
+        <p className="mb-1.5 text-sm text-muted-foreground">
+          Maximum completed/failed re-embed-all job records retained in Redis
+          before the oldest get swept. Takes effect on the <b>next</b> re-embed
+          run (existing queued jobs carry the previous value). Default: 150.
+        </p>
+        <input
+          id="admin-reembed-retention-input"
+          type="number"
+          min={10}
+          max={10000}
+          step={10}
+          value={effectiveRetention}
+          onChange={(e) => setReembedHistoryRetention(Number(e.target.value))}
+          className="glass-input w-40"
+          data-testid="admin-reembed-retention-input"
         />
       </div>
 

--- a/packages/contracts/src/schemas/admin.test.ts
+++ b/packages/contracts/src/schemas/admin.test.ts
@@ -7,6 +7,7 @@ const validReadPayload = {
   embeddingChunkSize: 500,
   embeddingChunkOverlap: 50,
   drawioEmbedUrl: null,
+  reembedHistoryRetention: 150,
 } as const;
 
 describe('AdminSettingsSchema (read)', () => {
@@ -68,4 +69,64 @@ describe('UpdateAdminSettingsSchema tri-state semantics', () => {
   // LLM-specific settings (openaiBaseUrl, openaiModel, ollamaModel, etc.)
   // moved to the `llm_providers` table + `/api/admin/llm-providers` route;
   // they are no longer part of AdminSettings.
+});
+
+// ─── Plan §2.6 / §4.8 RED #12 — reembedHistoryRetention validation ─────────
+describe('reembedHistoryRetention (issue #257)', () => {
+  describe('read schema', () => {
+    it('accepts a valid integer within [10, 10000]', () => {
+      const parsed = AdminSettingsSchema.parse({
+        ...validReadPayload,
+        reembedHistoryRetention: 500,
+      });
+      expect(parsed.reembedHistoryRetention).toBe(500);
+    });
+
+    it('rejects values below 10', () => {
+      expect(() =>
+        AdminSettingsSchema.parse({ ...validReadPayload, reembedHistoryRetention: 9 }),
+      ).toThrow();
+    });
+
+    it('rejects values above 10000', () => {
+      expect(() =>
+        AdminSettingsSchema.parse({ ...validReadPayload, reembedHistoryRetention: 10_001 }),
+      ).toThrow();
+    });
+
+    it('rejects non-integer values', () => {
+      expect(() =>
+        AdminSettingsSchema.parse({ ...validReadPayload, reembedHistoryRetention: 100.5 }),
+      ).toThrow();
+    });
+
+    it('requires the field to be present (not optional on read)', () => {
+      const { reembedHistoryRetention: _r, ...withoutField } = validReadPayload;
+      expect(() => AdminSettingsSchema.parse(withoutField)).toThrow();
+    });
+  });
+
+  describe('update schema', () => {
+    it('accepts a valid integer within [10, 10000]', () => {
+      const parsed = UpdateAdminSettingsSchema.parse({ reembedHistoryRetention: 250 });
+      expect(parsed.reembedHistoryRetention).toBe(250);
+    });
+
+    it('treats omitted field as undefined (leave unchanged)', () => {
+      const parsed = UpdateAdminSettingsSchema.parse({});
+      expect(parsed.reembedHistoryRetention).toBeUndefined();
+    });
+
+    it('rejects values below 10', () => {
+      expect(() =>
+        UpdateAdminSettingsSchema.parse({ reembedHistoryRetention: 5 }),
+      ).toThrow();
+    });
+
+    it('rejects values above 10000', () => {
+      expect(() =>
+        UpdateAdminSettingsSchema.parse({ reembedHistoryRetention: 20_000 }),
+      ).toThrow();
+    });
+  });
 });

--- a/packages/contracts/src/schemas/admin.test.ts
+++ b/packages/contracts/src/schemas/admin.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { UpdateAdminSettingsSchema, AdminSettingsSchema } from './admin.js';
+import {
+  UpdateAdminSettingsSchema,
+  AdminSettingsSchema,
+  EmbeddingLockSnapshotSchema,
+  AdminEmbeddingLocksResponseSchema,
+  ForceReleaseLockResponseSchema,
+} from './admin.js';
 
 const validReadPayload = {
   embeddingDimensions: 1024,
@@ -128,5 +134,85 @@ describe('reembedHistoryRetention (issue #257)', () => {
         UpdateAdminSettingsSchema.parse({ reembedHistoryRetention: 20_000 }),
       ).toThrow();
     });
+  });
+});
+
+// ─── Plan §3.3 / §4.8 RED #12a — Embedding lock admin schemas ────────────
+describe('EmbeddingLockSnapshotSchema (issue #257)', () => {
+  it('parses a valid snapshot round-trip', () => {
+    const parsed = EmbeddingLockSnapshotSchema.parse({
+      userId: 'alice',
+      holderEpoch: '11111111-2222-3333-4444-555555555555',
+      ttlRemainingMs: 3_400_000,
+    });
+    expect(parsed.userId).toBe('alice');
+    expect(parsed.ttlRemainingMs).toBe(3_400_000);
+  });
+
+  it('accepts -1 and -2 as special TTL values (never-expires / key-not-found)', () => {
+    expect(
+      EmbeddingLockSnapshotSchema.parse({ userId: 'a', holderEpoch: '', ttlRemainingMs: -1 }).ttlRemainingMs,
+    ).toBe(-1);
+    expect(
+      EmbeddingLockSnapshotSchema.parse({ userId: 'a', holderEpoch: '', ttlRemainingMs: -2 }).ttlRemainingMs,
+    ).toBe(-2);
+  });
+
+  it('accepts an empty holderEpoch (lock race: GET returned null but SCAN saw the key)', () => {
+    const parsed = EmbeddingLockSnapshotSchema.parse({ userId: 'alice', holderEpoch: '', ttlRemainingMs: 100 });
+    expect(parsed.holderEpoch).toBe('');
+  });
+
+  it('rejects missing userId', () => {
+    expect(() =>
+      EmbeddingLockSnapshotSchema.parse({ holderEpoch: 'x', ttlRemainingMs: 100 }),
+    ).toThrow();
+  });
+
+  it('rejects non-integer ttlRemainingMs', () => {
+    expect(() =>
+      EmbeddingLockSnapshotSchema.parse({ userId: 'a', holderEpoch: 'x', ttlRemainingMs: 100.5 }),
+    ).toThrow();
+  });
+});
+
+describe('AdminEmbeddingLocksResponseSchema (issue #257)', () => {
+  it('accepts empty array', () => {
+    const parsed = AdminEmbeddingLocksResponseSchema.parse({ locks: [] });
+    expect(parsed.locks).toEqual([]);
+  });
+
+  it('accepts multiple snapshots', () => {
+    const parsed = AdminEmbeddingLocksResponseSchema.parse({
+      locks: [
+        { userId: 'alice', holderEpoch: 'u1', ttlRemainingMs: 1000 },
+        { userId: 'bob', holderEpoch: 'u2', ttlRemainingMs: 2000 },
+      ],
+    });
+    expect(parsed.locks).toHaveLength(2);
+  });
+
+  it('rejects missing locks array', () => {
+    expect(() => AdminEmbeddingLocksResponseSchema.parse({})).toThrow();
+  });
+});
+
+describe('ForceReleaseLockResponseSchema (issue #257)', () => {
+  it('accepts { released: true, userId }', () => {
+    const parsed = ForceReleaseLockResponseSchema.parse({ released: true, userId: 'alice' });
+    expect(parsed).toEqual({ released: true, userId: 'alice' });
+  });
+
+  it('accepts { released: false, userId } (idempotent no-op)', () => {
+    const parsed = ForceReleaseLockResponseSchema.parse({ released: false, userId: 'alice' });
+    expect(parsed.released).toBe(false);
+  });
+
+  it('rejects missing userId', () => {
+    expect(() => ForceReleaseLockResponseSchema.parse({ released: true })).toThrow();
+  });
+
+  it('rejects non-boolean released', () => {
+    expect(() => ForceReleaseLockResponseSchema.parse({ released: 'yes', userId: 'alice' })).toThrow();
   });
 });

--- a/packages/contracts/src/schemas/admin.ts
+++ b/packages/contracts/src/schemas/admin.ts
@@ -81,6 +81,15 @@ export type UpdateAdminSettingsInput = z.infer<typeof UpdateAdminSettingsSchema>
 // Shared contract between `GET /api/admin/embedding/locks` / the force-release
 // POST and the frontend `ActiveEmbeddingLocksBanner`. See plan §2.10 / §3.3.
 
+/**
+ * Safety TTL on every `embedding:lock:${userId}` key in Redis (milliseconds).
+ * Mirrors `EMBEDDING_LOCK_TTL` in `backend/src/core/services/redis-cache.ts`
+ * (1 hour, in seconds there — kept aligned across both sides). Exposed from
+ * the contracts package so the frontend can derive "held for" without
+ * hardcoding the value. When the backend constant moves, update this too.
+ */
+export const EMBEDDING_LOCK_TTL_MS = 3_600_000;
+
 export const EmbeddingLockSnapshotSchema = z.object({
   /** Lock holder. Usually a user id, but can also be the synthetic
    *  `__reembed_all__` system lock (which the admin endpoint filters out). */

--- a/packages/contracts/src/schemas/admin.ts
+++ b/packages/contracts/src/schemas/admin.ts
@@ -76,3 +76,35 @@ export const UpdateAdminSettingsSchema = z.object({
 
 export type AdminSettings = z.infer<typeof AdminSettingsSchema>;
 export type UpdateAdminSettingsInput = z.infer<typeof UpdateAdminSettingsSchema>;
+
+// ─── Issue #257 — admin embedding-lock visibility + force-release ────────
+// Shared contract between `GET /api/admin/embedding/locks` / the force-release
+// POST and the frontend `ActiveEmbeddingLocksBanner`. See plan §2.10 / §3.3.
+
+export const EmbeddingLockSnapshotSchema = z.object({
+  /** Lock holder. Usually a user id, but can also be the synthetic
+   *  `__reembed_all__` system lock (which the admin endpoint filters out). */
+  userId: z.string().min(1),
+  /** Random UUID written by `acquireEmbeddingLock`. The worker's holder-epoch
+   *  guard compares this every 20 pages to detect a force-release. May be
+   *  the empty string when the SCAN caught the key but the subsequent GET
+   *  raced against a release. */
+  holderEpoch: z.string(),
+  /** `PTTL` return in milliseconds. `-1` = no TTL (shouldn't happen),
+   *  `-2` = key missing. */
+  ttlRemainingMs: z.number().int(),
+});
+export type EmbeddingLockSnapshot = z.infer<typeof EmbeddingLockSnapshotSchema>;
+
+export const AdminEmbeddingLocksResponseSchema = z.object({
+  locks: z.array(EmbeddingLockSnapshotSchema),
+});
+export type AdminEmbeddingLocksResponse = z.infer<typeof AdminEmbeddingLocksResponseSchema>;
+
+export const ForceReleaseLockResponseSchema = z.object({
+  /** `true` when the key existed and was deleted; `false` when the lock was
+   *  already gone (idempotent — no 404). */
+  released: z.boolean(),
+  userId: z.string().min(1),
+});
+export type ForceReleaseLockResponse = z.infer<typeof ForceReleaseLockResponseSchema>;

--- a/packages/contracts/src/schemas/admin.ts
+++ b/packages/contracts/src/schemas/admin.ts
@@ -39,6 +39,13 @@ export const AdminSettingsSchema = z.object({
   rateLimitAdmin: z.number().int().min(5).max(1000).optional(),
   rateLimitLlmStream: z.number().int().min(1).max(1000).optional(),
   rateLimitLlmEmbedding: z.number().int().min(1).max(1000).optional(),
+  /**
+   * Issue #257 — how many completed/failed re-embed-all BullMQ jobs are
+   * retained in Redis before the oldest get swept. Takes effect on the
+   * next re-embed run (read per-enqueue inside `enqueueReembedAll`).
+   * Default 150, clamped to [10, 10000].
+   */
+  reembedHistoryRetention: z.number().int().min(10).max(10_000),
 });
 
 export const UpdateAdminSettingsSchema = z.object({
@@ -63,6 +70,8 @@ export const UpdateAdminSettingsSchema = z.object({
   rateLimitAdmin: z.number().int().min(5).max(1000).optional(),
   rateLimitLlmStream: z.number().int().min(1).max(1000).optional(),
   rateLimitLlmEmbedding: z.number().int().min(1).max(1000).optional(),
+  /** Issue #257 — optional on update; omitted → leave unchanged. */
+  reembedHistoryRetention: z.number().int().min(10).max(10_000).optional(),
 });
 
 export type AdminSettings = z.infer<typeof AdminSettingsSchema>;


### PR DESCRIPTION
## Summary

Replaces the `TODO(#257)` stub in `enqueueReembedAll` with a real BullMQ-backed worker, adds admin visibility + escape hatches around the per-user embedding locks that gate it, and makes job-history retention admin-configurable.

Closes #257.

## What ships

- **BullMQ `reembed-all` queue + worker.** Worker reuses `processDirtyPages`, emits `job.updateProgress` every 100 pages, and aborts cleanly via a new holder-epoch guard (re-checks the lock every 20 pages; existing Lua safe-release turns the `finally` into a no-op for a superseded holder).
- **Idempotency (Q3).** Fixed `jobId='reembed-all'` collapses concurrent triggers. Explicit lazy-removal sweep before `queue.add()` lets completed jobs' IDs be reused — POST after completion starts a fresh run, POST during active run returns the existing job.
- **Wait-on-locks (Q2).** Before the cursor loop, the worker polls `listActiveEmbeddingLocks()` up to `REEMBED_WAIT_LOCKS_MS` (10 min default) and emits `phase: 'waiting-on-user-locks'` with offender userIds. `isProcessingUser` now also blocks on the `__reembed_all__` lock.
- **Admin visibility.** New dedicated `GET /api/admin/embedding/locks` → `EmbeddingLockSnapshot[]` (userId, holderEpoch, ttlRemainingMs). `POST /api/admin/embedding/locks/:userId/release` force-release (audit-logged via `ADMIN_ACTION.embedding_lock.force_release_embedding_lock`). POST `/admin/embedding/reembed` now returns `heldBy` so the UI can render "Embedding in progress: alice, bob — re-embed-all will start after these complete."
- **Configurable retention (Q4).** New `reembed_history_retention` admin setting (default 150, range [10, 10000]) drives `removeOnComplete`/`removeOnFail`. Migration `055` seeds the default.
- **Frontend.** New `ActiveEmbeddingLocksBanner` (uses the repo's existing inline-confirm pattern — no new modal primitive) with per-row Force-release. Retention field in `EmbeddingTab`. Warning about "worker not implemented" removed from `EmbeddingReembedBanner`.

## Plan reference

Full plan committed on branch as `eb87acc` — see `docs/issues/257-implementation-plan.md` (v3, incorporates four rounds of Q&A with the architect agent).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — **3808 / 3808 pass** (contracts 36, backend 1960, frontend 1812)
- [x] ~83 new test cases across unit + route + worker + UI layers (RED #1–#20 from plan §4)
- [x] Playwright `e2e/llm-providers.spec.ts` — adds "reembed-all completes within 60s" (RED #20)
- [ ] Manual live E2E on a seeded instance before merge — verify `waiting-on-user-locks` phase actually renders end-to-end

## Architecture impact

None beyond one additive `admin_settings` row (migration 055). No new domain boundary, no new container, no schema DDL. Diagrams not touched.

## Follow-ups (separate issues/PRs)

1. ADR-014 still contains the stale "a simple interval is sufficient" paragraph even though the worker table now lists 5+ BullMQ queues — dedicated cleanup PR.
2. Cross-cutting audit log on *denied* force-release attempts (403 rejections fire before the handler).
3. SCAN → dedicated `embedding:locks:active` set upgrade if `/api/admin/embedding/locks` P99 ever exceeds 50 ms.
4. Pre-existing frontend jsdom console warnings ("Not implemented: Window's scrollTo()") — not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)