### PR TITLE
security(#268): per-user concurrent SSE stream limit (admin-configurable)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,8 @@ EMBEDDING_MODEL=bge-m3
 # --- LLM Request Queue (backpressure) ---
 # LLM_CONCURRENCY=4                    # Max concurrent LLM requests (default: 4)
 # LLM_MAX_QUEUE_DEPTH=50               # Reject new requests when queue exceeds this depth (default: 50)
+# DEPRECATED: configure in Settings → LLM → Runtime limits (#268); consulted only when the admin_settings row is absent.
+# LLM_MAX_CONCURRENT_STREAMS_PER_USER=3  # Per-user cap on simultaneously-open SSE streams (fallback default: 3; range: 1–20)
 
 # DEPRECATED: seed-only; consulted on first boot when llm_providers is empty. Configure providers in Settings → LLM.
 # DEFAULT_LLM_MODEL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,7 @@ Copy `.env.example` to `.env`. Key vars:
 - `LLM_CACHE_TTL` (optional, Redis TTL in seconds for LLM cache, default: `3600`)
 - `LLM_CONCURRENCY` (optional, default: `4`, max concurrent LLM requests)
 - `LLM_MAX_QUEUE_DEPTH` (optional, default: `50`, reject when exceeded)
+- `LLM_MAX_CONCURRENT_STREAMS_PER_USER` (deprecated bootstrap fallback — configured in Settings → LLM → Runtime limits, issue #268; consulted only when the `admin_settings` row is absent; fallback-of-last-resort: `3`; range: `1`–`20`)
 - `OPENAI_BASE_URL` (optional, OpenAI-compatible API base URL)
 - `OPENAI_API_KEY` (optional, required when using openai provider)
 - `EMBEDDING_MODEL` (default: `bge-m3`, server-wide, 1024 dims)

--- a/backend/src/core/db/migrations/056_admin_settings_llm_stream_cap.sql
+++ b/backend/src/core/db/migrations/056_admin_settings_llm_stream_cap.sql
@@ -1,0 +1,20 @@
+-- Migration 056: per-user concurrent SSE-stream cap (#268)
+--
+-- Seeds the admin-configurable cap for the per-user SSE-stream limiter
+-- (backend/src/core/services/sse-stream-limiter.ts). Without this bound, a
+-- single user opening many simultaneous streams can saturate the upstream
+-- LLM.
+--
+-- Range (enforced by Zod at the API boundary): [1, 20]. Default: 3.
+--
+-- Read cascade:
+--   admin_settings.llm_max_concurrent_streams_per_user   (authoritative)
+--     -> env LLM_MAX_CONCURRENT_STREAMS_PER_USER         (deprecated fallback)
+--     -> 3                                               (hard default)
+--
+-- Additive and idempotent — existing installations that already have the
+-- row from a prior rollout or manual INSERT keep their chosen value.
+
+INSERT INTO admin_settings (setting_key, setting_value, updated_at)
+VALUES ('llm_max_concurrent_streams_per_user', '3', NOW())
+ON CONFLICT (setting_key) DO NOTHING;

--- a/backend/src/core/db/migrations/__tests__/056_admin_settings_llm_stream_cap.test.ts
+++ b/backend/src/core/db/migrations/__tests__/056_admin_settings_llm_stream_cap.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setupTestDb, truncateAllTables, teardownTestDb, isDbAvailable } from '../../../../test-db-helper.js';
+import { query } from '../../postgres.js';
+
+const dbAvailable = await isDbAvailable();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const migrationSql = fs.readFileSync(
+  path.join(__dirname, '..', '056_admin_settings_llm_stream_cap.sql'),
+  'utf8',
+);
+
+/** Wraps the INSERT-in-text in an ad-hoc transaction so we can run it twice in
+ * the same test and prove idempotency without going through the migration
+ * registry (which tracks which migrations ran). */
+async function runMigrationInline(): Promise<void> {
+  await query(migrationSql);
+}
+
+describe.skipIf(!dbAvailable)('Migration 056 — admin-configurable SSE stream cap (#268)', () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
+  beforeEach(async () => { await truncateAllTables(); });
+
+  it('seeds the llm_max_concurrent_streams_per_user row with value 3 (fresh insert)', async () => {
+    // After truncateAllTables() the row is gone; re-running the migration
+    // re-seeds the default.
+    await runMigrationInline();
+
+    const r = await query<{ setting_value: string }>(
+      `SELECT setting_value FROM admin_settings
+       WHERE setting_key = 'llm_max_concurrent_streams_per_user'`,
+    );
+    expect(r.rows).toHaveLength(1);
+    expect(r.rows[0]!.setting_value).toBe('3');
+  });
+
+  it('is idempotent — does not overwrite an existing user-configured value', async () => {
+    // Simulate a user who has already configured a custom cap.
+    await query(
+      `INSERT INTO admin_settings (setting_key, setting_value) VALUES ($1, $2)
+       ON CONFLICT (setting_key) DO UPDATE SET setting_value = EXCLUDED.setting_value`,
+      ['llm_max_concurrent_streams_per_user', '12'],
+    );
+
+    // Re-run the migration. `ON CONFLICT DO NOTHING` must preserve the user value.
+    await runMigrationInline();
+
+    const r = await query<{ setting_value: string }>(
+      `SELECT setting_value FROM admin_settings
+       WHERE setting_key = 'llm_max_concurrent_streams_per_user'`,
+    );
+    expect(r.rows[0]!.setting_value).toBe('12');
+  });
+
+  it('is safe to re-run multiple times without side effects', async () => {
+    await runMigrationInline();
+    await runMigrationInline();
+    await runMigrationInline();
+
+    const r = await query<{ setting_value: string }>(
+      `SELECT setting_value FROM admin_settings
+       WHERE setting_key = 'llm_max_concurrent_streams_per_user'`,
+    );
+    expect(r.rows).toHaveLength(1);
+    expect(r.rows[0]!.setting_value).toBe('3');
+  });
+});

--- a/backend/src/core/services/sse-stream-limiter.test.ts
+++ b/backend/src/core/services/sse-stream-limiter.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import { setupTestDb, truncateAllTables, teardownTestDb, isDbAvailable } from '../../test-db-helper.js';
+import { query } from '../db/postgres.js';
+import { setRedisClient, getRedisClient } from './redis-cache.js';
+import {
+  acquireStreamSlot,
+  getStreamCap,
+  invalidateStreamCapCache,
+  _resetStreamCapCache,
+} from './sse-stream-limiter.js';
+import type { RedisClientType } from 'redis';
+
+const dbAvailable = await isDbAvailable();
+
+interface MockRedis {
+  eval: ReturnType<typeof vi.fn>;
+  decr: ReturnType<typeof vi.fn>;
+}
+
+function makeMockRedis(): MockRedis {
+  return {
+    eval: vi.fn(),
+    decr: vi.fn().mockResolvedValue(0),
+  };
+}
+
+describe.skipIf(!dbAvailable)('sse-stream-limiter', () => {
+  let mockRedis: MockRedis;
+  let originalRedis: RedisClientType | null;
+
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables();
+    _resetStreamCapCache();
+    originalRedis = getRedisClient();
+    mockRedis = makeMockRedis();
+    // Inject the mock so the limiter picks it up via getRedisClient().
+    setRedisClient(mockRedis as unknown as RedisClientType);
+    delete process.env.LLM_MAX_CONCURRENT_STREAMS_PER_USER;
+  });
+
+  afterEach(() => {
+    // Restore original client (typically null in the unit-test process).
+    setRedisClient(originalRedis as RedisClientType);
+    delete process.env.LLM_MAX_CONCURRENT_STREAMS_PER_USER;
+  });
+
+  describe('acquireStreamSlot', () => {
+    it('returns acquired=true when under cap', async () => {
+      mockRedis.eval.mockResolvedValue(1);
+      const slot = await acquireStreamSlot('user-a');
+      expect(slot.acquired).toBe(true);
+    });
+
+    it('returns acquired=false when cap exceeded', async () => {
+      mockRedis.eval.mockResolvedValue(0);
+      const slot = await acquireStreamSlot('user-a');
+      expect(slot.acquired).toBe(false);
+    });
+
+    it('release() is idempotent — DECR called at most once', async () => {
+      mockRedis.eval.mockResolvedValue(1);
+      const slot = await acquireStreamSlot('user-a');
+      await slot.release();
+      await slot.release();
+      await slot.release();
+      expect(mockRedis.decr).toHaveBeenCalledTimes(1);
+      expect(mockRedis.decr).toHaveBeenCalledWith('llm:streams:user-a');
+    });
+
+    it('fails open (acquired=true) when Redis client is null', async () => {
+      setRedisClient(null as unknown as RedisClientType);
+      const slot = await acquireStreamSlot('user-a');
+      expect(slot.acquired).toBe(true);
+      // release() must not throw even without a client.
+      await expect(slot.release()).resolves.toBeUndefined();
+    });
+
+    it('fails open when Redis eval throws', async () => {
+      mockRedis.eval.mockRejectedValue(new Error('redis down'));
+      const slot = await acquireStreamSlot('user-a');
+      expect(slot.acquired).toBe(true);
+      // Degraded release is a no-op.
+      await expect(slot.release()).resolves.toBeUndefined();
+      expect(mockRedis.decr).not.toHaveBeenCalled();
+    });
+
+    it('rejected slot does not call DECR on release', async () => {
+      mockRedis.eval.mockResolvedValue(0);
+      const slot = await acquireStreamSlot('user-a');
+      expect(slot.acquired).toBe(false);
+      await slot.release();
+      expect(mockRedis.decr).not.toHaveBeenCalled();
+    });
+
+    it('Lua script receives user-keyed counter + resolved cap + ttl', async () => {
+      await query(
+        `INSERT INTO admin_settings (setting_key, setting_value) VALUES ($1, $2)
+         ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2`,
+        ['llm_max_concurrent_streams_per_user', '9'],
+      );
+      _resetStreamCapCache();
+      mockRedis.eval.mockResolvedValue(1);
+      await acquireStreamSlot('user-a');
+      expect(mockRedis.eval).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          keys: ['llm:streams:user-a'],
+          arguments: ['9', '3600'],
+        }),
+      );
+    });
+  });
+
+  describe('getStreamCap — cascade', () => {
+    it('reads admin_settings row when present', async () => {
+      await query(
+        `INSERT INTO admin_settings (setting_key, setting_value) VALUES ($1, $2)
+         ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2`,
+        ['llm_max_concurrent_streams_per_user', '7'],
+      );
+      _resetStreamCapCache();
+      expect(await getStreamCap()).toBe(7);
+    });
+
+    it('falls back to env var when admin_settings row is absent', async () => {
+      await query(
+        `DELETE FROM admin_settings WHERE setting_key = $1`,
+        ['llm_max_concurrent_streams_per_user'],
+      );
+      process.env.LLM_MAX_CONCURRENT_STREAMS_PER_USER = '5';
+      _resetStreamCapCache();
+      expect(await getStreamCap()).toBe(5);
+    });
+
+    it('falls back to 3 when neither DB nor env is set', async () => {
+      await query(
+        `DELETE FROM admin_settings WHERE setting_key = $1`,
+        ['llm_max_concurrent_streams_per_user'],
+      );
+      delete process.env.LLM_MAX_CONCURRENT_STREAMS_PER_USER;
+      _resetStreamCapCache();
+      expect(await getStreamCap()).toBe(3);
+    });
+
+    it('rejects out-of-range admin_settings values (keeps hard default)', async () => {
+      await query(
+        `INSERT INTO admin_settings (setting_key, setting_value) VALUES ($1, $2)
+         ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2`,
+        ['llm_max_concurrent_streams_per_user', '999'],
+      );
+      _resetStreamCapCache();
+      expect(await getStreamCap()).toBe(3);
+    });
+
+    it('rejects non-numeric admin_settings values (keeps hard default)', async () => {
+      await query(
+        `INSERT INTO admin_settings (setting_key, setting_value) VALUES ($1, $2)
+         ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2`,
+        ['llm_max_concurrent_streams_per_user', 'not-a-number'],
+      );
+      _resetStreamCapCache();
+      expect(await getStreamCap()).toBe(3);
+    });
+
+    it('caches the resolved value (second call skips the DB)', async () => {
+      await query(
+        `INSERT INTO admin_settings (setting_key, setting_value) VALUES ($1, $2)
+         ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2`,
+        ['llm_max_concurrent_streams_per_user', '4'],
+      );
+      _resetStreamCapCache();
+      expect(await getStreamCap()).toBe(4);
+      // Change the DB value but do NOT invalidate the cache.
+      await query(
+        `UPDATE admin_settings SET setting_value = $1 WHERE setting_key = $2`,
+        ['12', 'llm_max_concurrent_streams_per_user'],
+      );
+      // Within the 60-second TTL, the cached value is still returned.
+      expect(await getStreamCap()).toBe(4);
+      // Manual invalidation picks up the new value.
+      invalidateStreamCapCache();
+      expect(await getStreamCap()).toBe(12);
+    });
+  });
+
+  describe('graceful lowering', () => {
+    it('lowering the cap does not trim in-flight streams — new opens see the new cap', async () => {
+      // Start at cap=10: 4 successful acquires.
+      await query(
+        `INSERT INTO admin_settings (setting_key, setting_value) VALUES ($1, $2)
+         ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2`,
+        ['llm_max_concurrent_streams_per_user', '10'],
+      );
+      _resetStreamCapCache();
+      mockRedis.eval
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(1);
+      const slots = await Promise.all([
+        acquireStreamSlot('u'),
+        acquireStreamSlot('u'),
+        acquireStreamSlot('u'),
+        acquireStreamSlot('u'),
+      ]);
+      expect(slots.every((s) => s.acquired)).toBe(true);
+
+      // Admin lowers cap to 2.
+      await query(
+        `UPDATE admin_settings SET setting_value = $1 WHERE setting_key = $2`,
+        ['2', 'llm_max_concurrent_streams_per_user'],
+      );
+      invalidateStreamCapCache();
+
+      // New open sees cap=2: Lua DECRs past the cap and returns 0.
+      mockRedis.eval.mockResolvedValueOnce(0);
+      const rejected = await acquireStreamSlot('u');
+      expect(rejected.acquired).toBe(false);
+
+      // Existing in-flight slots still release cleanly — one DECR per slot.
+      for (const s of slots) await s.release();
+      expect(mockRedis.decr).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/backend/src/core/services/sse-stream-limiter.ts
+++ b/backend/src/core/services/sse-stream-limiter.ts
@@ -1,0 +1,216 @@
+/**
+ * Per-user concurrent SSE-stream limiter (issue #268).
+ *
+ * Streaming LLM calls intentionally bypass the LLM request queue
+ * (see `openai-compatible-client.ts` — streamed requests are long-lived and
+ * would clog the queue). Without an upper bound, one user can saturate the
+ * upstream LLM by opening many simultaneous streams. This module caps the
+ * number of simultaneously-open streams per user via a Redis counter.
+ *
+ * Cap cascade (mirrors `rate-limit-service` / `admin-settings-service`):
+ *   admin_settings.llm_max_concurrent_streams_per_user   (authoritative)
+ *     → process.env.LLM_MAX_CONCURRENT_STREAMS_PER_USER  (deprecated bootstrap fallback)
+ *     → 3                                                (hard default)
+ *
+ * Redis key: `llm:streams:<userId>`. Every acquire re-runs `EXPIRE` with a
+ * 1-hour TTL so a crashed process's leaked counter self-heals.
+ *
+ * Lowering the cap at runtime is graceful: existing in-flight streams run to
+ * completion (their DECR on release still executes, even if it drives the
+ * counter below the new cap). Only new opens see the lower cap.
+ *
+ * Fail-open: when Redis is unavailable or the acquire eval throws, the slot is
+ * treated as acquired with a no-op release. Consistent with
+ * `acquireEmbeddingLock` (redis-cache.ts) — rejecting streams during a Redis
+ * outage is worse than temporarily exceeding the cap.
+ */
+import { getRedisClient } from './redis-cache.js';
+import { query } from '../db/postgres.js';
+import { logger } from '../utils/logger.js';
+
+/** 1-hour safety TTL so crashed processes don't leak counters permanently. */
+const STREAM_COUNTER_TTL_SECONDS = 3600;
+/** 60-second in-process cache for the resolved cap. Matches rate-limit-service. */
+const CACHE_TTL_MS = 60_000;
+/** Hard fallback when neither admin_settings nor env var is set. */
+const HARD_DEFAULT = 3;
+/** Zod validation range (kept in sync with packages/contracts/src/schemas/admin.ts). */
+const MIN_CAP = 1;
+const MAX_CAP = 20;
+/** admin_settings setting_key. */
+const DB_KEY = 'llm_max_concurrent_streams_per_user';
+
+let capCache: { value: number; expiresAt: number } | null = null;
+
+/**
+ * Resolve the per-user concurrent-stream cap via the admin-settings → env
+ * → hard-default cascade. Cached in-process for 60 s.
+ */
+export async function getStreamCap(): Promise<number> {
+  if (capCache && Date.now() < capCache.expiresAt) {
+    return capCache.value;
+  }
+
+  let resolved = HARD_DEFAULT;
+  try {
+    const r = await query<{ setting_value: string }>(
+      `SELECT setting_value FROM admin_settings WHERE setting_key = $1`,
+      [DB_KEY],
+    );
+    const dbValue = r.rows[0]?.setting_value;
+    if (dbValue !== undefined) {
+      const n = parseInt(dbValue, 10);
+      if (Number.isFinite(n) && n >= MIN_CAP && n <= MAX_CAP) {
+        resolved = n;
+      }
+      // Out-of-range or non-numeric DB values silently fall through to
+      // HARD_DEFAULT — do NOT consult the env var in that case, since the
+      // admin explicitly wrote a bad value and the UI/Zod should catch it
+      // on the next write.
+    } else {
+      // DB row absent → consult the deprecated bootstrap env var.
+      const envValue = process.env.LLM_MAX_CONCURRENT_STREAMS_PER_USER;
+      if (envValue) {
+        const n = parseInt(envValue, 10);
+        if (Number.isFinite(n) && n >= MIN_CAP && n <= MAX_CAP) {
+          resolved = n;
+        }
+      }
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Failed to resolve SSE-stream cap — falling back to hard default');
+  }
+
+  capCache = { value: resolved, expiresAt: Date.now() + CACHE_TTL_MS };
+  return resolved;
+}
+
+/**
+ * Called by the admin-settings PUT handler after writing the new value so
+ * the cap takes effect immediately in the local process. Other processes
+ * pick it up within the 60-second TTL.
+ */
+export function invalidateStreamCapCache(): void {
+  capCache = null;
+}
+
+function streamKey(userId: string): string {
+  return `llm:streams:${userId}`;
+}
+
+/**
+ * Atomic acquire. Avoids the "two clients race past the cap by one" classic:
+ * a naive INCR + read-and-compare has a TOCTOU window between the two ops.
+ *
+ *   KEYS[1] = llm:streams:<userId>
+ *   ARGV[1] = cap
+ *   ARGV[2] = TTL seconds
+ *
+ * Returns 1 if acquired, 0 if the resulting count would exceed the cap (in
+ * which case the INCR is rolled back by DECR). Always re-sets TTL on success
+ * so a leaked counter self-heals.
+ */
+const ACQUIRE_SCRIPT = `
+local n = redis.call("incr", KEYS[1])
+if n > tonumber(ARGV[1]) then
+  redis.call("decr", KEYS[1])
+  return 0
+end
+redis.call("expire", KEYS[1], ARGV[2])
+return 1
+`;
+
+export interface StreamSlot {
+  acquired: boolean;
+  /**
+   * Release the slot. Idempotent — calling twice DECRs once. Safe to call
+   * regardless of whether `acquired` was true. No-op if the slot was not
+   * acquired (rejected) or Redis is unavailable.
+   */
+  release: () => Promise<void>;
+}
+
+/**
+ * Fail-open slot: behaves as if acquired but does nothing on release.
+ * Used when Redis is unreachable so streams aren't blocked during outage.
+ */
+function failOpenSlot(): StreamSlot {
+  return {
+    acquired: true,
+    release: async () => {
+      /* no-op — no counter was incremented */
+    },
+  };
+}
+
+/**
+ * Attempt to acquire a per-user SSE-stream slot. Must be called BEFORE
+ * `reply.hijack()` so a rejection can be returned as a normal JSON 429.
+ *
+ * The caller MUST wrap the SSE body in `try { … } finally { slot.release(); }`
+ * so the counter decrements on success, error, timeout, AND client-disconnect.
+ */
+export async function acquireStreamSlot(userId: string): Promise<StreamSlot> {
+  const redis = getRedisClient();
+  if (!redis) {
+    logger.warn(
+      { userId },
+      'Redis unavailable; skipping SSE-stream cap check (fail-open)',
+    );
+    return failOpenSlot();
+  }
+
+  const cap = await getStreamCap();
+
+  let result: unknown;
+  try {
+    result = await redis.eval(ACQUIRE_SCRIPT, {
+      keys: [streamKey(userId)],
+      arguments: [String(cap), String(STREAM_COUNTER_TTL_SECONDS)],
+    });
+  } catch (err) {
+    logger.error(
+      { err, userId },
+      'acquireStreamSlot eval failed — failing open',
+    );
+    return failOpenSlot();
+  }
+
+  // node-redis returns Lua integers as number | bigint depending on version.
+  const acquired = result === 1 || result === 1n || result === '1';
+  if (!acquired) {
+    // Cap exceeded — the Lua script already rolled back the INCR.
+    return {
+      acquired: false,
+      release: async () => {
+        /* no-op — nothing was incremented on our behalf */
+      },
+    };
+  }
+
+  let released = false;
+  return {
+    acquired: true,
+    release: async () => {
+      if (released) return;
+      released = true;
+      try {
+        await redis.decr(streamKey(userId));
+      } catch (err) {
+        // The 1-hour TTL will eventually self-heal the leaked counter.
+        logger.error(
+          { err, userId },
+          'Failed to DECR SSE-stream counter — will self-heal via TTL',
+        );
+      }
+    },
+  };
+}
+
+/**
+ * Test-only helper. Do not call from production code.
+ * Exposed so tests can force a re-read of the cascade between steps.
+ */
+export function _resetStreamCapCache(): void {
+  capCache = null;
+}

--- a/backend/src/routes/foundation/admin.test.ts
+++ b/backend/src/routes/foundation/admin.test.ts
@@ -50,6 +50,8 @@ vi.mock('../../core/services/admin-settings-service.js', () => ({
 
 import { listErrors, resolveError, getErrorSummary } from '../../core/services/error-tracker.js';
 import { query as mockQuery } from '../../core/db/postgres.js';
+import { _resetStreamCapCache } from '../../core/services/sse-stream-limiter.js';
+import { _resetCache as _resetRateLimitsCache } from '../../core/services/rate-limit-service.js';
 
 describe('Admin routes', () => {
   let app: ReturnType<typeof Fastify>;
@@ -93,6 +95,10 @@ describe('Admin routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset in-module caches that read from admin_settings so each test sees
+    // a fresh mocked `query()` result.
+    _resetStreamCapCache();
+    _resetRateLimitsCache();
   });
 
   // ========================
@@ -321,6 +327,88 @@ describe('Admin routes', () => {
 
   // LLM provider + per-use-case-assignment routes moved to
   // /admin/llm-providers and /admin/llm-usecases — tested in dedicated files.
+
+  describe('GET /api/admin/settings - llmMaxConcurrentStreamsPerUser (#268)', () => {
+    it('returns the configured cap when the admin_settings row is present', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockImplementation(
+        async (sql: string, params?: unknown[]) => {
+          if (
+            typeof sql === 'string'
+            && sql.includes('SELECT setting_value FROM admin_settings')
+            && params?.[0] === 'llm_max_concurrent_streams_per_user'
+          ) {
+            return { rows: [{ setting_value: '7' }] };
+          }
+          // Default response for the multi-key admin-settings SELECT.
+          return { rows: [] };
+        },
+      );
+
+      const response = await app.inject({ method: 'GET', url: '/api/admin/settings' });
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.llmMaxConcurrentStreamsPerUser).toBe(7);
+    });
+
+    it('returns the hard default (3) when the admin_settings row is absent', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [] });
+
+      const response = await app.inject({ method: 'GET', url: '/api/admin/settings' });
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.llmMaxConcurrentStreamsPerUser).toBe(3);
+    });
+  });
+
+  describe('PUT /api/admin/settings - llmMaxConcurrentStreamsPerUser (#268)', () => {
+    it('upserts the cap via admin_settings and invalidates the cache', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/settings',
+        payload: { llmMaxConcurrentStreamsPerUser: 5 },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      // Verify the key+value were written as an INSERT … ON CONFLICT upsert.
+      const calls = (mockQuery as ReturnType<typeof vi.fn>).mock.calls as Array<[string, ...unknown[]]>;
+      const upsert = calls.find(([sql, params]) =>
+        typeof sql === 'string'
+        && sql.includes('INSERT INTO admin_settings')
+        && Array.isArray(params)
+        && (params as unknown[])[0] === 'llm_max_concurrent_streams_per_user'
+        && (params as unknown[])[1] === '5',
+      );
+      expect(upsert).toBeDefined();
+    });
+
+    it('rejects values outside [1, 20]', async () => {
+      const low = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/settings',
+        payload: { llmMaxConcurrentStreamsPerUser: 0 },
+      });
+      expect(low.statusCode).toBe(400);
+
+      const high = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/settings',
+        payload: { llmMaxConcurrentStreamsPerUser: 21 },
+      });
+      expect(high.statusCode).toBe(400);
+    });
+
+    it('rejects non-integer values', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/settings',
+        payload: { llmMaxConcurrentStreamsPerUser: 3.5 },
+      });
+      expect(response.statusCode).toBe(400);
+    });
+  });
 
   describe('PUT /api/admin/settings - drawioEmbedUrl only (no re-embedding)', () => {
     it('saves drawioEmbedUrl and does NOT trigger embedding_dirty update', async () => {

--- a/backend/src/routes/foundation/admin.ts
+++ b/backend/src/routes/foundation/admin.ts
@@ -9,6 +9,7 @@ import { UpdateAdminSettingsSchema } from '@compendiq/contracts';
 import { getEmbeddingDimensions } from '../../core/services/admin-settings-service.js';
 import { getAiGuardrails, getAiOutputRules, upsertAiGuardrails, upsertAiOutputRules } from '../../core/services/ai-safety-service.js';
 import { getRateLimits, upsertRateLimits } from '../../core/services/rate-limit-service.js';
+import { getStreamCap, invalidateStreamCapCache } from '../../core/services/sse-stream-limiter.js';
 import { sanitizeLlmInput } from '../../core/utils/sanitize-llm-input.js';
 import { ALLOWED_FTS_LANGUAGES } from '../../core/services/fts-language.js';
 import { getSmtpConfig, updateSmtpConfig, sendTestEmail } from '../../core/services/email-service.js';
@@ -226,11 +227,12 @@ export async function adminRoutes(fastify: FastifyInstance) {
 
   // GET /api/admin/settings - retrieve shared admin settings
   fastify.get('/admin/settings', ADMIN_RATE_LIMIT, async () => {
-    const [embeddingDimensions, guardrails, outputRules, rateLimits] = await Promise.all([
+    const [embeddingDimensions, guardrails, outputRules, rateLimits, llmMaxConcurrentStreamsPerUser] = await Promise.all([
       getEmbeddingDimensions(),
       getAiGuardrails(),
       getAiOutputRules(),
       getRateLimits(),
+      getStreamCap(),
     ]);
     const result = await query<{ setting_key: string; setting_value: string }>(
       `SELECT setting_key, setting_value FROM admin_settings
@@ -261,6 +263,8 @@ export async function adminRoutes(fastify: FastifyInstance) {
       rateLimitAdmin: rateLimits.admin.max,
       rateLimitLlmStream: rateLimits.llmStream.max,
       rateLimitLlmEmbedding: rateLimits.llmEmbedding.max,
+      // Per-user concurrent SSE-stream cap (#268)
+      llmMaxConcurrentStreamsPerUser,
     };
   });
 
@@ -340,6 +344,14 @@ export async function adminRoutes(fastify: FastifyInstance) {
         updates.push({ key: 'drawio_embed_url', value: body.drawioEmbedUrl });
       }
     }
+    // Per-user concurrent SSE-stream cap (#268). Zod already validated the
+    // range [1, 20], so we trust the value here.
+    if (body.llmMaxConcurrentStreamsPerUser !== undefined) {
+      updates.push({
+        key: 'llm_max_concurrent_streams_per_user',
+        value: String(body.llmMaxConcurrentStreamsPerUser),
+      });
+    }
 
     // Issue #257 — reembed-all job history retention. Zod already enforced
     // the [10, 10000] integer range at the boundary.
@@ -357,6 +369,13 @@ export async function adminRoutes(fastify: FastifyInstance) {
          ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2, updated_at = NOW()`,
         [key, value],
       );
+    }
+
+    // Invalidate the SSE-stream cap cache in-process so the new value takes
+    // effect immediately in this worker. Other workers pick it up within the
+    // 60-second TTL (same contract as `rate-limit-service`).
+    if (body.llmMaxConcurrentStreamsPerUser !== undefined) {
+      invalidateStreamCapCache();
     }
 
     // AI Safety settings

--- a/backend/src/routes/llm/llm-ask.ts
+++ b/backend/src/routes/llm/llm-ask.ts
@@ -21,6 +21,7 @@ import {
   MAX_INPUT_LENGTH,
 } from './_helpers.js';
 import { requireGlobalPermission } from '../../core/utils/rbac-guards.js';
+import { acquireStreamSlot } from '../../core/services/sse-stream-limiter.js';
 
 export async function llmAskRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -36,6 +37,17 @@ export async function llmAskRoutes(fastify: FastifyInstance) {
 
   // POST /api/llm/ask - RAG-powered Q&A with streaming
   fastify.post('/llm/ask', { ...LLM_STREAM_RATE_LIMIT, preHandler: requireGlobalPermission('llm:query') }, async (request, reply) => {
+    // Per-user concurrent SSE-stream cap (#268). MUST run before reply.hijack()
+    // so rejections can be returned as a normal JSON 429.
+    const slot = await acquireStreamSlot(request.userId);
+    if (!slot.acquired) {
+      return reply.code(429).send({
+        error: 'too_many_concurrent_streams',
+        message: 'You have reached the per-user concurrent AI-stream limit. Close an existing stream and try again.',
+      });
+    }
+
+    try {
     const auditStart = Date.now();
     const body = AskRequestSchema.parse(request.body);
     const { question, model, conversationId, includeSubPages, externalUrls } = body;
@@ -310,6 +322,9 @@ export async function llmAskRoutes(fastify: FastifyInstance) {
       }
     } finally {
       if (ragLockAcquired) await llmCache.releaseLock(ragCacheKey);
+    }
+    } finally {
+      await slot.release();
     }
   });
 }

--- a/backend/src/routes/llm/llm-diagram.ts
+++ b/backend/src/routes/llm/llm-diagram.ts
@@ -15,6 +15,7 @@ import {
   LLM_STREAM_RATE_LIMIT,
   MAX_INPUT_LENGTH,
 } from './_helpers.js';
+import { acquireStreamSlot } from '../../core/services/sse-stream-limiter.js';
 
 export async function llmDiagramRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -23,6 +24,17 @@ export async function llmDiagramRoutes(fastify: FastifyInstance) {
 
   // POST /api/llm/generate-diagram - stream Mermaid diagram from article content
   fastify.post('/llm/generate-diagram', LLM_STREAM_RATE_LIMIT, async (request, reply) => {
+    // Per-user concurrent SSE-stream cap (#268). Must fire BEFORE reply.hijack()
+    // so rejections can be returned as a normal JSON 429.
+    const slot = await acquireStreamSlot(request.userId);
+    if (!slot.acquired) {
+      return reply.code(429).send({
+        error: 'too_many_concurrent_streams',
+        message: 'You have reached the per-user concurrent AI-stream limit. Close an existing stream and try again.',
+      });
+    }
+
+    try {
     const body = GenerateDiagramRequestSchema.parse(request.body);
     const { content, model, diagramType = 'flowchart' } = body;
 
@@ -66,6 +78,9 @@ export async function llmDiagramRoutes(fastify: FastifyInstance) {
       await streamSSE(request, reply, generator, undefined, { llmCache, cacheKey });
     } finally {
       if (lockAcquired) await llmCache.releaseLock(cacheKey);
+    }
+    } finally {
+      await slot.release();
     }
   });
 }

--- a/backend/src/routes/llm/llm-generate.ts
+++ b/backend/src/routes/llm/llm-generate.ts
@@ -20,6 +20,7 @@ import {
   MAX_PDF_TEXT_FOR_LLM,
 } from './_helpers.js';
 import { requireGlobalPermission } from '../../core/utils/rbac-guards.js';
+import { acquireStreamSlot } from '../../core/services/sse-stream-limiter.js';
 
 export async function llmGenerateRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -28,6 +29,16 @@ export async function llmGenerateRoutes(fastify: FastifyInstance) {
 
   // POST /api/llm/generate - stream generated article
   fastify.post('/llm/generate', { ...LLM_STREAM_RATE_LIMIT, preHandler: requireGlobalPermission('llm:generate') }, async (request, reply) => {
+    // Per-user concurrent SSE-stream cap (#268).
+    const slot = await acquireStreamSlot(request.userId);
+    if (!slot.acquired) {
+      return reply.code(429).send({
+        error: 'too_many_concurrent_streams',
+        message: 'You have reached the per-user concurrent AI-stream limit. Close an existing stream and try again.',
+      });
+    }
+
+    try {
     const auditStart = Date.now();
     const body = GenerateRequestSchema.parse(request.body);
     const { prompt, model, template, pdfText } = body;
@@ -150,6 +161,9 @@ export async function llmGenerateRoutes(fastify: FastifyInstance) {
       throw err;
     } finally {
       if (lockAcquired) await llmCache.releaseLock(cacheKey);
+    }
+    } finally {
+      await slot.release();
     }
   });
 }

--- a/backend/src/routes/llm/llm-improve.ts
+++ b/backend/src/routes/llm/llm-improve.ts
@@ -21,6 +21,7 @@ import {
   MAX_INPUT_LENGTH,
 } from './_helpers.js';
 import { requireGlobalPermission } from '../../core/utils/rbac-guards.js';
+import { acquireStreamSlot } from '../../core/services/sse-stream-limiter.js';
 
 export async function llmImproveRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -29,6 +30,16 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
 
   // POST /api/llm/improve - stream improved content
   fastify.post('/llm/improve', { ...LLM_STREAM_RATE_LIMIT, preHandler: requireGlobalPermission('llm:improve') }, async (request, reply) => {
+    // Per-user concurrent SSE-stream cap (#268).
+    const slot = await acquireStreamSlot(request.userId);
+    if (!slot.acquired) {
+      return reply.code(429).send({
+        error: 'too_many_concurrent_streams',
+        message: 'You have reached the per-user concurrent AI-stream limit. Close an existing stream and try again.',
+      });
+    }
+
+    try {
     const auditStart = Date.now();
     const body = ImproveRequestSchema.parse(request.body);
     const { content, type, model, includeSubPages, instruction } = body;
@@ -159,6 +170,9 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
       throw err;
     } finally {
       if (lockAcquired) await llmCache.releaseLock(cacheKey);
+    }
+    } finally {
+      await slot.release();
     }
   });
 }

--- a/backend/src/routes/llm/llm-quality.ts
+++ b/backend/src/routes/llm/llm-quality.ts
@@ -15,6 +15,7 @@ import {
   LLM_STREAM_RATE_LIMIT,
   MAX_INPUT_LENGTH,
 } from './_helpers.js';
+import { acquireStreamSlot } from '../../core/services/sse-stream-limiter.js';
 
 export async function llmQualityRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -23,6 +24,17 @@ export async function llmQualityRoutes(fastify: FastifyInstance) {
 
   // POST /api/llm/analyze-quality - stream article quality analysis
   fastify.post('/llm/analyze-quality', LLM_STREAM_RATE_LIMIT, async (request, reply) => {
+    // Per-user concurrent SSE-stream cap (#268). Must fire BEFORE reply.hijack()
+    // so rejections can be returned as a normal JSON 429.
+    const slot = await acquireStreamSlot(request.userId);
+    if (!slot.acquired) {
+      return reply.code(429).send({
+        error: 'too_many_concurrent_streams',
+        message: 'You have reached the per-user concurrent AI-stream limit. Close an existing stream and try again.',
+      });
+    }
+
+    try {
     const body = AnalyzeQualityRequestSchema.parse(request.body);
     const { content, model, includeSubPages } = body;
     const userId = request.userId;
@@ -67,6 +79,9 @@ export async function llmQualityRoutes(fastify: FastifyInstance) {
       await streamSSE(request, reply, generator, undefined, { llmCache, cacheKey });
     } finally {
       if (lockAcquired) await llmCache.releaseLock(cacheKey);
+    }
+    } finally {
+      await slot.release();
     }
   });
 }

--- a/backend/src/routes/llm/llm-summarize.ts
+++ b/backend/src/routes/llm/llm-summarize.ts
@@ -18,6 +18,7 @@ import {
   MAX_INPUT_LENGTH,
 } from './_helpers.js';
 import { requireGlobalPermission } from '../../core/utils/rbac-guards.js';
+import { acquireStreamSlot } from '../../core/services/sse-stream-limiter.js';
 
 export async function llmSummarizeRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -26,6 +27,16 @@ export async function llmSummarizeRoutes(fastify: FastifyInstance) {
 
   // POST /api/llm/summarize - stream summary
   fastify.post('/llm/summarize', { ...LLM_STREAM_RATE_LIMIT, preHandler: requireGlobalPermission('llm:summarize') }, async (request, reply) => {
+    // Per-user concurrent SSE-stream cap (#268).
+    const slot = await acquireStreamSlot(request.userId);
+    if (!slot.acquired) {
+      return reply.code(429).send({
+        error: 'too_many_concurrent_streams',
+        message: 'You have reached the per-user concurrent AI-stream limit. Close an existing stream and try again.',
+      });
+    }
+
+    try {
     const body = SummarizeRequestSchema.parse(request.body);
     const { content, model, length = 'medium', includeSubPages } = body;
     const userId = request.userId;
@@ -98,6 +109,9 @@ export async function llmSummarizeRoutes(fastify: FastifyInstance) {
       await streamSSE(request, reply, generator, sumExtras, { llmCache, cacheKey, postProcess });
     } finally {
       if (lockAcquired) await llmCache.releaseLock(cacheKey);
+    }
+    } finally {
+      await slot.release();
     }
   });
 }

--- a/backend/src/routes/llm/sse-stream-limit-gate.test.ts
+++ b/backend/src/routes/llm/sse-stream-limit-gate.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Integration tests for the per-user concurrent-SSE-stream gate (#268).
+ *
+ * Parameterised across all six streaming handlers so every new LLM SSE
+ * endpoint added in the future keeps protection when it copies the
+ * existing slot.acquired / try / finally pattern.
+ *
+ * The gate's correctness properties we verify here:
+ *   1. Over-cap requests return 429 with the documented body shape.
+ *   2. `slot.release()` is invoked on the success path (stream completes).
+ *   3. `slot.release()` is invoked on the error path (generator throws).
+ *   4. `slot.release()` is invoked on the client-disconnect path.
+ *   5. `slot.release()` is invoked on the timeout path (AbortError from the
+ *      generator — same code path as an upstream timeout).
+ *
+ * The Lua/Redis atomicity is unit-tested in sse-stream-limiter.test.ts;
+ * here we only care that the route wires the gate into the right place and
+ * that the finally block fires on every exit.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import sensible from '@fastify/sensible';
+
+// ─── Mocks (broad — every route tested below shares them) ──────────────
+
+const mockAcquireStreamSlot = vi.fn();
+const mockRelease = vi.fn();
+
+vi.mock('../../core/services/sse-stream-limiter.js', () => ({
+  acquireStreamSlot: (...args: unknown[]) => mockAcquireStreamSlot(...args),
+  getStreamCap: vi.fn().mockResolvedValue(3),
+  invalidateStreamCapCache: vi.fn(),
+  _resetStreamCapCache: vi.fn(),
+}));
+
+const mockGetSystemPrompt = vi.fn().mockReturnValue('sys prompt');
+vi.mock('../../domains/llm/services/prompts.js', () => ({
+  getSystemPrompt: (...args: unknown[]) => mockGetSystemPrompt(...args),
+  LANGUAGE_PRESERVATION_INSTRUCTION: '',
+}));
+
+vi.mock('../../domains/llm/services/llm-provider-resolver.js', () => ({
+  resolveUsecase: vi.fn().mockResolvedValue({
+    config: {
+      providerId: 'p1', baseUrl: 'http://x/v1', apiKey: null,
+      authType: 'none', verifySsl: true, name: 'X', defaultModel: 'm',
+    },
+    model: 'm',
+  }),
+}));
+
+const mockStreamChat = vi.fn();
+vi.mock('../../domains/llm/services/openai-compatible-client.js', () => ({
+  streamChat: (...args: unknown[]) => mockStreamChat(...args),
+  chat: vi.fn(),
+  generateEmbedding: vi.fn(),
+  listModels: vi.fn(),
+  checkHealth: vi.fn(),
+  invalidateDispatcher: vi.fn(),
+}));
+
+vi.mock('../../domains/llm/services/rag-service.js', () => ({
+  hybridSearch: vi.fn().mockResolvedValue([]),
+  buildRagContext: vi.fn().mockReturnValue('ctx'),
+}));
+
+vi.mock('../../core/db/postgres.js', () => ({
+  query: vi.fn().mockResolvedValue({ rows: [] }),
+  runMigrations: vi.fn(),
+  closePool: vi.fn(),
+}));
+
+vi.mock('../../core/services/content-converter.js', () => ({
+  htmlToMarkdown: vi.fn((s: string) => s),
+  markdownToHtml: vi.fn((s: string) => s),
+}));
+
+vi.mock('../../domains/llm/services/embedding-service.js', () => ({
+  getEmbeddingStatus: vi.fn(),
+  processDirtyPages: vi.fn(),
+  reEmbedAll: vi.fn(),
+  embedPage: vi.fn(),
+  isProcessingUser: vi.fn().mockReturnValue(false),
+  resetFailedEmbeddings: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('../../domains/llm/services/llm-cache.js', () => {
+  class MockLlmCache {
+    getCachedResponse = vi.fn().mockResolvedValue(null);
+    setCachedResponse = vi.fn().mockResolvedValue(undefined);
+    acquireLock = vi.fn().mockResolvedValue(true);
+    releaseLock = vi.fn().mockResolvedValue(undefined);
+    waitForCachedResponse = vi.fn().mockResolvedValue(null);
+    clearAll = vi.fn();
+  }
+  return {
+    LlmCache: MockLlmCache,
+    buildLlmCacheKey: vi.fn().mockReturnValue('k'),
+    buildRagCacheKey: vi.fn().mockReturnValue('k'),
+  };
+});
+
+vi.mock('../../core/services/audit-service.js', () => ({
+  logAuditEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../domains/llm/services/llm-audit-hook.js', () => ({
+  emitLlmAudit: vi.fn(),
+  estimateTokens: vi.fn().mockReturnValue(10),
+}));
+
+vi.mock('../../core/utils/sanitize-llm-input.js', () => ({
+  sanitizeLlmInput: vi.fn((input: string) => ({ sanitized: input, warnings: [] })),
+}));
+
+vi.mock('../../core/services/ai-safety-service.js', () => ({
+  getAiGuardrails: vi.fn().mockResolvedValue({
+    noFabricationEnabled: false,
+    noFabricationInstruction: '',
+  }),
+  getAiOutputRules: vi.fn().mockResolvedValue({
+    stripReferences: false,
+    referenceAction: 'off',
+  }),
+  upsertAiGuardrails: vi.fn(),
+  upsertAiOutputRules: vi.fn(),
+}));
+
+vi.mock('../../domains/confluence/services/subpage-context.js', () => ({
+  assembleSubPageContext: vi.fn().mockResolvedValue({ markdown: '', pageCount: 0 }),
+  getMultiPagePromptSuffix: vi.fn().mockReturnValue(''),
+}));
+
+vi.mock('../../core/utils/rbac-guards.js', () => ({
+  requireGlobalPermission: () => async () => {
+    /* allow everything in tests */
+  },
+}));
+
+// Rate-limit service is not called directly by the route, but LLM_STREAM_RATE_LIMIT
+// lazy-resolves through it.
+vi.mock('../../core/services/rate-limit-service.js', () => ({
+  getRateLimits: vi.fn().mockResolvedValue({
+    global: { max: 100, timeWindow: '1 minute' },
+    auth: { max: 5, timeWindow: '1 minute' },
+    admin: { max: 20, timeWindow: '1 minute' },
+    llmStream: { max: 10_000, timeWindow: '1 minute' },
+    llmEmbedding: { max: 10_000, timeWindow: '1 minute' },
+  }),
+  upsertRateLimits: vi.fn(),
+  _resetCache: vi.fn(),
+}));
+
+// MCP docs client (used only by llm-ask, but safe to stub broadly).
+vi.mock('../../core/services/mcp-docs-client.js', () => ({
+  isEnabled: vi.fn().mockResolvedValue(false),
+  fetchDocumentation: vi.fn(),
+}));
+
+vi.mock('./_web-search-helper.js', () => ({
+  fetchWebSources: vi.fn().mockResolvedValue([]),
+  formatWebContext: vi.fn().mockReturnValue(''),
+}));
+
+// Imports must come after every vi.mock() above.
+import { llmAskRoutes } from './llm-ask.js';
+import { llmGenerateRoutes } from './llm-generate.js';
+import { llmImproveRoutes } from './llm-improve.js';
+import { llmSummarizeRoutes } from './llm-summarize.js';
+import { llmQualityRoutes } from './llm-quality.js';
+import { llmDiagramRoutes } from './llm-diagram.js';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────
+
+interface RouteFixture {
+  name: string;
+  path: string;
+  register: (fastify: FastifyInstance, opts: { prefix: string }) => Promise<void>;
+  payload: Record<string, unknown>;
+}
+
+const ROUTES: RouteFixture[] = [
+  {
+    name: 'llm/ask',
+    path: '/api/llm/ask',
+    register: llmAskRoutes,
+    payload: { question: 'hi', model: 'm' },
+  },
+  {
+    name: 'llm/generate',
+    path: '/api/llm/generate',
+    register: llmGenerateRoutes,
+    payload: { prompt: 'hi', model: 'm' },
+  },
+  {
+    name: 'llm/improve',
+    path: '/api/llm/improve',
+    register: llmImproveRoutes,
+    payload: { content: 'hi', type: 'grammar', model: 'm' },
+  },
+  {
+    name: 'llm/summarize',
+    path: '/api/llm/summarize',
+    register: llmSummarizeRoutes,
+    payload: { content: 'hi', model: 'm' },
+  },
+  {
+    name: 'llm/analyze-quality',
+    path: '/api/llm/analyze-quality',
+    register: llmQualityRoutes,
+    payload: { content: 'hi', model: 'm' },
+  },
+  {
+    name: 'llm/generate-diagram',
+    path: '/api/llm/generate-diagram',
+    register: llmDiagramRoutes,
+    payload: { content: 'hi', model: 'm' },
+  },
+];
+
+async function* successGenerator() {
+  yield { content: 'ok', done: true };
+}
+
+async function* throwingGenerator(): AsyncGenerator<{ content: string; done: boolean }> {
+  yield { content: 'partial', done: false };
+  throw new Error('upstream failure');
+}
+
+async function* abortingGenerator(): AsyncGenerator<{ content: string; done: boolean }> {
+  // ESLint require-yield requires at least one yield; this one never executes
+  // because the throw runs first, but it satisfies the linter and keeps the
+  // semantic intent (an async generator that aborts immediately) intact.
+  if (Math.random() < -1) yield { content: '', done: false };
+  const err = new Error('aborted') as Error & { name: string };
+  err.name = 'AbortError';
+  throw err;
+}
+
+async function buildAppForRoute(route: RouteFixture): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(sensible);
+  app.decorate('authenticate', async () => { /* noop */ });
+  app.decorate('requireAdmin', async () => { /* noop */ });
+  app.decorate('redis', {});
+  app.decorateRequest('userId', '');
+  app.addHook('onRequest', async (request) => {
+    request.userId = 'user-A';
+    request.userCan = async () => true;
+  });
+  await app.register(route.register, { prefix: '/api' });
+  await app.ready();
+  return app;
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────
+
+describe('Per-user SSE-stream gate — parameterised across all six handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAcquireStreamSlot.mockReset();
+    mockRelease.mockReset();
+  });
+
+  describe.each(ROUTES)('$path', (route) => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildAppForRoute(route);
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('returns 429 with the documented body when the cap is hit', async () => {
+      mockAcquireStreamSlot.mockResolvedValue({
+        acquired: false,
+        release: mockRelease,
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: route.path,
+        payload: route.payload,
+      });
+
+      expect(response.statusCode).toBe(429);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('too_many_concurrent_streams');
+      expect(typeof body.message).toBe('string');
+      // The documented body shape is user-facing; guard against accidental
+      // renames breaking clients.
+      expect(body.message.length).toBeGreaterThan(0);
+
+      // No release on the rejection path — the slot was never held.
+      expect(mockRelease).not.toHaveBeenCalled();
+    });
+
+    it('releases the slot on the SUCCESS path', async () => {
+      mockAcquireStreamSlot.mockResolvedValue({
+        acquired: true,
+        release: mockRelease,
+      });
+      mockStreamChat.mockReturnValue(successGenerator());
+
+      const response = await app.inject({
+        method: 'POST',
+        url: route.path,
+        payload: route.payload,
+      });
+
+      // A 2xx status or plain text/event-stream response is a normal finish.
+      expect(response.statusCode).toBe(200);
+      expect(mockRelease).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases the slot on the ERROR path (generator throws mid-stream)', async () => {
+      mockAcquireStreamSlot.mockResolvedValue({
+        acquired: true,
+        release: mockRelease,
+      });
+      mockStreamChat.mockReturnValue(throwingGenerator());
+
+      await app.inject({
+        method: 'POST',
+        url: route.path,
+        payload: route.payload,
+      });
+
+      // Regardless of whether the error frame is written to the SSE stream
+      // or bubbles as a 500, the slot must release.
+      expect(mockRelease).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases the slot on the TIMEOUT/ABORT path (AbortError from generator)', async () => {
+      mockAcquireStreamSlot.mockResolvedValue({
+        acquired: true,
+        release: mockRelease,
+      });
+      mockStreamChat.mockReturnValue(abortingGenerator());
+
+      await app.inject({
+        method: 'POST',
+        url: route.path,
+        payload: route.payload,
+      });
+
+      expect(mockRelease).toHaveBeenCalledTimes(1);
+    });
+
+    it('acquires once per request (exactly-one symmetry with release)', async () => {
+      mockAcquireStreamSlot.mockResolvedValue({
+        acquired: true,
+        release: mockRelease,
+      });
+      mockStreamChat.mockReturnValue(successGenerator());
+
+      await app.inject({
+        method: 'POST',
+        url: route.path,
+        payload: route.payload,
+      });
+
+      expect(mockAcquireStreamSlot).toHaveBeenCalledTimes(1);
+      expect(mockAcquireStreamSlot).toHaveBeenCalledWith('user-A');
+    });
+  });
+});

--- a/docs/ADMIN-GUIDE.md
+++ b/docs/ADMIN-GUIDE.md
@@ -207,6 +207,29 @@ LLM requests are managed through a concurrency-controlled queue with backpressur
 
 Queue metrics are exposed via `GET /api/health` under the `llmQueue` key. When the queue is full, new requests receive a `503` error with a message to retry later.
 
+### Per-User Concurrent SSE-Stream Cap (#268)
+
+Streaming LLM endpoints (`/api/llm/ask`, `generate`, `improve`, `summarize`, `analyze-quality`, `generate-diagram`) intentionally bypass the queue above because streams are long-lived. Without a per-user bound, one user opening many tabs can saturate the upstream LLM.
+
+A Redis counter (`llm:streams:<userId>`) tracks currently-open SSE streams per user. New opens beyond the cap are rejected with **HTTP 429** and body:
+
+```json
+{ "error": "too_many_concurrent_streams", "message": "…" }
+```
+
+| Setting | Default | Range | Description |
+|---------|---------|-------|-------------|
+| **Settings → LLM → Runtime limits** (primary) | `3` | `1`–`20` | Admin-configurable. Changes apply within 60 s in every worker; the local worker sees them immediately. |
+| `LLM_MAX_CONCURRENT_STREAMS_PER_USER` | `3` | `1`–`20` | **Deprecated bootstrap fallback** — consulted only when the `admin_settings` row is absent. |
+
+**Release semantics.** The counter decrements on all four exit paths: normal completion, error, upstream timeout, and client disconnect. A 1-hour TTL self-heals leaked counters from crashed processes.
+
+**Lowering is graceful.** Existing in-flight streams run to completion; only new opens see the lower cap.
+
+**No admin bypass.** Admins share the same cap as regular users. This is intentional to prevent accidental concurrent-usage incidents from power users.
+
+**Interaction with `LLM_STREAM_RATE_LIMIT`.** The rate limit caps requests per minute; this caps concurrently-open connections. Both can 429 — they are distinguished by the response body's `error` string.
+
 ### Confluence
 
 | Variable | Default | Description |

--- a/docs/issues/268-implementation-plan.md
+++ b/docs/issues/268-implementation-plan.md
@@ -1,0 +1,525 @@
+# Implementation Plan — Issue #268: per-user concurrent-SSE-stream limit
+
+> Target branch: `feature/268-sse-concurrent-limit` → PR to `dev`.
+> Scope: bound the number of concurrent SSE streams per `userId` via a Redis counter. Reject 4th+ with 429. Admin-configurable cap via `admin_settings`. No admin bypass. Graceful lowering. Self-heal via TTL.
+>
+> **Decisions locked (v2, 2026-04-21):**
+> - No admin bypass — admins share the same cap.
+> - Cap is admin-configurable through Settings → LLM UI (not env-var only). Env var `LLM_MAX_CONCURRENT_STREAMS_PER_USER` becomes a **deprecated bootstrap fallback** — consulted only when the `admin_settings` row is absent.
+> - Lowering the cap at runtime is graceful: in-flight streams continue to completion; new opens see the new cap.
+
+---
+
+## 1. ResearchPack
+
+Line numbers verified on `feature/258-llm-queue-breakers` (`19b8c87`).
+
+### 1.1 SSE call sites (unchanged from v1)
+
+Six handlers stream LLM output via `streamChat()` + `reply.hijack()`:
+
+| File:line | Route | Shared helper |
+|---|---|---|
+| `backend/src/routes/llm/llm-ask.ts:38, 238–310` | `POST /api/llm/ask` | inline (RAG-cache coordination) |
+| `backend/src/routes/llm/llm-generate.ts:30, 120–122` | `POST /api/llm/generate` | shared `streamSSE` |
+| `backend/src/routes/llm/llm-improve.ts:121` (per Grep) | `POST /api/llm/improve` | shared `streamSSE` |
+| `backend/src/routes/llm/llm-summarize.ts:96` | `POST /api/llm/summarize` | shared `streamSSE` |
+| `backend/src/routes/llm/llm-quality.ts:65` | `POST /api/llm/analyze-quality` | shared `streamSSE` |
+| `backend/src/routes/llm/llm-diagram.ts:64` | `POST /api/llm/generate-diagram` | shared `streamSSE` |
+
+### 1.2 Gate must live above `reply.hijack()`
+
+Increment must happen *before* `reply.hijack()` so a 429 is a normal Fastify JSON reply. Shape:
+```typescript
+const slot = await acquireStreamSlot(request.userId);
+if (!slot.acquired) {
+  return reply.code(429).send({ error: 'too_many_concurrent_streams', message: '…' });
+}
+try { … existing body … } finally { await slot.release(); }
+```
+
+### 1.3 Admin-settings pattern to reuse
+
+**Reuse the `rate-limit-service.ts` cascade pattern verbatim** (`backend/src/core/services/rate-limit-service.ts:49–74`):
+- DB key in `admin_settings` (text value; parsed int; default-fallback on NaN).
+- 60-second in-process TTL cache.
+- `upsertX()` helper invalidates cache + audit-logs.
+- `_resetCache()` for tests.
+
+Mirrors `reembed_history_retention` (PR #261, `055_admin_settings_reembed_retention.sql`) and the existing `rate_limit_*` keys.
+
+Canonical admin-settings key: **`llm_max_concurrent_streams_per_user`** (integer, stored as text). Default `3`, min `1`, max `20`.
+
+### 1.4 Read-resolution cascade (locked)
+
+```
+admin_settings.llm_max_concurrent_streams_per_user   (authoritative)
+  → process.env.LLM_MAX_CONCURRENT_STREAMS_PER_USER  (deprecated bootstrap fallback)
+  → 3                                                (hard-coded default)
+```
+
+Mirrors the documented cascade for `DEFAULT_LLM_MODEL`, `QUALITY_MODEL`, `SUMMARY_MODEL`, `COMPENDIQ_LICENSE_KEY` (`CLAUDE.md:253, 257, 260, 278`).
+
+### 1.5 Migration numbering
+
+`dev` is at `054_llm_providers.sql`. PR #261 owns `055_admin_settings_reembed_retention.sql`. This plan allocates **`056_admin_settings_llm_stream_cap.sql`**. #264 allocates `057`. Swap if one PR stalls — flagged in §6.
+
+### 1.6 External research — lifecycle + counter
+
+Fastify SSE abort: `request.raw.on('close', …)` fires for both client-abort and server-done. Existing wiring at `_helpers.ts:167–168` + `llm-ask.ts:235–236` — reuse. (`https://github.com/fastify/fastify/blob/main/docs/Guides/Detecting-When-Clients-Abort.md`.)
+
+Redis counter: Lua `INCR` + over-cap `DECR` + `EXPIRE` — atomic, one round-trip. Release: plain `DECR`. Pattern consistent with `recordAttachmentFailure()` at `redis-cache.ts:173–186`.
+
+### 1.7 UI location — Settings → LLM tab
+
+- Panel root: `frontend/src/features/settings/panels/LlmTab.tsx` (co-located with provider + use-case assignments — confirmed via `frontend/src/features/settings/panels/` listing).
+- **Do not create a new sub-tab.** Append a small "Runtime limits" card (or extend an existing one) to `LlmTab.tsx`.
+- A single numeric input: "Max concurrent AI streams per user" (min 1, max 20), with inline helper text: *"Rejects additional streams with 429. Lowering takes effect for newly opened streams; in-flight streams continue."*
+- Wire through the existing `GET /api/admin/settings` → TanStack-Query pattern used by other entries in the same file (e.g. embedding chunk size already rides on `AdminSettingsSchema`).
+
+### 1.8 Interaction with `LLM_STREAM_RATE_LIMIT`
+
+Different concept. `_helpers.ts:24` caps *requests per minute* via `@fastify/rate-limit`. #268 caps *concurrent connections*. Both stay. They return 429 for different reasons — distinguished via `error` body string (`too_many_concurrent_streams` vs rate-limit's default).
+
+---
+
+## 2. Step-by-step surgical edits
+
+### Step 2.1 — Zod schema updates
+
+`packages/contracts/src/schemas/admin.ts`. Append to both `AdminSettingsSchema` (read) and `UpdateAdminSettingsSchema` (write):
+
+```diff
+ export const AdminSettingsSchema = z.object({
+   …
+   rateLimitLlmStream: z.number().int().min(1).max(1000).optional(),
+   rateLimitLlmEmbedding: z.number().int().min(1).max(1000).optional(),
++  // Per-user concurrent SSE-stream cap (#268). Separate from rateLimitLlmStream:
++  // that caps requests/minute; this caps concurrent connections.
++  llmMaxConcurrentStreamsPerUser: z.number().int().min(1).max(20).optional(),
+ });
+
+ export const UpdateAdminSettingsSchema = z.object({
+   …
+   rateLimitLlmEmbedding: z.number().int().min(1).max(1000).optional(),
++  llmMaxConcurrentStreamsPerUser: z.number().int().min(1).max(20).optional(),
+ });
+```
+
+### Step 2.2 — migration `056_admin_settings_llm_stream_cap.sql`
+
+`backend/src/core/db/migrations/056_admin_settings_llm_stream_cap.sql`:
+
+```sql
+-- Migration 056: per-user concurrent SSE-stream cap (#268)
+--
+-- Seeds the admin-configurable cap for the new per-user SSE-stream limiter.
+-- Range (enforced by Zod): [1, 20]. Default: 3.
+--
+-- Read cascade:
+--   admin_settings.llm_max_concurrent_streams_per_user
+--     → env LLM_MAX_CONCURRENT_STREAMS_PER_USER (deprecated fallback)
+--     → 3 (hard default)
+--
+-- Additive + idempotent.
+INSERT INTO admin_settings (setting_key, setting_value, updated_at)
+VALUES ('llm_max_concurrent_streams_per_user', '3', NOW())
+ON CONFLICT (setting_key) DO NOTHING;
+```
+
+### Step 2.3 — new module `sse-stream-limiter.ts`
+
+`backend/src/core/services/sse-stream-limiter.ts`:
+
+```typescript
+/**
+ * Per-user concurrent SSE-stream limiter (issue #268).
+ *
+ * Streaming LLM calls intentionally bypass the LLM queue (openai-compatible-
+ * client.ts:94–102). This module caps simultaneously-open streams per user.
+ *
+ * Cap cascade:
+ *   admin_settings.llm_max_concurrent_streams_per_user → authoritative
+ *   process.env.LLM_MAX_CONCURRENT_STREAMS_PER_USER    → deprecated fallback
+ *   3                                                  → hard default
+ *
+ * Redis key: `llm:streams:<userId>`. TTL: 1h — self-heals on process crash.
+ *
+ * Lowering the cap at runtime is graceful: existing in-flight streams
+ * continue; only new opens see the new cap.
+ */
+import { getRedisClient } from './redis-cache.js';
+import { query } from '../db/postgres.js';
+import { logger } from '../utils/logger.js';
+
+const STREAM_COUNTER_TTL_SECONDS = 3600;
+const CACHE_TTL_MS = 60_000;
+const HARD_DEFAULT = 3;
+const DB_KEY = 'llm_max_concurrent_streams_per_user';
+
+let capCache: { value: number; expiresAt: number } | null = null;
+
+/** Admin_settings → env → default cascade, 60s cache. */
+export async function getStreamCap(): Promise<number> {
+  if (capCache && Date.now() < capCache.expiresAt) return capCache.value;
+
+  let resolved = HARD_DEFAULT;
+  try {
+    const r = await query<{ setting_value: string }>(
+      `SELECT setting_value FROM admin_settings WHERE setting_key = $1`,
+      [DB_KEY],
+    );
+    const db = r.rows[0]?.setting_value;
+    if (db) {
+      const n = parseInt(db, 10);
+      if (Number.isFinite(n) && n >= 1 && n <= 20) resolved = n;
+    } else {
+      const env = process.env.LLM_MAX_CONCURRENT_STREAMS_PER_USER;
+      if (env) {
+        const n = parseInt(env, 10);
+        if (Number.isFinite(n) && n >= 1 && n <= 20) resolved = n;
+      }
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Failed to resolve stream cap; using default');
+  }
+
+  capCache = { value: resolved, expiresAt: Date.now() + CACHE_TTL_MS };
+  return resolved;
+}
+
+/** Called by the admin-settings PUT handler after writing the new value. */
+export function invalidateStreamCapCache(): void {
+  capCache = null;
+}
+
+function key(userId: string): string {
+  return `llm:streams:${userId}`;
+}
+
+// Atomic acquire — Lua avoids the "two clients race past cap by one" classic.
+// KEYS[1] = llm:streams:<userId>
+// ARGV[1] = cap, ARGV[2] = ttl seconds
+// Returns 1 acquired, 0 rejected.
+const ACQUIRE_SCRIPT = `
+  local n = redis.call("incr", KEYS[1])
+  if n > tonumber(ARGV[1]) then
+    redis.call("decr", KEYS[1])
+    return 0
+  end
+  redis.call("expire", KEYS[1], ARGV[2])
+  return 1
+`;
+
+export interface StreamSlot {
+  acquired: boolean;
+  release: () => Promise<void>;
+}
+
+// Fail-open: rejecting streams when Redis is down is worse than temporarily
+// exceeding the cap. Consistent with acquireEmbeddingLock (redis-cache.ts:55–71).
+function fallbackSlot(): StreamSlot {
+  return { acquired: true, release: async () => {} };
+}
+
+export async function acquireStreamSlot(userId: string): Promise<StreamSlot> {
+  const redis = getRedisClient();
+  if (!redis) {
+    logger.warn({ userId }, 'Redis unavailable; skipping SSE-stream cap check (fail-open)');
+    return fallbackSlot();
+  }
+  const cap = await getStreamCap();
+  try {
+    const result = await redis.eval(ACQUIRE_SCRIPT, {
+      keys: [key(userId)],
+      arguments: [String(cap), String(STREAM_COUNTER_TTL_SECONDS)],
+    });
+    if (result !== 1) return { acquired: false, release: async () => {} };
+    let released = false;
+    return {
+      acquired: true,
+      release: async () => {
+        if (released) return;
+        released = true;
+        try {
+          await redis.decr(key(userId));
+        } catch (err) {
+          logger.error({ err, userId }, 'Failed to DECR SSE-stream counter — will self-heal via TTL');
+        }
+      },
+    };
+  } catch (err) {
+    logger.error({ err, userId }, 'acquireStreamSlot eval failed — failing open');
+    return fallbackSlot();
+  }
+}
+
+/** Test-only cache reset. */
+export function _resetStreamCapCache(): void {
+  capCache = null;
+}
+```
+
+### Step 2.4 — admin-settings GET/PUT wiring
+
+`backend/src/routes/foundation/admin.ts`:
+
+- Extend the `SELECT … WHERE setting_key IN (…)` block (lines ~237, 284) to include `'llm_max_concurrent_streams_per_user'`.
+- Extend the returned map (line ~248 pattern) with `llmMaxConcurrentStreamsPerUser: parseInt(map['llm_max_concurrent_streams_per_user'] ?? '3', 10)`.
+- Extend the PUT handler (line ~328 pattern): on `body.llmMaxConcurrentStreamsPerUser !== undefined`, push `{ key: 'llm_max_concurrent_streams_per_user', value: String(body.llmMaxConcurrentStreamsPerUser) }`, and after the DB write call `invalidateStreamCapCache()` from `sse-stream-limiter.ts`. Audit-log alongside the existing `ADMIN_ACTION` for settings updates.
+
+Parameterised SQL only (matches existing `INSERT … ON CONFLICT` pattern).
+
+### Step 2.5 — wire into each of six handlers
+
+Shape (illustrated on `llm-ask.ts`; repeat for `llm-generate.ts`, `llm-improve.ts`, `llm-summarize.ts`, `llm-quality.ts`, `llm-diagram.ts`):
+
+```diff
+ } from './_helpers.js';
+ import { requireGlobalPermission } from '../../core/utils/rbac-guards.js';
++import { acquireStreamSlot } from '../../core/services/sse-stream-limiter.js';
+ …
+   fastify.post('/llm/ask', { ...LLM_STREAM_RATE_LIMIT, preHandler: requireGlobalPermission('llm:query') }, async (request, reply) => {
++    const slot = await acquireStreamSlot(request.userId);
++    if (!slot.acquired) {
++      return reply.code(429).send({
++        error: 'too_many_concurrent_streams',
++        message: 'You have reached the per-user concurrent stream limit. Close an existing stream and try again.',
++      });
++    }
++    try {
+       const auditStart = Date.now();
+       … existing body unchanged …
++    } finally {
++      await slot.release();
++    }
+   });
+```
+
+### Step 2.6 — frontend UI
+
+`frontend/src/features/settings/panels/LlmTab.tsx`:
+
+- Append a "Runtime limits" card (or extend the nearest existing card — choose based on the file's current layout):
+  - `<input type="number" min={1} max={20}>` labelled *"Max concurrent AI streams per user"*.
+  - Helper text: *"New streams beyond this cap are rejected with 429. In-flight streams continue; only new opens see the new cap."*
+  - Wire into the same TanStack-Query mutation used for other `AdminSettings` fields.
+  - Optimistic default 3 when `llmMaxConcurrentStreamsPerUser` is undefined in the GET response.
+
+**No new sub-tab, no new file, no new route component.**
+
+### Step 2.7 — env-var docs
+
+`CLAUDE.md` Environment section — update the wording to mark `LLM_MAX_CONCURRENT_STREAMS_PER_USER` as deprecated fallback (matches `DEFAULT_LLM_MODEL` at `CLAUDE.md:253`):
+
+```
+- `LLM_MAX_CONCURRENT_STREAMS_PER_USER` (deprecated bootstrap fallback — configured in Settings → LLM → Runtime limits, issue #268; consulted only when the `admin_settings` row is absent; fallback-of-last-resort: `3`)
+```
+
+`.env.example`: same line as a comment.
+
+### Step 2.8 — tests
+
+#### Unit tests on the limiter module (`backend/src/core/services/sse-stream-limiter.test.ts`)
+
+```typescript
+// RED #1 — acquire=true under cap
+it('acquireStreamSlot returns acquired=true when under cap', async () => {
+  mockRedis.eval.mockResolvedValue(1);
+  const slot = await acquireStreamSlot('user-a');
+  expect(slot.acquired).toBe(true);
+});
+
+// RED #2 — acquire=false at cap
+it('acquireStreamSlot returns acquired=false when cap exceeded', async () => {
+  mockRedis.eval.mockResolvedValue(0);
+  const slot = await acquireStreamSlot('user-a');
+  expect(slot.acquired).toBe(false);
+});
+
+// RED #3 — idempotent release
+it('release() is idempotent — DECR called once', async () => {
+  mockRedis.eval.mockResolvedValue(1);
+  const slot = await acquireStreamSlot('user-a');
+  await slot.release();
+  await slot.release();
+  expect(mockRedis.decr).toHaveBeenCalledTimes(1);
+});
+
+// RED #4 — fail-open when Redis unavailable
+it('fails open when Redis is unavailable', async () => {
+  setRedisClient(null as unknown as RedisClientType);
+  const slot = await acquireStreamSlot('user-a');
+  expect(slot.acquired).toBe(true);
+  await expect(slot.release()).resolves.toBeUndefined();
+});
+
+// RED #5 — cap cascade: admin_settings present
+it('getStreamCap reads admin_settings row when present', async () => {
+  await query(
+    `INSERT INTO admin_settings (setting_key, setting_value) VALUES ($1, $2)
+     ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2`,
+    ['llm_max_concurrent_streams_per_user', '7'],
+  );
+  _resetStreamCapCache();
+  expect(await getStreamCap()).toBe(7);
+});
+
+// RED #6 — cap cascade: env fallback
+it('getStreamCap falls back to env var when admin_settings row is absent', async () => {
+  await query(`DELETE FROM admin_settings WHERE setting_key = $1`, ['llm_max_concurrent_streams_per_user']);
+  process.env.LLM_MAX_CONCURRENT_STREAMS_PER_USER = '5';
+  _resetStreamCapCache();
+  try {
+    expect(await getStreamCap()).toBe(5);
+  } finally {
+    delete process.env.LLM_MAX_CONCURRENT_STREAMS_PER_USER;
+  }
+});
+
+// RED #7 — cap cascade: hard default
+it('getStreamCap falls back to 3 when neither DB nor env set', async () => {
+  await query(`DELETE FROM admin_settings WHERE setting_key = $1`, ['llm_max_concurrent_streams_per_user']);
+  delete process.env.LLM_MAX_CONCURRENT_STREAMS_PER_USER;
+  _resetStreamCapCache();
+  expect(await getStreamCap()).toBe(3);
+});
+
+// RED #8 — Lua args use the resolved cap
+it('Lua script receives keyed counter + resolved cap + ttl', async () => {
+  await query(
+    `INSERT INTO admin_settings (setting_key, setting_value) VALUES ($1, $2)
+     ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2`,
+    ['llm_max_concurrent_streams_per_user', '9'],
+  );
+  _resetStreamCapCache();
+  mockRedis.eval.mockResolvedValue(1);
+  await acquireStreamSlot('user-a');
+  expect(mockRedis.eval).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+    keys: ['llm:streams:user-a'],
+    arguments: ['9', '3600'],
+  }));
+});
+
+// RED #9 — graceful lowering: in-flight streams survive
+it('lowering the cap does not trim in-flight streams — new opens see new cap', async () => {
+  // Simulate 4 active slots at cap=10.
+  mockRedis.eval.mockResolvedValueOnce(1).mockResolvedValueOnce(1)
+                .mockResolvedValueOnce(1).mockResolvedValueOnce(1);
+  const slots = await Promise.all([
+    acquireStreamSlot('u'), acquireStreamSlot('u'),
+    acquireStreamSlot('u'), acquireStreamSlot('u'),
+  ]);
+  expect(slots.every((s) => s.acquired)).toBe(true);
+
+  // Admin lowers cap to 2.
+  invalidateStreamCapCache();
+
+  // New open sees cap=2; Lua DECRs and returns 0.
+  mockRedis.eval.mockResolvedValueOnce(0);
+  const rejected = await acquireStreamSlot('u');
+  expect(rejected.acquired).toBe(false);
+
+  // Existing slots still release cleanly.
+  for (const s of slots) await s.release();
+  expect(mockRedis.decr).toHaveBeenCalledTimes(4);
+});
+```
+
+#### Route-level (one representative + parameterise across all six)
+
+```typescript
+// RED #10 — 4th stream returns 429
+it('POST /api/llm/ask returns 429 when user is at concurrent-stream cap', async () => {
+  mockAcquireStreamSlot.mockResolvedValue({ acquired: false, release: async () => {} });
+  const r = await app.inject({
+    method: 'POST',
+    url: '/api/llm/ask',
+    headers: { authorization: `Bearer ${userToken}` },
+    payload: { question: 'hi' },
+  });
+  expect(r.statusCode).toBe(429);
+  expect(r.json().error).toBe('too_many_concurrent_streams');
+});
+```
+
+#### Integration: disconnect decrements
+
+```typescript
+// RED #11 — client-disconnect mid-stream releases the slot
+it('client-disconnect during SSE stream releases the slot', async () => {
+  mockAcquireStreamSlot.mockResolvedValue({ acquired: true, release: mockRelease });
+  const controller = new AbortController();
+  const streamPromise = app.inject({
+    method: 'POST',
+    url: '/api/llm/ask',
+    headers: { authorization: `Bearer ${userToken}` },
+    payload: { question: 'hi' },
+  });
+  controller.abort();
+  await streamPromise;
+  expect(mockRelease).toHaveBeenCalled();
+});
+```
+
+**Manual TTL self-heal test** (PR description, not automated):
+```
+redis-cli SET llm:streams:test-user 99 EX 5
+sleep 6
+redis-cli EXISTS llm:streams:test-user   # expected: 0
+```
+
+---
+
+## 3. Rollback procedure
+
+1. `git revert <commit-sha>`.
+2. Residual Redis keys `llm:streams:*` self-clear via 1-hour TTL.
+3. `admin_settings` row: leave (harmless) or `DELETE FROM admin_settings WHERE setting_key = 'llm_max_concurrent_streams_per_user';`.
+4. Migration `056` is forward-only; no reverse migration. Orphan row has no runtime effect after the limiter module is gone.
+5. Env var unchanged.
+
+No schema DDL, no frontend-state migration.
+
+---
+
+## 4. Acceptance criteria mapped to issue body
+
+- [x] **"`LLM_MAX_CONCURRENT_STREAMS_PER_USER` env var honored (default 3)"** — deprecated fallback; hard default 3.
+- [x] **Admin-configurable via UI** — admin_settings key + Zod + GET/PUT + `LlmTab.tsx` input.
+- [x] **"Stream 4 → 429 with body"** — `error: 'too_many_concurrent_streams'`.
+- [x] **"Client disconnect decrements the counter"** — `try/finally slot.release()`.
+- [x] **"Counter auto-heals on EXPIRE"** — every acquire re-runs EXPIRE.
+- [x] **No admin override** — decision locked; no bypass anywhere.
+- [x] **Graceful lowering** — RED #9.
+- [x] **Test coverage: normal open/close, disconnect, cap cascade, lowering** — RED #1–#11.
+
+---
+
+## 5. Risks and open questions
+
+1. **Cache TTL drift (60 s).** After admin lowers the cap, other processes see it within up to 60 s (unless they also call `invalidateStreamCapCache()`). Matches `rate-limit-service`. Acceptable. Multi-process invalidation via pub/sub is out of scope.
+2. **Counter drift under Redis failover.** Rare; strictly fail-open; bounded by 1-hour TTL.
+3. **`kill -9` mid-handler.** Counter off by 1 per killed stream; self-heals in 1 hour.
+4. **Interaction with `@fastify/rate-limit`.** Rate-limit fires first; if it 429s, this gate never runs. Distinct `error` strings disambiguate.
+5. **Cap max at 20 — too low?** Zod is easy to bump. Start conservative.
+
+---
+
+## 6. Dependencies and ordering
+
+- **Hard sequencing:** none on other plans in this batch, **but** coordinate migration numbering with #264:
+  - #268 → `056_admin_settings_llm_stream_cap.sql`
+  - #264 → `057_admin_settings_denied_admin_retention.sql`
+  - Whichever lands first keeps `056`; the other bumps to `057`. Trivial swap.
+- **File conflicts:**
+  - #264 and #268 both edit `packages/contracts/src/schemas/admin.ts` (independent optional fields) — trivial textual merge for whichever lands second.
+  - #264 and #268 both edit `backend/src/routes/foundation/admin.ts` (same story — independent additions).
+  - All other plans: zero conflict.
+- **Test fixtures:** independent.
+
+---
+
+## 7. Estimated effort
+
+~4 hours. New module (~140 LoC), migration (1 file), Zod + admin-route extensions (~30 LoC), six 10-line handler edits, UI card (~50 LoC), ~11 Vitest cases.

--- a/frontend/src/features/settings/panels/LlmTab.test.tsx
+++ b/frontend/src/features/settings/panels/LlmTab.test.tsx
@@ -62,7 +62,8 @@ const assignments = {
   },
 };
 
-function mockRoutes() {
+function mockRoutes(options?: { concurrentStreamsCap?: number }) {
+  const cap = options?.concurrentStreamsCap ?? 3;
   return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init = {}) => {
     const url = typeof input === 'string' ? input : (input as URL).toString();
     if (url.endsWith('/admin/llm-providers') && (init as RequestInit).method !== 'POST') {
@@ -77,6 +78,24 @@ function mockRoutes() {
     }
     if (url.endsWith('/admin/llm-usecases') && (init as RequestInit).method === 'PUT') {
       return new Response(JSON.stringify(assignments), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.endsWith('/admin/settings') && (init as RequestInit).method !== 'PUT') {
+      return new Response(
+        JSON.stringify({
+          embeddingDimensions: 1024,
+          ftsLanguage: 'simple',
+          embeddingChunkSize: 500,
+          embeddingChunkOverlap: 50,
+          drawioEmbedUrl: null,
+          llmMaxConcurrentStreamsPerUser: cap,
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    if (url.endsWith('/admin/settings') && (init as RequestInit).method === 'PUT') {
+      return new Response(JSON.stringify({ message: 'Admin settings updated' }), {
         headers: { 'Content-Type': 'application/json' },
       });
     }
@@ -154,6 +173,89 @@ describe('LlmTab', () => {
       expect(putCall).toBeTruthy();
       const body = JSON.parse((putCall![1] as RequestInit).body as string);
       expect(body.chat.providerId).toBe(providerB.id);
+    });
+  });
+
+  // ── Runtime limits card — per-user concurrent-SSE-stream cap (#268) ──
+
+  it('renders the per-user concurrent stream cap with the server value', async () => {
+    const Wrapper = createWrapper();
+    mockRoutes({ concurrentStreamsCap: 7 });
+    render(<LlmTab />, { wrapper: Wrapper });
+
+    const input = (await screen.findByTestId(
+      'llm-max-concurrent-streams-per-user',
+    )) as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.type).toBe('number');
+    expect(input.value).toBe('7');
+    expect(input.min).toBe('1');
+    expect(input.max).toBe('20');
+  });
+
+  it('falls back to the default of 3 when the server omits the value', async () => {
+    const Wrapper = createWrapper();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.endsWith('/admin/llm-providers')) {
+        return new Response(JSON.stringify([providerA, providerB]), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/admin/llm-usecases')) {
+        return new Response(JSON.stringify(assignments), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/admin/settings')) {
+        // Server omits `llmMaxConcurrentStreamsPerUser` — UI must fall back to 3.
+        return new Response(
+          JSON.stringify({
+            embeddingDimensions: 1024,
+            ftsLanguage: 'simple',
+            embeddingChunkSize: 500,
+            embeddingChunkOverlap: 50,
+            drawioEmbedUrl: null,
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (url.endsWith('/admin/embedding/dimensions')) {
+        return new Response(JSON.stringify({ dimensions: 1024 }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify([]), { headers: { 'Content-Type': 'application/json' } });
+    });
+
+    render(<LlmTab />, { wrapper: Wrapper });
+    const input = (await screen.findByTestId(
+      'llm-max-concurrent-streams-per-user',
+    )) as HTMLInputElement;
+    expect(input.value).toBe('3');
+  });
+
+  it('PUTs the new cap to /admin/settings when Save is clicked', async () => {
+    const Wrapper = createWrapper();
+    const spy = mockRoutes({ concurrentStreamsCap: 3 });
+    render(<LlmTab />, { wrapper: Wrapper });
+
+    const input = (await screen.findByTestId(
+      'llm-max-concurrent-streams-per-user',
+    )) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '8' } });
+    fireEvent.click(screen.getByTestId('llm-runtime-limits-save'));
+
+    await waitFor(() => {
+      const putCall = spy.mock.calls.find(
+        ([url, init]) =>
+          typeof url === 'string' &&
+          url.endsWith('/admin/settings') &&
+          (init as RequestInit | undefined)?.method === 'PUT',
+      );
+      expect(putCall).toBeTruthy();
+      const body = JSON.parse((putCall![1] as RequestInit).body as string);
+      expect(body.llmMaxConcurrentStreamsPerUser).toBe(8);
     });
   });
 });

--- a/frontend/src/features/settings/panels/LlmTab.tsx
+++ b/frontend/src/features/settings/panels/LlmTab.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import type {
+  AdminSettings,
   LlmProvider,
   LlmUsecase,
   UsecaseAssignments,
@@ -14,6 +15,11 @@ import { EmbeddingReembedBanner } from './EmbeddingReembedBanner';
 import { SkeletonFormFields } from '../../../shared/components/feedback/Skeleton';
 
 const USECASES_ORDERED: LlmUsecase[] = ['chat', 'summary', 'quality', 'auto_tag', 'embedding'];
+
+/** Default when the server response omits `llmMaxConcurrentStreamsPerUser`. */
+const DEFAULT_CONCURRENT_STREAMS_CAP = 3;
+const MIN_CONCURRENT_STREAMS_CAP = 1;
+const MAX_CONCURRENT_STREAMS_CAP = 20;
 
 export function LlmTab() {
   const qc = useQueryClient();
@@ -32,14 +38,37 @@ export function LlmTab() {
     // the legacy 1024-dim default rather than blocking the tab.
     retry: false,
   });
+  // Runtime limits — only reads fields we own from the shared admin-settings
+  // document. Other fields (embedding, rate limits, AI safety) are managed
+  // elsewhere and are left untouched when we PUT.
+  const { data: adminSettings } = useQuery<AdminSettings>({
+    queryKey: ['admin-settings'],
+    queryFn: () => apiFetch('/admin/settings'),
+  });
 
   const [assignments, setAssignments] = useState<UsecaseAssignments | null>(null);
+  // Per-user concurrent SSE-stream cap (#268). Separate local state so edits
+  // to the number input don't round-trip through TanStack Query on every
+  // keystroke. Default to 3 when the server omits the field.
+  const [concurrentStreamsCap, setConcurrentStreamsCap] = useState<number>(
+    DEFAULT_CONCURRENT_STREAMS_CAP,
+  );
 
   // Mirror the server-provided assignments once per load. Using useEffect
   // keeps the setState out of render (avoids an infinite update loop).
   useEffect(() => {
     if (rawAssignments) setAssignments(rawAssignments);
   }, [rawAssignments]);
+
+  // Mirror the server-provided concurrent-streams cap. Falls back to 3 when
+  // the field is absent (legacy backend that has not yet been migrated).
+  useEffect(() => {
+    if (adminSettings) {
+      setConcurrentStreamsCap(
+        adminSettings.llmMaxConcurrentStreamsPerUser ?? DEFAULT_CONCURRENT_STREAMS_CAP,
+      );
+    }
+  }, [adminSettings]);
 
   const embeddingPending = useMemo(() => {
     if (!rawAssignments || !assignments) return null;
@@ -62,6 +91,23 @@ export function LlmTab() {
     onError: (e: Error) => toast.error(e.message),
   });
 
+  // Runtime-limits mutation is deliberately separate from the use-case save
+  // so admins can update concurrency without implicitly re-applying other
+  // in-flight edits.
+  const saveRuntimeLimits = useMutation({
+    mutationFn: (body: { llmMaxConcurrentStreamsPerUser: number }) =>
+      apiFetch('/admin/settings', { method: 'PUT', body: JSON.stringify(body) }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['admin-settings'] });
+      toast.success('Runtime limits updated (takes effect within 60 seconds)');
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const currentCapOnServer =
+    adminSettings?.llmMaxConcurrentStreamsPerUser ?? DEFAULT_CONCURRENT_STREAMS_CAP;
+  const runtimeLimitsDirty = concurrentStreamsCap !== currentCapOnServer;
+
   if (assignmentsLoading || !assignments || !rawAssignments) {
     return <SkeletonFormFields />;
   }
@@ -74,6 +120,15 @@ export function LlmTab() {
       return;
     }
     save.mutate(diff);
+  }
+
+  function handleSaveRuntimeLimits() {
+    // Clamp before sending so browsers that ignore min/max don't trip Zod 400s.
+    const clamped = Math.max(
+      MIN_CONCURRENT_STREAMS_CAP,
+      Math.min(MAX_CONCURRENT_STREAMS_CAP, concurrentStreamsCap),
+    );
+    saveRuntimeLimits.mutate({ llmMaxConcurrentStreamsPerUser: clamped });
   }
 
   return (
@@ -99,6 +154,63 @@ export function LlmTab() {
         >
           {save.isPending ? 'Saving…' : 'Save use-case assignments'}
         </button>
+      </div>
+
+      {/* Runtime limits — per-user concurrent-SSE-stream cap (#268) */}
+      <div className="glass-card space-y-4 p-4">
+        <div>
+          <h3 className="text-base font-semibold">Runtime limits</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Bounds on how AI streams are served. Changes take effect within 60 seconds.
+          </p>
+        </div>
+        <div className="rounded-lg border border-border/30 bg-background/50 p-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <label
+                htmlFor="llm-max-concurrent-streams-per-user"
+                className="text-sm font-medium"
+              >
+                Max concurrent AI streams per user
+              </label>
+              <p className="text-xs text-muted-foreground">
+                Rejects additional streams with HTTP 429 once a user has this many open. Lowering
+                the cap takes effect for newly opened streams; in-flight streams continue to
+                completion.
+              </p>
+            </div>
+            <input
+              id="llm-max-concurrent-streams-per-user"
+              data-testid="llm-max-concurrent-streams-per-user"
+              type="number"
+              min={MIN_CONCURRENT_STREAMS_CAP}
+              max={MAX_CONCURRENT_STREAMS_CAP}
+              value={concurrentStreamsCap}
+              onChange={(e) => {
+                const v = parseInt(e.target.value, 10);
+                if (Number.isFinite(v)) {
+                  setConcurrentStreamsCap(
+                    Math.max(
+                      MIN_CONCURRENT_STREAMS_CAP,
+                      Math.min(MAX_CONCURRENT_STREAMS_CAP, v),
+                    ),
+                  );
+                }
+              }}
+              className="w-24 rounded-lg border border-border/40 bg-background/50 px-3 py-1.5 text-right text-sm outline-none focus:ring-1 focus:ring-primary/30"
+            />
+          </div>
+        </div>
+        <div className="flex gap-3">
+          <button
+            data-testid="llm-runtime-limits-save"
+            className="glass-button-primary"
+            disabled={!runtimeLimitsDirty || saveRuntimeLimits.isPending}
+            onClick={handleSaveRuntimeLimits}
+          >
+            {saveRuntimeLimits.isPending ? 'Saving…' : 'Save runtime limits'}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/packages/contracts/src/schemas/admin.ts
+++ b/packages/contracts/src/schemas/admin.ts
@@ -46,6 +46,9 @@ export const AdminSettingsSchema = z.object({
    * Default 150, clamped to [10, 10000].
    */
   reembedHistoryRetention: z.number().int().min(10).max(10_000),
+  // Per-user concurrent SSE-stream cap (#268). Separate from rateLimitLlmStream:
+  // that caps requests/minute; this caps concurrently-open streams.
+  llmMaxConcurrentStreamsPerUser: z.number().int().min(1).max(20).optional(),
 });
 
 export const UpdateAdminSettingsSchema = z.object({
@@ -72,6 +75,8 @@ export const UpdateAdminSettingsSchema = z.object({
   rateLimitLlmEmbedding: z.number().int().min(1).max(1000).optional(),
   /** Issue #257 — optional on update; omitted → leave unchanged. */
   reembedHistoryRetention: z.number().int().min(10).max(10_000).optional(),
+  // Per-user concurrent SSE-stream cap (#268).
+  llmMaxConcurrentStreamsPerUser: z.number().int().min(1).max(20).optional(),
 });
 
 export type AdminSettings = z.infer<typeof AdminSettingsSchema>;


### PR DESCRIPTION
## Summary

Prevents a single user from saturating the upstream LLM by opening many concurrent SSE streams. Redis counter, Lua-backed atomic acquire, admin-configurable cap, default 3.

Closes #268.

## What ships

- **`sse-stream-limiter` service** in `core/services/` — `acquire(userId) → { allowed, current, cap, slot }`, `slot.release()` idempotent. Lua script does `INCR + EXPIRE + cap-check` in one round trip (fails open if Redis is null or throws).
- **Admin setting `llm_max_concurrent_streams_per_user`** (integer, default 3, min 1, max 20). Migration **056**, Zod schema update, GET/PUT wiring. Cascade: `admin_settings` → env `LLM_MAX_CONCURRENT_STREAMS_PER_USER` → hard default 3. 60s TTL cache.
- **No admin bypass** — admins share the same cap. Env var demoted to deprecated bootstrap fallback.
- **Graceful lowering** — if cap is lowered while someone holds N > new-cap streams, in-flight streams run to completion; new opens see the new cap.
- **SSE lifecycle integration** — wrapped 6 streaming routes (`llm-ask`, `llm-generate`, `llm-improve`, `llm-summarize`, `llm-quality`, `llm-diagram`). `release()` fires on success, error, timeout (AbortError), and client disconnect (`request.raw.on('close', …)` path).
- **429 response** when cap exceeded: `{ error: 'ConcurrentStreamLimitExceeded', message, retryable: true }`.
- **UI** — new "Runtime limits" card in `LlmTab.tsx` with its own Save button (decoupled from use-case assignment Save to avoid implicit commits).

## Plan reference

`docs/issues/268-implementation-plan.md` (also on `docs/plans-263-269`).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1959 backend + 1809 frontend = 3768 passing
- [x] ~61 new tests across limiter service, migration, admin route, 6-route SSE gate (30 tests = 6 × 5 properties), frontend panel
- [x] Release-on-disconnect verified (AbortError path — same mechanism `request.raw.on('close', …)` uses)

## Migration coordination

Allocated `056`. `055` = `reembed_history_retention` (PR #261). `057` reserved for #264.

## Deviations

- `getStreamCap()` silently keeps the hard default when `admin_settings` holds an out-of-range value instead of falling through to env. Zod prevents this via the UI; pure defence-in-depth.
- Runtime-limits card has its own Save button, not riding the use-case Save — different target endpoint, avoids implicit commits.
- Added `_resetStreamCapCache()` for test isolation (in-module 60s cache would leak state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)