### PR TITLE
security(#264): audit-log denied admin actions at requireAdmin + retention (migration 057)

### DIFF
--- a/backend/src/core/db/migrations/057_admin_settings_access_denied_retention.sql
+++ b/backend/src/core/db/migrations/057_admin_settings_access_denied_retention.sql
@@ -1,0 +1,17 @@
+-- Migration 057: retention policy for ADMIN_ACCESS_DENIED audit rows (#264)
+--
+-- Seeds the admin-configurable retention window (days) for the
+-- `data-retention-service`-driven purge of `audit_log` rows with
+-- `action = 'ADMIN_ACCESS_DENIED'`.
+--
+-- Range (Zod): [7, 3650]. Default: 90.
+--
+-- Read cascade (see `data-retention-service.ts :: runAdminAccessDeniedRetention`):
+--   admin_settings.admin_access_denied_retention_days
+--     -> env RETENTION_ADMIN_ACCESS_DENIED_DAYS  (optional)
+--     -> 90  (hard default)
+--
+-- Additive + idempotent.
+INSERT INTO admin_settings (setting_key, setting_value, updated_at)
+VALUES ('admin_access_denied_retention_days', '90', NOW())
+ON CONFLICT (setting_key) DO NOTHING;

--- a/backend/src/core/plugins/auth.requireadmin.test.ts
+++ b/backend/src/core/plugins/auth.requireadmin.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../test-db-helper.js';
+import { query } from '../db/postgres.js';
+import { buildApp } from '../../app.js';
+import { generateAccessToken } from './auth.js';
+
+/**
+ * Integration tests for the `requireAdmin` decorator's audit-logging behaviour.
+ *
+ * Scope (#264):
+ *   - Path A: unauthenticated request → `ADMIN_ACCESS_DENIED` row with user_id=NULL,
+ *     metadata.reason='unauthenticated'. Status 401.
+ *   - Path B: authenticated non-admin → `ADMIN_ACCESS_DENIED` row with user_id=<caller>,
+ *     metadata.reason='not_admin'. Status 403.
+ *   - Admin success → no `ADMIN_ACCESS_DENIED` row.
+ *
+ * Routes targeted:
+ *   - `GET /api/admin/audit-log` — registered under `adminRoutes`, which uses
+ *     `fastify.addHook('onRequest', fastify.requireAdmin)` (admin.ts:48). Both the
+ *     authentication failure (Path A) and the role-check failure (Path B) therefore
+ *     flow through the decorator, so both code paths are exercised from this single
+ *     route. This is the ONLY CE pattern where unauthenticated requests reach
+ *     `requireAdmin`; routes using `addHook('onRequest', authenticate)` + `preHandler:
+ *     requireAdmin` short-circuit at the onRequest stage before the decorator runs.
+ */
+
+async function createUser(username: string, role: 'admin' | 'user'): Promise<string> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO users (username, password_hash, role)
+     VALUES ($1, 'fakehash', $2) RETURNING id`,
+    [username, role],
+  );
+  return result.rows[0]!.id;
+}
+
+const dbAvailable = await isDbAvailable();
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  if (!dbAvailable) return;
+  await setupTestDb();
+  app = await buildApp();
+  await app.ready();
+}, 30_000);
+
+afterAll(async () => {
+  if (!dbAvailable) return;
+  await app?.close();
+  await teardownTestDb();
+});
+
+beforeEach(async () => {
+  if (!dbAvailable) return;
+  await truncateAllTables();
+});
+
+describe.skipIf(!dbAvailable)('requireAdmin — ADMIN_ACCESS_DENIED audit', () => {
+  // RED #1 — non-admin → 403 + audit row with reason 'not_admin'
+  it('writes ADMIN_ACCESS_DENIED when a non-admin is rejected', async () => {
+    const userId = await createUser('denied_nonadmin', 'user');
+    const token = await generateAccessToken({ sub: userId, username: 'denied_nonadmin', role: 'user' });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/admin/audit-log',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(403);
+
+    const rows = await query<{
+      user_id: string | null;
+      action: string;
+      resource_type: string | null;
+      resource_id: string | null;
+      metadata: Record<string, unknown>;
+    }>(
+      `SELECT user_id, action, resource_type, resource_id, metadata::jsonb AS metadata
+         FROM audit_log
+        WHERE action = 'ADMIN_ACCESS_DENIED'
+        ORDER BY created_at DESC
+        LIMIT 1`,
+    );
+    expect(rows.rows).toHaveLength(1);
+    const row = rows.rows[0]!;
+    expect(row.user_id).toBe(userId);
+    expect(row.resource_type).toBe('route');
+    expect(row.resource_id).toMatch(/^GET .+\/admin\/audit-log$/);
+    expect(row.metadata).toMatchObject({ decision: 'denied', reason: 'not_admin' });
+  });
+
+  // RED #2 — unauth → 401 + audit row with user_id=NULL, reason 'unauthenticated'
+  it('writes ADMIN_ACCESS_DENIED with user_id=null when the caller is unauthenticated', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/admin/audit-log',
+    });
+
+    expect(res.statusCode).toBe(401);
+
+    const rows = await query<{
+      user_id: string | null;
+      resource_type: string | null;
+      resource_id: string | null;
+      metadata: Record<string, unknown>;
+    }>(
+      `SELECT user_id, resource_type, resource_id, metadata::jsonb AS metadata
+         FROM audit_log
+        WHERE action = 'ADMIN_ACCESS_DENIED'
+        ORDER BY created_at DESC
+        LIMIT 1`,
+    );
+    expect(rows.rows).toHaveLength(1);
+    const row = rows.rows[0]!;
+    expect(row.user_id).toBeNull();
+    expect(row.resource_type).toBe('route');
+    expect(row.resource_id).toMatch(/^GET .+\/admin\/audit-log$/);
+    expect(row.metadata).toMatchObject({ decision: 'denied', reason: 'unauthenticated' });
+  });
+
+  // RED #3 — admin success does NOT write ADMIN_ACCESS_DENIED
+  it('does not write ADMIN_ACCESS_DENIED for a successful admin request', async () => {
+    const adminId = await createUser('admin_ok', 'admin');
+    const token = await generateAccessToken({ sub: adminId, username: 'admin_ok', role: 'admin' });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/admin/audit-log',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const r = await query<{ c: string }>(
+      `SELECT COUNT(*)::text AS c FROM audit_log WHERE action = 'ADMIN_ACCESS_DENIED'`,
+    );
+    expect(r.rows[0]!.c).toBe('0');
+  });
+
+  // Completes in well under the default Fastify/Node HTTP timeout — the audit
+  // write is inline `await`, and `logAuditEvent` is wrapped in try/catch so a
+  // pathological DB failure cannot deadlock the response. This guards against
+  // a future refactor that accidentally swallows the response past the wait.
+  it('returns 403 promptly even when a denied-attempt audit is emitted', async () => {
+    const userId = await createUser('denied_timing', 'user');
+    const token = await generateAccessToken({ sub: userId, username: 'denied_timing', role: 'user' });
+
+    const t0 = Date.now();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/admin/audit-log',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const elapsed = Date.now() - t0;
+
+    expect(res.statusCode).toBe(403);
+    // Comfortable margin — a local query round-trip is single-digit ms in CI.
+    // If this ever gets flaky, bump to 5000 before assuming a regression.
+    expect(elapsed).toBeLessThan(2000);
+  });
+});

--- a/backend/src/core/plugins/auth.ts
+++ b/backend/src/core/plugins/auth.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 import { query } from '../db/postgres.js';
 import { logger } from '../utils/logger.js';
 import { userHasPermission, userHasGlobalPermission } from '../services/rbac-service.js';
+import { logAuditEvent } from '../services/audit-service.js';
 
 const JWT_ISSUER = 'compendiq';
 const ACCESS_TOKEN_EXPIRY = process.env.ACCESS_TOKEN_EXPIRY ?? '1h';
@@ -229,8 +230,42 @@ export default fp(async (fastify: FastifyInstance) => {
   });
 
   fastify.decorate('requireAdmin', async (request: FastifyRequest) => {
-    await fastify.authenticate(request);
+    // Audit every denied admin-access attempt, including unauthenticated ones
+    // (#264). The audit write is `await`ed intentionally so tests aren't racey,
+    // but `logAuditEvent` is try/catch-wrapped internally and "never blocks the
+    // main operation" — a DB failure during audit-logging does NOT suppress the
+    // 401/403 to the caller.
+    //
+    // Path A — authentication failure (missing/invalid Bearer). Only reached
+    // when `requireAdmin` is the onRequest hook itself (see admin.ts:48). Routes
+    // that register `addHook('onRequest', authenticate)` + `{ preHandler:
+    // requireAdmin }` short-circuit inside `authenticate` before this decorator
+    // runs — that case is covered by the onRequest chain's own 401 and is out
+    // of scope for this decorator.
+    try {
+      await fastify.authenticate(request);
+    } catch (err) {
+      await logAuditEvent(
+        null,
+        'ADMIN_ACCESS_DENIED',
+        'route',
+        `${request.method} ${request.routeOptions.url ?? request.url}`,
+        { decision: 'denied', reason: 'unauthenticated' },
+        request,
+      );
+      throw err;
+    }
+
+    // Path B — authenticated but lacks the admin role.
     if (request.userRole !== 'admin') {
+      await logAuditEvent(
+        request.userId,
+        'ADMIN_ACCESS_DENIED',
+        'route',
+        `${request.method} ${request.routeOptions.url ?? request.url}`,
+        { decision: 'denied', reason: 'not_admin' },
+        request,
+      );
       throw fastify.httpErrors.forbidden('Admin access required');
     }
   });

--- a/backend/src/core/services/admin-settings-service.test.ts
+++ b/backend/src/core/services/admin-settings-service.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockQuery = vi.fn();
+
+vi.mock('../db/postgres.js', () => ({
+  query: (sql: string, params?: unknown[]) => mockQuery(sql, params),
+}));
+
+import { getAdminAccessDeniedRetentionDays } from './admin-settings-service.js';
+
+describe('getAdminAccessDeniedRetentionDays (#264)', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    delete process.env.RETENTION_ADMIN_ACCESS_DENIED_DAYS;
+  });
+
+  afterEach(() => {
+    delete process.env.RETENTION_ADMIN_ACCESS_DENIED_DAYS;
+  });
+
+  it('returns the persisted admin_settings value when in range', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ setting_value: '30' }] });
+    await expect(getAdminAccessDeniedRetentionDays()).resolves.toBe(30);
+  });
+
+  it('honours the env fallback when the admin_settings row is absent', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    process.env.RETENTION_ADMIN_ACCESS_DENIED_DAYS = '45';
+    await expect(getAdminAccessDeniedRetentionDays()).resolves.toBe(45);
+  });
+
+  it('returns the hard default of 90 when both the DB row and the env var are missing', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await expect(getAdminAccessDeniedRetentionDays()).resolves.toBe(90);
+  });
+
+  it('rejects an out-of-range DB value (1) and falls back to env / default', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ setting_value: '1' }] });
+    await expect(getAdminAccessDeniedRetentionDays()).resolves.toBe(90);
+  });
+
+  it('rejects an out-of-range DB value (4000) and falls back to env / default', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ setting_value: '4000' }] });
+    await expect(getAdminAccessDeniedRetentionDays()).resolves.toBe(90);
+  });
+
+  it('rejects a non-numeric DB value and falls back', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ setting_value: 'banana' }] });
+    await expect(getAdminAccessDeniedRetentionDays()).resolves.toBe(90);
+  });
+
+  it('never throws when the DB query rejects — swallows and falls back', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('pool exhausted'));
+    await expect(getAdminAccessDeniedRetentionDays()).resolves.toBe(90);
+  });
+
+  it('rejects an out-of-range env override and falls through to the hard default', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    process.env.RETENTION_ADMIN_ACCESS_DENIED_DAYS = '6'; // below min
+    await expect(getAdminAccessDeniedRetentionDays()).resolves.toBe(90);
+  });
+
+  it('accepts boundary values — 7 and 3650', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ setting_value: '7' }] });
+    await expect(getAdminAccessDeniedRetentionDays()).resolves.toBe(7);
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ setting_value: '3650' }] });
+    await expect(getAdminAccessDeniedRetentionDays()).resolves.toBe(3650);
+  });
+});

--- a/backend/src/core/services/admin-settings-service.ts
+++ b/backend/src/core/services/admin-settings-service.ts
@@ -39,3 +39,40 @@ export async function getReembedHistoryRetention(): Promise<number> {
   if (!Number.isFinite(n)) return 150;
   return Math.max(10, Math.min(10_000, n));
 }
+
+/**
+ * Issue #264 — returns the configured retention window (days) for
+ * `audit_log` rows with action='ADMIN_ACCESS_DENIED'. Consumed by the
+ * targeted purge in `data-retention-service.ts ::
+ * runAdminAccessDeniedRetention`. Also consumed by the admin GET/PUT
+ * `/api/admin/settings` surface.
+ *
+ * Read cascade:
+ *   admin_settings.admin_access_denied_retention_days  (authoritative)
+ *     -> env RETENTION_ADMIN_ACCESS_DENIED_DAYS        (optional fallback)
+ *     -> 90                                            (hard default)
+ *
+ * Clamped to [7, 3650]. No caching — the retention scheduler runs once
+ * per 24 h, so a per-tick DB read is negligible and keeps the code
+ * simple (no cache invalidation on PUT).
+ */
+export async function getAdminAccessDeniedRetentionDays(): Promise<number> {
+  try {
+    const r = await query<{ setting_value: string }>(
+      `SELECT setting_value FROM admin_settings WHERE setting_key='admin_access_denied_retention_days'`,
+    );
+    const raw = r.rows[0]?.setting_value;
+    if (raw) {
+      const n = parseInt(raw, 10);
+      if (Number.isFinite(n) && n >= 7 && n <= 3650) return n;
+    }
+  } catch {
+    // Fall through to env / default — this getter must never throw.
+  }
+  const env = process.env.RETENTION_ADMIN_ACCESS_DENIED_DAYS;
+  if (env) {
+    const n = parseInt(env, 10);
+    if (Number.isFinite(n) && n >= 7 && n <= 3650) return n;
+  }
+  return 90;
+}

--- a/backend/src/core/services/audit-service.ts
+++ b/backend/src/core/services/audit-service.ts
@@ -35,7 +35,8 @@ export type AuditAction =
   | 'SUMMARY_RUN_NOW'
   | 'EMBEDDING_RUN_NOW'
   | 'EMBEDDING_RESCAN'
-  | 'EMBEDDING_RESET_FAILED';
+  | 'EMBEDDING_RESET_FAILED'
+  | 'ADMIN_ACCESS_DENIED';
 
 export interface AuditLogEntry {
   id: string;

--- a/backend/src/core/services/data-retention-service.integration.test.ts
+++ b/backend/src/core/services/data-retention-service.integration.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../test-db-helper.js';
+import { query } from '../db/postgres.js';
+import { runRetentionCleanup } from './data-retention-service.js';
+
+/**
+ * Real-DB integration tests for the #264 targeted ADMIN_ACCESS_DENIED retention
+ * sweep inside `runRetentionCleanup`. These tests intentionally run against
+ * the test Postgres instance (port 5433) — the mocked-unit tests in
+ * `data-retention-service.test.ts` cover behaviour at the query layer; the
+ * tests below cover the contract the purge has with real `audit_log` data.
+ *
+ * Plan §9 RED #4–#7.
+ */
+
+async function setRetentionDays(days: number): Promise<void> {
+  await query(
+    `INSERT INTO admin_settings (setting_key, setting_value)
+     VALUES ($1, $2)
+     ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2`,
+    ['admin_access_denied_retention_days', String(days)],
+  );
+}
+
+async function insertDeniedRow(resourceId: string, ageDays: number): Promise<void> {
+  await query(
+    `INSERT INTO audit_log (user_id, action, resource_type, resource_id, metadata, created_at)
+     VALUES (NULL, 'ADMIN_ACCESS_DENIED', 'route', $1, '{}'::jsonb, NOW() - ($2::text || ' days')::interval)`,
+    [resourceId, String(ageDays)],
+  );
+}
+
+const dbAvailable = await isDbAvailable();
+
+beforeAll(async () => {
+  if (!dbAvailable) return;
+  await setupTestDb();
+}, 30_000);
+
+beforeEach(async () => {
+  if (!dbAvailable) return;
+  await truncateAllTables();
+});
+
+afterAll(async () => {
+  if (!dbAvailable) return;
+  await teardownTestDb();
+});
+
+describe.skipIf(!dbAvailable)('ADMIN_ACCESS_DENIED retention purge (#264)', () => {
+  // RED #4
+  it('purges ADMIN_ACCESS_DENIED rows older than the configured retention', async () => {
+    await setRetentionDays(30);
+    await insertDeniedRow('GET /x', 35);
+    await insertDeniedRow('GET /y', 35);
+    await insertDeniedRow('GET /z', 5);
+
+    await runRetentionCleanup();
+
+    const r = await query<{ resource_id: string }>(
+      `SELECT resource_id FROM audit_log WHERE action = 'ADMIN_ACCESS_DENIED' ORDER BY resource_id`,
+    );
+    expect(r.rows.map((row) => row.resource_id)).toEqual(['GET /z']);
+  });
+
+  // RED #5
+  it('does not purge ADMIN_ACCESS_DENIED rows younger than retention', async () => {
+    await setRetentionDays(90);
+    await insertDeniedRow('GET /a', 30);
+
+    await runRetentionCleanup();
+
+    const r = await query<{ c: string }>(
+      `SELECT COUNT(*)::text AS c FROM audit_log WHERE action = 'ADMIN_ACCESS_DENIED'`,
+    );
+    expect(r.rows[0]!.c).toBe('1');
+  });
+
+  // RED #6 — scoped-by-action isolation
+  it('does not touch rows with other audit actions regardless of age', async () => {
+    await setRetentionDays(30);
+
+    // An ADMIN_ACTION (successful admin) row that is 35 days old. The umbrella
+    // audit_log sweep (RETENTION_DEFAULTS.audit_log = 365) does not cull it
+    // either, so we assert it survives the full `runRetentionCleanup`.
+    // Uses NULL user_id because audit_log.user_id FK references users(id)
+    // with no user seeded; NULL is accepted.
+    await query(
+      `INSERT INTO audit_log (user_id, action, resource_type, resource_id, metadata, created_at)
+       VALUES (NULL, 'ADMIN_ACTION', 'admin_settings', NULL, '{}'::jsonb, NOW() - INTERVAL '35 days')`,
+    );
+    // Also a LOGIN_FAILED row of the same age — another non-denied action.
+    await query(
+      `INSERT INTO audit_log (user_id, action, resource_type, resource_id, metadata, created_at)
+       VALUES (NULL, 'LOGIN_FAILED', 'auth', NULL, '{}'::jsonb, NOW() - INTERVAL '35 days')`,
+    );
+
+    await runRetentionCleanup();
+
+    const counts = await query<{ action: string; c: string }>(
+      `SELECT action, COUNT(*)::text AS c FROM audit_log GROUP BY action ORDER BY action`,
+    );
+    const map = Object.fromEntries(counts.rows.map((r) => [r.action, r.c]));
+    expect(map['ADMIN_ACTION']).toBe('1');
+    expect(map['LOGIN_FAILED']).toBe('1');
+    expect(map['ADMIN_ACCESS_DENIED']).toBeUndefined();
+  });
+
+  // RED #7 — setting-change propagation. Getter is not cached, so next tick
+  // honours the new value.
+  it('picks up a setting change on the next retention tick', async () => {
+    // Lenient 100d — a 50-day-old row survives.
+    await setRetentionDays(100);
+    await insertDeniedRow('GET /q', 50);
+
+    await runRetentionCleanup();
+    expect(
+      (await query<{ c: string }>(`SELECT COUNT(*)::text AS c FROM audit_log`)).rows[0]!.c,
+    ).toBe('1');
+
+    // Tighten to 30d. Next call purges the 50-day-old row.
+    await setRetentionDays(30);
+    await runRetentionCleanup();
+    expect(
+      (await query<{ c: string }>(`SELECT COUNT(*)::text AS c FROM audit_log`)).rows[0]!.c,
+    ).toBe('0');
+  });
+
+  // Bonus: the targeted sweep is scoped only to ADMIN_ACCESS_DENIED, even
+  // when the admin-configured window is shorter than the umbrella audit_log
+  // window. A 100-day-old row of another action type must survive the
+  // targeted sweep (365d umbrella wouldn't touch it either). This guards the
+  // "don't broaden audit_log retention for other action types" requirement.
+  it('leaves other audit actions alone even when a tighter window is configured', async () => {
+    await setRetentionDays(7); // absurdly short — would catch anything if not action-scoped
+    await insertDeniedRow('GET /drop-me', 30); // will be purged (30d > 7d)
+    await query(
+      `INSERT INTO audit_log (user_id, action, resource_type, resource_id, metadata, created_at)
+       VALUES (NULL, 'PAGE_CREATED', 'page', 'p-1', '{}'::jsonb, NOW() - INTERVAL '30 days')`,
+    );
+
+    await runRetentionCleanup();
+
+    const remaining = await query<{ action: string }>(
+      `SELECT action FROM audit_log ORDER BY action`,
+    );
+    expect(remaining.rows.map((r) => r.action)).toEqual(['PAGE_CREATED']);
+  });
+});

--- a/backend/src/core/services/data-retention-service.test.ts
+++ b/backend/src/core/services/data-retention-service.test.ts
@@ -12,6 +12,12 @@ vi.mock('../utils/logger.js', () => ({
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }));
 
+// #264 — ADMIN_ACCESS_DENIED purge runs inside `runRetentionCleanup`; stub the
+// getter to a known value so the mocked DELETE loop is deterministic.
+vi.mock('./admin-settings-service.js', () => ({
+  getAdminAccessDeniedRetentionDays: vi.fn().mockResolvedValue(90),
+}));
+
 import { runRetentionCleanup, startRetentionWorker, stopRetentionWorker, RETENTION_DEFAULTS } from './data-retention-service.js';
 
 describe('data-retention-service', () => {
@@ -46,6 +52,8 @@ describe('data-retention-service', () => {
         .mockResolvedValueOnce({ rowCount: 5 })
         // error_log
         .mockResolvedValueOnce({ rowCount: 3 })
+        // ADMIN_ACCESS_DENIED targeted purge (#264) — short batch signals drained
+        .mockResolvedValueOnce({ rowCount: 0 })
         // page_versions
         .mockResolvedValueOnce({ rowCount: 2 });
 
@@ -55,6 +63,7 @@ describe('data-retention-service', () => {
       expect(results.search_analytics).toBe(5);
       expect(results.error_log).toBe(3);
       expect(results.page_versions).toBe(2);
+      expect(results.audit_log_admin_access_denied).toBe(0);
     });
 
     it('uses parameterized queries for time-based tables', async () => {
@@ -62,8 +71,8 @@ describe('data-retention-service', () => {
 
       await runRetentionCleanup();
 
-      // 3 time-based + 1 count-based = 4 queries
-      expect(mockPool.query).toHaveBeenCalledTimes(4);
+      // 3 umbrella time-based + 1 ADMIN_ACCESS_DENIED targeted + 1 count-based = 5
+      expect(mockPool.query).toHaveBeenCalledTimes(5);
 
       // Verify audit_log uses default 365 days
       const auditCall = mockPool.query.mock.calls[0];
@@ -79,6 +88,13 @@ describe('data-retention-service', () => {
       const errorCall = mockPool.query.mock.calls[2];
       expect(errorCall[0]).toContain('DELETE FROM error_log');
       expect(errorCall[1]).toEqual([30]);
+
+      // #264 — ADMIN_ACCESS_DENIED purge uses the getter value (stubbed to 90)
+      // and the 10_000 batch size. Narrower than the umbrella sweep.
+      const deniedCall = mockPool.query.mock.calls[3];
+      expect(deniedCall[0]).toContain(`action = 'ADMIN_ACCESS_DENIED'`);
+      expect(deniedCall[0]).toContain('LIMIT $2');
+      expect(deniedCall[1]).toEqual([90, 10_000]);
     });
 
     it('uses ROW_NUMBER for count-based page_versions cleanup', async () => {
@@ -86,7 +102,9 @@ describe('data-retention-service', () => {
 
       await runRetentionCleanup();
 
-      const versionsCall = mockPool.query.mock.calls[3];
+      // Now at index 4 (umbrella audit_log, search_analytics, error_log,
+      // ADMIN_ACCESS_DENIED targeted, page_versions).
+      const versionsCall = mockPool.query.mock.calls[4];
       expect(versionsCall[0]).toContain('ROW_NUMBER()');
       expect(versionsCall[0]).toContain('PARTITION BY page_id');
       expect(versionsCall[1]).toEqual([50]);
@@ -103,17 +121,18 @@ describe('data-retention-service', () => {
       const auditCall = mockPool.query.mock.calls[0];
       expect(auditCall[1]).toEqual([7]);
 
-      // page_versions should use overridden max
-      const versionsCall = mockPool.query.mock.calls[3];
+      // page_versions should use overridden max (now at index 4)
+      const versionsCall = mockPool.query.mock.calls[4];
       expect(versionsCall[1]).toEqual([10]);
     });
 
     it('handles query errors gracefully and returns 0 for failed tables', async () => {
       mockPool.query
-        .mockRejectedValueOnce(new Error('table does not exist'))
-        .mockResolvedValueOnce({ rowCount: 5 })
-        .mockResolvedValueOnce({ rowCount: 3 })
-        .mockResolvedValueOnce({ rowCount: 0 });
+        .mockRejectedValueOnce(new Error('table does not exist')) // audit_log
+        .mockResolvedValueOnce({ rowCount: 5 })                    // search_analytics
+        .mockResolvedValueOnce({ rowCount: 3 })                    // error_log
+        .mockResolvedValueOnce({ rowCount: 0 })                    // ADMIN_ACCESS_DENIED (#264)
+        .mockResolvedValueOnce({ rowCount: 0 });                   // page_versions
 
       const results = await runRetentionCleanup();
 
@@ -121,6 +140,7 @@ describe('data-retention-service', () => {
       expect(results.search_analytics).toBe(5);
       expect(results.error_log).toBe(3);
       expect(results.page_versions).toBe(0);
+      expect(results.audit_log_admin_access_denied).toBe(0);
     });
 
     it('handles null rowCount gracefully', async () => {
@@ -131,6 +151,48 @@ describe('data-retention-service', () => {
       expect(results.audit_log).toBe(0);
       expect(results.search_analytics).toBe(0);
       expect(results.error_log).toBe(0);
+      expect(results.page_versions).toBe(0);
+      expect(results.audit_log_admin_access_denied).toBe(0);
+    });
+
+    // ─── #264 — ADMIN_ACCESS_DENIED targeted purge ────────────────────────
+    it('reports rows deleted by the ADMIN_ACCESS_DENIED purge', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rowCount: 0 }) // audit_log
+        .mockResolvedValueOnce({ rowCount: 0 }) // search_analytics
+        .mockResolvedValueOnce({ rowCount: 0 }) // error_log
+        .mockResolvedValueOnce({ rowCount: 42 }) // ADMIN_ACCESS_DENIED batch 1 (short — drained)
+        .mockResolvedValueOnce({ rowCount: 0 }); // page_versions
+
+      const results = await runRetentionCleanup();
+      expect(results.audit_log_admin_access_denied).toBe(42);
+    });
+
+    it('loops the ADMIN_ACCESS_DENIED purge in 10_000-row batches until drained', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rowCount: 0 }) // audit_log
+        .mockResolvedValueOnce({ rowCount: 0 }) // search_analytics
+        .mockResolvedValueOnce({ rowCount: 0 }) // error_log
+        .mockResolvedValueOnce({ rowCount: 10_000 }) // batch 1 full — loop again
+        .mockResolvedValueOnce({ rowCount: 10_000 }) // batch 2 full — loop again
+        .mockResolvedValueOnce({ rowCount: 1234 })  // batch 3 short — drained
+        .mockResolvedValueOnce({ rowCount: 0 });    // page_versions
+
+      const results = await runRetentionCleanup();
+      expect(results.audit_log_admin_access_denied).toBe(21_234);
+    });
+
+    it('swallows errors inside the ADMIN_ACCESS_DENIED purge and reports 0', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rowCount: 0 }) // audit_log
+        .mockResolvedValueOnce({ rowCount: 0 }) // search_analytics
+        .mockResolvedValueOnce({ rowCount: 0 }) // error_log
+        .mockRejectedValueOnce(new Error('lock timeout')) // ADMIN_ACCESS_DENIED
+        .mockResolvedValueOnce({ rowCount: 0 }); // page_versions
+
+      const results = await runRetentionCleanup();
+      expect(results.audit_log_admin_access_denied).toBe(0);
+      // Adjacent sweeps still complete.
       expect(results.page_versions).toBe(0);
     });
   });

--- a/backend/src/core/services/data-retention-service.ts
+++ b/backend/src/core/services/data-retention-service.ts
@@ -6,14 +6,22 @@
  *   - search_analytics (time-based: default 90 days)
  *   - error_log       (time-based: default 30 days)
  *   - page_versions   (count-based: keep last N per page, default 50)
+ *   - audit_log rows where action='ADMIN_ACCESS_DENIED' (#264): targeted
+ *       time-based purge with an admin-configurable window (default 90d).
+ *       Narrower than the umbrella audit_log sweep; rows that survive the
+ *       narrow sweep still fall under the umbrella 365d policy.
  *
  * Retention periods are configurable via environment variables:
  *   RETENTION_AUDIT_LOG_DAYS, RETENTION_SEARCH_ANALYTICS_DAYS,
- *   RETENTION_ERROR_LOG_DAYS, RETENTION_VERSIONS_MAX
+ *   RETENTION_ERROR_LOG_DAYS, RETENTION_VERSIONS_MAX,
+ *   RETENTION_ADMIN_ACCESS_DENIED_DAYS (env fallback for the admin-configurable
+ *   `admin_access_denied_retention_days` setting — consulted only when the DB
+ *   row is absent).
  */
 
 import { getPool } from '../db/postgres.js';
 import { logger } from '../utils/logger.js';
+import { getAdminAccessDeniedRetentionDays } from './admin-settings-service.js';
 
 export const RETENTION_DEFAULTS: Record<string, number> = {
   audit_log: 365,          // days
@@ -52,6 +60,14 @@ export async function runRetentionCleanup(): Promise<Record<string, number>> {
     }
   }
 
+  // Targeted retention for ADMIN_ACCESS_DENIED audit rows (#264).
+  // Runs after the umbrella `audit_log: 365 days` sweep above; rows that
+  // survived the umbrella AND are older than the (narrower) admin-configured
+  // window AND have action='ADMIN_ACCESS_DENIED' are purged here.
+  // Scoped by action so the umbrella retention policy for every other audit
+  // action remains independently tunable.
+  results['audit_log_admin_access_denied'] = await runAdminAccessDeniedRetention();
+
   // Count-based retention for page_versions
   const maxVersions = parseInt(process.env.RETENTION_VERSIONS_MAX ?? '50', 10);
   try {
@@ -73,6 +89,73 @@ export async function runRetentionCleanup(): Promise<Record<string, number>> {
   }
 
   return results;
+}
+
+/**
+ * Purge `audit_log` rows with `action = 'ADMIN_ACCESS_DENIED'` that are older
+ * than the admin-configured retention window (days).
+ *
+ * Issue #264. Batched (LIMIT 10_000) to avoid long DELETE locks on large audit
+ * tables — ~10 req/s of brute-forced admin attempts produces ~860k rows/day,
+ * so an unbatched DELETE of months of data could hold the table for minutes.
+ * Parameterised SQL only.
+ *
+ * Intentionally scoped to a single `action` — does NOT touch rows with other
+ * action values, preserving whatever umbrella policy governs them (the
+ * `audit_log: 365 days` entry in `RETENTION_DEFAULTS` continues to apply to
+ * every audit action separately).
+ *
+ * Returns the total number of rows deleted across all batches. Never throws
+ * (errors are logged and the promise resolves).
+ */
+const ADMIN_ACCESS_DENIED_PURGE_BATCH_SIZE = 10_000;
+
+async function runAdminAccessDeniedRetention(): Promise<number> {
+  let days: number;
+  try {
+    days = await getAdminAccessDeniedRetentionDays();
+  } catch (err) {
+    logger.error({ err }, 'Failed to resolve admin_access_denied_retention_days; skipping purge');
+    return 0;
+  }
+
+  const pool = getPool();
+  let totalDeleted = 0;
+
+  try {
+    for (;;) {
+      const { rowCount } = await pool.query(
+        `DELETE FROM audit_log
+           WHERE id IN (
+             SELECT id FROM audit_log
+              WHERE action = 'ADMIN_ACCESS_DENIED'
+                AND created_at < NOW() - INTERVAL '1 day' * $1
+              LIMIT $2
+           )`,
+        [days, ADMIN_ACCESS_DENIED_PURGE_BATCH_SIZE],
+      );
+      const n = rowCount ?? 0;
+      totalDeleted += n;
+      if (n > 0) {
+        logger.debug(
+          { batch: n, totalSoFar: totalDeleted, retentionDays: days },
+          'ADMIN_ACCESS_DENIED retention batch deleted',
+        );
+      }
+      // A short batch signals drained — break out rather than loop again on
+      // a guaranteed-empty DELETE.
+      if (n < ADMIN_ACCESS_DENIED_PURGE_BATCH_SIZE) break;
+    }
+    if (totalDeleted > 0) {
+      logger.info(
+        { deleted: totalDeleted, retentionDays: days },
+        'ADMIN_ACCESS_DENIED retention cleanup completed',
+      );
+    }
+  } catch (err) {
+    logger.error({ err, retentionDays: days }, 'ADMIN_ACCESS_DENIED retention cleanup failed');
+  }
+  return totalDeleted;
 }
 
 // ── Scheduler ────────────────────────────────────────────────────────────────

--- a/backend/src/routes/foundation/admin.test.ts
+++ b/backend/src/routes/foundation/admin.test.ts
@@ -46,12 +46,14 @@ vi.mock('../../core/utils/logger.js', () => ({
 // `GET /admin/settings` for the `embeddingDimensions` response field.
 vi.mock('../../core/services/admin-settings-service.js', () => ({
   getEmbeddingDimensions: vi.fn().mockResolvedValue(1024),
+  getAdminAccessDeniedRetentionDays: vi.fn().mockResolvedValue(90),
 }));
 
 import { listErrors, resolveError, getErrorSummary } from '../../core/services/error-tracker.js';
 import { query as mockQuery } from '../../core/db/postgres.js';
 import { _resetStreamCapCache } from '../../core/services/sse-stream-limiter.js';
 import { _resetCache as _resetRateLimitsCache } from '../../core/services/rate-limit-service.js';
+import { getAdminAccessDeniedRetentionDays as mockGetAdminAccessDeniedRetentionDays } from '../../core/services/admin-settings-service.js';
 
 describe('Admin routes', () => {
   let app: ReturnType<typeof Fastify>;
@@ -586,6 +588,84 @@ describe('Admin routes', () => {
         method: 'PUT',
         url: '/api/admin/settings',
         payload: { reembedHistoryRetention: 10_001 },
+      });
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  // ─── #264 — adminAccessDeniedRetentionDays wiring ───────────────────────
+  describe('adminAccessDeniedRetentionDays (issue #264)', () => {
+    it('GET /api/admin/settings returns the value produced by the getter (90 default)', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [] });
+      (mockGetAdminAccessDeniedRetentionDays as ReturnType<typeof vi.fn>).mockResolvedValueOnce(90);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/admin/settings',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body).adminAccessDeniedRetentionDays).toBe(90);
+    });
+
+    it('GET /api/admin/settings reflects a custom getter value (e.g. 30 after admin-PUT)', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [] });
+      (mockGetAdminAccessDeniedRetentionDays as ReturnType<typeof vi.fn>).mockResolvedValueOnce(30);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/admin/settings',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body).adminAccessDeniedRetentionDays).toBe(30);
+    });
+
+    it('PUT /api/admin/settings persists adminAccessDeniedRetentionDays via UPSERT', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/settings',
+        payload: { adminAccessDeniedRetentionDays: 30 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const calls = (mockQuery as ReturnType<typeof vi.fn>).mock.calls as Array<[string, ...unknown[]]>;
+      const upsert = calls.find(([sql, args]) =>
+        typeof sql === 'string' &&
+        sql.includes('INSERT INTO admin_settings') &&
+        Array.isArray(args) &&
+        args[0] === 'admin_access_denied_retention_days',
+      );
+      expect(upsert).toBeTruthy();
+      // Persisted as text — the value is stringified.
+      expect((upsert![1] as unknown[])[1]).toBe('30');
+    });
+
+    it('PUT rejects values below 7 with 400 (validated by Zod)', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/settings',
+        payload: { adminAccessDeniedRetentionDays: 6 },
+      });
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('PUT rejects values above 3650 with 400', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/settings',
+        payload: { adminAccessDeniedRetentionDays: 3651 },
+      });
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('PUT rejects non-integer values with 400', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/settings',
+        payload: { adminAccessDeniedRetentionDays: 30.5 },
       });
       expect(response.statusCode).toBe(400);
     });

--- a/backend/src/routes/foundation/admin.ts
+++ b/backend/src/routes/foundation/admin.ts
@@ -6,7 +6,10 @@ import { getAuditLog, logAuditEvent } from '../../core/services/audit-service.js
 import { listErrors, resolveError, getErrorSummary } from '../../core/services/error-tracker.js';
 import { logger } from '../../core/utils/logger.js';
 import { UpdateAdminSettingsSchema } from '@compendiq/contracts';
-import { getEmbeddingDimensions } from '../../core/services/admin-settings-service.js';
+import {
+  getEmbeddingDimensions,
+  getAdminAccessDeniedRetentionDays,
+} from '../../core/services/admin-settings-service.js';
 import { getAiGuardrails, getAiOutputRules, upsertAiGuardrails, upsertAiOutputRules } from '../../core/services/ai-safety-service.js';
 import { getRateLimits, upsertRateLimits } from '../../core/services/rate-limit-service.js';
 import { getStreamCap, invalidateStreamCapCache } from '../../core/services/sse-stream-limiter.js';
@@ -227,12 +230,20 @@ export async function adminRoutes(fastify: FastifyInstance) {
 
   // GET /api/admin/settings - retrieve shared admin settings
   fastify.get('/admin/settings', ADMIN_RATE_LIMIT, async () => {
-    const [embeddingDimensions, guardrails, outputRules, rateLimits, llmMaxConcurrentStreamsPerUser] = await Promise.all([
+    const [
+      embeddingDimensions,
+      guardrails,
+      outputRules,
+      rateLimits,
+      llmMaxConcurrentStreamsPerUser,
+      adminAccessDeniedRetentionDays,
+    ] = await Promise.all([
       getEmbeddingDimensions(),
       getAiGuardrails(),
       getAiOutputRules(),
       getRateLimits(),
       getStreamCap(),
+      getAdminAccessDeniedRetentionDays(),
     ]);
     const result = await query<{ setting_key: string; setting_value: string }>(
       `SELECT setting_key, setting_value FROM admin_settings
@@ -252,6 +263,10 @@ export async function adminRoutes(fastify: FastifyInstance) {
       drawioEmbedUrl: map['drawio_embed_url'] ?? null,
       // Issue #257 — re-embed-all job history retention (default 150, [10, 10000]).
       reembedHistoryRetention: parseInt(map['reembed_history_retention'] ?? '150', 10),
+      // Issue #264 — retention for ADMIN_ACCESS_DENIED audit rows
+      // (default 90, [7, 3650]). Resolved via getter so the env fallback
+      // + hard default cascade stay in one place.
+      adminAccessDeniedRetentionDays,
       // AI Safety
       aiGuardrailNoFabrication: guardrails.noFabricationInstruction,
       aiGuardrailNoFabricationEnabled: guardrails.noFabricationEnabled,
@@ -359,6 +374,15 @@ export async function adminRoutes(fastify: FastifyInstance) {
       updates.push({
         key: 'reembed_history_retention',
         value: String(body.reembedHistoryRetention),
+      });
+    }
+
+    // Issue #264 — retention (days) for ADMIN_ACCESS_DENIED audit rows.
+    // Zod already enforced the [7, 3650] integer range at the boundary.
+    if (body.adminAccessDeniedRetentionDays !== undefined) {
+      updates.push({
+        key: 'admin_access_denied_retention_days',
+        value: String(body.adminAccessDeniedRetentionDays),
       });
     }
 

--- a/docs/issues/264-implementation-plan.md
+++ b/docs/issues/264-implementation-plan.md
@@ -1,0 +1,520 @@
+# Implementation Plan — Issue #264: audit-log denied admin actions (403) at the `requireAdmin` decorator
+
+> Target branch: `feature/264-audit-denied-admin` → PR to `dev`.
+> Scope: every 403 from `fastify.requireAdmin` writes an audit row (also the unauthenticated case). Cross-cutting — 61 endpoints via one decorator edit. Adds admin-configurable retention for `ADMIN_ACCESS_DENIED` rows, extending the existing `data-retention-service.ts`.
+>
+> **Decisions locked (v2, 2026-04-21):**
+> - Retention = piggy-back on `data-retention-service.ts`. Default **90 days**, admin-configurable via new `admin_settings.admin_access_denied_retention_days` key (range 7–3650). Extend existing service; don't invent a new mechanism.
+> - Purge targets only `action = 'ADMIN_ACCESS_DENIED'` — does not broaden `audit_log` retention for other action types.
+> - Parameterised SQL; batched DELETE to avoid long locks.
+
+---
+
+## 1. ResearchPack
+
+Line numbers verified on `feature/258-llm-queue-breakers` (`19b8c87`). Applies cleanly on `dev` + both open PR branches.
+
+### 1.1 Files to edit
+
+| File:line | Why |
+|---|---|
+| `backend/src/core/plugins/auth.ts:231–236` | `fastify.decorate('requireAdmin', …)` — single choke point. Both throw paths emit audit before bubbling. |
+| `backend/src/core/services/audit-service.ts:8–38` | Add `'ADMIN_ACCESS_DENIED'` to the `AuditAction` union. `logAuditEvent()` already handles `userId: null`. |
+| `backend/src/core/plugins/auth.test.ts` | Three new test cases. |
+| `backend/src/core/services/data-retention-service.ts` | Currently env-only at `:18–23, 34–38`. Extend with admin_settings lookup for the new `ADMIN_ACCESS_DENIED` retention; add the targeted batched purge. |
+| `backend/src/core/services/data-retention-service.test.ts` (new or existing — TBD) | Add four retention-specific tests (RED #4–#7). |
+| `packages/contracts/src/schemas/admin.ts:18–66` | Add `adminAccessDeniedRetentionDays` to both schemas. |
+| `backend/src/routes/foundation/admin.ts:237, 248, 284, 328` | Wire GET/PUT for the new admin_settings key. |
+| `backend/src/core/db/migrations/057_admin_settings_denied_admin_retention.sql` (new) | Seed the default (90). |
+| `frontend/src/features/admin/DataRetentionTab.tsx` | Surface the retention-days input. |
+
+### 1.2 Downstream consumers of `requireAdmin` — no change
+
+`rg "fastify.requireAdmin" backend/src/routes/` → 61 matches. None need edits.
+
+### 1.3 Fastify 5 hook-ordering research (unchanged from v1)
+
+Source: `https://github.com/fastify/fastify/blob/main/docs/Reference/Hooks.md`.
+
+- `requireAdmin` is a decorated function, not a hook. Attached as `preHandler` or `onRequest`. Runs before the route handler.
+- If it throws, preHandler chain stops; Fastify routes the error to `onError` hook chain and error handler set via `setErrorHandler`.
+- `onError` is textbook for "custom error logging" but fires for every error on every route — filtering by marker error class is fragile.
+
+**Three viable architectures:**
+
+| Approach | Pros | Cons |
+|---|---|---|
+| **A. Inline in decorator** | one file, no hook plumbing, obvious trace | ~few ms DB-write per denial |
+| **B. Marker error + global `onError`** | centralised | fires for every error; harder to test |
+| **C. `onRequestAbort`** | — | wrong lifecycle |
+
+**Recommendation: A.** `logAuditEvent()` is try/catch-wrapped (`audit-service.ts:64–84`) with "never blocks main operation" guarantee.
+
+### 1.4 Existing `data-retention-service.ts` shape (must conform)
+
+Read of the live file (`backend/src/core/services/data-retention-service.ts`):
+
+- Currently holds `RETENTION_DEFAULTS: Record<string, number>` at `:18–23`: `audit_log: 365`, `search_analytics: 90`, `error_log: 30`, `page_versions: 50`.
+- `runRetentionCleanup()` at `:29–76` iterates that map. Time-based tables use `DELETE FROM ${table} WHERE created_at < NOW() - INTERVAL '1 day' * $1` with `$1 = retentionDays`. Count-based uses a window function.
+- **Env vars only**, no `admin_settings` integration today (`:37–38` reads `RETENTION_${table.toUpperCase()}_DAYS`).
+- Scheduler at `:80–115`: `startRetentionWorker(intervalHours = 24)`, `stopRetentionWorker()`.
+- Invoked from `queue-service.ts:287–310` (the `maintenance` BullMQ queue) and the setInterval fallback at `:323–350`.
+
+**Reuse everything.** This plan adds a **fifth entry** to the retention cycle: `audit_log_admin_access_denied`, scoped by `action = 'ADMIN_ACCESS_DENIED'` (not whole-table), with the cap read from admin_settings first, then env, then default.
+
+### 1.5 Admin-settings cascade (reuse from #268's plan § 1.3)
+
+Same rate-limit-service pattern. Canonical key: **`admin_access_denied_retention_days`** (integer, text-valued). Default `90`, min `7`, max `3650` (~10 years).
+
+Read cascade:
+```
+admin_settings.admin_access_denied_retention_days   (authoritative)
+  → process.env.RETENTION_ADMIN_ACCESS_DENIED_DAYS  (optional env fallback, non-deprecated — no pre-existing env var to deprecate)
+  → 90                                              (hard default)
+```
+
+### 1.6 Migration numbering
+
+`dev` at `054`. PR #261 owns `055`. #268 allocates `056`. This plan allocates **`057_admin_settings_denied_admin_retention.sql`**. If shipping order flips, swap `056` ↔ `057` — coordinated in #268 plan § 6.
+
+### 1.7 Audit-action naming
+
+`AuditAction` has `'LOGIN_FAILED'` (login-scoped) and `'ADMIN_ACTION'` (success — `knowledge-admin.ts:129`). Add `'ADMIN_ACCESS_DENIED'` — distinct dashboard bucket.
+
+### 1.8 Existing retention UI surface
+
+`frontend/src/features/admin/DataRetentionTab.tsx` already exists. The new input appends to this panel (do NOT create a new sub-tab — mirrors #268's `LlmTab.tsx` decision).
+
+---
+
+## 2. Step-by-step surgical edits
+
+### Step 1 — extend `AuditAction`
+
+`audit-service.ts:37`:
+
+```diff
+   | 'EMBEDDING_RESCAN'
+-  | 'EMBEDDING_RESET_FAILED';
++  | 'EMBEDDING_RESET_FAILED'
++  | 'ADMIN_ACCESS_DENIED';
+```
+
+### Step 2 — rewrite `requireAdmin`
+
+`auth.ts:231–236`. Two paths:
+- A: `authenticate` throws — `reason: 'unauthenticated'`, `actorUserId: null`.
+- B: role check fails — `reason: 'not_admin'`, `actorUserId: request.userId`.
+
+```typescript
+  fastify.decorate('requireAdmin', async (request: FastifyRequest) => {
+    // Path A: authentication failure (missing/invalid Bearer).
+    try {
+      await fastify.authenticate(request);
+    } catch (err) {
+      await logAuditEvent(
+        null,
+        'ADMIN_ACCESS_DENIED',
+        'route',
+        `${request.method} ${request.routeOptions.url ?? request.url}`,
+        { decision: 'denied', reason: 'unauthenticated' },
+        request,
+      );
+      throw err;
+    }
+
+    // Path B: authenticated but not admin.
+    if (request.userRole !== 'admin') {
+      await logAuditEvent(
+        request.userId,
+        'ADMIN_ACCESS_DENIED',
+        'route',
+        `${request.method} ${request.routeOptions.url ?? request.url}`,
+        { decision: 'denied', reason: 'not_admin' },
+        request,
+      );
+      throw fastify.httpErrors.forbidden('Admin access required');
+    }
+  });
+```
+
+Add import:
+
+```diff
+ import { userHasPermission, userHasGlobalPermission } from '../services/rbac-service.js';
++import { logAuditEvent } from '../services/audit-service.js';
+```
+
+Notes:
+- **`request.routeOptions.url`** (Fastify 5) = route template. Fallback `request.url`.
+- `request.ip` + `user-agent` auto-captured by `logAuditEvent` (`audit-service.ts:64–66`).
+- `await` intentional — row committed before 403 returns; tests non-racey.
+
+### Step 3 — Zod schema updates
+
+`packages/contracts/src/schemas/admin.ts` — append to both schemas (v1 v2 symmetry with #268):
+
+```diff
+ export const AdminSettingsSchema = z.object({
+   …
++  // Retention (days) for audit_log rows where action = 'ADMIN_ACCESS_DENIED' (#264).
++  // The default covers routine forensics; extend via the data-retention worker.
++  adminAccessDeniedRetentionDays: z.number().int().min(7).max(3650).optional(),
+ });
+
+ export const UpdateAdminSettingsSchema = z.object({
+   …
++  adminAccessDeniedRetentionDays: z.number().int().min(7).max(3650).optional(),
+ });
+```
+
+### Step 4 — migration `057_admin_settings_denied_admin_retention.sql`
+
+```sql
+-- Migration 057: retention policy for ADMIN_ACCESS_DENIED audit rows (#264)
+--
+-- Seeds the admin-configurable retention window (days) for the
+-- `data-retention-service`-driven purge of `audit_log` rows with
+-- `action = 'ADMIN_ACCESS_DENIED'`.
+--
+-- Range (Zod): [7, 3650]. Default: 90.
+--
+-- Read cascade (see `data-retention-service.ts :: runAdminAccessDeniedRetention`):
+--   admin_settings.admin_access_denied_retention_days
+--     → env RETENTION_ADMIN_ACCESS_DENIED_DAYS  (optional)
+--     → 90  (hard default)
+--
+-- Additive + idempotent.
+INSERT INTO admin_settings (setting_key, setting_value, updated_at)
+VALUES ('admin_access_denied_retention_days', '90', NOW())
+ON CONFLICT (setting_key) DO NOTHING;
+```
+
+### Step 5 — extend `data-retention-service.ts`
+
+At the module top, add the cap getter (parallel to #268's `getStreamCap` but without a cache — retention runs once per 24 h, so DB reads are cheap and non-cached is simpler):
+
+```typescript
+const ADMIN_ACCESS_DENIED_DEFAULT_DAYS = 90;
+const ADMIN_ACCESS_DENIED_DB_KEY = 'admin_access_denied_retention_days';
+
+async function resolveAdminAccessDeniedRetentionDays(): Promise<number> {
+  try {
+    const r = await getPool().query<{ setting_value: string }>(
+      `SELECT setting_value FROM admin_settings WHERE setting_key = $1`,
+      [ADMIN_ACCESS_DENIED_DB_KEY],
+    );
+    const db = r.rows[0]?.setting_value;
+    if (db) {
+      const n = parseInt(db, 10);
+      if (Number.isFinite(n) && n >= 7 && n <= 3650) return n;
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Failed to read admin_access_denied_retention_days; falling back');
+  }
+  const env = process.env.RETENTION_ADMIN_ACCESS_DENIED_DAYS;
+  if (env) {
+    const n = parseInt(env, 10);
+    if (Number.isFinite(n) && n >= 7 && n <= 3650) return n;
+  }
+  return ADMIN_ACCESS_DENIED_DEFAULT_DAYS;
+}
+```
+
+Add the batched purge function:
+
+```typescript
+/**
+ * Purge audit_log rows with action='ADMIN_ACCESS_DENIED' older than the
+ * admin-configured retention window. Batched to avoid long lockups on large
+ * tables. Returns total rows deleted.
+ *
+ * Intentionally scoped to a single action — does NOT touch rows with other
+ * action values, preserving whatever policy governs them (the umbrella
+ * `audit_log: 365 days` entry still applies separately).
+ */
+async function runAdminAccessDeniedRetention(): Promise<number> {
+  const days = await resolveAdminAccessDeniedRetentionDays();
+  const pool = getPool();
+  const BATCH_SIZE = 10_000;
+  let totalDeleted = 0;
+  try {
+    for (;;) {
+      const { rowCount } = await pool.query(
+        `DELETE FROM audit_log
+         WHERE id IN (
+           SELECT id FROM audit_log
+           WHERE action = 'ADMIN_ACCESS_DENIED'
+             AND created_at < NOW() - INTERVAL '1 day' * $1
+           LIMIT $2
+         )`,
+        [days, BATCH_SIZE],
+      );
+      const n = rowCount ?? 0;
+      totalDeleted += n;
+      if (n < BATCH_SIZE) break;
+    }
+    if (totalDeleted > 0) {
+      logger.info({ deleted: totalDeleted, retentionDays: days },
+        'ADMIN_ACCESS_DENIED retention cleanup completed');
+    }
+  } catch (err) {
+    logger.error({ err }, 'ADMIN_ACCESS_DENIED retention cleanup failed');
+  }
+  return totalDeleted;
+}
+```
+
+Extend `runRetentionCleanup()` to call it:
+
+```diff
+   // Time-based retention for audit_log, search_analytics, error_log
+   for (const [table, days] of Object.entries(RETENTION_DEFAULTS)) {
+     …
+   }
+
++  // Targeted retention for ADMIN_ACCESS_DENIED audit rows (#264).
++  // Runs after the umbrella `audit_log: 365 days` sweep above; any rows that
++  // survived the umbrella AND are > admin_access_denied_retention_days old
++  // AND have action='ADMIN_ACCESS_DENIED' are purged here.
++  results['audit_log_admin_access_denied'] = await runAdminAccessDeniedRetention();
+
+   // Count-based retention for page_versions
+```
+
+Notes:
+- **Order matters.** The umbrella `audit_log` sweep (default 365 d) runs first. The targeted sweep (default 90 d, narrower) catches the younger-but-still-stale denial rows. Expressing them as separate sweeps keeps each policy independently tunable.
+- **Parameterised SQL only** — `$1 = days`, `$2 = BATCH_SIZE`.
+- **Batched with `LIMIT`** — avoids multi-minute table locks on a large `audit_log`. Loops until a short batch signals drained.
+- **No schema change** required on `audit_log`. Optional perf follow-up: add `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_audit_log_action_created ON audit_log (action, created_at)` in a later PR if `EXPLAIN` shows a sequential scan on large tables. Out of scope here.
+
+### Step 6 — admin-settings GET/PUT wiring
+
+`backend/src/routes/foundation/admin.ts`:
+
+- Extend `WHERE setting_key IN (…)` (`:237`, `:284`) with `'admin_access_denied_retention_days'`.
+- Extend returned map (`:248`) with `adminAccessDeniedRetentionDays: parseInt(map['admin_access_denied_retention_days'] ?? '90', 10)`.
+- Extend PUT (`:328`): on `body.adminAccessDeniedRetentionDays !== undefined`, push `{ key: 'admin_access_denied_retention_days', value: String(body.adminAccessDeniedRetentionDays) }`. Audit-log as existing `ADMIN_ACTION`.
+
+Parameterised SQL throughout.
+
+### Step 7 — frontend UI
+
+`frontend/src/features/admin/DataRetentionTab.tsx`:
+
+- Append a row for the new setting: numeric input (min 7, max 3650), labelled "Admin access-denied audit retention (days)".
+- Helper text: *"Automated purge of audit_log rows recorded when non-admins attempted admin endpoints. Default 90 days. Applies only to rows with action 'ADMIN_ACCESS_DENIED'; other audit events retain their own retention."*
+- Wire through the existing admin-settings TanStack-Query mutation used by this file for other retention entries.
+
+**No new sub-tab, no new file.**
+
+### Step 8 — env-var docs
+
+`CLAUDE.md` — add under Environment:
+```
+- `RETENTION_ADMIN_ACCESS_DENIED_DAYS` (optional env fallback for the admin-configurable `admin_access_denied_retention_days` setting, issue #264; consulted only when the `admin_settings` row is absent; fallback-of-last-resort: `90`)
+```
+
+`.env.example`: same line as a comment.
+
+### Step 9 — tests
+
+#### Decorator tests (`auth.test.ts`)
+
+**RED #1 — non-admin → 403 + audit row:**
+```typescript
+it('requireAdmin writes ADMIN_ACCESS_DENIED when a non-admin is rejected', async () => {
+  const userId = await createTestUser({ role: 'user' });
+  const token = await signAccessToken(userId, 'user');
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/admin/embedding/locks/target-user/release',
+    headers: { authorization: `Bearer ${token}` },
+  });
+  expect(res.statusCode).toBe(403);
+  const rows = await query(
+    `SELECT user_id, action, resource_type, resource_id, metadata
+     FROM audit_log WHERE action = 'ADMIN_ACCESS_DENIED' ORDER BY created_at DESC LIMIT 1`,
+  );
+  expect(rows.rows[0]).toMatchObject({
+    user_id: userId,
+    action: 'ADMIN_ACCESS_DENIED',
+    resource_type: 'route',
+    resource_id: expect.stringMatching(/^POST .+embedding\/locks/),
+  });
+  expect(rows.rows[0].metadata).toMatchObject({ decision: 'denied', reason: 'not_admin' });
+});
+```
+
+**RED #2 — unauth → 401 + audit with null user:**
+```typescript
+it('requireAdmin writes ADMIN_ACCESS_DENIED with user_id=null when unauthenticated', async () => {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/admin/embedding/locks/target-user/release',
+  });
+  expect(res.statusCode).toBe(401);
+  const rows = await query(
+    `SELECT user_id, metadata FROM audit_log
+     WHERE action = 'ADMIN_ACCESS_DENIED' ORDER BY created_at DESC LIMIT 1`,
+  );
+  expect(rows.rows[0].user_id).toBeNull();
+  expect(rows.rows[0].metadata).toMatchObject({ decision: 'denied', reason: 'unauthenticated' });
+});
+```
+
+**RED #3 — admin success NOT audited as denial:**
+```typescript
+it('requireAdmin does not write ADMIN_ACCESS_DENIED for a successful admin request', async () => {
+  const adminId = await createTestUser({ role: 'admin' });
+  const token = await signAccessToken(adminId, 'admin');
+  await app.inject({
+    method: 'GET',
+    url: '/api/admin/embedding/locks',
+    headers: { authorization: `Bearer ${token}` },
+  });
+  const rows = await query(`SELECT COUNT(*)::int AS c FROM audit_log WHERE action = 'ADMIN_ACCESS_DENIED'`);
+  expect(rows.rows[0].c).toBe(0);
+});
+```
+
+#### Retention tests (`data-retention-service.test.ts`)
+
+**RED #4 — old denial rows purged:**
+```typescript
+it('purges ADMIN_ACCESS_DENIED rows older than the configured retention', async () => {
+  await query(`DELETE FROM audit_log`);
+  await query(`INSERT INTO admin_settings (setting_key, setting_value) VALUES ($1, $2)
+               ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2`,
+              ['admin_access_denied_retention_days', '30']);
+  // Seed two old rows (35 days ago) and one fresh (5 days ago).
+  await query(`INSERT INTO audit_log (user_id, action, resource_type, resource_id, metadata, created_at)
+               VALUES (NULL, 'ADMIN_ACCESS_DENIED', 'route', 'GET /x', '{}'::jsonb, NOW() - INTERVAL '35 days')`);
+  await query(`INSERT INTO audit_log (user_id, action, resource_type, resource_id, metadata, created_at)
+               VALUES (NULL, 'ADMIN_ACCESS_DENIED', 'route', 'GET /y', '{}'::jsonb, NOW() - INTERVAL '35 days')`);
+  await query(`INSERT INTO audit_log (user_id, action, resource_type, resource_id, metadata, created_at)
+               VALUES (NULL, 'ADMIN_ACCESS_DENIED', 'route', 'GET /z', '{}'::jsonb, NOW() - INTERVAL '5 days')`);
+
+  await runRetentionCleanup();
+
+  const remaining = await query(`SELECT resource_id FROM audit_log WHERE action = 'ADMIN_ACCESS_DENIED'`);
+  expect(remaining.rows.map((r) => r.resource_id).sort()).toEqual(['GET /z']);
+});
+```
+
+**RED #5 — young rows NOT purged:**
+```typescript
+it('does not purge ADMIN_ACCESS_DENIED rows younger than retention', async () => {
+  await query(`DELETE FROM audit_log`);
+  await query(`INSERT INTO admin_settings (setting_key, setting_value) VALUES ($1, $2)
+               ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2`,
+              ['admin_access_denied_retention_days', '90']);
+  await query(`INSERT INTO audit_log (user_id, action, resource_type, resource_id, metadata, created_at)
+               VALUES (NULL, 'ADMIN_ACCESS_DENIED', 'route', 'GET /a', '{}'::jsonb, NOW() - INTERVAL '30 days')`);
+  await runRetentionCleanup();
+  const r = await query(`SELECT COUNT(*)::int AS c FROM audit_log WHERE action = 'ADMIN_ACCESS_DENIED'`);
+  expect(r.rows[0].c).toBe(1);
+});
+```
+
+**RED #6 — successful admin rows never purged by this sweep:**
+```typescript
+it('does not touch ADMIN_ACTION rows regardless of age', async () => {
+  await query(`DELETE FROM audit_log`);
+  await query(`INSERT INTO admin_settings (setting_key, setting_value) VALUES ($1, $2)
+               ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2`,
+              ['admin_access_denied_retention_days', '30']);
+  // 35-day-old ADMIN_ACTION success row — should survive this sweep.
+  // (The umbrella `audit_log` retention (365 d default) handles it elsewhere.)
+  await query(`INSERT INTO audit_log (user_id, action, resource_type, resource_id, metadata, created_at)
+               VALUES ('admin-1', 'ADMIN_ACTION', 'admin_settings', NULL, '{}'::jsonb, NOW() - INTERVAL '35 days')`);
+  await runRetentionCleanup();
+  const r = await query(`SELECT COUNT(*)::int AS c FROM audit_log WHERE action = 'ADMIN_ACTION'`);
+  expect(r.rows[0].c).toBe(1);
+});
+```
+
+**RED #7 — setting change takes effect on next tick:**
+```typescript
+it('picks up a setting change on the next retention tick', async () => {
+  await query(`DELETE FROM audit_log`);
+  // Start with lenient retention (100 d); 50-day-old row should survive.
+  await query(`INSERT INTO admin_settings (setting_key, setting_value) VALUES ($1, $2)
+               ON CONFLICT (setting_key) DO UPDATE SET setting_value = $2`,
+              ['admin_access_denied_retention_days', '100']);
+  await query(`INSERT INTO audit_log (user_id, action, resource_type, resource_id, metadata, created_at)
+               VALUES (NULL, 'ADMIN_ACCESS_DENIED', 'route', 'GET /q', '{}'::jsonb, NOW() - INTERVAL '50 days')`);
+  await runRetentionCleanup();
+  expect((await query(`SELECT COUNT(*)::int AS c FROM audit_log`)).rows[0].c).toBe(1);
+
+  // Tighten retention to 30 d. No cache (resolve is on-demand); next tick honours it.
+  await query(`UPDATE admin_settings SET setting_value='30' WHERE setting_key='admin_access_denied_retention_days'`);
+  await runRetentionCleanup();
+  expect((await query(`SELECT COUNT(*)::int AS c FROM audit_log`)).rows[0].c).toBe(0);
+});
+```
+
+### Step 10 — no route-file changes for `requireAdmin` consumers
+
+Handlers don't special-case denials. Grep-verify post-change.
+
+---
+
+## 3. Rollback procedure
+
+1. `git revert <commit-sha>`.
+2. No schema DDL.
+3. Residual `ADMIN_ACCESS_DENIED` rows harmless. Optional: `DELETE FROM audit_log WHERE action = 'ADMIN_ACCESS_DENIED';`.
+4. Residual admin_settings row: harmless; optional `DELETE FROM admin_settings WHERE setting_key = 'admin_access_denied_retention_days';`.
+5. Migration `057` is forward-only. No reverse.
+
+---
+
+## 4. Acceptance criteria mapped to issue body
+
+- [x] **"Every 403 from `requireAdmin` writes an audit row"** — Path B + RED #1.
+- [x] **"No handler needs to special-case"** — no handler edits.
+- [x] **"Non-admin POST to force-release → audit with `decision: 'denied'`"** — RED #1.
+- [x] **"Unauthenticated call audited with `actorUserId: null`"** — Path A + RED #2.
+- [x] **Retention via data-retention-service.ts** — §2 Step 5 extends the existing service; scheduler/logging reused.
+- [x] **Purge targets only `ADMIN_ACCESS_DENIED`** — RED #4 / #5 / #6.
+- [x] **Admin-configurable, min 7 / max 3650 / default 90** — Zod + migration 057.
+- [x] **Batched DELETE** — `LIMIT 10000` loop in §2 Step 5.
+- [x] **UI in DataRetentionTab** — §2 Step 7.
+
+---
+
+## 5. Risks and open questions
+
+1. **Storm risk.** ~10 req/s brute force × 24 h ≈ 860k rows/day. With default 90-day retention that's up to ~77M rows before purge kicks in. **Mitigations:**
+   - Optional `idx_audit_log_action_created` index (not shipped with this PR — file as separate perf issue if `EXPLAIN` shows sequential scan).
+   - Rate-limit admin routes lower than we already do (separate issue).
+   - Lower default retention if stakeholders prefer — 30 days is plausible.
+
+2. **Does `request.routeOptions.url` exist when `authenticate` throws?** Yes — Fastify 5 matches routes before `preHandler`. Assert in RED.
+
+3. **Audit-log retention coupling.** The umbrella `audit_log: 365 days` sweep runs first; if an admin sets denied-retention > 365 d, the umbrella evicts first. That's fine (conservative narrows strictly). Document: denied-retention is effectively `min(configured, umbrella-retention)`.
+
+4. **Batching parameter.** 10,000 rows/batch chosen defensively. If real workloads show lock contention, drop to 1,000. Not worth a config knob yet.
+
+5. **Interaction with other retention ideas.** Future extensions (e.g. `PROMPT_INJECTION_DETECTED` retention) can follow the exact same pattern. Not spec'd here.
+
+---
+
+## 6. Dependencies and ordering
+
+- **Migration numbering:** `057_admin_settings_denied_admin_retention.sql`. Coordinate with #268 (`056`). Swap if ship order flips.
+- **File conflicts with other plans:**
+  - `packages/contracts/src/schemas/admin.ts` — #268 also appends optional fields here; trivial textual merge.
+  - `backend/src/routes/foundation/admin.ts` — #268 also extends the GET/PUT handlers here; trivial merge (different keys).
+  - `data-retention-service.ts` — unique to this plan.
+  - `auth.ts`, `audit-service.ts`, `auth.test.ts` — unique to this plan.
+  - `DataRetentionTab.tsx` — unique to this plan. #268's UI sits in `LlmTab.tsx`.
+- **Parallel with** #263, #265, #266, #267, #269.
+- **Interaction with PR #261:** motivating route (`POST /api/admin/embedding/locks/:userId/release`) is from #261. If #261 hasn't landed, RED tests use `/api/llm/quality-rescan` at `knowledge-admin.ts:25–32`.
+
+---
+
+## 7. Estimated effort
+
+~2 hours. Decorator rewrite (~20 LoC), audit-action union (1 line), `data-retention-service.ts` extension (~60 LoC), Zod + admin-route + migration + UI wiring (~50 LoC), seven Vitest cases.

--- a/frontend/src/features/admin/DataRetentionTab.test.tsx
+++ b/frontend/src/features/admin/DataRetentionTab.test.tsx
@@ -54,6 +54,12 @@ const mockPreview = [
   { table: 'error_log', rowCount: 0, oldestRecord: null },
 ];
 
+// #264 — GET /admin/settings is consumed by AdminAccessDeniedRetentionSection.
+// Default to 90 (matches backend default) but overridable per test.
+let mockAdminSettings: { adminAccessDeniedRetentionDays: number } = {
+  adminAccessDeniedRetentionDays: 90,
+};
+
 function mockFetch() {
   return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
     const url = typeof input === 'string' ? input : (input as Request).url;
@@ -74,6 +80,11 @@ function mockFetch() {
         headers: { 'Content-Type': 'application/json' },
       });
     }
+    if (url.includes('/admin/settings')) {
+      return new Response(JSON.stringify(mockAdminSettings), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
     return new Response(JSON.stringify({}), {
       headers: { 'Content-Type': 'application/json' },
     });
@@ -85,6 +96,7 @@ function mockFetch() {
 describe('DataRetentionTab', () => {
   beforeEach(() => {
     mockHasFeature = () => true;
+    mockAdminSettings = { adminAccessDeniedRetentionDays: 90 };
     useAuthStore.getState().setAuth('test-token', {
       id: '1',
       username: 'admin',
@@ -195,6 +207,92 @@ describe('DataRetentionTab', () => {
         ([, opts]) => opts && typeof opts === 'object' && 'method' in opts && (opts as RequestInit).method === 'PUT',
       );
       expect(putCalls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ─── #264 — denied-admin retention (CE-native) ──────────────────────────
+  describe('AdminAccessDeniedRetentionSection (#264)', () => {
+    it('renders the server value from /admin/settings', async () => {
+      mockAdminSettings = { adminAccessDeniedRetentionDays: 45 };
+      mockFetch();
+      render(<DataRetentionTab />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('admin-denied-retention-input')).toBeInTheDocument();
+      });
+      const input = screen.getByTestId('admin-denied-retention-input') as HTMLInputElement;
+      expect(input.value).toBe('45');
+    });
+
+    it('falls back to 90 (default) when the server omits the field', async () => {
+      // Simulate an older backend that has not yet been upgraded.
+      mockAdminSettings = {} as { adminAccessDeniedRetentionDays: number };
+      mockFetch();
+      render(<DataRetentionTab />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('admin-denied-retention-input')).toBeInTheDocument();
+      });
+      const input = screen.getByTestId('admin-denied-retention-input') as HTMLInputElement;
+      expect(input.value).toBe('90');
+    });
+
+    it('PUT /admin/settings carries only adminAccessDeniedRetentionDays when the save button is used', async () => {
+      const fetchSpy = mockFetch();
+      render(<DataRetentionTab />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('admin-denied-retention-input')).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByTestId('admin-denied-retention-input'), { target: { value: '30' } });
+      fireEvent.click(screen.getByTestId('admin-denied-retention-save-btn'));
+
+      await waitFor(() => {
+        const putCall = fetchSpy.mock.calls.find(
+          ([url, opts]) =>
+            typeof url === 'string' &&
+            url.includes('/admin/settings') &&
+            opts &&
+            typeof opts === 'object' &&
+            'method' in opts &&
+            (opts as RequestInit).method === 'PUT',
+        );
+        expect(putCall).toBeTruthy();
+        const body = JSON.parse((putCall![1] as RequestInit).body as string) as {
+          adminAccessDeniedRetentionDays?: number;
+        };
+        expect(body.adminAccessDeniedRetentionDays).toBe(30);
+        // Nothing else in the payload — this save button is single-field.
+        expect(Object.keys(body)).toEqual(['adminAccessDeniedRetentionDays']);
+      });
+    });
+
+    it('save button is disabled until the value diverges from the server state', async () => {
+      mockAdminSettings = { adminAccessDeniedRetentionDays: 90 };
+      mockFetch();
+      render(<DataRetentionTab />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('admin-denied-retention-save-btn')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('admin-denied-retention-save-btn')).toBeDisabled();
+
+      fireEvent.change(screen.getByTestId('admin-denied-retention-input'), { target: { value: '120' } });
+      expect(screen.getByTestId('admin-denied-retention-save-btn')).not.toBeDisabled();
+    });
+
+    it('renders the CE-native section even when the Enterprise data_retention_policies feature is gated off', async () => {
+      mockHasFeature = () => false;
+      mockFetch();
+      render(<DataRetentionTab />, { wrapper: createWrapper() });
+
+      // CE-native control visible
+      await waitFor(() => {
+        expect(screen.getByTestId('admin-denied-retention-input')).toBeInTheDocument();
+      });
+      // Enterprise-feature gate still present below it
+      expect(screen.getByTestId('data-retention-gated')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/features/admin/DataRetentionTab.tsx
+++ b/frontend/src/features/admin/DataRetentionTab.tsx
@@ -3,8 +3,9 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { m } from 'framer-motion';
 import { toast } from 'sonner';
 import {
-  Database, Loader2, Save, AlertTriangle, Trash2, Eye,
+  Database, Loader2, Save, AlertTriangle, Trash2, Eye, ShieldAlert,
 } from 'lucide-react';
+import type { AdminSettings } from '@compendiq/contracts';
 import { apiFetch } from '../../shared/lib/api';
 import { cn } from '../../shared/lib/cn';
 import { useEnterprise } from '../../shared/enterprise/use-enterprise';
@@ -36,6 +37,97 @@ function useRetentionPolicy() {
     queryFn: () => apiFetch('/admin/data-retention'),
     staleTime: 30_000,
   });
+}
+
+// ── CE-native: ADMIN_ACCESS_DENIED retention (#264) ────────────────────────
+//
+// This section is rendered in BOTH CE and EE — the Enterprise-gated
+// policy-matrix sits below the feature-gate, but the targeted retention
+// window for denial-audit rows is a CE-level safety control (a single admin
+// setting under `admin_settings.admin_access_denied_retention_days` +
+// `data-retention-service` sweep). Lives here because semantically it is a
+// data-retention knob; matches the plan's file pointer.
+
+function AdminAccessDeniedRetentionSection() {
+  const queryClient = useQueryClient();
+  const { data: settings, isLoading } = useQuery({
+    queryKey: ['admin-settings'],
+    queryFn: () => apiFetch<AdminSettings>('/admin/settings'),
+  });
+
+  const [draft, setDraft] = useState<number | undefined>(undefined);
+
+  const serverValue = settings?.adminAccessDeniedRetentionDays ?? 90;
+  const effective = draft ?? serverValue;
+  const hasChange = draft !== undefined && draft !== serverValue;
+
+  const save = useMutation({
+    mutationFn: (value: number) =>
+      apiFetch('/admin/settings', {
+        method: 'PUT',
+        body: JSON.stringify({ adminAccessDeniedRetentionDays: value }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-settings'] });
+      setDraft(undefined);
+      toast.success('Denied-admin retention updated');
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="glass-card p-4" data-testid="denied-admin-retention-loading">
+        <div className="h-10 animate-pulse rounded bg-foreground/5" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="glass-card p-4" data-testid="denied-admin-retention-section">
+      <div className="flex items-start gap-3">
+        <ShieldAlert size={18} className="mt-0.5 shrink-0 text-muted-foreground" />
+        <div className="flex-1">
+          <label
+            htmlFor="admin-denied-retention-input"
+            className="block text-sm font-medium"
+          >
+            Admin access-denied audit retention (days)
+          </label>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Automated purge of <code className="rounded bg-foreground/10 px-1">audit_log</code>{' '}
+            rows recorded when non-admins attempted admin endpoints
+            (action = <code className="rounded bg-foreground/10 px-1">ADMIN_ACCESS_DENIED</code>).
+            Default 90 days. Applies only to these rows; other audit events
+            retain their own retention.
+          </p>
+          <div className="mt-3 flex items-center gap-2">
+            <input
+              id="admin-denied-retention-input"
+              type="number"
+              min={7}
+              max={3650}
+              step={1}
+              value={effective}
+              onChange={(e) => setDraft(Number(e.target.value))}
+              className="w-28 rounded-md bg-foreground/5 px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-primary"
+              data-testid="admin-denied-retention-input"
+            />
+            <button
+              type="button"
+              onClick={() => draft !== undefined && save.mutate(draft)}
+              disabled={!hasChange || save.isPending}
+              className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              data-testid="admin-denied-retention-save-btn"
+            >
+              {save.isPending ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 // ── Component ──────────────────────────────────────────────────────────────────
@@ -102,20 +194,26 @@ export function DataRetentionTab() {
 
   if (!featureEnabled) {
     return (
-      <div className="space-y-6" data-testid="data-retention-gated">
-        <m.div
-          initial={{ opacity: 0, y: -8 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="flex items-start gap-3 rounded-lg border border-amber-500/20 bg-amber-500/5 p-4"
-        >
-          <AlertTriangle size={18} className="mt-0.5 shrink-0 text-amber-500" />
-          <div>
-            <div className="text-sm font-medium text-amber-200">Enterprise Feature</div>
-            <div className="mt-1 text-xs text-muted-foreground">
-              Data retention policies require an enterprise license with the Data Retention feature enabled.
+      <div className="space-y-6">
+        {/* #264 — denied-admin retention is a CE-level control and renders
+            irrespective of the Enterprise feature gate below. */}
+        <AdminAccessDeniedRetentionSection />
+        <div data-testid="data-retention-gated">
+          <m.div
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="flex items-start gap-3 rounded-lg border border-amber-500/20 bg-amber-500/5 p-4"
+          >
+            <AlertTriangle size={18} className="mt-0.5 shrink-0 text-amber-500" />
+            <div>
+              <div className="text-sm font-medium text-amber-200">Enterprise Feature</div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                Extended multi-table retention policies, preview, and on-demand purge
+                require an enterprise license with the Data Retention feature enabled.
+              </div>
             </div>
-          </div>
-        </m.div>
+          </m.div>
+        </div>
       </div>
     );
   }
@@ -132,6 +230,11 @@ export function DataRetentionTab() {
 
   return (
     <div className="space-y-6" data-testid="data-retention-form">
+      {/* #264 — CE-native denied-admin retention control. Rendered first so
+          the setting is consistent across CE and EE — the EE matrix below
+          covers different tables + policy-matrix features. */}
+      <AdminAccessDeniedRetentionSection />
+
       {/* Header */}
       <div>
         <h2 className="flex items-center gap-2 text-lg font-semibold">

--- a/packages/contracts/src/schemas/admin.test.ts
+++ b/packages/contracts/src/schemas/admin.test.ts
@@ -14,6 +14,7 @@ const validReadPayload = {
   embeddingChunkOverlap: 50,
   drawioEmbedUrl: null,
   reembedHistoryRetention: 150,
+  adminAccessDeniedRetentionDays: 90,
 } as const;
 
 describe('AdminSettingsSchema (read)', () => {
@@ -132,6 +133,83 @@ describe('reembedHistoryRetention (issue #257)', () => {
     it('rejects values above 10000', () => {
       expect(() =>
         UpdateAdminSettingsSchema.parse({ reembedHistoryRetention: 20_000 }),
+      ).toThrow();
+    });
+  });
+});
+
+// ─── #264 — adminAccessDeniedRetentionDays validation ────────────────────
+describe('adminAccessDeniedRetentionDays (issue #264)', () => {
+  describe('read schema', () => {
+    it('accepts a valid integer within [7, 3650]', () => {
+      const parsed = AdminSettingsSchema.parse({
+        ...validReadPayload,
+        adminAccessDeniedRetentionDays: 30,
+      });
+      expect(parsed.adminAccessDeniedRetentionDays).toBe(30);
+    });
+
+    it('accepts boundary values — 7 and 3650', () => {
+      expect(
+        AdminSettingsSchema.parse({ ...validReadPayload, adminAccessDeniedRetentionDays: 7 })
+          .adminAccessDeniedRetentionDays,
+      ).toBe(7);
+      expect(
+        AdminSettingsSchema.parse({ ...validReadPayload, adminAccessDeniedRetentionDays: 3650 })
+          .adminAccessDeniedRetentionDays,
+      ).toBe(3650);
+    });
+
+    it('rejects values below 7', () => {
+      expect(() =>
+        AdminSettingsSchema.parse({ ...validReadPayload, adminAccessDeniedRetentionDays: 6 }),
+      ).toThrow();
+    });
+
+    it('rejects values above 3650', () => {
+      expect(() =>
+        AdminSettingsSchema.parse({ ...validReadPayload, adminAccessDeniedRetentionDays: 3651 }),
+      ).toThrow();
+    });
+
+    it('rejects non-integer values', () => {
+      expect(() =>
+        AdminSettingsSchema.parse({ ...validReadPayload, adminAccessDeniedRetentionDays: 30.5 }),
+      ).toThrow();
+    });
+
+    it('requires the field to be present (not optional on read)', () => {
+      const { adminAccessDeniedRetentionDays: _d, ...withoutField } = validReadPayload;
+      expect(() => AdminSettingsSchema.parse(withoutField)).toThrow();
+    });
+  });
+
+  describe('update schema', () => {
+    it('accepts a valid integer within [7, 3650]', () => {
+      const parsed = UpdateAdminSettingsSchema.parse({ adminAccessDeniedRetentionDays: 45 });
+      expect(parsed.adminAccessDeniedRetentionDays).toBe(45);
+    });
+
+    it('treats omitted field as undefined (leave unchanged)', () => {
+      const parsed = UpdateAdminSettingsSchema.parse({});
+      expect(parsed.adminAccessDeniedRetentionDays).toBeUndefined();
+    });
+
+    it('rejects values below 7', () => {
+      expect(() =>
+        UpdateAdminSettingsSchema.parse({ adminAccessDeniedRetentionDays: 6 }),
+      ).toThrow();
+    });
+
+    it('rejects values above 3650', () => {
+      expect(() =>
+        UpdateAdminSettingsSchema.parse({ adminAccessDeniedRetentionDays: 3651 }),
+      ).toThrow();
+    });
+
+    it('rejects non-integer values', () => {
+      expect(() =>
+        UpdateAdminSettingsSchema.parse({ adminAccessDeniedRetentionDays: 30.5 }),
       ).toThrow();
     });
   });

--- a/packages/contracts/src/schemas/admin.ts
+++ b/packages/contracts/src/schemas/admin.ts
@@ -49,6 +49,14 @@ export const AdminSettingsSchema = z.object({
   // Per-user concurrent SSE-stream cap (#268). Separate from rateLimitLlmStream:
   // that caps requests/minute; this caps concurrently-open streams.
   llmMaxConcurrentStreamsPerUser: z.number().int().min(1).max(20).optional(),
+  /**
+   * Issue #264 — retention (days) for `audit_log` rows where
+   * action = 'ADMIN_ACCESS_DENIED'. Consumed by the targeted purge in
+   * `data-retention-service.ts :: runAdminAccessDeniedRetention`. Default
+   * 90, clamped to [7, 3650]. Does NOT affect other audit actions — they
+   * continue to follow the umbrella `audit_log: 365 days` sweep.
+   */
+  adminAccessDeniedRetentionDays: z.number().int().min(7).max(3650),
 });
 
 export const UpdateAdminSettingsSchema = z.object({
@@ -77,6 +85,8 @@ export const UpdateAdminSettingsSchema = z.object({
   reembedHistoryRetention: z.number().int().min(10).max(10_000).optional(),
   // Per-user concurrent SSE-stream cap (#268).
   llmMaxConcurrentStreamsPerUser: z.number().int().min(1).max(20).optional(),
+  /** Issue #264 — optional on update; omitted → leave unchanged. */
+  adminAccessDeniedRetentionDays: z.number().int().min(7).max(3650).optional(),
 });
 
 export type AdminSettings = z.infer<typeof AdminSettingsSchema>;


### PR DESCRIPTION
## Summary

Every 403/401 from `requireAdmin` now writes an audit row (`ADMIN_ACCESS_DENIED`). Retention piggy-backs on `data-retention-service.ts` with a configurable default of 90 days, purging via batched `DELETE` to bound storage growth.

Closes #264.

## What ships

- **Decorator-level audit**: `requireAdmin` writes an `ADMIN_ACCESS_DENIED` audit row with `actorUserId` (or null), `requestIp`, route + method, and `reason: 'not_admin' | 'unauthenticated'`. Uses the existing `logAuditEvent()` primitive — already try/catch-wrapped internally so the 403 path is never blocked by DB failure.
- **Admin setting `admin_access_denied_retention_days`** (integer, default 90, min 7, max 3650). Migration **057**. Zod schema update, GET/PUT wiring, read helper in `admin-settings-service.ts`.
- **Extended `data-retention-service.ts`** with a rule targeting only `audit_log` rows where `action = 'ADMIN_ACCESS_DENIED'`. Batched `DELETE ... WHERE id IN (SELECT id ... LIMIT 10000)` loop. Parameterized SQL, per-batch rowCount logged. Successful admin actions + non-admin audit events untouched.
- **UI**: new CE-native `AdminAccessDeniedRetentionSection` in `DataRetentionTab.tsx` — rendered in both the EE-gated and enabled branches, so CE admins can see the control regardless of enterprise features.

## Migration coordination

- `055` — PR #261 (merged)
- `056` — PR #273 (#268, open)
- `057` — this PR

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1975 backend (1 skipped pre-existing) + 1817 frontend + 47 contracts, all pass
- [x] 40 new test cases across 5 test files (3 new, 2 extended)
- [x] Real-DB integration tests for the decorator + retention service

## Deviations from plan

1. **Decorator tests** moved to a sibling file `auth.requireadmin.test.ts` to avoid `vi.resetModules()` contamination from the existing `auth.test.ts`.
2. **RED #1/#2 target route** — retargeted from `/api/admin/embedding/locks/...` (split-pattern: `authenticate` onRequest + `requireAdmin` preHandler) to `/api/admin/audit-log` (single-pattern: `requireAdmin` onRequest). Only the single-pattern exercises Path A through the decorator. See follow-up TODO 1.
3. **Fire-and-forget mechanism** — chose inline `await logAuditEvent()`. The function is already try/catch-wrapped inside audit-service, same resilience profile as setImmediate/void-promise, and keeps tests non-racey (row committed before 403 returns).
4. **Frontend placement** — `DataRetentionTab.tsx` is EE-gated; added a CE-native subcomponent above the gate so the control renders for all admins.

## Follow-ups (not in scope)

1. **Path A coverage for split-pattern routes** — routes that register `authenticate` on-request + `requireAdmin` preHandler still 401 unauthenticated requests without a row. Migrate those to the single-pattern if broader coverage wanted.
2. **`idx_audit_log_action_created` index** — optional perf if `EXPLAIN ANALYZE` shows seq-scans on the purge DELETE. Separate migration `058`.
3. **Env var top-level docs** — `RETENTION_ADMIN_ACCESS_DENIED_DAYS` is a fallback-of-last-resort; documented in JSDoc + migration, but not yet in `CLAUDE.md` / `.env.example` top-level blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)