### PR TITLE
chore(#277): remove deprecated /api/ollama/circuit-breaker-status alias

### DIFF
--- a/backend/src/routes/llm/llm-models.test.ts
+++ b/backend/src/routes/llm/llm-models.test.ts
@@ -90,11 +90,6 @@ describe('llm-models routes — auth required', () => {
     expect(r.statusCode).toBe(401);
   });
 
-  it('returns 401 for GET /api/ollama/circuit-breaker-status without auth', async () => {
-    const r = await app.inject({ method: 'GET', url: '/api/ollama/circuit-breaker-status' });
-    expect(r.statusCode).toBe(401);
-  });
-
   it('returns 401 for GET /api/llm/circuit-breaker-status without auth', async () => {
     const r = await app.inject({ method: 'GET', url: '/api/llm/circuit-breaker-status' });
     expect(r.statusCode).toBe(401);
@@ -168,9 +163,9 @@ describe('llm-models routes — models + status', () => {
     expect(r.json()).toEqual([]);
   });
 
-  // --- GET /api/llm/circuit-breaker-status (canonical) + /api/ollama/circuit-breaker-status (deprecated alias, issue #266) ---
+  // --- GET /api/llm/circuit-breaker-status ---
 
-  it('GET /api/llm/circuit-breaker-status returns the provider-keyed flat map with no deprecation headers', async () => {
+  it('returns the provider-keyed flat map', async () => {
     mockListProviderBreakers.mockReturnValue([
       { providerId: 'p1', state: 'closed', failureCount: 0, nextRetryTime: null },
       { providerId: 'p2', state: 'open',   failureCount: 3, nextRetryTime: 123 },
@@ -181,39 +176,17 @@ describe('llm-models routes — models + status', () => {
       p1: { state: 'closed', failureCount: 0, nextRetryTime: null },
       p2: { state: 'open',   failureCount: 3, nextRetryTime: 123 },
     });
-    expect(r.headers['deprecation']).toBeUndefined();
-    expect(r.headers['sunset']).toBeUndefined();
-    expect(r.headers['link']).toBeUndefined();
   });
 
-  it('GET /api/ollama/circuit-breaker-status is a deprecated alias with RFC 9745 / 8594 headers and parity payload', async () => {
-    mockListProviderBreakers.mockReturnValue([
-      { providerId: 'p1', state: 'closed', failureCount: 0, nextRetryTime: null },
-    ]);
-    const r = await app.inject({ method: 'GET', url: '/api/ollama/circuit-breaker-status' });
-    expect(r.statusCode).toBe(200);
-    // Payload parity with the canonical route.
-    expect(r.json()).toEqual({
-      p1: { state: 'closed', failureCount: 0, nextRetryTime: null },
-    });
-    // RFC 9745 Structured Item — `@`-prefixed Unix epoch. NOT "true".
-    expect(r.headers['deprecation']).toMatch(/^@\d+$/);
-    expect(r.headers['deprecation']).not.toBe('true');
-    // RFC 8594 IMF-fixdate.
-    expect(r.headers['sunset']).toMatch(
-      /^[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} GMT$/,
-    );
-    // RFC 9745 §2 successor-version link pointing at the canonical path.
-    expect(r.headers['link']).toBe('</api/llm/circuit-breaker-status>; rel="successor-version"');
-  });
-
-  it('Sunset date is strictly after Deprecation date on the deprecated alias (RFC 9745 constraint)', async () => {
+  it('returns an empty object when no provider breakers have booted yet', async () => {
     mockListProviderBreakers.mockReturnValue([]);
-    const r = await app.inject({ method: 'GET', url: '/api/ollama/circuit-breaker-status' });
+    const r = await app.inject({ method: 'GET', url: '/api/llm/circuit-breaker-status' });
     expect(r.statusCode).toBe(200);
-    const depEpochMs = parseInt((r.headers['deprecation'] as string).slice(1), 10) * 1000;
-    const sunsetEpochMs = new Date(r.headers['sunset'] as string).getTime();
-    expect(Number.isFinite(sunsetEpochMs)).toBe(true);
-    expect(sunsetEpochMs).toBeGreaterThan(depEpochMs);
+    expect(r.json()).toEqual({});
+  });
+
+  it('no longer serves the retired /api/ollama/circuit-breaker-status alias (#277)', async () => {
+    const r = await app.inject({ method: 'GET', url: '/api/ollama/circuit-breaker-status' });
+    expect(r.statusCode).toBe(404);
   });
 });

--- a/backend/src/routes/llm/llm-models.ts
+++ b/backend/src/routes/llm/llm-models.ts
@@ -11,24 +11,6 @@ import { decryptPat } from '../../core/utils/crypto.js';
 import { listProviderBreakers } from '../../core/services/circuit-breaker.js';
 import { logger } from '../../core/utils/logger.js';
 
-// ─── Deprecation header constants — single source of truth (issue #266) ────
-//
-// The /api/ollama/circuit-breaker-status route is a deprecated alias for
-// /api/llm/circuit-breaker-status. These constants MUST stay consistent:
-//   - `DEPRECATION_EPOCH` is the moment this alias was marked deprecated. It is
-//     the `@`-prefixed Structured Date value per RFC 9745 §2 (Structured Item
-//     form) — NOT the non-spec "true" sentinel.
-//   - `SUNSET_HTTP_DATE` is the HTTP-date per RFC 8594, strictly later than
-//     `DEPRECATION_EPOCH`. After this moment the follow-up PR removes the
-//     alias entirely (see docs/issues/266-implementation-plan.md §3).
-//   - `SUCCESSOR_URL` is the canonical replacement route; surfaced via a
-//     `Link: <…>; rel="successor-version"` header per RFC 9745 §2.
-//
-// Grace window: 6 months (2026-04-21 → 2026-10-21) per implementer directive.
-const DEPRECATION_EPOCH = 1776729600; // 2026-04-21T00:00:00Z
-const SUNSET_HTTP_DATE = 'Wed, 21 Oct 2026 00:00:00 GMT';
-const SUCCESSOR_URL = '/api/llm/circuit-breaker-status';
-
 async function getDefaultProviderConfig(): Promise<ProviderConfig | null> {
   const row = await query<{
     id: string; base_url: string; api_key: string | null;
@@ -119,14 +101,10 @@ export async function llmModelRoutes(fastify: FastifyInstance) {
     };
   });
 
-  // Shared handler for both the canonical route and its deprecated alias.
-  // Returns a provider-keyed flat map of live circuit-breaker state — only
-  // providers that have actually been contacted show up (see
-  // core/services/circuit-breaker.ts → listProviderBreakers).
-  function buildBreakerStatus(): Record<
-    string,
-    { state: string; failureCount: number; nextRetryTime: number | null }
-  > {
+  // GET /api/llm/circuit-breaker-status — provider-keyed flat map of live
+  // circuit-breaker state. Only providers that have actually been contacted
+  // show up (see core/services/circuit-breaker.ts → listProviderBreakers).
+  fastify.get('/llm/circuit-breaker-status', async () => {
     const out: Record<
       string,
       { state: string; failureCount: number; nextRetryTime: number | null }
@@ -139,20 +117,5 @@ export async function llmModelRoutes(fastify: FastifyInstance) {
       };
     }
     return out;
-  }
-
-  // GET /api/llm/circuit-breaker-status — canonical (issue #266).
-  fastify.get('/llm/circuit-breaker-status', async () => buildBreakerStatus());
-
-  // GET /api/ollama/circuit-breaker-status — DEPRECATED alias. Removed after
-  // sunset (see docs/issues/266-implementation-plan.md §3, follow-up PR).
-  fastify.get('/ollama/circuit-breaker-status', async (_request, reply) => {
-    // RFC 9745 §2 Structured Item form — `@`-prefixed Unix epoch. NOT "true".
-    reply.header('Deprecation', `@${DEPRECATION_EPOCH}`);
-    // RFC 8594 — HTTP-date, strictly later than Deprecation (asserted in tests).
-    reply.header('Sunset', SUNSET_HTTP_DATE);
-    // RFC 9745 §2 — canonical field for tooling auto-migration to the successor.
-    reply.header('Link', `<${SUCCESSOR_URL}>; rel="successor-version"`);
-    return buildBreakerStatus();
   });
 }

--- a/docs/ADMIN-GUIDE.md
+++ b/docs/ADMIN-GUIDE.md
@@ -403,8 +403,6 @@ Compendiq provides Kubernetes-compatible health probes:
 | `GET /api/health/start` | Startup probe | Startup complete + PostgreSQL + LLM availability |
 | `GET /api/llm/circuit-breaker-status` | Per-provider circuit-breaker state | Returns a provider-keyed flat map: `{ [providerId]: { state, failureCount, nextRetryTime } }`. Requires auth. |
 
-> The legacy path `GET /api/ollama/circuit-breaker-status` remains as a **deprecated alias** during a 6-month grace window (through **2026-10-21**, issue [#266](https://github.com/Compendiq/compendiq-ce/issues/266)). Responses from the alias include **RFC 9745** `Deprecation: @<epoch>` (Structured Item form — *not* `Deprecation: true`), **RFC 8594** `Sunset: Wed, 21 Oct 2026 00:00:00 GMT`, and `Link: </api/llm/circuit-breaker-status>; rel="successor-version"` so clients can auto-migrate. Update any operator tooling to the canonical path before the sunset date.
-
 Example response from `GET /api/health`:
 
 ```json


### PR DESCRIPTION
## Summary

Removes the deprecated `/api/ollama/circuit-breaker-status` alias that was introduced in PR #272 with a 6-month RFC 8594 grace window.

Given there are no external consumers on the legacy path yet, the grace window is theatre — the deprecation headers were shipped today, so nobody has had a chance to rely on them either way. Deleting the alias now removes ~30 lines of scaffolding and consolidates the surface on the canonical `/api/llm/circuit-breaker-status`.

Closes #277.

## What changes

- Remove `DEPRECATION_EPOCH`, `SUNSET_HTTP_DATE`, `SUCCESSOR_URL` constants from `llm-models.ts`.
- Remove the `/api/ollama/circuit-breaker-status` handler and its `reply.header(...)` wiring.
- Inline `buildBreakerStatus()` back into the single canonical route (no longer needed as a shared helper).
- Drop the two alias-specific tests (RFC 9745 header assertions, Sunset-after-Deprecation constraint).
- Add a 404 regression guard: `GET /api/ollama/circuit-breaker-status` returns 404 now.
- Remove the deprecation footnote from `docs/ADMIN-GUIDE.md`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — all pass (10/10 in `llm-models.test.ts`)
- [x] New regression test asserts `GET /api/ollama/circuit-breaker-status` returns 404

Net: **-80 lines, +14 lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)