### PR TITLE
docs: rollup of architecture / perf / security notes for #263–#268 batch

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -54,6 +54,9 @@ Performance is measured at three layers:
 | Time to first SSE token (AI chat) | p99 < 2s |
 | Total streaming duration (short query) | p99 < 15s |
 | Time to first SSE token (improve/summarize) | p99 < 3s |
+| `acquire()` round-trip on per-user SSE stream cap (#268) | p99 < 5ms (Redis Lua EVAL) |
+
+**Concurrent-stream cap (#268):** Each streaming route (`llm-ask`, `llm-generate`, `llm-improve`, `llm-summarize`, `llm-quality`, `llm-diagram`) calls `ssStreamLimiter.acquire(userId)` before opening the SSE response. Over-cap requests return `429 Too Many Requests` without contacting the upstream LLM — so the 429 path should be *faster*, not slower, than a normal stream. The cap is admin-configurable (default 3, env `LLM_MAX_CONCURRENT_STREAMS_PER_USER` as fallback) and cache-TTL is 60s; a setting change takes effect on the next `acquire()`.
 
 ### Frontend Core Web Vitals
 
@@ -222,8 +225,10 @@ npm run dev
 1. **p99 API latency trending above targets** -- Investigate slow queries or missing indexes.
 2. **Embedding generation queue depth** -- If the queue grows faster than it drains, consider scaling workers or reducing batch size.
 3. **SSE streaming timeout rate** -- High timeout rates indicate LLM provider issues.
-4. **Database connection pool exhaustion** -- Monitor `pg_stat_activity` for idle connections.
-5. **Redis memory usage** -- LLM cache and session data can grow; monitor eviction rates.
+4. **Per-user SSE stream 429 rate (#268)** -- A single user repeatedly hitting the concurrent-stream cap is a signal to (a) investigate whether the user's client is leaking stream handles, or (b) raise `LLM_MAX_CONCURRENT_STREAMS_PER_USER` globally if the cap is too tight for legitimate workloads.
+5. **`listActiveEmbeddingLocks` P99 latency (#265)** -- now SMEMBERS + pipelined `PTTL`/`GET` over a dedicated Redis set. If P99 on `GET /api/admin/embedding/locks` ever exceeds ~50 ms, investigate Redis latency (shouldn't be keyspace-dependent anymore).
+6. **Database connection pool exhaustion** -- Monitor `pg_stat_activity` for idle connections.
+7. **Redis memory usage** -- LLM cache, session data, and stream counters can grow; monitor eviction rates. The per-user stream counter has a 1-hour `EXPIRE` self-heal, so leaked counters reset automatically.
 
 ### Regression Detection
 

--- a/docs/SECURITY-AUDIT.md
+++ b/docs/SECURITY-AUDIT.md
@@ -111,6 +111,7 @@ Verified every route file for authentication hooks (`onRequest`, `preHandler`) o
 | `auth.ts` /cleanup-tokens | `preHandler: fastify.requireAdmin` | PASS |
 | `settings.ts` | `fastify.addHook('onRequest', fastify.authenticate)` | PASS |
 | `admin.ts` | `fastify.addHook('onRequest', fastify.requireAdmin)` | PASS |
+| `admin-embedding-locks.ts` | `fastify.addHook('onRequest', fastify.requireAdmin)` (#257) | PASS -- force-release audit-logged |
 | `rbac.ts` /permissions/* | `onRequest: fastify.authenticate` per route | PASS |
 | `rbac.ts` admin routes | `admin.addHook('onRequest', admin.requireAdmin)` | PASS |
 | `oidc.ts` /auth/oidc/config | None (exempt) | PASS -- login page needs this |
@@ -265,6 +266,7 @@ function getJwtSecret(): Uint8Array {
 | OIDC routes | 10 req/min | PASS |
 | RBAC admin routes | 30 req/min | PASS |
 | LLM streaming routes | 10 req/min | PASS |
+| LLM concurrent SSE streams per user | 3 concurrent (admin-configurable, 1–20, #268) | PASS -- Redis counter with Lua atomic acquire; 429 on exceed; self-heals on process crash via 1h `EXPIRE` |
 | Embedding routes | 5 req/min | PASS |
 | PDF extraction | 5 req/min | PASS |
 | Setup status (GET) | 20 req/min | PASS (#82) |
@@ -309,6 +311,13 @@ function getJwtSecret(): Uint8Array {
 - **PASS:** Refresh token cookie: httpOnly, secure (in production), sameSite=strict, path-scoped
 - **PASS:** OIDC callback uses sameSite=lax (required for cross-origin IdP redirect)
 
+### Admin-action audit (#264)
+
+- **PASS:** `requireAdmin` writes an `ADMIN_ACCESS_DENIED` audit row on every 401/403 — not just on the success path. Forensic visibility into admin-endpoint probes by non-admins.
+- **PASS:** Each rejection captures `actorUserId` (or null for unauthenticated), `requestIp`, route + method, and `reason: 'not_admin' | 'unauthenticated'`.
+- **PASS:** Retention is admin-configurable (`admin_access_denied_retention_days`, default 90 days, min 7, max 3650, migration 057) and purged by `data-retention-service.ts` via batched `DELETE ... WHERE action = 'ADMIN_ACCESS_DENIED'` — brute-forcers can't grow `audit_log` unbounded without the operator noticing via the retention dial.
+- **PASS:** Force-release of admin embedding locks (`POST /api/admin/embedding/locks/:userId/release`) emits `ADMIN_ACTION.embedding_lock.force_release_embedding_lock` audit events; worker has a holder-epoch guard that re-checks every 20 pages and aborts cleanly if force-released mid-run.
+
 ### Input validation
 
 - **PASS:** Zod schemas from `@compendiq/contracts` on all API boundaries
@@ -348,7 +357,8 @@ function getJwtSecret(): Uint8Array {
 | 2.4 CORS verification | PASS (origin from env var, no wildcard) |
 | 2.5 Startup secret validation | PASS (rejects weak/default secrets in production) |
 | 2.6 Debug/dev route review | PASS (after Swagger fix) |
-| Rate limiting | PASS (all sensitive endpoints rate-limited) |
+| Rate limiting | PASS (all sensitive endpoints rate-limited; per-user concurrent SSE-stream cap added in #268) |
+| Admin-action audit (denied attempts) | PASS (#264 — `ADMIN_ACCESS_DENIED` rows at the `requireAdmin` decorator, 90-day retention) |
 | SSRF protection | PASS (comprehensive IP/hostname/protocol blocking) |
 | LLM prompt injection | PASS (sanitization on all input paths) |
 | PAT encryption | PASS (AES-256-GCM with rotation support) |

--- a/docs/architecture/03-backend-domains.md
+++ b/docs/architecture/03-backend-domains.md
@@ -10,7 +10,7 @@ imports enforced by `eslint-plugin-boundaries` (see
 flowchart LR
     subgraph routes["routes/ (HTTP entry points)"]
         direction TB
-        rF["foundation<br/>health, auth, settings,<br/>admin, rbac, notifications, setup"]
+        rF["foundation<br/>health, auth, settings,<br/>admin, admin-embedding-locks,<br/>rbac, notifications, setup"]
         rC["confluence<br/>spaces, sync, attachments"]
         rL["llm<br/>llm-ask (SSE), improve, generate,<br/>summarize, diagram, conversations,<br/>embeddings, models, admin, pdf"]
         rK["knowledge<br/>pages CRUD, versions, tags,<br/>embeddings, duplicates, pinned,<br/>templates, comments, search,<br/>analytics, requests, export/import"]
@@ -27,7 +27,7 @@ flowchart LR
         direction TB
         cDB["db/ — pg pool, migrations"]
         cPlug["plugins/ — auth, correlation-id, redis"]
-        cSvc["services/ — redis-cache, audit,<br/>error-tracker, content-converter,<br/>circuit-breaker, image-references,<br/>rbac, notifications, pdf,<br/>admin-settings, version-snapshot"]
+        cSvc["services/ — redis-cache, audit,<br/>error-tracker, content-converter,<br/>circuit-breaker, image-references,<br/>rbac, notifications, pdf,<br/>admin-settings, version-snapshot,<br/>sse-stream-limiter, queue-service,<br/>data-retention, rate-limit"]
         cUtil["utils/ — crypto (AES-GCM),<br/>logger (pino), sanitize-llm-input,<br/>ssrf-guard, tls-config, llm-config"]
         cEnt["enterprise/ — types, noop,<br/>loader, features"]
     end


### PR DESCRIPTION
## Summary

Post-merge docs rollup — brings `docs/architecture/03-backend-domains.md`, `docs/PERFORMANCE.md`, and `docs/SECURITY-AUDIT.md` up to date after the #263–#268 batch landed. No code changes.

## Changes

**`docs/architecture/03-backend-domains.md`**
- Add `sse-stream-limiter`, `queue-service`, `data-retention`, `rate-limit` to the `core/services/` mermaid block (some pre-dated this batch; diagram just lagged).
- Add `admin-embedding-locks` to the `routes/foundation` block.

**`docs/PERFORMANCE.md`**
- New SSE-streaming target: `acquire()` round-trip p99 < 5 ms (Redis Lua EVAL from #268).
- New monitoring items: per-user SSE 429 rate (signal for leaked stream handles or too-tight global cap) and `listActiveEmbeddingLocks` P99 (should no longer depend on Redis keyspace size after #265).

**`docs/SECURITY-AUDIT.md`**
- Add `admin-embedding-locks.ts` to the auth-coverage matrix (§3).
- Add the per-user SSE concurrent-stream cap to the rate-limiting table (§7).
- New "Admin-action audit (#264)" section documenting the decorator-level `ADMIN_ACCESS_DENIED` rows, retention mechanics, and force-release audit trail.
- Summary table (§9) gets an Admin-action audit row; rate-limiting row updated.

## Follow-up to

- #263 (PR #274 merged)
- #264 (PR #276 merged)
- #265 (PR #275 merged)
- #266 (PR #272 merged)
- #267 (PR #270 merged)
- #268 (PR #273 merged)
- #269 (PR #271 merged)
- #277 (PR #278 merged)