### PR TITLE
fix(admin): align LLM Policy, LLM Audit, Data Retention tabs with real API

### DIFF
--- a/frontend/src/features/admin/DataRetentionTab.test.tsx
+++ b/frontend/src/features/admin/DataRetentionTab.test.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { DataRetentionTab } from './DataRetentionTab';
 import { useAuthStore } from '../../stores/auth-store';
 
-// ── Mock useEnterprise ────────────────────────────────────���────────────────────
+// ── Mock useEnterprise ─────────────────────────────────────────────────────────
 
 let mockHasFeature = (_f: string) => true;
 
@@ -39,19 +39,22 @@ function createWrapper() {
   };
 }
 
-const mockRetentionPolicy = {
-  rules: [
-    { table: 'llm_audit_log', retentionDays: 90, enabled: true },
-    { table: 'sync_history', retentionDays: 30, enabled: true },
-    { table: 'error_log', retentionDays: null, enabled: false },
+// Matches backend `RetentionConfig` returned by GET /admin/data-retention.
+const mockRetentionConfig = {
+  policies: [
+    { tableName: 'llm_audit_log', displayName: 'LLM Audit Log', retentionDays: 90, enabled: true },
+    { tableName: 'audit_log', displayName: 'Audit Log', retentionDays: 30, enabled: true },
+    { tableName: 'error_log', displayName: 'Error Log', retentionDays: 0, enabled: false },
   ],
-  extendedRetention: false,
+  extendedRetentionEnabled: false,
+  extendedRetentionDays: 365,
 };
 
+// Matches backend `RetentionPreview[]` from GET /admin/data-retention/preview.
 const mockPreview = [
-  { table: 'llm_audit_log', rowCount: 1250, oldestRecord: '2025-01-15T00:00:00Z' },
-  { table: 'sync_history', rowCount: 340, oldestRecord: '2025-03-01T00:00:00Z' },
-  { table: 'error_log', rowCount: 0, oldestRecord: null },
+  { tableName: 'llm_audit_log', displayName: 'LLM Audit Log', retentionDays: 90, estimatedRows: 1250 },
+  { tableName: 'audit_log', displayName: 'Audit Log', retentionDays: 30, estimatedRows: 340 },
+  { tableName: 'error_log', displayName: 'Error Log', retentionDays: 0, estimatedRows: 0 },
 ];
 
 // #264 — GET /admin/settings is consumed by AdminAccessDeniedRetentionSection.
@@ -71,12 +74,17 @@ function mockFetch() {
       });
     }
     if (url.includes('/admin/data-retention/purge') && method === 'POST') {
-      return new Response(JSON.stringify({ success: true }), {
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return new Response(
+        JSON.stringify({
+          results: [
+            { tableName: 'llm_audit_log', displayName: 'LLM Audit Log', deletedRows: 1250 },
+          ],
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
     }
     if (url.includes('/admin/data-retention')) {
-      return new Response(JSON.stringify(mockRetentionPolicy), {
+      return new Response(JSON.stringify(mockRetentionConfig), {
         headers: { 'Content-Type': 'application/json' },
       });
     }
@@ -91,7 +99,7 @@ function mockFetch() {
   });
 }
 
-// ── Tests ────────────���─────────────────────��───────────────────────────────��───
+// ── Tests ──────────────────────────────────────────────────────────────────────
 
 describe('DataRetentionTab', () => {
   beforeEach(() => {
@@ -126,25 +134,27 @@ describe('DataRetentionTab', () => {
     });
   });
 
-  it('displays retention rules table with data from API', async () => {
+  it('displays per-table policies with displayName + tableName from the API', async () => {
     mockFetch();
     render(<DataRetentionTab />, { wrapper: createWrapper() });
 
     await waitFor(() => {
       expect(screen.getByTestId('retention-rules-table')).toBeInTheDocument();
     });
+    expect(screen.getByText('LLM Audit Log')).toBeInTheDocument();
     expect(screen.getByText('llm_audit_log')).toBeInTheDocument();
-    expect(screen.getByText('sync_history')).toBeInTheDocument();
+    expect(screen.getByText('audit_log')).toBeInTheDocument();
     expect(screen.getByText('error_log')).toBeInTheDocument();
   });
 
-  it('has extended retention toggle', async () => {
+  it('has extended retention toggle and days input', async () => {
     mockFetch();
     render(<DataRetentionTab />, { wrapper: createWrapper() });
 
     await waitFor(() => {
       expect(screen.getByTestId('extended-retention-toggle')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('extended-retention-days-input')).toBeInTheDocument();
   });
 
   it('shows preview results when preview button is clicked', async () => {
@@ -160,6 +170,9 @@ describe('DataRetentionTab', () => {
     await waitFor(() => {
       expect(screen.getByTestId('preview-results')).toBeInTheDocument();
     });
+    // estimatedRows from mock
+    expect(screen.getByText('1,250')).toBeInTheDocument();
+    expect(screen.getByText('340')).toBeInTheDocument();
   });
 
   it('shows purge confirmation dialog requiring type-to-confirm', async () => {
@@ -192,7 +205,7 @@ describe('DataRetentionTab', () => {
     });
   });
 
-  it('submits PUT when save is clicked', async () => {
+  it('submits PUT with policies/extendedRetentionEnabled/extendedRetentionDays matching the backend schema', async () => {
     const fetchSpy = mockFetch();
     render(<DataRetentionTab />, { wrapper: createWrapper() });
 
@@ -203,10 +216,22 @@ describe('DataRetentionTab', () => {
     fireEvent.click(screen.getByTestId('data-retention-save-btn'));
 
     await waitFor(() => {
-      const putCalls = fetchSpy.mock.calls.filter(
-        ([, opts]) => opts && typeof opts === 'object' && 'method' in opts && (opts as RequestInit).method === 'PUT',
+      const putCall = fetchSpy.mock.calls.find(
+        ([url, opts]) =>
+          typeof url === 'string' &&
+          url.includes('/admin/data-retention') &&
+          !url.includes('/preview') &&
+          !url.includes('/purge') &&
+          opts && typeof opts === 'object' && 'method' in opts && (opts as RequestInit).method === 'PUT',
       );
-      expect(putCalls.length).toBeGreaterThanOrEqual(1);
+      expect(putCall).toBeTruthy();
+      const body = JSON.parse((putCall![1] as RequestInit).body as string);
+      expect(Array.isArray(body.policies)).toBe(true);
+      expect(body.policies[0]).toHaveProperty('tableName');
+      expect(body.policies[0]).toHaveProperty('retentionDays');
+      expect(body.policies[0]).not.toHaveProperty('table');
+      expect(typeof body.extendedRetentionEnabled).toBe('boolean');
+      expect(typeof body.extendedRetentionDays).toBe('number');
     });
   });
 

--- a/frontend/src/features/admin/DataRetentionTab.tsx
+++ b/frontend/src/features/admin/DataRetentionTab.tsx
@@ -10,29 +10,36 @@ import { apiFetch } from '../../shared/lib/api';
 import { cn } from '../../shared/lib/cn';
 import { useEnterprise } from '../../shared/enterprise/use-enterprise';
 
-// ── Types ──────────────────────────────────────────────────────────────────────
+// ── Types (match backend data-retention-service.ts) ───────────────────────────
 
-interface RetentionRule {
-  table: string;
-  retentionDays: number | null;
+interface RetentionPolicy {
+  tableName: string;
+  displayName: string;
+  retentionDays: number; // 0 means "keep forever"
   enabled: boolean;
 }
 
-interface RetentionPolicy {
-  rules: RetentionRule[];
-  extendedRetention: boolean;
+interface RetentionConfig {
+  policies: RetentionPolicy[];
+  extendedRetentionEnabled: boolean;
+  extendedRetentionDays: number;
 }
 
-interface PreviewResult {
-  table: string;
-  rowCount: number;
-  oldestRecord: string | null;
+interface RetentionPreview {
+  tableName: string;
+  displayName: string;
+  retentionDays: number;
+  estimatedRows: number;
+}
+
+interface PurgeResponse {
+  results: Array<{ tableName: string; displayName: string; deletedRows: number }>;
 }
 
 // ── Hooks ──────────────────────────────────────────────────────────────────────
 
-function useRetentionPolicy() {
-  return useQuery<RetentionPolicy>({
+function useRetentionConfig() {
+  return useQuery<RetentionConfig>({
     queryKey: ['admin', 'data-retention'],
     queryFn: () => apiFetch('/admin/data-retention'),
     staleTime: 30_000,
@@ -135,27 +142,39 @@ function AdminAccessDeniedRetentionSection() {
 export function DataRetentionTab() {
   const queryClient = useQueryClient();
   const { hasFeature } = useEnterprise();
-  const { data: policy, isLoading } = useRetentionPolicy();
+  const { data: config, isLoading } = useRetentionConfig();
 
-  const [rules, setRules] = useState<RetentionRule[]>([]);
-  const [extendedRetention, setExtendedRetention] = useState(false);
+  const [policies, setPolicies] = useState<RetentionPolicy[]>([]);
+  const [extendedRetentionEnabled, setExtendedRetentionEnabled] = useState(false);
+  const [extendedRetentionDays, setExtendedRetentionDays] = useState(365);
   const [initialized, setInitialized] = useState(false);
-  const [preview, setPreview] = useState<PreviewResult[] | null>(null);
+  const [preview, setPreview] = useState<RetentionPreview[] | null>(null);
   const [purgeConfirm, setPurgeConfirm] = useState('');
   const [showPurgeDialog, setShowPurgeDialog] = useState(false);
 
   const featureEnabled = hasFeature('data_retention_policies');
 
   // Populate form when data loads
-  if (policy && !initialized) {
-    setRules(policy.rules);
-    setExtendedRetention(policy.extendedRetention);
+  if (config && !initialized) {
+    setPolicies(config.policies ?? []);
+    setExtendedRetentionEnabled(Boolean(config.extendedRetentionEnabled));
+    setExtendedRetentionDays(config.extendedRetentionDays ?? 365);
     setInitialized(true);
   }
 
   const saveMutation = useMutation({
-    mutationFn: (body: RetentionPolicy) =>
-      apiFetch('/admin/data-retention', { method: 'PUT', body: JSON.stringify(body) }),
+    mutationFn: () =>
+      apiFetch('/admin/data-retention', {
+        method: 'PUT',
+        body: JSON.stringify({
+          policies: policies.map((p) => ({
+            tableName: p.tableName,
+            retentionDays: p.retentionDays,
+          })),
+          extendedRetentionEnabled,
+          extendedRetentionDays,
+        }),
+      }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'data-retention'] });
       toast.success('Retention policy saved');
@@ -164,16 +183,17 @@ export function DataRetentionTab() {
   });
 
   const previewMutation = useMutation({
-    mutationFn: () => apiFetch<PreviewResult[]>('/admin/data-retention/preview'),
+    mutationFn: () => apiFetch<RetentionPreview[]>('/admin/data-retention/preview'),
     onSuccess: (data) => setPreview(data),
     onError: (err) => toast.error(err.message),
   });
 
   const purgeMutation = useMutation({
     mutationFn: () =>
-      apiFetch('/admin/data-retention/purge', { method: 'POST' }),
-    onSuccess: () => {
-      toast.success('Data purge completed');
+      apiFetch<PurgeResponse>('/admin/data-retention/purge', { method: 'POST' }),
+    onSuccess: (data) => {
+      const totalDeleted = data.results?.reduce((s, r) => s + Math.max(0, r.deletedRows), 0) ?? 0;
+      toast.success(`Data purge completed — ${totalDeleted.toLocaleString()} rows deleted`);
       setShowPurgeDialog(false);
       setPurgeConfirm('');
       setPreview(null);
@@ -182,15 +202,28 @@ export function DataRetentionTab() {
     onError: (err) => toast.error(err.message),
   });
 
-  const handleRuleChange = useCallback((index: number, field: keyof RetentionRule, value: unknown) => {
-    setRules((prev) => prev.map((r, i) =>
-      i === index ? { ...r, [field]: value } : r,
-    ));
-  }, []);
+  const handlePolicyChange = useCallback(
+    (index: number, field: 'retentionDays' | 'enabled', value: unknown) => {
+      setPolicies((prev) =>
+        prev.map((p, i) => {
+          if (i !== index) return p;
+          if (field === 'retentionDays') {
+            const days = typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0;
+            return { ...p, retentionDays: days, enabled: days > 0 };
+          }
+          if (field === 'enabled') {
+            return { ...p, enabled: Boolean(value) };
+          }
+          return p;
+        }),
+      );
+    },
+    [],
+  );
 
   const handleSave = useCallback(() => {
-    saveMutation.mutate({ rules, extendedRetention });
-  }, [rules, extendedRetention, saveMutation]);
+    saveMutation.mutate();
+  }, [saveMutation]);
 
   if (!featureEnabled) {
     return (
@@ -242,29 +275,45 @@ export function DataRetentionTab() {
           Data Retention Policies
         </h2>
         <p className="text-sm text-muted-foreground">
-          Configure how long data is kept in each table before automatic cleanup.
+          Configure how long data is kept in each table before automatic cleanup. Set retention to 0 to keep rows forever.
         </p>
       </div>
 
-      {/* Extended retention toggle */}
-      <div className="glass-card p-4">
+      {/* Extended retention */}
+      <div className="glass-card space-y-3 p-4">
         <label className="flex items-center gap-2 text-sm">
           <input
             type="checkbox"
-            checked={extendedRetention}
-            onChange={(e) => setExtendedRetention(e.target.checked)}
+            checked={extendedRetentionEnabled}
+            onChange={(e) => setExtendedRetentionEnabled(e.target.checked)}
             className="h-4 w-4 rounded border-border accent-primary"
             data-testid="extended-retention-toggle"
           />
           <span className="font-medium">Extended retention mode</span>
         </label>
         <p className="ml-6 text-xs text-muted-foreground">
-          When enabled, all retention periods are doubled for compliance-heavy environments.
+          When enabled, retention for the LLM audit log is extended (up to 7 years) for compliance-heavy environments.
         </p>
+        <div className={cn('ml-6 flex items-center gap-2', !extendedRetentionEnabled && 'opacity-50')}>
+          <label htmlFor="extended-retention-days" className="text-xs font-medium text-muted-foreground">
+            Extended retention (days)
+          </label>
+          <input
+            id="extended-retention-days"
+            type="number"
+            min={1}
+            max={2555}
+            value={extendedRetentionDays}
+            onChange={(e) => setExtendedRetentionDays(parseInt(e.target.value, 10) || 1)}
+            disabled={!extendedRetentionEnabled}
+            className="w-28 rounded-md bg-foreground/5 px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-primary disabled:cursor-not-allowed"
+            data-testid="extended-retention-days-input"
+          />
+        </div>
       </div>
 
       {/* Per-table rules */}
-      {rules.length > 0 ? (
+      {policies.length > 0 ? (
         <div className="glass-card overflow-hidden">
           <table className="w-full text-sm">
             <thead>
@@ -275,28 +324,38 @@ export function DataRetentionTab() {
               </tr>
             </thead>
             <tbody className="divide-y divide-border/30" data-testid="retention-rules-table">
-              {rules.map((rule, i) => (
-                <tr key={rule.table} className="hover:bg-foreground/5">
-                  <td className="px-4 py-2.5 font-mono text-xs">{rule.table}</td>
+              {policies.map((policy, i) => (
+                <tr key={policy.tableName} className="hover:bg-foreground/5">
                   <td className="px-4 py-2.5">
-                    <input
-                      type="number"
-                      value={rule.retentionDays ?? ''}
-                      onChange={(e) => handleRuleChange(i, 'retentionDays', e.target.value ? parseInt(e.target.value, 10) : null)}
-                      placeholder="No limit"
-                      min={1}
-                      className="w-24 rounded-md bg-foreground/5 px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-primary"
-                      data-testid={`retention-days-${rule.table}`}
-                    />
+                    <div className="text-sm">{policy.displayName}</div>
+                    <div className="font-mono text-xs text-muted-foreground">{policy.tableName}</div>
                   </td>
                   <td className="px-4 py-2.5">
                     <input
-                      type="checkbox"
-                      checked={rule.enabled}
-                      onChange={(e) => handleRuleChange(i, 'enabled', e.target.checked)}
-                      className="h-4 w-4 rounded border-border accent-primary"
-                      data-testid={`retention-enabled-${rule.table}`}
+                      type="number"
+                      value={policy.retentionDays}
+                      onChange={(e) =>
+                        handlePolicyChange(i, 'retentionDays', parseInt(e.target.value, 10) || 0)
+                      }
+                      placeholder="0 = keep forever"
+                      min={0}
+                      max={3650}
+                      className="w-28 rounded-md bg-foreground/5 px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-primary"
+                      data-testid={`retention-days-${policy.tableName}`}
                     />
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <span
+                      className={cn(
+                        'rounded px-2 py-0.5 text-xs font-medium',
+                        policy.enabled
+                          ? 'bg-emerald-500/10 text-emerald-400'
+                          : 'bg-foreground/10 text-muted-foreground',
+                      )}
+                      data-testid={`retention-enabled-${policy.tableName}`}
+                    >
+                      {policy.enabled ? 'On' : 'Keep forever'}
+                    </span>
                   </td>
                 </tr>
               ))}
@@ -305,7 +364,7 @@ export function DataRetentionTab() {
         </div>
       ) : (
         <div className="glass-card py-12 text-center text-sm text-muted-foreground">
-          No retention rules configured. Save will create default rules.
+          No retention rules configured.
         </div>
       )}
 
@@ -347,24 +406,31 @@ export function DataRetentionTab() {
             <thead>
               <tr className="border-b border-border/50 text-left text-xs text-muted-foreground">
                 <th className="px-4 py-2 font-medium">Table</th>
+                <th className="px-4 py-2 font-medium">Retention (days)</th>
                 <th className="px-4 py-2 font-medium">Rows</th>
-                <th className="px-4 py-2 font-medium">Oldest Record</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border/30">
               {preview.map((row) => (
-                <tr key={row.table}>
-                  <td className="px-4 py-2 font-mono text-xs">{row.table}</td>
+                <tr key={row.tableName}>
+                  <td className="px-4 py-2">
+                    <div className="text-sm">{row.displayName}</div>
+                    <div className="font-mono text-xs text-muted-foreground">{row.tableName}</div>
+                  </td>
+                  <td className="px-4 py-2 text-xs text-muted-foreground">
+                    {row.retentionDays === 0 ? 'forever' : row.retentionDays}
+                  </td>
                   <td className="px-4 py-2">
                     <span className={cn(
                       'rounded px-2 py-0.5 text-xs font-medium',
-                      row.rowCount > 0 ? 'bg-amber-500/10 text-amber-400' : 'bg-emerald-500/10 text-emerald-400',
+                      row.estimatedRows < 0
+                        ? 'bg-destructive/10 text-destructive'
+                        : row.estimatedRows > 0
+                          ? 'bg-amber-500/10 text-amber-400'
+                          : 'bg-emerald-500/10 text-emerald-400',
                     )}>
-                      {row.rowCount.toLocaleString()}
+                      {row.estimatedRows < 0 ? 'error' : row.estimatedRows.toLocaleString()}
                     </span>
-                  </td>
-                  <td className="px-4 py-2 text-xs text-muted-foreground">
-                    {row.oldestRecord ? new Date(row.oldestRecord).toLocaleDateString() : '—'}
                   </td>
                 </tr>
               ))}

--- a/frontend/src/features/admin/LlmAuditPage.test.tsx
+++ b/frontend/src/features/admin/LlmAuditPage.test.tsx
@@ -39,36 +39,44 @@ function createWrapper() {
   };
 }
 
-const mockAuditEntries = [
+// Matches the backend `llm_audit_log` row shape — see
+// `overlay/backend/src/routes/foundation/llm-audit.ts`.
+const mockAuditItems = [
   {
     id: 1,
-    userId: 'u1',
-    username: 'alice',
+    user_id: '11111111-1111-1111-1111-111111111111',
     action: 'chat',
     model: 'gpt-4o',
     provider: 'openai',
-    tokensUsed: 1500,
+    input_tokens: 500,
+    output_tokens: 1000,
+    duration_ms: 1200,
     status: 'success' as const,
-    createdAt: '2026-04-10T10:00:00Z',
+    error_message: null,
+    created_at: '2026-04-10T10:00:00Z',
   },
   {
     id: 2,
-    userId: 'u2',
-    username: 'bob',
+    user_id: '22222222-2222-2222-2222-222222222222',
     action: 'embed',
     model: 'bge-m3',
     provider: 'ollama',
-    tokensUsed: 256,
+    input_tokens: 256,
+    output_tokens: 0,
+    duration_ms: 80,
     status: 'error' as const,
-    createdAt: '2026-04-10T11:00:00Z',
+    error_message: 'timeout',
+    created_at: '2026-04-10T11:00:00Z',
   },
 ];
 
 const mockStats = {
   totalRequests: 5000,
-  totalTokens: 1250000,
-  uniqueUsers: 42,
-  errorRate: 0.03,
+  totalInputTokens: 250_000,
+  totalOutputTokens: 1_000_000,
+  byAction: { chat: 4000, embed: 1000 },
+  byModel: { 'gpt-4o': 4000, 'bge-m3': 1000 },
+  byStatus: { success: 4850, error: 150 },
 };
 
 function mockFetch() {
@@ -90,10 +98,10 @@ function mockFetch() {
     }
     if (url.includes('/admin/llm-audit')) {
       return new Response(JSON.stringify({
-        entries: mockAuditEntries,
+        items: mockAuditItems,
         total: 2,
         page: 1,
-        pageSize: 25,
+        limit: 25,
       }), {
         headers: { 'Content-Type': 'application/json' },
       });
@@ -109,16 +117,24 @@ function mockFetchEmpty() {
     const url = typeof input === 'string' ? input : (input as Request).url;
 
     if (url.includes('/admin/llm-audit/stats')) {
-      return new Response(JSON.stringify({ totalRequests: 0, totalTokens: 0, uniqueUsers: 0, errorRate: 0 }), {
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return new Response(
+        JSON.stringify({
+          totalRequests: 0,
+          totalInputTokens: 0,
+          totalOutputTokens: 0,
+          byAction: {},
+          byModel: {},
+          byStatus: {},
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
     }
     if (url.includes('/admin/llm-audit')) {
       return new Response(JSON.stringify({
-        entries: [],
+        items: [],
         total: 0,
         page: 1,
-        pageSize: 25,
+        limit: 25,
       }), {
         headers: { 'Content-Type': 'application/json' },
       });
@@ -163,28 +179,33 @@ describe('LlmAuditPage', () => {
     });
   });
 
-  it('shows the audit table with entries', async () => {
+  it('shows the audit table with items and sums tokens per row', async () => {
     mockFetch();
     render(<LlmAuditPage />, { wrapper: createWrapper() });
 
     await waitFor(() => {
       expect(screen.getByTestId('audit-table')).toBeInTheDocument();
     });
-    expect(screen.getByText('alice')).toBeInTheDocument();
-    expect(screen.getByText('bob')).toBeInTheDocument();
+    // Tokens = input + output = 1500 & 256 respectively
+    expect(screen.getByText('1,500')).toBeInTheDocument();
+    expect(screen.getByText('256')).toBeInTheDocument();
     expect(screen.getByText('gpt-4o')).toBeInTheDocument();
+    expect(screen.getByText('bge-m3')).toBeInTheDocument();
   });
 
-  it('shows stats cards', async () => {
+  it('derives total tokens + error rate from stats', async () => {
     mockFetch();
     render(<LlmAuditPage />, { wrapper: createWrapper() });
 
     await waitFor(() => {
       expect(screen.getByTestId('audit-stats')).toBeInTheDocument();
     });
+    // totalRequests
     expect(screen.getByText('5,000')).toBeInTheDocument();
+    // totalTokens = 250_000 + 1_000_000 = 1_250_000
     expect(screen.getByText('1,250,000')).toBeInTheDocument();
-    expect(screen.getByText('42')).toBeInTheDocument();
+    // errorRate = 150 / 5000 = 3.0%
+    expect(screen.getByText('3.0%')).toBeInTheDocument();
   });
 
   it('shows empty state when no entries', async () => {
@@ -213,6 +234,24 @@ describe('LlmAuditPage', () => {
     expect(screen.getByTestId('filter-user')).toBeInTheDocument();
     expect(screen.getByTestId('filter-action')).toBeInTheDocument();
     expect(screen.getByTestId('filter-status')).toBeInTheDocument();
+  });
+
+  it('requests the page with page+limit query params that the backend accepts', async () => {
+    const fetchSpy = mockFetch();
+    render(<LlmAuditPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('audit-table')).toBeInTheDocument();
+    });
+
+    const listCall = fetchSpy.mock.calls.find(([url]) =>
+      typeof url === 'string' && url.includes('/admin/llm-audit?') && !url.includes('/stats') && !url.includes('/export'),
+    );
+    expect(listCall).toBeTruthy();
+    const url = listCall![0] as string;
+    expect(url).toContain('page=1');
+    expect(url).toContain('limit=25');
+    expect(url).not.toContain('pageSize=');
   });
 
   it('has an export CSV button', async () => {

--- a/frontend/src/features/admin/LlmAuditPage.tsx
+++ b/frontend/src/features/admin/LlmAuditPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { m } from 'framer-motion';
 import { toast } from 'sonner';
@@ -12,51 +12,67 @@ import { useEnterprise } from '../../shared/enterprise/use-enterprise';
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
+// Matches the backend `llm_audit_log` row shape (snake_case columns).
 interface AuditEntry {
   id: number;
-  userId: string;
-  username: string;
+  user_id: string | null;
   action: string;
   model: string;
   provider: string;
-  tokensUsed: number;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  duration_ms: number | null;
   status: 'success' | 'error';
-  createdAt: string;
+  error_message: string | null;
+  created_at: string;
 }
 
 interface AuditResponse {
-  entries: AuditEntry[];
+  items: AuditEntry[];
   total: number;
   page: number;
-  pageSize: number;
+  limit: number;
 }
 
 interface AuditStats {
   totalRequests: number;
-  totalTokens: number;
-  uniqueUsers: number;
-  errorRate: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  byAction: Record<string, number>;
+  byModel: Record<string, number>;
+  byStatus: Record<string, number>;
 }
 
 // ── Hooks ──────────────────────────────────────────────────────────────────────
 
+// Convert a YYYY-MM-DD from the date input to an ISO-8601 string with offset,
+// which is what the backend Zod schema (`z.string().datetime({ offset: true })`)
+// accepts. Returns `undefined` when the input is empty.
+function dateInputToIso(value: string, endOfDay = false): string | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return undefined;
+  if (endOfDay) d.setUTCHours(23, 59, 59, 999);
+  return d.toISOString();
+}
+
 function useAuditLog(params: {
   page: number;
-  pageSize: number;
+  limit: number;
   userId?: string;
   action?: string;
   status?: string;
-  from?: string;
-  to?: string;
+  startDate?: string;
+  endDate?: string;
 }) {
   const searchParams = new URLSearchParams();
   searchParams.set('page', String(params.page));
-  searchParams.set('pageSize', String(params.pageSize));
+  searchParams.set('limit', String(params.limit));
   if (params.userId) searchParams.set('userId', params.userId);
   if (params.action) searchParams.set('action', params.action);
   if (params.status) searchParams.set('status', params.status);
-  if (params.from) searchParams.set('from', params.from);
-  if (params.to) searchParams.set('to', params.to);
+  if (params.startDate) searchParams.set('startDate', params.startDate);
+  if (params.endDate) searchParams.set('endDate', params.endDate);
 
   return useQuery<AuditResponse>({
     queryKey: ['admin', 'llm-audit', params],
@@ -89,17 +105,33 @@ export function LlmAuditPage() {
 
   const featureEnabled = hasFeature('llm_audit_trail');
 
+  // Validate userId filter: the backend requires a UUID. Silently drop
+  // partial input so the list doesn't error out on every keystroke.
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
   const { data, isLoading } = useAuditLog({
     page,
-    pageSize,
-    userId: filterUser || undefined,
+    limit: pageSize,
+    userId: isUuid.test(filterUser.trim()) ? filterUser.trim() : undefined,
     action: filterAction || undefined,
     status: filterStatus || undefined,
-    from: filterFrom || undefined,
-    to: filterTo || undefined,
+    startDate: dateInputToIso(filterFrom),
+    endDate: dateInputToIso(filterTo, true),
   });
 
   const { data: stats } = useAuditStats();
+
+  const derivedStats = useMemo(() => {
+    if (!stats) return null;
+    const totalTokens = (stats.totalInputTokens ?? 0) + (stats.totalOutputTokens ?? 0);
+    const errorCount = stats.byStatus?.error ?? 0;
+    const errorRate = stats.totalRequests > 0 ? errorCount / stats.totalRequests : 0;
+    return {
+      totalRequests: stats.totalRequests ?? 0,
+      totalTokens,
+      errorRate,
+    };
+  }, [stats]);
 
   const handleExportCsv = useCallback(async () => {
     try {
@@ -144,6 +176,8 @@ export function LlmAuditPage() {
     );
   }
 
+  const items = data?.items ?? [];
+
   return (
     <div className="space-y-6" data-testid="llm-audit-page">
       {/* Header */}
@@ -183,15 +217,14 @@ export function LlmAuditPage() {
       </div>
 
       {/* Stats cards */}
-      {stats && (
-        <div className="grid gap-3 sm:grid-cols-4" data-testid="audit-stats">
-          <StatCard label="Total Requests" value={stats.totalRequests.toLocaleString()} />
-          <StatCard label="Total Tokens" value={stats.totalTokens.toLocaleString()} />
-          <StatCard label="Unique Users" value={stats.uniqueUsers.toLocaleString()} />
+      {derivedStats && (
+        <div className="grid gap-3 sm:grid-cols-3" data-testid="audit-stats">
+          <StatCard label="Total Requests" value={derivedStats.totalRequests.toLocaleString()} />
+          <StatCard label="Total Tokens" value={derivedStats.totalTokens.toLocaleString()} />
           <StatCard
             label="Error Rate"
-            value={`${(stats.errorRate * 100).toFixed(1)}%`}
-            variant={stats.errorRate > 0.1 ? 'warning' : 'default'}
+            value={`${(derivedStats.errorRate * 100).toFixed(1)}%`}
+            variant={derivedStats.errorRate > 0.1 ? 'warning' : 'default'}
           />
         </div>
       )}
@@ -206,12 +239,12 @@ export function LlmAuditPage() {
         >
           <div className="grid gap-3 sm:grid-cols-5">
             <div>
-              <label className="mb-1 block text-xs font-medium text-muted-foreground">User ID</label>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">User ID (UUID)</label>
               <input
                 type="text"
                 value={filterUser}
                 onChange={(e) => { setFilterUser(e.target.value); setPage(1); }}
-                placeholder="Filter by user"
+                placeholder="Filter by user UUID"
                 className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary"
                 data-testid="filter-user"
               />
@@ -271,7 +304,7 @@ export function LlmAuditPage() {
             <div key={i} className="h-12 animate-pulse rounded-lg bg-foreground/5" />
           ))}
         </div>
-      ) : !data?.entries.length ? (
+      ) : items.length === 0 ? (
         <div className="glass-card py-12 text-center text-sm text-muted-foreground" data-testid="audit-empty">
           No audit entries found
         </div>
@@ -281,7 +314,7 @@ export function LlmAuditPage() {
             <thead>
               <tr className="border-b border-border/50 text-left text-xs text-muted-foreground">
                 <th className="px-4 py-3 font-medium">Time</th>
-                <th className="px-4 py-3 font-medium">User</th>
+                <th className="px-4 py-3 font-medium">User ID</th>
                 <th className="px-4 py-3 font-medium">Action</th>
                 <th className="px-4 py-3 font-medium">Model</th>
                 <th className="px-4 py-3 font-medium">Tokens</th>
@@ -289,31 +322,36 @@ export function LlmAuditPage() {
               </tr>
             </thead>
             <tbody className="divide-y divide-border/30">
-              {data.entries.map((entry) => (
-                <tr key={entry.id} className="hover:bg-foreground/5">
-                  <td className="px-4 py-2.5 text-xs text-muted-foreground">
-                    {new Date(entry.createdAt).toLocaleString()}
-                  </td>
-                  <td className="px-4 py-2.5 text-xs">{entry.username}</td>
-                  <td className="px-4 py-2.5">
-                    <span className="rounded bg-primary/10 px-2 py-0.5 text-xs text-primary">
-                      {entry.action}
-                    </span>
-                  </td>
-                  <td className="px-4 py-2.5 font-mono text-xs">{entry.model}</td>
-                  <td className="px-4 py-2.5 text-xs">{entry.tokensUsed.toLocaleString()}</td>
-                  <td className="px-4 py-2.5">
-                    <span className={cn(
-                      'rounded px-2 py-0.5 text-xs font-medium',
-                      entry.status === 'success'
-                        ? 'bg-emerald-500/10 text-emerald-400'
-                        : 'bg-destructive/10 text-destructive',
-                    )}>
-                      {entry.status}
-                    </span>
-                  </td>
-                </tr>
-              ))}
+              {items.map((entry) => {
+                const tokens = (entry.input_tokens ?? 0) + (entry.output_tokens ?? 0);
+                return (
+                  <tr key={entry.id} className="hover:bg-foreground/5">
+                    <td className="px-4 py-2.5 text-xs text-muted-foreground">
+                      {entry.created_at ? new Date(entry.created_at).toLocaleString() : '—'}
+                    </td>
+                    <td className="px-4 py-2.5 font-mono text-xs text-muted-foreground">
+                      {entry.user_id ? entry.user_id.slice(0, 8) : '—'}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <span className="rounded bg-primary/10 px-2 py-0.5 text-xs text-primary">
+                        {entry.action}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2.5 font-mono text-xs">{entry.model}</td>
+                    <td className="px-4 py-2.5 text-xs">{tokens.toLocaleString()}</td>
+                    <td className="px-4 py-2.5">
+                      <span className={cn(
+                        'rounded px-2 py-0.5 text-xs font-medium',
+                        entry.status === 'success'
+                          ? 'bg-emerald-500/10 text-emerald-400'
+                          : 'bg-destructive/10 text-destructive',
+                      )}>
+                        {entry.status}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/frontend/src/features/admin/LlmPolicyTab.test.tsx
+++ b/frontend/src/features/admin/LlmPolicyTab.test.tsx
@@ -39,18 +39,19 @@ function createWrapper() {
   };
 }
 
+// Matches the backend `OrgLlmPolicy` shape exposed by
+// GET /api/admin/llm-policy (see `llm-policy-service.ts`).
 const mockPolicy = {
-  providerLock: 'none',
-  modelAllowlist: ['gpt-4o', 'qwen3:4b'],
-  maxTokensPerRequest: 4096,
-  userOverrideAllowed: true,
+  enabled: true,
+  provider: 'openai' as const,
+  model: 'gpt-4o',
 };
 
-function mockFetch() {
+function mockFetch(overrides: Partial<typeof mockPolicy> = {}) {
   return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
     const url = typeof input === 'string' ? input : (input as Request).url;
     if (url.includes('/admin/llm-policy')) {
-      return new Response(JSON.stringify(mockPolicy), {
+      return new Response(JSON.stringify({ ...mockPolicy, ...overrides }), {
         headers: { 'Content-Type': 'application/json' },
       });
     }
@@ -103,14 +104,36 @@ describe('LlmPolicyTab', () => {
     });
   });
 
-  it('shows model allowlist chips from fetched policy', async () => {
+  it('hydrates the enable toggle, provider, and model from the fetched policy', async () => {
     mockFetch();
     render(<LlmPolicyTab />, { wrapper: createWrapper() });
 
     await waitFor(() => {
-      expect(screen.getByTestId('model-chip-gpt-4o')).toBeInTheDocument();
+      expect(screen.getByTestId('llm-policy-enabled-toggle')).toBeInTheDocument();
     });
-    expect(screen.getByTestId('model-chip-qwen3:4b')).toBeInTheDocument();
+
+    const toggle = screen.getByTestId('llm-policy-enabled-toggle') as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+
+    const openaiRadio = screen.getByTestId('provider-openai') as HTMLInputElement;
+    expect(openaiRadio.checked).toBe(true);
+
+    const modelInput = screen.getByTestId('model-input') as HTMLInputElement;
+    expect(modelInput.value).toBe('gpt-4o');
+  });
+
+  it('does not crash when the backend returns a disabled policy with null provider/model', async () => {
+    mockFetch({ enabled: false, provider: null as unknown as 'openai', model: null as unknown as string });
+    render(<LlmPolicyTab />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('llm-policy-form')).toBeInTheDocument();
+    });
+
+    const toggle = screen.getByTestId('llm-policy-enabled-toggle') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    const modelInput = screen.getByTestId('model-input') as HTMLInputElement;
+    expect(modelInput.value).toBe('');
   });
 
   it('has a save button', async () => {
@@ -122,7 +145,7 @@ describe('LlmPolicyTab', () => {
     });
   });
 
-  it('submits PUT with proper body when save is clicked', async () => {
+  it('submits PUT with { enabled, provider, model } matching the backend schema', async () => {
     const fetchSpy = mockFetch();
     render(<LlmPolicyTab />, { wrapper: createWrapper() });
 
@@ -133,27 +156,33 @@ describe('LlmPolicyTab', () => {
     fireEvent.click(screen.getByTestId('llm-policy-save-btn'));
 
     await waitFor(() => {
-      const putCalls = fetchSpy.mock.calls.filter(
+      const putCall = fetchSpy.mock.calls.find(
         ([, opts]) => opts && typeof opts === 'object' && 'method' in opts && (opts as RequestInit).method === 'PUT',
       );
-      expect(putCalls.length).toBeGreaterThanOrEqual(1);
+      expect(putCall).toBeTruthy();
+      const body = JSON.parse((putCall![1] as RequestInit).body as string);
+      expect(body).toEqual({ enabled: true, provider: 'openai', model: 'gpt-4o' });
     });
   });
 
-  it('adds a model to the allowlist via input', async () => {
-    mockFetch();
+  it('sends provider=null and model=null when the policy is toggled off', async () => {
+    const fetchSpy = mockFetch();
     render(<LlmPolicyTab />, { wrapper: createWrapper() });
 
     await waitFor(() => {
-      expect(screen.getByTestId('model-allowlist-input')).toBeInTheDocument();
+      expect(screen.getByTestId('llm-policy-enabled-toggle')).toBeInTheDocument();
     });
 
-    const input = screen.getByTestId('model-allowlist-input');
-    fireEvent.change(input, { target: { value: 'llama3' } });
-    fireEvent.click(screen.getByTestId('add-model-btn'));
+    fireEvent.click(screen.getByTestId('llm-policy-enabled-toggle'));
+    fireEvent.click(screen.getByTestId('llm-policy-save-btn'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('model-chip-llama3')).toBeInTheDocument();
+      const putCall = fetchSpy.mock.calls.find(
+        ([, opts]) => opts && typeof opts === 'object' && 'method' in opts && (opts as RequestInit).method === 'PUT',
+      );
+      expect(putCall).toBeTruthy();
+      const body = JSON.parse((putCall![1] as RequestInit).body as string);
+      expect(body).toEqual({ enabled: false, provider: null, model: null });
     });
   });
 });

--- a/frontend/src/features/admin/LlmPolicyTab.tsx
+++ b/frontend/src/features/admin/LlmPolicyTab.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { m } from 'framer-motion';
 import { toast } from 'sonner';
 import {
-  Shield, Loader2, Save, AlertTriangle, X,
+  Shield, Loader2, Save, AlertTriangle,
 } from 'lucide-react';
 import { apiFetch } from '../../shared/lib/api';
 import { cn } from '../../shared/lib/cn';
@@ -11,13 +11,12 @@ import { useEnterprise } from '../../shared/enterprise/use-enterprise';
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
-type ProviderLock = 'none' | 'ollama' | 'openai';
+type OrgLlmProvider = 'ollama' | 'openai';
 
 interface LlmPolicy {
-  providerLock: ProviderLock;
-  modelAllowlist: string[];
-  maxTokensPerRequest: number | null;
-  userOverrideAllowed: boolean;
+  enabled: boolean;
+  provider: OrgLlmProvider | null;
+  model: string | null;
 }
 
 // ── Hooks ──────────────────────────────────────────────────────────────────────
@@ -37,21 +36,18 @@ export function LlmPolicyTab() {
   const { hasFeature } = useEnterprise();
   const { data: policy, isLoading } = useLlmPolicy();
 
-  const [providerLock, setProviderLock] = useState<ProviderLock>('none');
-  const [modelAllowlist, setModelAllowlist] = useState<string[]>([]);
-  const [modelInput, setModelInput] = useState('');
-  const [maxTokens, setMaxTokens] = useState<string>('');
-  const [userOverride, setUserOverride] = useState(false);
+  const [enabled, setEnabled] = useState(false);
+  const [provider, setProvider] = useState<OrgLlmProvider | null>(null);
+  const [model, setModel] = useState('');
   const [initialized, setInitialized] = useState(false);
 
   const featureEnabled = hasFeature('org_llm_policy');
 
   // Populate form when data loads
   if (policy && !initialized) {
-    setProviderLock(policy.providerLock);
-    setModelAllowlist(policy.modelAllowlist);
-    setMaxTokens(policy.maxTokensPerRequest?.toString() ?? '');
-    setUserOverride(policy.userOverrideAllowed);
+    setEnabled(Boolean(policy.enabled));
+    setProvider(policy.provider ?? null);
+    setModel(policy.model ?? '');
     setInitialized(true);
   }
 
@@ -65,26 +61,13 @@ export function LlmPolicyTab() {
     onError: (err) => toast.error(err.message),
   });
 
-  const handleAddModel = useCallback(() => {
-    const trimmed = modelInput.trim();
-    if (trimmed && !modelAllowlist.includes(trimmed)) {
-      setModelAllowlist((prev) => [...prev, trimmed]);
-      setModelInput('');
-    }
-  }, [modelInput, modelAllowlist]);
-
-  const handleRemoveModel = useCallback((model: string) => {
-    setModelAllowlist((prev) => prev.filter((m) => m !== model));
-  }, []);
-
   const handleSave = useCallback(() => {
     saveMutation.mutate({
-      providerLock,
-      modelAllowlist,
-      maxTokensPerRequest: maxTokens ? parseInt(maxTokens, 10) : null,
-      userOverrideAllowed: userOverride,
+      enabled,
+      provider: enabled ? provider : null,
+      model: enabled ? (model.trim() || null) : null,
     });
-  }, [providerLock, modelAllowlist, maxTokens, userOverride, saveMutation]);
+  }, [enabled, provider, model, saveMutation]);
 
   if (!featureEnabled) {
     return (
@@ -130,131 +113,76 @@ export function LlmPolicyTab() {
         </div>
       </m.div>
 
-      {/* Provider lock */}
+      {/* Enable toggle */}
       <div>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            className="h-4 w-4 rounded border-border accent-primary"
+            data-testid="llm-policy-enabled-toggle"
+          />
+          <span className="font-medium">Enforce organization-wide LLM policy</span>
+        </label>
+        <p className="ml-6 text-xs text-muted-foreground">
+          When enabled, all users are locked to the provider and model selected below.
+        </p>
+      </div>
+
+      {/* Provider */}
+      <div className={cn(!enabled && 'opacity-50 pointer-events-none')}>
         <label className="mb-1.5 flex items-center gap-1.5 text-sm font-medium">
           <Shield size={14} className="text-muted-foreground" />
-          Provider Lock
+          Provider
         </label>
         <p className="mb-2 text-xs text-muted-foreground">
-          Restrict which LLM provider users can select.
+          Locked LLM provider for the organization.
         </p>
         <div className="flex gap-3">
-          {(['none', 'ollama', 'openai'] as const).map((option) => (
+          {(['ollama', 'openai'] as const).map((option) => (
             <label
               key={option}
               className={cn(
                 'flex items-center gap-2 rounded-md border px-4 py-2 text-sm cursor-pointer transition-colors',
-                providerLock === option
+                provider === option
                   ? 'border-primary/50 bg-primary/10 text-primary'
                   : 'border-border/50 bg-foreground/5 text-muted-foreground hover:bg-foreground/10',
               )}
             >
               <input
                 type="radio"
-                name="providerLock"
+                name="provider"
                 value={option}
-                checked={providerLock === option}
-                onChange={() => setProviderLock(option)}
+                checked={provider === option}
+                onChange={() => setProvider(option)}
+                disabled={!enabled}
                 className="sr-only"
-                data-testid={`provider-lock-${option}`}
+                data-testid={`provider-${option}`}
               />
-              {option === 'none' ? 'No restriction' : option.charAt(0).toUpperCase() + option.slice(1)}
+              {option.charAt(0).toUpperCase() + option.slice(1)}
             </label>
           ))}
         </div>
       </div>
 
-      {/* Model allowlist */}
-      <div>
+      {/* Model */}
+      <div className={cn(!enabled && 'opacity-50 pointer-events-none')}>
         <label className="mb-1.5 flex items-center gap-1.5 text-sm font-medium">
-          Model Allowlist
+          Model
         </label>
         <p className="mb-2 text-xs text-muted-foreground">
-          If set, users can only select from these models. Leave empty to allow all models.
-        </p>
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={modelInput}
-            onChange={(e) => setModelInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                handleAddModel();
-              }
-            }}
-            placeholder="e.g. gpt-4o, qwen3:4b"
-            className="flex-1 rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary"
-            data-testid="model-allowlist-input"
-          />
-          <button
-            type="button"
-            onClick={handleAddModel}
-            disabled={!modelInput.trim()}
-            className="rounded-md bg-foreground/5 px-3 py-2 text-sm hover:bg-foreground/10 disabled:opacity-50"
-            data-testid="add-model-btn"
-          >
-            Add
-          </button>
-        </div>
-        {modelAllowlist.length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-1.5">
-            {modelAllowlist.map((model) => (
-              <span
-                key={model}
-                className="flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-1 text-xs text-primary"
-                data-testid={`model-chip-${model}`}
-              >
-                {model}
-                <button
-                  type="button"
-                  onClick={() => handleRemoveModel(model)}
-                  className="rounded-full p-0.5 hover:bg-primary/20"
-                  aria-label={`Remove ${model}`}
-                >
-                  <X size={10} />
-                </button>
-              </span>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {/* Max tokens */}
-      <div>
-        <label className="mb-1.5 flex items-center gap-1.5 text-sm font-medium">
-          Max Tokens per Request
-        </label>
-        <p className="mb-2 text-xs text-muted-foreground">
-          Leave empty for no limit.
+          Exact model identifier to enforce. Leave blank to let users pick any model from the locked provider.
         </p>
         <input
-          type="number"
-          value={maxTokens}
-          onChange={(e) => setMaxTokens(e.target.value)}
-          placeholder="e.g. 4096"
-          min={1}
-          className="w-48 rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary"
-          data-testid="max-tokens-input"
+          type="text"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          placeholder="e.g. gpt-4o, qwen3:4b"
+          disabled={!enabled}
+          className="w-full max-w-md rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary disabled:cursor-not-allowed"
+          data-testid="model-input"
         />
-      </div>
-
-      {/* User override toggle */}
-      <div>
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={userOverride}
-            onChange={(e) => setUserOverride(e.target.checked)}
-            className="h-4 w-4 rounded border-border accent-primary"
-            data-testid="user-override-toggle"
-          />
-          Allow users to override policy settings
-        </label>
-        <p className="ml-6 text-xs text-muted-foreground">
-          When enabled, individual users can change their LLM provider and model even if a policy is set.
-        </p>
       </div>
 
       {/* Save button */}


### PR DESCRIPTION
## Summary

All three Enterprise admin tabs (LLM Policy, LLM Audit, Data Retention) crashed on open because the frontend was scaffolded against shapes that never matched the EE backend responses.

### Root cause
| Tab | Frontend expected | Backend returns | Throw site |
|---|---|---|---|
| LLM Policy | \`{ providerLock, modelAllowlist, maxTokensPerRequest, userOverrideAllowed }\` | \`{ enabled, provider, model }\` | \`modelAllowlist.length\` on undefined |
| LLM Audit | \`data.entries[].tokensUsed\`, \`stats.totalTokens\` | \`data.items[].{input_tokens,output_tokens}\`, \`stats.{totalInputTokens,totalOutputTokens,byStatus}\` | \`data.entries.length\` + \`undefined.toLocaleString()\` |
| Data Retention | \`policy.rules[].table\`, \`extendedRetention\` | \`config.policies[].{tableName,displayName}\`, \`extendedRetentionEnabled\`, \`extendedRetentionDays\` | \`rules.length\` on undefined |

### Fix
- Rewrote the three components to match the real contracts in \`llm-policy-service.ts\`, \`llm-audit.ts\`, and \`data-retention-service.ts\`.
- Simplified **LLM Policy** UI to enable / provider / model (the richer knobs weren't backed).
- **LLM Audit**: sums \`input_tokens + output_tokens\` per row; derives error rate from \`byStatus\`; uses \`limit\`, \`startDate\`/\`endDate\` query params and validates the \`userId\` filter as UUID before sending.
- **Data Retention**: displays \`displayName\` + \`tableName\`, PUT body now matches the Zod schema (\`{ policies: [{tableName, retentionDays}], extendedRetentionEnabled, extendedRetentionDays }\`); preview uses \`estimatedRows\`.
- Vitest suites updated so fetch mocks mirror the real API.

## Test plan
- [x] \`npm run typecheck -w frontend\` passes
- [x] \`npx vitest run\` for the three specs — 30/30 pass
- [x] Rebuilt \`ghcr.io/compendiq/compendiq-ce-frontend:dev\` and recreated the EE frontend container (healthy)
- [ ] Reviewer: log in as admin and open Settings → **LLM Policy**, **LLM Audit**, **Data Retention**; confirm each loads without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)