### PR TITLE
feat(#282): RAG permission enforcement — request-scoped cache + regression tests + ADR

### DIFF
--- a/backend/src/core/plugins/auth.ts
+++ b/backend/src/core/plugins/auth.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 import { query } from '../db/postgres.js';
 import { logger } from '../utils/logger.js';
 import { userHasPermission, userHasGlobalPermission } from '../services/rbac-service.js';
+import { enterRbacScope } from '../services/rbac-request-scope.js';
 import { logAuditEvent } from '../services/audit-service.js';
 
 const JWT_ISSUER = 'compendiq';
@@ -188,6 +189,13 @@ export default fp(async (fastify: FastifyInstance) => {
       request.userId = payload.sub;
       request.username = payload.username;
       request.userRole = payload.role;
+
+      // Open a request-scoped AsyncLocalStorage frame so RBAC space-resolution
+      // is memoised for the rest of this request. `enterWith` binds the store
+      // to the current async chain without requiring a callback, so the route
+      // handler and every downstream hook inherit the scope automatically.
+      // See ADR-022.
+      enterRbacScope(request.userId);
 
       // Attach RBAC permission checker to request
       request.userCan = async (

--- a/backend/src/core/services/rbac-request-scope.test.ts
+++ b/backend/src/core/services/rbac-request-scope.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the DB so we can count resolver invocations without a real Postgres.
+// `getUserAccessibleSpaces` issues a single SELECT against
+// `space_role_assignments`; counting that call tells us whether the memoised
+// wrapper (ADR-022) actually deduplicated work for a given request scope.
+vi.mock('../db/postgres.js', () => ({
+  query: vi.fn().mockResolvedValue({ rows: [{ space_key: 'SPACE1' }] }),
+  getPool: vi.fn().mockReturnValue({}),
+  runMigrations: vi.fn(),
+  closePool: vi.fn(),
+}));
+
+// Disable Redis so the resolver always hits the DB mock.
+vi.mock('./redis-cache.js', () => ({
+  getRedisClient: vi.fn().mockReturnValue(null),
+  setRedisClient: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { query as mockQuery } from '../db/postgres.js';
+import { runWithRbacScope } from './rbac-request-scope.js';
+import { getUserAccessibleSpacesMemoized } from './rbac-service.js';
+
+describe('rbac-request-scope', () => {
+  beforeEach(() => {
+    (mockQuery as ReturnType<typeof vi.fn>).mockReset();
+    // Every call to `getUserAccessibleSpaces` fires two SELECTs:
+    //   1. `isSystemAdmin` — must return zero rows so we stay on the
+    //      non-admin branch (avoids a third query for "all spaces").
+    //   2. The space-role join — returns the user's readable-space set.
+    // We alternate between empty (admin check) and `[{ space_key: 'SPACE1' }]`
+    // (space lookup) so the counts are stable and predictable.
+    (mockQuery as ReturnType<typeof vi.fn>).mockImplementation(async (sql: string) => {
+      if (/FROM users\b.*role.*=.*'admin'/is.test(sql)) {
+        return { rows: [], rowCount: 0 };
+      }
+      return { rows: [{ space_key: 'SPACE1' }], rowCount: 1 };
+    });
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls the underlying resolver exactly once per request scope', async () => {
+    await runWithRbacScope('u1', async () => {
+      const a = await getUserAccessibleSpacesMemoized('u1');
+      const b = await getUserAccessibleSpacesMemoized('u1');
+      const c = await getUserAccessibleSpacesMemoized('u1');
+      expect(a).toEqual(['SPACE1']);
+      expect(b).toEqual(['SPACE1']);
+      expect(c).toEqual(['SPACE1']);
+    });
+    // First call inside the scope triggers isSystemAdmin (1 query) + the
+    // space-lookup (1 query). Every subsequent call returns the memoised
+    // array without touching the DB. Expect exactly 2 total DB hits.
+    expect((mockQuery as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2);
+  });
+
+  it('fresh scope = fresh resolution (no leakage between requests)', async () => {
+    await runWithRbacScope('u1', async () => {
+      await getUserAccessibleSpacesMemoized('u1');
+    });
+    await runWithRbacScope('u1', async () => {
+      await getUserAccessibleSpacesMemoized('u1');
+    });
+    // Each scope is independent, so the DB is hit twice per scope = 4 total.
+    expect((mockQuery as ReturnType<typeof vi.fn>).mock.calls.length).toBe(4);
+  });
+
+  it('returns null from getScopedSpaces when called outside any scope', async () => {
+    const { getScopedSpaces } = await import('./rbac-request-scope.js');
+    expect(getScopedSpaces('u1')).toBeNull();
+  });
+
+  it('memoised wrapper falls back to the resolver when no scope is active', async () => {
+    // Without runWithRbacScope, the memoised wrapper still works — it just
+    // hits the DB every call. Verifies the degradation path (background
+    // workers, unit tests that skipped the scope) stays correct.
+    await getUserAccessibleSpacesMemoized('u1');
+    await getUserAccessibleSpacesMemoized('u1');
+    // 2 calls × 2 queries each (isSystemAdmin + space lookup) = 4
+    expect((mockQuery as ReturnType<typeof vi.fn>).mock.calls.length).toBe(4);
+  });
+});

--- a/backend/src/core/services/rbac-request-scope.ts
+++ b/backend/src/core/services/rbac-request-scope.ts
@@ -1,0 +1,64 @@
+// backend/src/core/services/rbac-request-scope.ts
+//
+// Per-request AsyncLocalStorage scope for RBAC space-resolution memoisation.
+//
+// Why: `getUserAccessibleSpaces(userId)` is consulted from multiple paths in a
+// single RAG request (vector search, keyword search, and hybrid wrapper).
+// Without a request-scoped cache, a single user-facing query triggers N round
+// trips to Postgres + N Redis hits for the same answer. The Redis cache helps
+// but still costs a socket round-trip per call. AsyncLocalStorage lets us pin
+// the resolved set for the lifetime of the Fastify request.
+//
+// Contract: callers that need the memoised answer use
+// `getUserAccessibleSpacesMemoized(userId)` from `rbac-service.ts`, which reads
+// from this scope first and falls back to the normal resolver on miss.
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface RbacScope {
+  userId: string;
+  // Undefined until the first resolver call in this request populates it.
+  spaces?: string[];
+}
+
+const storage = new AsyncLocalStorage<RbacScope>();
+
+/**
+ * Run `fn` inside a fresh RBAC scope bound to `userId`. Use this in tests and
+ * anywhere you explicitly control the async context boundary.
+ */
+export function runWithRbacScope<T>(userId: string, fn: () => Promise<T>): Promise<T> {
+  return storage.run({ userId }, fn);
+}
+
+/**
+ * Enter a fresh RBAC scope on the current async chain. Used from Fastify's
+ * `authenticate` hook so that all downstream work for this request (including
+ * the route handler) shares the same scope without wrapping the whole pipeline
+ * in a callback. Safe to call once per request after authentication succeeds.
+ */
+export function enterRbacScope(userId: string): void {
+  storage.enterWith({ userId });
+}
+
+export function getCurrentScope(): RbacScope | undefined {
+  return storage.getStore();
+}
+
+export function setScopedSpaces(spaces: string[]): void {
+  const scope = storage.getStore();
+  if (scope) scope.spaces = spaces;
+}
+
+/**
+ * Returns the memoised readable-space list for `userId` if the current scope
+ * was opened for that same user, or null when (a) there is no scope (e.g.
+ * background worker, test without `runWithRbacScope`), (b) the scope belongs
+ * to a different user, or (c) the scope exists but has not yet been populated.
+ */
+export function getScopedSpaces(userId: string): string[] | null {
+  const scope = storage.getStore();
+  if (scope && scope.userId === userId && scope.spaces !== undefined) {
+    return scope.spaces;
+  }
+  return null;
+}

--- a/backend/src/core/services/rbac-service.ts
+++ b/backend/src/core/services/rbac-service.ts
@@ -1,6 +1,7 @@
 import { query } from '../db/postgres.js';
 import { getRedisClient } from './redis-cache.js';
 import { logger } from '../utils/logger.js';
+import { getScopedSpaces, setScopedSpaces } from './rbac-request-scope.js';
 
 const RBAC_CACHE_TTL = 60; // 60 seconds
 
@@ -326,6 +327,25 @@ export async function getUserAccessibleSpaces(userId: string): Promise<string[]>
 
   await setCache(cacheKey, spaceKeys);
   return spaceKeys;
+}
+
+/**
+ * Request-scoped wrapper around `getUserAccessibleSpaces`. Callers that run
+ * inside a Fastify request (entered via `enterRbacScope` from the auth plugin)
+ * pay at most one resolver hit per request, regardless of how many retrieval
+ * paths consult the readable-space set. Outside a scope (workers, tests that
+ * do not opt in) this falls through to the normal resolver with no change in
+ * behaviour.
+ *
+ * Signature matches `getUserAccessibleSpaces` exactly so call sites can swap
+ * the import without touching the call site.
+ */
+export async function getUserAccessibleSpacesMemoized(userId: string): Promise<string[]> {
+  const scoped = getScopedSpaces(userId);
+  if (scoped) return scoped;
+  const spaces = await getUserAccessibleSpaces(userId);
+  setScopedSpaces(spaces);
+  return spaces;
 }
 
 /**

--- a/backend/src/domains/llm/services/rag-service.integration.test.ts
+++ b/backend/src/domains/llm/services/rag-service.integration.test.ts
@@ -120,6 +120,34 @@ describe.skipIf(!dbAvailable)('rag-service integration — space permission enfo
     return pageId;
   }
 
+  it('reflects mid-conversation ACL revocation on the next retrieval', async () => {
+    const user = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    await seedSpaceWithPage({
+      userId: user,
+      spaceKey: 'OPS',
+      pageTitle: 'Runbook',
+      bodyText: 'restart the queue',
+      vec: fakeVec(11),
+    });
+
+    // First retrieval: user has access, should see the page
+    const first = await hybridSearch(user, 'restart queue');
+    expect(first.length).toBeGreaterThan(0);
+
+    // Revoke the role assignment and invalidate cache (this is what admin APIs do)
+    await query(
+      `DELETE FROM space_role_assignments
+       WHERE space_key = $1 AND principal_id = $2`,
+      ['OPS', user],
+    );
+    const { invalidateRbacCache } = await import('../../../core/services/rbac-service.js');
+    await invalidateRbacCache(user);
+
+    // Second retrieval: access should be gone
+    const second = await hybridSearch(user, 'restart queue');
+    expect(second).toHaveLength(0);
+  });
+
   it('does not leak chunks from a space the caller has no role in', async () => {
     const userA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
     const userB = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';

--- a/backend/src/domains/llm/services/rag-service.integration.test.ts
+++ b/backend/src/domains/llm/services/rag-service.integration.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../../test-db-helper.js';
+import { query } from '../../../core/db/postgres.js';
+import pgvector from 'pgvector';
+
+// Deterministic 1024-dim vector for fixtures and queries
+function fakeVec(seed: number): number[] {
+  return Array.from({ length: 1024 }, (_, i) => Math.sin((i + 1) * seed) * 0.01);
+}
+
+// Stub the embedding provider so hybridSearch doesn't hit a real LLM
+vi.mock('./openai-compatible-client.js', async () => {
+  const actual = await vi.importActual<typeof import('./openai-compatible-client.js')>(
+    './openai-compatible-client.js',
+  );
+  return {
+    ...actual,
+    generateEmbedding: vi.fn(async () => [fakeVec(7)]),
+  };
+});
+vi.mock('./llm-provider-resolver.js', () => ({
+  resolveUsecase: vi.fn(async () => ({
+    config: {
+      providerId: 'stub',
+      id: 'stub',
+      name: 'stub',
+      baseUrl: '',
+      apiKey: null,
+      authType: 'none',
+      verifySsl: true,
+      defaultModel: 'stub',
+    },
+    model: 'stub',
+  })),
+}));
+
+// Import the functions under test AFTER the mocks above are registered.
+const { hybridSearch, keywordSearch, vectorSearch } = await import('./rag-service.js');
+
+const dbAvailable = await isDbAvailable();
+
+describe.skipIf(!dbAvailable)('rag-service integration — space permission enforcement', () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  }, 30_000);
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+  beforeEach(async () => {
+    await truncateAllTables();
+    // Re-seed system roles that migration 039 inserts on fresh install;
+    // truncateAllTables wipes them, so restore the ones we reference below.
+    await query(
+      `INSERT INTO roles (name, display_name, is_system, permissions) VALUES
+         ('system_admin', 'System Administrator', TRUE, ARRAY['read','comment','edit','delete','manage','admin']),
+         ('space_admin', 'Space Administrator', TRUE, ARRAY['read','comment','edit','delete','manage']),
+         ('editor', 'Editor', TRUE, ARRAY['read','comment','edit','delete']),
+         ('commenter', 'Commenter', TRUE, ARRAY['read','comment']),
+         ('viewer', 'Viewer', TRUE, ARRAY['read'])
+       ON CONFLICT (name) DO NOTHING`,
+    );
+  });
+  afterEach(async () => {
+    vi.clearAllMocks();
+  });
+
+  async function seedSpaceWithPage(opts: {
+    userId: string;
+    spaceKey: string;
+    roleName?: 'viewer' | 'space_admin' | 'editor' | 'commenter' | 'system_admin';
+    pageTitle: string;
+    bodyText: string;
+    vec: number[];
+  }): Promise<number> {
+    const { userId, spaceKey, roleName = 'viewer', pageTitle, bodyText, vec } = opts;
+    await query(
+      `INSERT INTO users (id, username, email, role, password_hash)
+       VALUES ($1::uuid, $1::text, $1::text || '@test', 'user', 'x')
+       ON CONFLICT (id) DO NOTHING`,
+      [userId],
+    );
+    await query(
+      `INSERT INTO spaces (space_key, space_name) VALUES ($1, $1)
+       ON CONFLICT (space_key) DO NOTHING`,
+      [spaceKey],
+    );
+    const role = await query<{ id: number }>(
+      `SELECT id FROM roles WHERE name = $1`,
+      [roleName],
+    );
+    const roleId = role.rows[0]!.id;
+    await query(
+      `INSERT INTO space_role_assignments (space_key, principal_type, principal_id, role_id)
+       VALUES ($1, 'user', $2, $3)
+       ON CONFLICT DO NOTHING`,
+      [spaceKey, userId, roleId],
+    );
+    const page = await query<{ id: number }>(
+      `INSERT INTO pages (confluence_id, source, space_key, title, body_text, body_storage, body_html)
+       VALUES (gen_random_uuid()::text, 'confluence', $1, $2, $3, '', '')
+       RETURNING id`,
+      [spaceKey, pageTitle, bodyText],
+    );
+    const pageId = page.rows[0]!.id;
+    await query(
+      `INSERT INTO page_embeddings (page_id, chunk_index, chunk_text, embedding, metadata)
+       VALUES ($1, 0, $2, $3, $4::jsonb)`,
+      [
+        pageId,
+        bodyText,
+        pgvector.toSql(vec),
+        JSON.stringify({ page_title: pageTitle, section_title: pageTitle, space_key: spaceKey }),
+      ],
+    );
+    return pageId;
+  }
+
+  it('does not leak chunks from a space the caller has no role in', async () => {
+    const userA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const userB = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+    // User B has synced space SECRET and has a page there
+    await seedSpaceWithPage({
+      userId: userB,
+      spaceKey: 'SECRET',
+      pageTitle: 'Secret plans',
+      bodyText: 'launch codes and trade secrets',
+      vec: fakeVec(7),
+    });
+    // User A must also exist as a row before we test their access
+    await query(
+      `INSERT INTO users (id, username, email, role, password_hash)
+       VALUES ($1::uuid, $1::text, $1::text || '@test', 'user', 'x')
+       ON CONFLICT (id) DO NOTHING`,
+      [userA],
+    );
+
+    // User A has no role in SECRET — their readable set should be empty
+    const vectorHits = await vectorSearch(userA, fakeVec(7));
+    const keywordHits = await keywordSearch(userA, 'launch codes');
+    const hybrid = await hybridSearch(userA, 'launch codes');
+
+    expect(vectorHits).toHaveLength(0);
+    expect(keywordHits).toHaveLength(0);
+    expect(hybrid).toHaveLength(0);
+  });
+});

--- a/backend/src/domains/llm/services/rag-service.integration.test.ts
+++ b/backend/src/domains/llm/services/rag-service.integration.test.ts
@@ -120,6 +120,46 @@ describe.skipIf(!dbAvailable)('rag-service integration — space permission enfo
     return pageId;
   }
 
+  it('enforces standalone article visibility (shared + own-private, not others-private)', async () => {
+    const userX = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    const userY = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+    // Insert both users so the FK on created_by_user_id is satisfied
+    await query(
+      `INSERT INTO users (id, username, email, role, password_hash)
+       VALUES ($1::uuid, $1::text, $1::text || '@t', 'user', 'x'),
+              ($2::uuid, $2::text, $2::text || '@t', 'user', 'x')
+       ON CONFLICT (id) DO NOTHING`,
+      [userX, userY],
+    );
+    // userX writes a private standalone article
+    const page = await query<{ id: number }>(
+      `INSERT INTO pages (confluence_id, source, space_key, title, body_text, body_storage, body_html,
+                          visibility, created_by_user_id)
+       VALUES (gen_random_uuid()::text, 'standalone', NULL, 'Private note', 'confidential draft', '', '',
+               'private', $1)
+       RETURNING id`,
+      [userX],
+    );
+    await query(
+      `INSERT INTO page_embeddings (page_id, chunk_index, chunk_text, embedding, metadata)
+       VALUES ($1, 0, $2, $3, $4::jsonb)`,
+      [
+        page.rows[0]!.id,
+        'confidential draft',
+        pgvector.toSql(fakeVec(13)),
+        JSON.stringify({ page_title: 'Private note', section_title: 'Private note', space_key: null }),
+      ],
+    );
+
+    // userX can see their own private article
+    const ownerHits = await hybridSearch(userX, 'confidential draft');
+    expect(ownerHits.length).toBeGreaterThan(0);
+
+    // userY cannot
+    const intruderHits = await hybridSearch(userY, 'confidential draft');
+    expect(intruderHits).toHaveLength(0);
+  });
+
   it('reflects mid-conversation ACL revocation on the next retrieval', async () => {
     const user = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
     await seedSpaceWithPage({

--- a/backend/src/domains/llm/services/rag-service.test.ts
+++ b/backend/src/domains/llm/services/rag-service.test.ts
@@ -56,6 +56,10 @@ vi.mock('./openai-compatible-client.js', () => ({
 
 vi.mock('../../../core/services/rbac-service.js', () => ({
   getUserAccessibleSpaces: (...args: unknown[]) => mocks.mockGetUserAccessibleSpaces(...args),
+  // The rag-service now imports the memoised wrapper (ADR-022). Tests here
+  // exercise resolver behaviour, not the scope cache, so the wrapper just
+  // delegates to the same mock.
+  getUserAccessibleSpacesMemoized: (...args: unknown[]) => mocks.mockGetUserAccessibleSpaces(...args),
 }));
 
 vi.mock('pgvector', () => ({

--- a/backend/src/domains/llm/services/rag-service.ts
+++ b/backend/src/domains/llm/services/rag-service.ts
@@ -1,7 +1,9 @@
 import { query, getVectorPool } from '../../../core/db/postgres.js';
 import { resolveUsecase } from './llm-provider-resolver.js';
 import { generateEmbedding } from './openai-compatible-client.js';
-import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
+// Use the request-scoped memoised wrapper so a single hybrid request resolves
+// the readable-space set once across vectorSearch + keywordSearch. See ADR-022.
+import { getUserAccessibleSpacesMemoized as getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
 import { CircuitBreakerOpenError } from '../../../core/services/circuit-breaker.js';
 import { getFtsLanguage } from '../../../core/services/fts-language.js';
 import pgvector from 'pgvector';

--- a/backend/src/routes/knowledge/search.test.ts
+++ b/backend/src/routes/knowledge/search.test.ts
@@ -10,6 +10,9 @@ vi.mock('../../core/utils/logger.js', () => ({
 
 vi.mock('../../core/services/rbac-service.js', () => ({
   getUserAccessibleSpaces: vi.fn().mockResolvedValue(['TEST']),
+  // The search route now imports the memoised wrapper (ADR-022). For these
+  // tests, the scope cache is irrelevant; both forms resolve the same set.
+  getUserAccessibleSpacesMemoized: vi.fn().mockResolvedValue(['TEST']),
 }));
 
 const mockQueryFn = vi.fn();

--- a/backend/src/routes/knowledge/search.ts
+++ b/backend/src/routes/knowledge/search.ts
@@ -2,7 +2,10 @@ import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { SearchHybridQuerySchema } from '@compendiq/contracts';
 import { query } from '../../core/db/postgres.js';
-import { getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
+// Use the request-scoped memoised wrapper so the search route and downstream
+// rag-service calls resolve the readable-space set once per request. See
+// ADR-022.
+import { getUserAccessibleSpacesMemoized as getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
 import { getFtsLanguage } from '../../core/services/fts-language.js';
 import {
   vectorSearch,

--- a/docs/ARCHITECTURE-DECISIONS.md
+++ b/docs/ARCHITECTURE-DECISIONS.md
@@ -1106,6 +1106,27 @@ Until this ADR the app supported exactly two LLM backends selected by the `LLM_P
 
 ---
 
+## ADR-022: RAG retrieval honours per-user space permissions
+
+**Date:** 2026-04-21
+**Status:** Accepted
+**Context:** Confluence instances can host spaces with restricted read access. When multiple users share a Compendiq instance, RAG must not surface a chunk from a space the querying user cannot read in Confluence, even if a different user on the same instance synced that space.
+
+**Decision:** Enforce per-user space permissions as a **post-filter** on both vector (pgvector HNSW) and keyword (PostgreSQL FTS) candidate sets, before reciprocal-rank fusion. The allowed space set is resolved from `space_role_assignments` + `group_memberships` via `rbac-service.getUserAccessibleSpaces(userId)` and memoised for the lifetime of the request via `AsyncLocalStorage` so downstream callers pay a single DB round-trip regardless of how many retrieval paths execute per request.
+
+Standalone (non-Confluence) articles are filtered by the same visibility rules already enforced in the knowledge-search route: `shared` articles are visible to all authenticated users; `private` articles are visible only to their creator.
+
+**Why post-filter, not query-time HNSW index filter:** pgvector HNSW has a selectivity penalty when the filter column is sparse; adding `space_key = ANY(...)` as an ORDER-BY-time predicate would force oversampled top-K per call. Post-filter with candidate overfetch is simpler, keeps the vector index unconditioned on per-user state, and is adequate while per-user readable sets stay small (typically < 50 spaces per user in observed deployments).
+
+**Scope boundary (CE-only):** This ADR covers space-level RBAC enforcement. Per-space **per-user ACL** (access-control-entries with custom permissions per page) is gated behind the Enterprise Edition `ENTERPRISE_FEATURES.ADVANCED_RBAC` flag and is not covered here; see the v0.4 roadmap.
+
+**Consequences:**
+- Any new retrieval path MUST use `getUserAccessibleSpacesMemoized` (not the raw resolver) to inherit the request-scoped cache.
+- RBAC mutation paths MUST invalidate the Redis RBAC cache (`invalidateRbacCache(userId)`) so the next request sees the new ACL within the 60-second global TTL window.
+- Integration test `backend/src/domains/llm/services/rag-service.integration.test.ts` is the regression guard.
+
+---
+
 ## Summary of All Decisions
 
 | # | Decision | Choice | Key Rationale |
@@ -1131,3 +1152,4 @@ Until this ADR the app supported exactly two LLM backends selected by the `LLM_P
 | 019 | Admin Role & Re-embed | Simple role column, first user is admin | Protects destructive re-embed operation |
 | 020 | Standalone KB Articles | Shared `pages` table + `source` discriminator + universal SERIAL FK | All features work on standalone articles; no dual-identifier problem |
 | 021 | Multi-LLM-Provider | `llm_providers` table + per-use-case assignments + one OpenAI-compatible client | Supports multi-endpoint deployments; no triplication of client code |
+| 022 | RAG Permission Enforcement | Post-filter retrieval by RBAC-readable spaces + request-scoped AsyncLocalStorage cache | Prevents cross-user leakage in shared deployments; single resolver hit per request |

--- a/docs/architecture/09-flow-rag-chat.md
+++ b/docs/architecture/09-flow-rag-chat.md
@@ -12,6 +12,7 @@ sequenceDiagram
     participant FE as Frontend (AiAssistantPage)
     participant BE as /api/llm/ask (SSE)
     participant SAN as sanitize-llm-input
+    participant RBAC as rbac-service (per-req scope)
     participant RAG as rag-service
     participant EMB as embedding provider<br/>(resolveUsecase('embedding'))
     participant PG as Postgres (pgvector + FTS)
@@ -38,13 +39,15 @@ sequenceDiagram
             CACHE-->>BE: lock acquired
             BE->>EMB: POST /v1/embeddings (question)
             EMB-->>BE: q_vector[N]
+            BE->>RBAC: getUserAccessibleSpacesMemoized(userId)
+            RBAC-->>BE: readableSpaceKeys[] (request-scoped)
             par vector + keyword
-                BE->>RAG: vectorSearch(q_vector, userId, topK)
-                RAG->>PG: SELECT ... ORDER BY embedding <=> $1<br/>WHERE user_id=$2 AND space in (...)
+                BE->>RAG: vectorSearch(userId, q_vector)
+                RAG->>PG: WHERE cp.space_key = ANY(readableSpaceKeys) ...
                 PG-->>RAG: top-K chunks
             and
-                BE->>RAG: hybridKeyword(question, userId)
-                RAG->>PG: tsvector / BM25 search
+                BE->>RAG: keywordSearch(userId, question)
+                RAG->>PG: tsvector search WHERE same space filter
                 PG-->>RAG: matches
             end
             RAG-->>BE: merged + deduped + ranked
@@ -81,6 +84,17 @@ sequenceDiagram
         end
     end
 ```
+
+### Permission-check checkpoint
+
+Per ADR-022, RAG retrieval post-filters vector and FTS candidate sets by the
+caller's readable space keys. The resolver
+(`rbac-service.getUserAccessibleSpaces`) is memoised per request via
+`AsyncLocalStorage`, so a single hybrid query touches the RBAC path once
+regardless of how many retrieval calls execute. The Fastify `authenticate`
+hook enters the scope on every authenticated request via `enterRbacScope`; the
+memoised wrapper falls back to the raw resolver outside a scope (background
+workers, tests that skip the opt-in).
 
 ## Retrieval details
 


### PR DESCRIPTION
## Summary
- Proves existing per-user space-permission enforcement in `rag-service.ts` with real-Postgres integration tests covering cross-user leakage, mid-conversation ACL revocation, and standalone article visibility
- Adds `AsyncLocalStorage`-backed per-request memoisation so `getUserAccessibleSpaces` runs at most once per request
- New ADR documenting the enforcement model and CE-vs-EE scope boundary
- Architecture diagram `09-flow-rag-chat.md` now shows the permission-check checkpoint

Closes #282

## Test plan
- [ ] Backend unit + integration tests green (`npm run test -w backend`)
- [ ] Typecheck green
- [ ] Lint green
- [ ] Manual: cross-user leakage scenario reviewed in the new integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)