### PR TITLE
docs(#283): customer-facing v0.3.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> Customer-facing release notes for v0.3.0 live at [`docs/releases/v0.3.0.md`](docs/releases/v0.3.0.md). The entries below stay in commit voice for engineers.
+
 ### Added
 
 - **BullMQ re-embed-all worker + admin lock visibility** -- replaces the `TODO(#257)` stub in `enqueueReembedAll` with a real worker. Fixed `jobId='reembed-all'` collapses concurrent triggers; explicit lazy-removal sweep lets a completed jobId be reused on the next POST. Worker waits on per-user embedding locks (up to `REEMBED_WAIT_LOCKS_MS`) and emits `phase: 'waiting-on-user-locks'`. New admin-only `GET /api/admin/embedding/locks` returns `EmbeddingLockSnapshot[]` (userId, holderEpoch, ttlRemainingMs). `POST /api/admin/embedding/locks/:userId/release` is the force-release escape hatch — audit-logged via `ADMIN_ACTION.embedding_lock.force_release_embedding_lock`, with a holder-epoch guard in `processDirtyPages` that re-reads the lock every 20 pages and aborts on mismatch. Configurable `reembed_history_retention` admin setting (default 150, min 10, max 10000, migration 055) drives BullMQ `removeOnComplete`/`removeOnFail`. Frontend `ActiveEmbeddingLocksBanner` with per-row Force-release (inline-confirm pattern). (#257, PR #261)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   <a href="#what-it-does">Features</a> &middot;
   <a href="#architecture">Architecture</a> &middot;
   <a href="docs/USER-GUIDE.md">Docs</a> &middot;
+  <a href="docs/releases/v0.3.0.md">v0.3 release notes</a> &middot;
   <a href="https://github.com/Compendiq/compendiq-ce/discussions">Community</a> &middot;
   <a href="SECURITY.md">Security</a>
 </p>

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,129 @@
+# Compendiq v0.3.0 — release notes
+
+**Released:** 2026-04-22
+**Headline:** AI governance, multi-provider control, and privacy-respecting RAG.
+
+v0.3.0 is the **Phase 1.1** release. It closes the gap between "Compendiq has AI features" and "Compendiq is an AI platform you can operate in a regulated environment." Admins now decide which models each workflow uses, auditors see who asked what, and end-users only see knowledge they're allowed to see.
+
+This release contains changes in both **Compendiq Community Edition** (open-source, this repo) and **Compendiq Enterprise Edition** (commercial overlay). Where a section is EE-only, it is marked **[Enterprise]**. Everything else ships in CE.
+
+---
+
+## What's new
+
+### Run AI on your terms
+
+You can now attach **any number of OpenAI-compatible LLM endpoints** to a single Compendiq deployment and choose per-use-case which one handles which workflow.
+
+- **N named LLM providers.** Keep Ollama for local chat, OpenAI for premium summarisation, Azure OpenAI for compliance, and LM Studio for offline generation — all configured side-by-side in **Settings → LLM**. Each row holds its own base URL, bearer token (encrypted at rest with AES-256-GCM), TLS verification policy, and concurrency cap.
+- **Per-use-case assignments.** Map each of **chat · article improvement · summarisation · quality analysis · auto-tagging · embedding** to either "inherit the default provider" or an explicit `(provider, model)` pair. Want `llama3.1:70b` for chat but `qwen2.5:3b` for background auto-tagging? That's one form.
+- **Per-provider circuit breakers.** Each provider has an independent failure budget. If OpenAI rate-limits you, chat falls back or returns `503` cleanly while your background workers on Ollama keep running. The breaker map invalidates on provider deletion (no more O(n) stale entries).
+- **LLM request queue with backpressure.** Configurable concurrency (default 4) and queue depth (default 50), with health-endpoint visibility. Runaway streams can't starve the process any more.
+- **Per-user concurrent SSE stream cap** (default 3, admin-configurable 1–20). One user opening 50 chat tabs no longer saturates the upstream model. Graceful lowering: in-flight streams complete, new opens see the new cap.
+
+> **Breaking:** the old `LLM_PROVIDER=ollama|openai` two-slot toggle is gone. If your `.env` still sets it, it's ignored; configure providers in the admin UI instead. The env vars `OLLAMA_BASE_URL`, `LLM_BEARER_TOKEN`, `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `DEFAULT_LLM_MODEL`, `QUALITY_MODEL`, `SUMMARY_MODEL`, `EMBEDDING_MODEL`, and `LLM_MAX_CONCURRENT_STREAMS_PER_USER` still exist as **first-boot seed values only** — after the first successful start, the database row is authoritative.
+
+### Keep knowledge private
+
+**RAG retrieval now honours per-user Confluence space permissions.** Previously, if user B synced a restricted space, user A's AI assistant could see chunks from that space even though user A has no read access in Confluence. v0.3.0 post-filters both the vector and full-text candidate sets by the caller's readable space keys before reranking, and resolves the permission set once per request via AsyncLocalStorage.
+
+This closes a real least-privilege gap that matters on any shared-instance deployment. Details in [ADR-022](../ARCHITECTURE-DECISIONS.md).
+
+### See who asked what — **[Enterprise]**
+
+- **LLM audit trail.** Every LLM request lands in an immutable table: who asked, which provider and model answered, prompt summary, token cost, latency. Admin viewer with filter-by-user / filter-by-use-case / date range.
+- **Audit summaries with 7-year retention.** Daily aggregation rollup to a second table kept on RANGE-partitioned storage so old partitions can be archived and dropped without touching the hot path. Retention configurable via the admin UI.
+- **LLM audit hook extension point** (CE). Fire-and-forget `emitLlmAudit()` runs when an enterprise hook is registered, zero overhead when it isn't. CE customers can plug their own audit sink without forking.
+
+### Stay inside policy
+
+- **Organisational LLM policy lock — [Enterprise].** Admins pin each use case to a policy-approved provider and lock it. Once locked, users cannot override provider or model per-request, and attempts to change LLM settings via `PUT /api/admin/settings` are blocked by policy middleware. Prevents shadow-IT routing sensitive prompts to unapproved endpoints.
+- **Denied admin-action audit trail** (CE). Every 401/403 on an admin route writes an `ADMIN_ACCESS_DENIED` audit row with actor, IP, route, method, and reason. Visible in the existing audit log UI. Retention: 90 days by default, 7–3650 configurable. Useful for spotting credential-stuffing probes or misconfigured scripts.
+
+### Provision and govern users at scale — **[Enterprise]**
+
+- **SCIM 2.0 provisioning** against Azure AD, Okta, OneLogin, and Keycloak. CRUD on users and groups, group memberships round-trip, soft-delete via `PATCH replace active=false`, and a compliance suite driven by `python-scim/scim2-cli`. 32 of 48 scim2-cli assertions pass today; the remaining 16 are documented intentional deviations (filter complexity beyond `eq`, bulk endpoint, ETags) with rationale in `docs/phase1.1/enterprise-scim.md`.
+- **Advanced RBAC with 18 named permissions.** Fine-grained control over what each role can do: view pages, edit pages, delete pages, manage comments, trigger sync, query LLM, run generation, manage settings, and so on. Assign permissions to roles, roles to spaces. Group memberships synced from SCIM or OIDC participate automatically.
+- **Enterprise analytics dashboards.** Four new dashboards for organisational visibility: LLM usage by user / by model, knowledge-base health (stale pages, pages missing summaries, low-quality pages), audit-log activity, and SCIM provisioning state.
+- **Data retention policies.** Admin-configurable retention windows for audit logs (per action type), LLM audit rows, SCIM provisioning history, and sync job history. Daily BullMQ worker runs targeted batched deletes rather than whole-table scans.
+- **EE worker health + kill-switch.** All EE background workers report into `/api/health`; admins can stop a runaway worker from the UI without touching the process.
+
+### SSO that works on private networks — **[Enterprise]**
+
+- **OIDC/SSO** ships configured via the admin UI — paste an issuer discovery URL, client ID + secret, choose the groups claim, and map IdP groups to Compendiq roles. JIT provisioning creates users on first login with `auth_provider='oidc'`; subsequent logins with the same `sub` return the same user (no duplicate rows).
+- **Private-network IdP hosts are supported.** Earlier builds silently blocked discovery fetches against `http://sso.internal`, `http://10.0.0.x:8081`, or `localhost` Keycloak because the backend's SSRF guard treated them as internal-target attacks. OIDC provider URLs are now registered in the same allowlist Compendiq already uses for Confluence and LLM providers, so on-premise-only deployments can run their IdP inside the same VLAN.
+- **Automated end-to-end verification.** A new `oidc-e2e` GitHub Actions job spins up Keycloak, imports a realm, builds a fresh EE image, and drives the full login → callback → role-mapping → logout flow with Playwright on every push. Four specs cover login, role mapping, JIT provisioning idempotency, and logout.
+- **Admin guide.** `docs/phase1.1/admin-guide.md` has a new **Configure SSO (OIDC)** section: verified Keycloak walkthrough plus documented Okta and Entra ID setup steps (tagged *"not yet verified against a live tenant — please report issues"* pending the follow-up in [EE #99](https://github.com/Compendiq/compendiq-ee/issues/99)).
+- **Local Keycloak dev stack.** `docker/docker-compose.oidc-dev.yml` + committed realm export gets a developer from `docker compose up` to "logged in as alice" in about two minutes, with no Keycloak admin-UI clicks required.
+
+### Reorganise without breaking users
+
+- **Settings IA reorganisation.** The settings surface has been regrouped by audience: personal settings stay under `/settings`, admin settings live under `/admin/settings` with clear section headers (LLM · SCIM · SSO · Data retention · License · System). Old URLs redirect.
+- **Circuit-breaker route renamed** from `/api/ollama/circuit-breaker-status` to `/api/llm/circuit-breaker-status` to match the provider-keyed response shape. The alias was shipped with a 6-month RFC 9745 deprecation window but retired same-day in the closeout PR since no external consumers had adopted it. External integrations calling the old path will get `404`.
+
+### Operational robustness
+
+- **BullMQ re-embed-all worker.** The `POST /api/admin/embedding/reembed-all` endpoint is no longer a stub — it enqueues a real BullMQ job that waits on per-user embedding locks, reports progress phases, and respects a `reembed_history_retention` setting (default 150 runs). Admins can see who's holding an embedding lock at `GET /api/admin/embedding/locks` and force-release a stuck one from the UI (audit-logged, holder-epoch guarded).
+- **Embedding-lock listing is O(1) in keyspace size.** Upgraded from a Redis SCAN to a dedicated `embedding:locks:active` set, self-healing against stale members after a crash.
+
+---
+
+## Upgrade notes
+
+v0.3.0 is a minor release; the upgrade path is `docker compose pull && docker compose up -d`. Migrations run automatically at backend boot.
+
+### Migrations
+
+| Side | Range | Covers |
+|---|---|---|
+| CE | `052 – 057` | llm_providers table + per-provider configuration columns, admin_settings keys for use-case assignments, admin-denied-action audit retention column |
+| **[Enterprise]** | `060 – 065` | SCIM tables (users sync log, groups, memberships, provisioning events), advanced RBAC (roles × permissions × scope), LLM audit + audit_summary (RANGE-partitioned), data-retention policies, SSO providers config |
+
+All migrations are idempotent and have been exercised on fresh installs and on upgrades from v0.2.0 in CI. No manual data migration required.
+
+### Breaking changes
+
+1. **`LLM_PROVIDER` env var is gone.** Pre-0.3 deployments that pinned it are unaffected — its value was migrated on first boot into the first row of `llm_providers`. New deployments configure providers in the admin UI.
+2. **`/api/ollama/circuit-breaker-status` returns 404.** Use `/api/llm/circuit-breaker-status` — same shape, provider-keyed.
+3. **Deprecated env vars demoted to seed-only.** `DEFAULT_LLM_MODEL`, `QUALITY_MODEL`, `SUMMARY_MODEL`, `LLM_MAX_CONCURRENT_STREAMS_PER_USER`, and `COMPENDIQ_LICENSE_KEY` are consulted only on fresh installs when the corresponding `admin_settings` row is absent. Change the setting in the UI; the env var no longer overrides it.
+4. **[Enterprise]** SCIM bearer tokens issued under v0.2.x continue to work. If you generated tokens that include the pre-0.3 `scim:*` scopes literally, they'll map cleanly; no regeneration needed.
+
+### Pricing / edition gate
+
+v0.3.0 refines the open-core boundary:
+
+| Capability | CE | Enterprise |
+|---|---|---|
+| Multi-LLM provider config + per-use-case routing | ✅ | ✅ |
+| Per-provider circuit breakers + queue | ✅ | ✅ |
+| Per-user SSE stream cap | ✅ | ✅ |
+| RAG permission enforcement (space-level) | ✅ | ✅ |
+| Denied-admin-action audit | ✅ | ✅ |
+| Email notification service | ✅ | ✅ |
+| BullMQ re-embed-all + lock admin | ✅ | ✅ |
+| OIDC/SSO | ❌ | ✅ |
+| SCIM 2.0 provisioning | ❌ | ✅ |
+| Advanced RBAC (18 permissions × roles × spaces) | ❌ | ✅ |
+| LLM audit trail + admin viewer | ❌ | ✅ |
+| Organisational LLM policy lock | ❌ | ✅ |
+| Enterprise analytics dashboards | ❌ | ✅ |
+| Data retention policies (UI-configurable) | ❌ | ✅ |
+| Worker health + admin kill-switch | ❌ | ✅ |
+
+RAG permission enforcement at the **per-space ACL** level (different users seeing different chunks from the same space) remains **v0.4 scope** and is not yet shipped.
+
+---
+
+## Closing references
+
+- Full CHANGELOG: [`CHANGELOG.md`](../../CHANGELOG.md)
+- Architecture decisions added or rewritten for v0.3.0: ADR-014 (BullMQ), ADR-021 (multi-LLM providers), **ADR-022 (RAG permission enforcement)**
+- Admin guide: [`docs/phase1.1/admin-guide.md`](../phase1.1/admin-guide.md)
+- Enterprise SCIM: [`docs/phase1.1/enterprise-scim.md`](../phase1.1/enterprise-scim.md)
+- Known deviations and follow-ups: [`compendiq-ee` issues](https://github.com/Compendiq/compendiq-ee/issues) labelled `phase-1.1` or `scim-compliance`
+
+## Thanks
+
+v0.3.0 closes the Phase 1.1 plan in full. Between v0.2.0 (2026-04-14) and now, the team shipped 35 merged PRs across CE and EE, 11 new CE migrations, 6 new EE migrations, and a documented SCIM compliance baseline — alongside the baseline RAG, sync, and chat functionality staying feature-complete the whole way.
+
+Next on the roadmap: **v0.4** — per-space ACLs on RAG, more IdP interop (Okta and Entra ID live-tenant verification), and the first community feedback items from v0.3.


### PR DESCRIPTION
## Summary

Adds `docs/releases/v0.3.0.md` — customer-voice, outcome-grouped narrative covering the full Phase 1.1 closeout across CE + EE. Linked from `README.md` top-nav and from the `CHANGELOG.md` `[Unreleased]` header.

## Structure (outcome-driven, not issue-number-driven)

- **Run AI on your terms** — multi-provider config, per-use-case routing, per-provider breakers, LLM queue with backpressure, per-user SSE cap
- **Keep knowledge private** — RAG permission enforcement (ADR-022, CE #282)
- **See who asked what [EE]** — LLM audit trail + admin viewer + 7-year retention with RANGE partitioning
- **Stay inside policy** — org LLM policy lock [EE] + denied-admin-action audit [CE]
- **Provision and govern users at scale [EE]** — SCIM 2.0, advanced RBAC, analytics dashboards, data retention, worker health + kill-switch
- **SSO that works on private networks [EE]** — OIDC via admin UI, private-IdP-host support (the SSRF-allowlist fix from PR #103), automated Keycloak E2E, local dev stack
- **Reorganise without breaking users** — Settings IA, circuit-breaker route rename
- **Operational robustness** — BullMQ re-embed-all + lock admin, SCAN→set upgrade

Plus:
- **CE vs Enterprise pricing-gate matrix**
- **Migration table** (CE 052–057, EE 060–065)
- **Breaking changes** (`LLM_PROVIDER` env removed, `/api/ollama/circuit-breaker-status` → `/api/llm/...`, deprecated env vars demoted to seed-only)

Closes #283.

## Test plan
- [ ] Markdown renders cleanly on GitHub
- [ ] All cross-links resolve (ADR-022, phase1.1/admin-guide.md, phase1.1/enterprise-scim.md, EE issue #99)
- [ ] Content matches what actually shipped (spot-check the feature list against the Unreleased CHANGELOG entries)
- [ ] CE-vs-Enterprise matrix matches the runtime feature flags in `backend/src/core/enterprise/features.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)