### PR TITLE
release(#285): bump to v0.3.0 and stamp CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-22
+
 > Customer-facing release notes for v0.3.0 live at [`docs/releases/v0.3.0.md`](docs/releases/v0.3.0.md). The entries below stay in commit voice for engineers.
 
 ### Added

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/mcp-docs/package.json
+++ b/mcp-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq-mcp-docs",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Compendiq - AI-powered knowledge base management with Confluence integration and Ollama LLM backend",
   "workspaces": [

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compendiq/contracts",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Release prep PR for **v0.3.0**. Bumps \`"version"\` to \`0.3.0\` in all 5 package.json files and stamps the \`CHANGELOG.md [0.3.0]\` section with \`2026-04-22\`.

### Files changed
- \`package.json\` (root, source of truth per CLAUDE.md)
- \`backend/package.json\`
- \`frontend/package.json\`
- \`packages/contracts/package.json\`
- \`mcp-docs/package.json\` (was at \`0.1.0\`, now in line)
- \`CHANGELOG.md\` — adds \`## [0.3.0] - 2026-04-22\` header above the Unreleased block

### Sanity checks
- \`backend/src/core/utils/version.ts\` reads APP_VERSION from the root \`package.json\` at boot — will report \`0.3.0\` on the next start.
- \`frontend/vite.config.ts\` injects \`__APP_VERSION__\` via Vite \`define\` from the root \`package.json\` at build time — will bake \`0.3.0\` into the next frontend build.
- \`mcp-docs/src/index.ts\` reads its own \`package.json\` — now reports \`0.3.0\`.

Closes #285 (the PR portion — the remaining release steps are manual and listed below).

## Release checklist (human-driven, after this PR merges)

Per \`CLAUDE.md\` versioning / git workflow — tagging \`main\` and pushing Docker images are irreversible + user-visible, so I stopped here and handed back:

- [ ] Merge this PR to \`dev\`
- [ ] Open \`dev → main\` PR; merge it
- [ ] On \`main\`: \`git tag -a v0.3.0 -m "v0.3.0" && git push origin v0.3.0\`
- [ ] Rebuild + publish Docker images: \`ghcr.io/compendiq/compendiq-ce-backend:0.3.0\` and the \`0.3.0\`-tagged frontend
- [ ] Create GitHub Release for \`v0.3.0\`, body pulled from [\`docs/releases/v0.3.0.md\`](docs/releases/v0.3.0.md)
- [ ] Bump EE overlay to consume the CE \`0.3.0\` submodule / image tag
- [ ] Cut EE \`0.3.0\` release in \`compendiq-ee\` (mirror PR, same tag, same Docker image publish)
- [ ] Close #285

## Test plan
- [ ] CI green (typecheck, lint, tests, semgrep)
- [ ] Local \`curl /api/health\` on a fresh container reports \`"version":"0.3.0"\`
- [ ] Frontend build bundle contains \`0.3.0\` string (\`grep -r "0.3.0" frontend/dist/assets/*.js\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)