### PR TITLE
docs,test(#288): tighten ADR-022 scope + positive owner test assertion

### DIFF
--- a/backend/src/domains/llm/services/rag-service.integration.test.ts
+++ b/backend/src/domains/llm/services/rag-service.integration.test.ts
@@ -215,5 +215,17 @@ describe.skipIf(!dbAvailable)('rag-service integration — space permission enfo
     expect(vectorHits).toHaveLength(0);
     expect(keywordHits).toHaveLength(0);
     expect(hybrid).toHaveLength(0);
+
+    // Positive counterpart: user B (who has the SECRET role from the fixture)
+    // MUST still see the chunk. Without this, a bug that broke retrieval for
+    // everyone would pass the zero-leak assertions above — we want to rule
+    // out "retrieval is broken for everyone" as a false-positive pass.
+    const ownerVectorHits = await vectorSearch(userB, fakeVec(7));
+    const ownerKeywordHits = await keywordSearch(userB, 'launch codes');
+    const ownerHybrid = await hybridSearch(userB, 'launch codes');
+
+    expect(ownerVectorHits.length).toBeGreaterThan(0);
+    expect(ownerKeywordHits.length).toBeGreaterThan(0);
+    expect(ownerHybrid.length).toBeGreaterThan(0);
   });
 });

--- a/docs/ARCHITECTURE-DECISIONS.md
+++ b/docs/ARCHITECTURE-DECISIONS.md
@@ -1121,7 +1121,7 @@ Standalone (non-Confluence) articles are filtered by the same visibility rules a
 **Scope boundary (CE-only):** This ADR covers space-level RBAC enforcement. Per-space **per-user ACL** (access-control-entries with custom permissions per page) is gated behind the Enterprise Edition `ENTERPRISE_FEATURES.ADVANCED_RBAC` flag and is not covered here; see the v0.4 roadmap.
 
 **Consequences:**
-- Any new retrieval path MUST use `getUserAccessibleSpacesMemoized` (not the raw resolver) to inherit the request-scoped cache.
+- Any new **RAG retrieval** path MUST use `getUserAccessibleSpacesMemoized` (not the raw resolver) to inherit the request-scoped cache. Non-retrieval callers (admin tooling, sync workers, one-shot operations that run outside an authenticated HTTP request scope where `AsyncLocalStorage` has no context) continue to call `getUserAccessibleSpaces` directly — memoisation has no benefit there.
 - RBAC mutation paths MUST invalidate the Redis RBAC cache (`invalidateRbacCache(userId)`) so the next request sees the new ACL within the 60-second global TTL window.
 - Integration test `backend/src/domains/llm/services/rag-service.integration.test.ts` is the regression guard.
 


### PR DESCRIPTION
## Summary

Two small follow-ups to #287 from its PR review:

1. **ADR-022 consequence wording scoped to RAG retrieval paths.** The blanket "Any new retrieval path MUST use the memoised wrapper" was misleading — only the two RAG-adjacent callsites (`rag-service.ts`, `routes/knowledge/search.ts`) were migrated; the ~11 other callers (sync workers, admin tooling, one-shot ops outside an authenticated HTTP request scope where `AsyncLocalStorage` has no context) correctly continue to use the raw `getUserAccessibleSpaces`. Rewrote the bullet to say "Any new **RAG retrieval** path" and added a sentence explaining why non-retrieval callers are deliberately exempt.

2. **Positive owner-visibility assertion** in the cross-user leakage test. Previously, `does not leak chunks from a space the caller has no role in` only asserted that userA (no SECRET access) sees zero chunks. A regression that broke retrieval for **everyone** would still pass that test. Added assertions that userB (who holds the SECRET role from the fixture) still sees chunks via all three retrieval paths (`vectorSearch`, `keywordSearch`, `hybridSearch`).

Closes #288.

## Test plan
- [x] `cd backend && npx vitest run src/domains/llm/services/rag-service.integration.test.ts` — 3/3 green locally
- [ ] Backend test suite stays green in CI
- [ ] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)