### PR TITLE
fix(embedding): support dims >2000 via halfvec + no-index fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Embedding model switch no longer caps at 2000 dimensions.** `POST /api/admin/embedding/reembed` with `newDimensions > 2000` (e.g. switching to `qwen3-embedding:4b` at 2560 dims or `qwen3-embedding:8b` at 4096) previously rolled back the whole transaction with `column cannot have more than 2000 dimensions for hnsw index`. The re-embed path now tiers the column type + index choice: `≤ 2000` keeps the vector+HNSW path unchanged; `2001–4000` uses `halfvec(n)` + HNSW `halfvec_cosine_ops` (float16 storage, ~equivalent recall); `> 4000` stores as `vector(n)` with no HNSW index (sequential scan — correct but slower on large KBs, logged as a warning). DDL order now mirrors migration 048: DROP INDEX → ALTER COLUMN TYPE → CREATE INDEX. HNSW tuning `WITH (m=16, ef_construction=200)` applied consistently. Zod upper bound widened 8192 → 16000 (pgvector's max).
+
 ## [0.3.0] - 2026-04-22
 
 > Customer-facing release notes for v0.3.0 live at [`docs/releases/v0.3.0.md`](docs/releases/v0.3.0.md). The entries below stay in commit voice for engineers.

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -1051,12 +1051,14 @@ export async function enqueueReembedAll(
     // HNSW on plain vector; falling back to halfvec or seq-scan keeps them usable.
     let columnType: string;
     let indexSql: string | null;
+    // HNSW tuning parameters match migration 011 and 048 (m=16, ef_construction=200).
+    const HNSW_PARAMS = `WITH (m = 16, ef_construction = 200)`;
     if (n <= 2000) {
       columnType = `vector(${n})`;
-      indexSql = `CREATE INDEX idx_page_embeddings_hnsw ON page_embeddings USING hnsw (embedding vector_cosine_ops)`;
+      indexSql = `CREATE INDEX idx_page_embeddings_hnsw ON page_embeddings USING hnsw (embedding vector_cosine_ops) ${HNSW_PARAMS}`;
     } else if (n <= 4000) {
       columnType = `halfvec(${n})`;
-      indexSql = `CREATE INDEX idx_page_embeddings_hnsw ON page_embeddings USING hnsw (embedding halfvec_cosine_ops)`;
+      indexSql = `CREATE INDEX idx_page_embeddings_hnsw ON page_embeddings USING hnsw (embedding halfvec_cosine_ops) ${HNSW_PARAMS}`;
     } else {
       columnType = `vector(${n})`;
       indexSql = null;
@@ -1065,10 +1067,15 @@ export async function enqueueReembedAll(
     try {
       await client.query('BEGIN');
       await client.query(`TRUNCATE page_embeddings`);
-      // USING '...'::type lets Postgres cast from the current type if non-empty
-      // (TRUNCATE above makes the cast unnecessary, but kept for robustness).
+      // Order matters — mirrors migration 048's DROP → ALTER → CREATE. If we
+      // ALTER COLUMN TYPE while the old HNSW index (tied to the old opclass,
+      // e.g. vector_cosine_ops) still exists, Postgres tries to rebuild the
+      // index on the new type — which fails when (a) the new type is halfvec
+      // and the opclass only accepts vector, or (b) the new dim is >2000.
+      // Dropping the index first disentangles the ALTER from the rebuild.
+      await client.query(`DROP INDEX IF EXISTS idx_page_embeddings_hnsw`);
       await client.query(
-        `ALTER TABLE page_embeddings ALTER COLUMN embedding TYPE ${columnType} USING embedding::${columnType}`,
+        `ALTER TABLE page_embeddings ALTER COLUMN embedding TYPE ${columnType}`,
       );
       await client.query(
         `INSERT INTO admin_settings (setting_key, setting_value, updated_at)
@@ -1077,7 +1084,6 @@ export async function enqueueReembedAll(
            SET setting_value = EXCLUDED.setting_value, updated_at = NOW()`,
         [String(n)],
       );
-      await client.query(`DROP INDEX IF EXISTS idx_page_embeddings_hnsw`);
       if (indexSql) {
         await client.query(indexSql);
       } else {

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -1038,17 +1038,37 @@ export async function enqueueReembedAll(
   if (opts.newDimensions !== undefined) {
     // pgvector type args must be literal — validate strictly before interpolation.
     const n = Math.floor(opts.newDimensions);
-    if (!Number.isFinite(n) || n < 1 || n > 8192) {
+    if (!Number.isFinite(n) || n < 1 || n > 16000) {
       throw new Error(
         `refused dimension change to non-integer or out-of-range value: ${opts.newDimensions}`,
       );
+    }
+    // pgvector index tiers (pgvector 0.8+):
+    //   HNSW on vector:  max 2000 dims — best recall, fastest, full float32
+    //   HNSW on halfvec: max 4000 dims — float16 storage, ~50% smaller, ~equivalent recall
+    //   no index:        > 4000 dims — sequential scan; correct but slower on large KBs
+    // Large open-source models like qwen3-embedding:4b (2560) or :8b (4096) can't fit
+    // HNSW on plain vector; falling back to halfvec or seq-scan keeps them usable.
+    let columnType: string;
+    let indexSql: string | null;
+    if (n <= 2000) {
+      columnType = `vector(${n})`;
+      indexSql = `CREATE INDEX idx_page_embeddings_hnsw ON page_embeddings USING hnsw (embedding vector_cosine_ops)`;
+    } else if (n <= 4000) {
+      columnType = `halfvec(${n})`;
+      indexSql = `CREATE INDEX idx_page_embeddings_hnsw ON page_embeddings USING hnsw (embedding halfvec_cosine_ops)`;
+    } else {
+      columnType = `vector(${n})`;
+      indexSql = null;
     }
     const client = await getPool().connect();
     try {
       await client.query('BEGIN');
       await client.query(`TRUNCATE page_embeddings`);
+      // USING '...'::type lets Postgres cast from the current type if non-empty
+      // (TRUNCATE above makes the cast unnecessary, but kept for robustness).
       await client.query(
-        `ALTER TABLE page_embeddings ALTER COLUMN embedding TYPE vector(${n})`,
+        `ALTER TABLE page_embeddings ALTER COLUMN embedding TYPE ${columnType} USING embedding::${columnType}`,
       );
       await client.query(
         `INSERT INTO admin_settings (setting_key, setting_value, updated_at)
@@ -1058,9 +1078,14 @@ export async function enqueueReembedAll(
         [String(n)],
       );
       await client.query(`DROP INDEX IF EXISTS idx_page_embeddings_hnsw`);
-      await client.query(
-        `CREATE INDEX idx_page_embeddings_hnsw ON page_embeddings USING hnsw (embedding vector_cosine_ops)`,
-      );
+      if (indexSql) {
+        await client.query(indexSql);
+      } else {
+        logger.warn(
+          { dimensions: n },
+          'embedding dimensions exceed pgvector HNSW limit on halfvec (4000); skipping index. Vector queries will use sequential scan — expect slower retrieval on large knowledge bases.',
+        );
+      }
       await client.query('COMMIT');
     } catch (e) {
       await client.query('ROLLBACK').catch(() => {});

--- a/backend/src/routes/llm/llm-embedding-reembed.test.ts
+++ b/backend/src/routes/llm/llm-embedding-reembed.test.ts
@@ -55,9 +55,17 @@ beforeEach(async () => {
   await truncateAllTables();
   // Reset the page_embeddings column to 1024 dims + seed the admin_settings
   // row. An earlier test in this file may have ALTERed the column to a
-  // different dimension; without the reset, the next test's INSERT of a
-  // 1024-length vector would fail.
+  // different dimension (incl. halfvec) or dropped the HNSW index entirely
+  // via the seq-scan-tier path; the reset must DROP INDEX → ALTER → CREATE
+  // in that order to accommodate any prior leftover state, matching the
+  // service's own DDL order in enqueueReembedAll.
+  await query(`DROP INDEX IF EXISTS idx_page_embeddings_hnsw`);
   await query(`ALTER TABLE page_embeddings ALTER COLUMN embedding TYPE vector(1024)`);
+  await query(
+    `CREATE INDEX idx_page_embeddings_hnsw ON page_embeddings
+       USING hnsw (embedding vector_cosine_ops)
+       WITH (m = 16, ef_construction = 200)`,
+  );
   await query(
     `INSERT INTO admin_settings (setting_key, setting_value, updated_at)
      VALUES ('embedding_dimensions', '1024', NOW())
@@ -166,8 +174,96 @@ describe.skipIf(!dbAvailable)('POST /api/admin/embedding/reembed', () => {
       headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
       payload: JSON.stringify({ newDimensions: 99999 }),
     });
-    // Zod rejects at the boundary with 400 (max: 8192)
+    // Zod rejects at the boundary with 400 (max: 16000)
     expect(r.statusCode).toBe(400);
+  });
+
+  it('with newDimensions=2560 (halfvec tier), uses halfvec column + halfvec HNSW index', async () => {
+    // Seed an existing embedding row so the ALTER COLUMN TYPE path is exercised
+    // with non-empty data between TRUNCATE-and-ALTER (the prior order-of-ops
+    // bug only manifested once the index-rebuild-on-ALTER tried to run).
+    const pageResult = await query<{ id: number }>(
+      `INSERT INTO pages (confluence_id, space_key, title, body_text, body_html)
+       VALUES ('p-halfvec', $1, 'Before 2560', 'x', '<p>x</p>') RETURNING id`,
+      ['SPACE1'],
+    );
+    const pageId = pageResult.rows[0]!.id;
+    const v1024 = '[' + new Array(1024).fill('0.01').join(',') + ']';
+    await query(
+      `INSERT INTO page_embeddings (page_id, chunk_index, chunk_text, embedding, metadata)
+       VALUES ($1, 0, 'c', $2::vector, '{}'::jsonb)`,
+      [pageId, v1024],
+    );
+
+    const r = await app.inject({
+      method: 'POST',
+      url: '/api/admin/embedding/reembed',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({ newDimensions: 2560 }),
+    });
+    expect(r.statusCode).toBe(200);
+
+    // Column type should now be halfvec(2560)
+    const typeRows = await query<{ format_type: string }>(
+      `SELECT format_type(a.atttypid, a.atttypmod) AS format_type
+       FROM pg_attribute a
+       WHERE a.attrelid = 'page_embeddings'::regclass AND a.attname = 'embedding'`,
+    );
+    expect(typeRows.rows[0]!.format_type).toBe('halfvec(2560)');
+
+    // HNSW index should exist with the halfvec opclass
+    const indexRows = await query<{ indexdef: string }>(
+      `SELECT indexdef FROM pg_indexes
+       WHERE indexname = 'idx_page_embeddings_hnsw'`,
+    );
+    expect(indexRows.rows).toHaveLength(1);
+    expect(indexRows.rows[0]!.indexdef).toContain('halfvec_cosine_ops');
+
+    const settingRows = await query<{ setting_value: string }>(
+      `SELECT setting_value FROM admin_settings WHERE setting_key='embedding_dimensions'`,
+    );
+    expect(settingRows.rows[0]!.setting_value).toBe('2560');
+  });
+
+  it('with newDimensions=4096 (>4000, seq-scan tier), drops index and falls back to no index', async () => {
+    const pageResult = await query<{ id: number }>(
+      `INSERT INTO pages (confluence_id, space_key, title, body_text, body_html)
+       VALUES ('p-seq', $1, 'Before 4096', 'x', '<p>x</p>') RETURNING id`,
+      ['SPACE1'],
+    );
+    const pageId = pageResult.rows[0]!.id;
+    const v1024 = '[' + new Array(1024).fill('0.01').join(',') + ']';
+    await query(
+      `INSERT INTO page_embeddings (page_id, chunk_index, chunk_text, embedding, metadata)
+       VALUES ($1, 0, 'c', $2::vector, '{}'::jsonb)`,
+      [pageId, v1024],
+    );
+
+    const r = await app.inject({
+      method: 'POST',
+      url: '/api/admin/embedding/reembed',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({ newDimensions: 4096 }),
+    });
+    expect(r.statusCode).toBe(200);
+
+    // Column type switched to vector(4096); no HNSW index exists
+    const typeRows = await query<{ format_type: string }>(
+      `SELECT format_type(a.atttypid, a.atttypmod) AS format_type
+       FROM pg_attribute a
+       WHERE a.attrelid = 'page_embeddings'::regclass AND a.attname = 'embedding'`,
+    );
+    expect(typeRows.rows[0]!.format_type).toBe('vector(4096)');
+
+    const indexRows = await query<{ indexname: string }>(
+      `SELECT indexname FROM pg_indexes WHERE indexname = 'idx_page_embeddings_hnsw'`,
+    );
+    expect(indexRows.rows).toHaveLength(0);
+
+    const settingRows = await query<{ setting_value: string }>(
+      `SELECT setting_value FROM admin_settings WHERE setting_key='embedding_dimensions'`,
+    );
+    expect(settingRows.rows[0]!.setting_value).toBe('4096');
   });
 
   it('returns 403 when caller is not an admin', async () => {

--- a/backend/src/routes/llm/llm-embedding-reembed.ts
+++ b/backend/src/routes/llm/llm-embedding-reembed.ts
@@ -14,8 +14,13 @@ const ADMIN_RATE_LIMIT = {
 // embedding_dimensions row in admin_settings, enqueueReembedAll opens a
 // transaction that TRUNCATEs page_embeddings, ALTERs the vector column type,
 // and rebuilds the HNSW index.
+// Upper bound matches pgvector's absolute max for both `vector` and `halfvec`
+// (16000). The service tiers the column type + index path internally:
+//   ≤ 2000  → vector + HNSW vector_cosine_ops
+//   2001-4000 → halfvec + HNSW halfvec_cosine_ops
+//   > 4000  → vector, no index (sequential scan, logged warning)
 const ReembedBodySchema = z.object({
-  newDimensions: z.number().int().min(1).max(8192).optional(),
+  newDimensions: z.number().int().min(1).max(16000).optional(),
 });
 
 const ReembedJobParamsSchema = z.object({

--- a/docs/ARCHITECTURE-DECISIONS.md
+++ b/docs/ARCHITECTURE-DECISIONS.md
@@ -1088,7 +1088,15 @@ Until this ADR the app supported exactly two LLM backends selected by the `LLM_P
 
 **Unified client**: `openai-compatible-client.ts` replaces both `ollama-service.ts` and `openai-service.ts`. It queues requests (`LLM_CONCURRENCY`) and wraps calls in per-provider circuit breakers. Rate-limit and retry behavior is per-provider, not per-call-site.
 
-**Embedding dimension safety**: Changing the embedding model to one that returns a different vector length requires an `ALTER TABLE ... TYPE vector(N)` plus `CREATE INDEX ... USING hnsw (embedding vector_cosine_ops)` — a two-step confirmation banner in the UI drives a dedicated `/admin/embedding/probe` + `/admin/embedding/reembed {newDimensions}` flow.
+**Embedding dimension safety**: Changing the embedding model to one that returns a different vector length is a destructive operation gated by the `/admin/embedding/probe` + `/admin/embedding/reembed {newDimensions}` flow with a two-step confirmation banner in the UI. The reembed transaction picks a column type + index strategy from the requested dimension count (pgvector 0.8 caps: HNSW on `vector` ≤ 2000 dims; HNSW on `halfvec` ≤ 4000 dims):
+
+| Dimensions  | Column type   | Index                                           |
+|-------------|---------------|-------------------------------------------------|
+| `n ≤ 2000`  | `vector(n)`   | HNSW `vector_cosine_ops` (default tier)         |
+| `2001–4000` | `halfvec(n)`  | HNSW `halfvec_cosine_ops` (float16, ~50% size)  |
+| `n > 4000`  | `vector(n)`   | no index (sequential scan; warning logged)      |
+
+The DDL order inside the transaction is `TRUNCATE` → `DROP INDEX IF EXISTS` → `ALTER COLUMN TYPE` → `INSERT/UPDATE admin_settings.embedding_dimensions` → `CREATE INDEX` (skipped for the seq-scan tier). Dropping the index before the `ALTER` is mandatory: the old index is bound to its opclass (`vector_cosine_ops`), which Postgres tries to rebuild on the new column type and rejects when the new type is `halfvec` or the new dim exceeds the opclass cap. The validator caps `newDimensions` at `1..16000` (pgvector's absolute max for both `vector` and `halfvec`); pgvector implicitly casts vector literals to `halfvec` on the `<=>` operator, so RAG retrieval needs no per-tier code paths.
 
 **First-boot seed**: `llm-provider-bootstrap.ts` seeds one row from legacy env vars (`OLLAMA_BASE_URL`, `OPENAI_BASE_URL`, …) when `llm_providers` is empty. On subsequent boots the env vars are ignored.
 

--- a/docs/architecture/06-data-model.md
+++ b/docs/architecture/06-data-model.md
@@ -223,9 +223,22 @@ erDiagram
 
 - **User ownership is pervasive.** Almost every table carries `user_id`
   (UUID, FK → `users.id`) — Compendiq is multi-tenant at the user level.
-- **pgvector.** `page_embeddings.embedding` is `vector(1024)` with an HNSW
-  index (`m=16`, `ef_construction=64`) for cosine similarity. Query-time
-  `ef_search` is set per request.
+- **pgvector.** `page_embeddings.embedding` defaults to `vector(1024)` with
+  an HNSW index (`m=16`, `ef_construction=200`) for cosine similarity, sized
+  for `bge-m3`. The column type and index path are **dimension-driven** and
+  rewritten by `enqueueReembedAll({ newDimensions })` when the admin switches
+  the embedding model:
+
+  | Dimensions  | Column type   | Index                                           |
+  |-------------|---------------|-------------------------------------------------|
+  | `n ≤ 2000`  | `vector(n)`   | HNSW `vector_cosine_ops` (default tier)         |
+  | `2001–4000` | `halfvec(n)`  | HNSW `halfvec_cosine_ops` (float16, ~50% size)  |
+  | `n > 4000`  | `vector(n)`   | no index (sequential scan; warning logged)      |
+
+  pgvector 0.8 caps HNSW at 2000 dims for `vector` and 4000 dims for `halfvec`;
+  larger models (e.g. `qwen3-embedding:8b` at 4096) fall to the seq-scan tier.
+  Query-time `ef_search` is set per request. Source of truth:
+  `backend/src/domains/llm/services/embedding-service.ts` (`enqueueReembedAll`).
 - **Encryption at rest.** `user_settings.confluence_pat` is stored as a
   ciphertext blob (AES-256-GCM, key from `PAT_ENCRYPTION_KEY`). Never
   log or expose it to the frontend.


### PR DESCRIPTION
## Summary

Drops the hard 2000-dim HNSW cap in `enqueueReembedAll`. Users trying to switch the embedding model to e.g. `qwen3-embedding:8b` (4096 dims) or `qwen3-embedding:4b` (2560 dims) previously got:

```
error: column cannot have more than 2000 dimensions for hnsw index
    at enqueueReembedAll (embedding-service.js:821)
```

because the code unconditionally did `CREATE INDEX ... USING hnsw (embedding vector_cosine_ops)` — which pgvector rejects for vectors >2000 dims — and the whole transaction rolled back.

Closes #294.

## Tiered strategy (pgvector 0.8+)

| Dimensions | Column type | Index | Perf profile |
|---|---|---|---|
| `n ≤ 2000` | `vector(n)` | HNSW `vector_cosine_ops` | baseline (unchanged) |
| `2001 ≤ n ≤ 4000` | `halfvec(n)` | HNSW `halfvec_cosine_ops` | ~50% smaller storage, float16, ~equivalent recall |
| `n > 4000` | `vector(n)` | no index | sequential scan (correct but slower on large KBs) |

pgvector 0.8's HNSW caps at 2000 dims for `vector` and 4000 dims for `halfvec`. `qwen3-embedding:8b` at 4096 exceeds both, so it falls to the seq-scan tier — a warning is logged.

## Why no rag-service changes are needed

Verified locally against the test Postgres + pgvector 0.8.2:

1. Switched `page_embeddings.embedding` to `halfvec(2560)`
2. Created HNSW with `halfvec_cosine_ops`
3. Inserted rows via `pgvector.toSql(vec)` (which produces a `vector` literal)
4. Queried with `pe.embedding <=> $1` where `$1` is a vector literal
5. `EXPLAIN` output: `Index Scan using idx_page_embeddings_hnsw` ✅

pgvector implicitly casts the vector literal to halfvec on the `<=>` operator and the cost model still picks the HNSW path.

## Validator upper bound

Widened from `8192` to `16000` (pgvector's absolute max for both `vector` and `halfvec`), from which the tier logic picks the right column type + index path. Input validation still rejects non-integer / non-finite / negative values.

## Architecture docs (added in this revision)

- `docs/architecture/06-data-model.md` — replaced the static `vector(1024)` line with the tiered table; also fixed a stale `ef_construction=64` value (migration 011 already upgraded that to 200).
- `docs/ARCHITECTURE-DECISIONS.md` ADR-021 — replaced the single-tier paragraph with the dimension-driven decision tree, the mandatory DDL order (TRUNCATE → DROP INDEX → ALTER → upsert dim → CREATE INDEX), and the rationale for why RAG retrieval needs no per-tier code paths.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `embedding-service.test.ts` + `rag-service.test.ts` + `rag-service.integration.test.ts` — 127/127 green
- [x] `llm-embedding-reembed.test.ts` — added integration cases for halfvec tier (`newDimensions=2560`) and seq-scan tier (`newDimensions=4096`) on top of the original vector tier case
- [x] Local EXPLAIN smoke test confirms HNSW index is used on halfvec column with vector-literal query (both the index and the implicit cast work as claimed)
- [ ] Manual UI test: Settings → LLM → embedding model, switch to `qwen3-embedding:0.6b` (1024 → vector HNSW), then `qwen3-embedding:4b` (2560 → halfvec HNSW), then `qwen3-embedding:8b` (4096 → seq scan with warning) — verify each succeeds without the "2000 dimensions" error

## Non-goals

- Binary quantization for even larger embeddings (bit HNSW supports up to 64000 dims). Separate v0.4 item if demand appears.
- Admin-UI preview of the dimension tier / perf hint before confirming the switch. Worth considering as a UX follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)