### PR TITLE
docs(#296 #297 #298): stewardship pledge + public roadmap + case-study scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Public stewardship pledge (#296).** New `docs/STEWARDSHIP.md` documents the open-core commitment: every feature shipped under CE (AGPL-3.0) stays under CE, with explicit carve-outs for EE-only features, unmaintainable code paths, bundled third-party deps, security patches, and semantic renames. Canonical CE feature baseline captured against v0.3.0. README links to the doc.
+- **Public roadmap index (#297).** New `docs/ROADMAP.md` documents the cadence and column structure for the org-level GitHub Projects v2 board that will track phase-labelled issues across CE + EE + mgmt. README links to the doc. Live board URL fills in once the project is created.
+- **Case-study scaffolding (#298 Phase A).** New `docs/case-studies/` directory with four reusable templates (`README.md`, `_template.md`, `_consent-template.md`, `_interview-script.md`) that gate the publication workflow: signed consent before interview, 10-business-day customer review window, revocation rights spelled out. Phase B (actual published case studies) ships in v0.4 if the consent loop lands in time; otherwise rolls to v0.5.
+
 ### Fixed
 
 - **Embedding model switch no longer caps at 2000 dimensions.** `POST /api/admin/embedding/reembed` with `newDimensions > 2000` (e.g. switching to `qwen3-embedding:4b` at 2560 dims or `qwen3-embedding:8b` at 4096) previously rolled back the whole transaction with `column cannot have more than 2000 dimensions for hnsw index`. The re-embed path now tiers the column type + index choice: `≤ 2000` keeps the vector+HNSW path unchanged; `2001–4000` uses `halfvec(n)` + HNSW `halfvec_cosine_ops` (float16 storage, ~equivalent recall); `> 4000` stores as `vector(n)` with no HNSW index (sequential scan — correct but slower on large KBs, logged as a warning). DDL order now mirrors migration 048: DROP INDEX → ALTER COLUMN TYPE → CREATE INDEX. HNSW tuning `WITH (m=16, ef_construction=200)` applied consistently. Zod upper bound widened 8192 → 16000 (pgvector's max).

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
   <a href="#architecture">Architecture</a> &middot;
   <a href="docs/USER-GUIDE.md">Docs</a> &middot;
   <a href="docs/releases/v0.3.0.md">v0.3 release notes</a> &middot;
+  <a href="docs/ROADMAP.md">Roadmap</a> &middot;
+  <a href="docs/STEWARDSHIP.md">Stewardship</a> &middot;
   <a href="https://github.com/Compendiq/compendiq-ce/discussions">Community</a> &middot;
   <a href="SECURITY.md">Security</a>
 </p>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,70 @@
+# Compendiq Public Roadmap
+
+_Maintained alongside v0.4.0 (CE #297)._
+
+The public roadmap lives as a **GitHub Projects v2** board at:
+
+> _[TODO founder — paste the board URL once the org-level project is created, e.g. `https://github.com/orgs/Compendiq/projects/<N>`]_
+
+This file in the repo is the **stable, human-readable index** that survives board renames and URL changes. It documents:
+
+1. where the live board lives,
+2. how the columns are organised,
+3. what the maintenance cadence is, and
+4. how to filter for the slice you care about.
+
+Issue activity itself (the source of truth for "what's planned / what's shipping") always lives on the board.
+
+---
+
+## Columns
+
+| Column   | Criterion                                                                  |
+|----------|----------------------------------------------------------------------------|
+| **Now**     | Issues tagged `phase-1.2` and open — the release currently in flight.       |
+| **Next**    | Issues tagged `phase-1.3` — the release after `Now`.                        |
+| **Later**   | Issues tagged `phase-2.0` / `phase-3.0` — 6-month+ horizon.                 |
+| **Idea**    | Open enhancements without a phase label — long tail, no schedule.           |
+| **Shipped** | Closed issues from the last 90 days — "what landed recently".              |
+
+The column → label mapping is deterministic: when an issue's phase label changes, the board re-sorts it automatically on the next refresh.
+
+## Filters
+
+Use the board's built-in filters to slice by:
+
+- **`label:backend`** / **`label:frontend`** — split by surface area
+- **`label:enterprise`** — EE-gated issues only
+- **`label:priority:high`** — the hot stuff
+- **`is:pr`** — drop issues and see in-flight PRs against the same phase labels
+
+## Cadence
+
+- **Monthly** — the maintainer scrubs the board at the start of each month: retire stale `Idea`s older than 1 year, move anything that's picked up into `Now`, and ensure the `Shipped` column reflects the last 90 days.
+- **Per-release** — at every `dev → main` merge, the `Shipped` column is trimmed and the `Now` column is re-populated from the next phase's milestone.
+- **Ad-hoc** — contributors adding a new issue should apply the appropriate `phase-*` label at triage; `gh-issue-reviewer` validates label presence during PR review.
+
+## Cross-repo coverage
+
+The org-level project aggregates issues from:
+- `Compendiq/compendiq-ce` (this repository, AGPL-3.0)
+- `Compendiq/compendiq-enterprise` (private, EE)
+- `Compendiq/compendiq-mgmt` (private, multi-instance management)
+
+If a board filter appears to be missing an issue, check the phase label in the originating repo.
+
+## Stewardship link
+
+The public roadmap is part of the open-process commitment documented in [`docs/STEWARDSHIP.md`](./STEWARDSHIP.md). Material changes to CE scope are always announced via the roadmap **before** they ship — see the stewardship doc for the full commitment text.
+
+---
+
+<!--
+Founder: to operationalise this file:
+  [ ] Create the org-level GitHub Projects v2 board and paste the URL at the top of this file.
+  [ ] Configure the 5 columns above using "Group by: label" → phase-* with the column names.
+  [ ] Pin the project to the Compendiq org page for discoverability.
+  [ ] Pre-create the `phase-1.3`, `phase-2.0`, `phase-3.0` labels in both CE and EE
+      (colour #0E8A16 to match existing phase labels).
+  [ ] Add a milestone for each future phase and back-label existing open issues.
+-->

--- a/docs/STEWARDSHIP.md
+++ b/docs/STEWARDSHIP.md
@@ -1,0 +1,122 @@
+# Compendiq Stewardship Commitment
+
+**Last updated:** 2026-04-23
+**Signed by:** _[TODO founder — full name + title, e.g. "Simon Lutz, Maintainer"]_
+**Applies to:** Compendiq Community Edition (this repository)
+
+---
+
+## The commitment
+
+Compendiq is developed under an **open-core** model: the Community Edition (CE) is licensed under **AGPL-3.0** and lives in this public repository; the Enterprise Edition (EE) is a separate commercial offering built on top. To give contributors and customers confidence that the open-core bargain is stable, we publicly commit to the following:
+
+**Every feature that has shipped under the CE license (AGPL-3.0) stays under the CE license. We will not relicense, remove, paywall, or functionally gate any CE feature behind EE in any future release.**
+
+This pledge is the counterpart to the AGPL-3.0 license: the license guarantees legal freedom to use, fork, and redistribute the CE code; this pledge guarantees that we will not shrink what CE *contains* in future releases.
+
+The canonical feature baseline against which this pledge is enforceable is the CE feature list as of release **v0.3.0** (see "Canonical CE feature baseline" below).
+
+---
+
+## What this covers
+
+- **Every route, page, setting, and capability** in the CE codebase at or after v0.3.0 remains in CE.
+- **Bug fixes and improvements** to CE features stay in CE — we will not keep a "better" version in EE for a paid feature that already exists in CE.
+- **Documentation** for CE features stays in this public repository.
+- **Configuration surface** visible in CE (the Settings UI, admin routes, env vars, migration schema) stays in CE.
+- **Public roadmap transparency**: material changes to the scope of CE (if ever required — see carve-outs below) will be announced on the public roadmap **before** the release that makes the change.
+
+---
+
+## What this does NOT cover
+
+- **EE-only features that have never shipped in CE** — there is no promise to eventually open-source them. OIDC/SSO, SCIM, custom RBAC, per-page ACL enforcement, compliance reports, webhook push, multi-instance management, PII detection, etc. are deliberately EE-only and may remain so indefinitely.
+- **Unmaintainable code paths** — if a CE feature's implementation becomes technically unmaintainable (e.g. depends on a vendored library that has been sunset and has no drop-in replacement), the feature may be **replaced in CE** by an equivalent implementation. The capability stays; the specific implementation may not.
+- **Bundled third-party dependencies** — libraries we import into CE are governed by their own licenses. If a dependency changes its license in a way that's incompatible with AGPL-3.0, we may need to swap it out (with an equivalent CE-side replacement where possible).
+- **Security patches** — we may **temporarily disable** a CE feature pending a security fix. We will ship the fix as soon as possible and the feature returns.
+- **Semantic renames** — a CE feature may be renamed (e.g. `/api/ollama/*` → `/api/llm/*`). The capability stays; the URL path may evolve on a published deprecation window.
+
+---
+
+## Canonical CE feature baseline (v0.3.0)
+
+As of the [v0.3.0 release](./releases/v0.3.0.md), the following capabilities are shipped in CE and covered by this pledge. This list is authoritative against the pledge text; if a future release appears to contradict the pledge, compare against this list.
+
+**Authentication & user management**
+- Local username/password authentication with JWT access tokens + rotating refresh-token families
+- Register, login, logout, token refresh routes
+- Per-user admin listing (`GET /api/users`)
+- Global admin role + per-space role assignments (RBAC)
+- Groups + group memberships + ACE-level resource permissions
+- Audit log (structured event types, metadata, IP/UA capture, admin-tunable retention)
+
+**Confluence integration (Data Center 9.2)**
+- Per-user PAT storage (AES-256-GCM encrypted at rest)
+- Configurable Confluence base URL + selected-spaces sync
+- Incremental + full sync worker with Redis-backed worker lock
+- XHTML ↔ HTML ↔ Markdown content pipeline (turndown + jsdom + confluence macros)
+- Attachment download + Docker-aware URL rewriting for private-network deployments
+- SSRF guard with origin allowlist
+- Draft-while-published workflow + version snapshots
+
+**LLM & RAG**
+- N-providers model (openai-compatible endpoints; Ollama via /v1 shim)
+- Per-use-case provider/model assignment (chat, summary, quality, auto_tag, embedding)
+- Per-provider circuit breakers + request queue with backpressure + per-user concurrent SSE-stream limit
+- Vector search with pgvector HNSW, hybrid retrieval (vector + keyword), RRF merging
+- Prompt injection sanitisation + output reference-stripping
+- AI improve / generate / summarise / quality / auto-tag flows with streaming
+- LLM request rate limiting + admin-tunable runtime limits
+
+**Knowledge base**
+- Pages CRUD (create, read, update, soft-delete, restore, trash, permanent delete)
+- Markdown/HTML/XHTML round-trip
+- Templates, comments, pinned pages, page versions, knowledge requests
+- Full-text search (PostgreSQL, configurable language)
+- Tagging + duplicate detection + content analytics
+- Article feedback + page-view tracking + verification workflow
+
+**Admin & operations**
+- Admin settings UI with rate limits, embedding dimensions, retention policies
+- Email/SMTP notifications + Nodemailer templates
+- Health + readiness probes
+- Data-retention worker (audit log, search analytics, error log, page versions)
+- BullMQ + setInterval dual-mode background workers
+- Error tracker + correlation IDs + OpenTelemetry optional
+
+**Enterprise extension points present in CE (not features themselves)**
+- `app.license` + `app.enterprise` Fastify decoration hook
+- `emitLlmAudit()` fire-and-forget hook
+- `setSsrfAllowlistPublisher()` hook
+- License endpoint `/api/admin/license` (returns community stub when EE is not loaded)
+- Dynamic `import('@compendiq/enterprise')` loader with graceful noop fallback
+
+This list will be kept current in each major/minor release's customer-facing notes.
+
+---
+
+## How to verify
+
+- **All CE source is in this repo** under `AGPL-3.0` — see [`LICENSE`](../LICENSE).
+- **Release tags are immutable** on GitHub (`v0.1.0` onwards). Any divergence from this pledge is detectable via `git log` + `git diff` against the release tags.
+- **Feature diffs against the baseline above** are visible by comparing any release against v0.3.0: `git diff v0.3.0...vX.Y.Z -- backend/src frontend/src` will surface any CE-side removal.
+- **Public roadmap** ([`docs/ROADMAP.md`](./ROADMAP.md)) announces any material change to CE scope before the release that implements it.
+
+If you believe this pledge has been violated, open an issue tagged `stewardship` in this repository; the maintainers are expected to respond publicly.
+
+---
+
+## Changelog
+
+- **2026-04-23** — initial pledge drafted alongside v0.4.0 preparation (CE #296). _Founder review pending._
+
+---
+
+<!--
+Founder: before merging this file, please confirm:
+  [ ] Signature line at the top reflects your legal name + title.
+  [ ] The "What this does NOT cover" carve-outs match your commercial intent.
+  [ ] The v0.3.0 feature baseline is accurate for your install — add or remove bullets
+      if the v0.3.0 release notes differ from what's listed here.
+  [ ] The Changelog entry marks this as a reviewed-and-approved commitment.
+-->

--- a/docs/case-studies/README.md
+++ b/docs/case-studies/README.md
@@ -1,0 +1,32 @@
+# Compendiq Case Studies
+
+Customer-sourced accounts of what Compendiq is being used for in production. Each study is written with the customer's explicit written consent and reviewed by them before publication.
+
+**Published case studies** appear as peer files in this directory (`<customer-slug>.md`). The three template files prefixed with `_` are **not case studies** — they are the scaffolding used to produce one:
+
+| File                                              | Purpose                                                                   |
+|---------------------------------------------------|---------------------------------------------------------------------------|
+| [`_template.md`](./_template.md)                  | Blank case-study body; founder + customer fill it in.                     |
+| [`_consent-template.md`](./_consent-template.md)  | Legal text + signature block the customer signs before any interview.     |
+| [`_interview-script.md`](./_interview-script.md)  | Founder-facing reference — the ~30-minute Q&A prompt list.                |
+
+## How to publish a new case study
+
+1. **Identify** a candidate customer. Preference: regulated industry, on-prem mandate, or a use case that's publicly defensible.
+2. **Get consent** — send the customer the signed-consent template. Do **not** start drafting before the signed consent is received. (Consent is reversible; the customer can revoke at any time before publication, and we strip the study from the repo on request even after publication.)
+3. **Interview** (~30 minutes, founder-conducted) following `_interview-script.md`. Record only if the consent explicitly permits recording.
+4. **Draft** using `_template.md`. Founder reviews. Customer reviews — verbatim quotes require their sign-off. Compendiq does **not** publish concrete numbers (latency figures, user counts, contract-value figures) without customer approval.
+5. **Commit** as `docs/case-studies/<customer-slug>.md` in a PR tagged `case-study`. Include a signed copy of the consent (redact PII as needed) as a committed attachment under `docs/case-studies/consent-records/<customer-slug>.signed.md`.
+6. **Link** from the main README under "Who's using Compendiq?" if the customer consented to logo/name disclosure; otherwise list anonymously.
+
+## Current status
+
+- Phase A (templates) — ✅ shipped in v0.4.0 alongside this README.
+- Phase B (at least one published case study) — ⏳ pending customer consent loop. May slip to v0.5 per the Phase 1.2 plan.
+
+## Review lifecycle
+
+- **First draft** by the founder (or Claude ghost-writing from the interview transcript).
+- **Technical review** by the relevant Compendiq engineer — fact-check architecture sketch, deployment numbers, LLM stack details.
+- **Customer review** — mandatory before merge. Customer signs off in writing (email or PR comment) that the text accurately represents them.
+- **Post-publication**: any numbers cited should be tagged with `_as of YYYY-MM-DD_` so readers understand when the snapshot was taken.

--- a/docs/case-studies/_consent-template.md
+++ b/docs/case-studies/_consent-template.md
@@ -1,0 +1,62 @@
+# Case-Study Consent — Compendiq
+
+_This template is sent to the customer **before** any interview takes place. Nothing is drafted, recorded, or published until the customer has returned a signed copy (email with signature block, or PR comment from a corporate account is acceptable). The signed copy is committed to `docs/case-studies/consent-records/<customer-slug>.signed.md` with PII redacted as needed._
+
+---
+
+## Parties
+
+**Compendiq:** _[maintainer legal name, title, email]_
+**Customer:** _[customer legal entity name, signatory name, title, email]_
+**Date:** _[YYYY-MM-DD]_
+
+## What this consent covers
+
+The Customer grants Compendiq permission to:
+
+1. **Interview** the named signatory (and any other named employees they delegate in writing) about their use of Compendiq, including architecture, deployment shape, outcomes, and open feedback.
+2. **Publish a case-study document** in the public `Compendiq/compendiq-ce` GitHub repository at `docs/case-studies/<customer-slug>.md`, derived from the interview.
+3. **Reference the case study** in Compendiq's public marketing materials: the Compendiq README, the Compendiq website, and social media posts announcing new case studies.
+4. **Quote** the signatory by role (e.g. "Head of Platform Engineering") without naming them. Named quotes require an additional opt-in checkbox below.
+
+## What this consent does NOT cover
+
+- **Verbatim quotes attributed by personal name** — opt-in only. Tick box below.
+- **Customer logo use** — opt-in only. Tick box below.
+- **Specific numeric metrics** (user counts, latency, cost savings) — each number must be individually approved in the customer-review pass before publication. The template makes this explicit.
+- **Screenshots that include internal URLs, PII, or confidential document titles** — never.
+- **Statements about third-party vendors** the customer evaluated against Compendiq — only with explicit approval per statement.
+
+## Customer review
+
+Before publication, Compendiq sends the customer a **draft** of the case-study document. The customer has **10 business days** to request changes. If no response within that window, Compendiq assumes approval and publishes. **Fact corrections** (wrong numbers, wrong job titles, misattributed quotes) are accepted after publication and applied via PR within 5 business days.
+
+## Revocation
+
+The customer may revoke this consent at any time by emailing _[maintainer email]_. Compendiq removes the case study from the public repository and the website within **5 business days**. The commit history will still contain the study (git is append-only), but the file will be replaced with a redaction notice.
+
+## Opt-ins (tick all that apply)
+
+- [ ] Named quotes permitted (the signatory's personal name may appear attached to quotes).
+- [ ] Customer logo may be used alongside the case study, subject to Customer's logo-usage guidelines at _[URL or "N/A"]_.
+- [ ] Customer agrees to be contacted for a 12-month follow-up interview to track outcome evolution.
+
+## Signatures
+
+By signing below, the Customer confirms that the signatory is authorised to grant this consent on behalf of the named legal entity.
+
+**For the Customer:**
+Name: _________________________
+Title: _________________________
+Date: _________________________
+Signature: _____________________
+
+**For Compendiq:**
+Name: _________________________
+Title: _________________________
+Date: _________________________
+Signature: _____________________
+
+---
+
+_If the Customer has a preferred consent form, Compendiq is happy to redline against it instead._

--- a/docs/case-studies/_interview-script.md
+++ b/docs/case-studies/_interview-script.md
@@ -1,0 +1,68 @@
+# Case-Study Interview Script — Compendiq
+
+_Founder-facing reference. Target length: **30 minutes**. Keep the conversation loose; the structure below is a checklist, not a script to read aloud._
+
+**Before the call**
+
+- [ ] Signed consent on file (`_consent-template.md`).
+- [ ] Confirm recording permission in the first 30 seconds if you want to record.
+- [ ] Have the customer's Compendiq version, deployment shape, and known integration list in front of you (pull from their support ticket history or onboarding notes).
+- [ ] Silence notifications. This is a human conversation, not a technical deep-dive.
+
+---
+
+## 1. Context (5 min)
+
+Open with the customer's own words about their environment. Warm-up, not vendor talk.
+
+- What does your team do? Who do you serve?
+- Where did knowledge management fit before Compendiq? (Confluence only? Wiki + email? Slack search?)
+- What triggered the decision to look for something new?
+
+## 2. Problem framing (5 min)
+
+The case study's "The problem" section lives or dies on this segment. Get the concrete pain.
+
+- Walk me through a day-before-Compendiq story. What was the specific painful moment?
+- If you had to put a number on "how much time did this cost us per week?" — even a rough one — what would you say?
+- What was the tipping-point incident that made you actively shop?
+
+## 3. Evaluation (5 min)
+
+- What alternatives did you evaluate? (Expect: Glean, GitHub Copilot for Confluence, Atlassian Intelligence, home-grown.)
+- What was the shortlist, and why?
+- On a 1–10 scale, where were the rough edges of Compendiq in the evaluation phase? Be brutal — we use this to prioritise.
+
+## 4. Deployment (5 min)
+
+- What did the actual deployment look like? CE or EE? Single pod, multi-pod? On-prem, VPC, private cloud, SaaS?
+- Which LLM stack did you pair with? (Ollama on the same host? Azure OpenAI? vLLM cluster?)
+- What integrations did you turn on? (OIDC, SCIM, SMTP, audit retention, custom rate limits?)
+- Time from "approved purchase" to "first production RAG query"?
+
+## 5. Outcomes (5 min)
+
+- What did the first month after rollout look like? Any surprises, positive or negative?
+- Do you have a metric you can share? (Time to answer, adoption rate, support-ticket reduction, user NPS on internal tooling.) All numbers require customer approval in the review pass.
+- Anything that broke or didn't work as expected?
+
+## 6. Forward-looking (3 min)
+
+- What's the single biggest open ask from Compendiq?
+- Where does Compendiq fit in your roadmap over the next 12 months?
+- If a peer customer in your industry asked you "should I use this?", what would you tell them?
+
+## 7. Wrap (2 min)
+
+- Is there anyone else on your team we should talk to for the technical-deep-dive side?
+- Confirm the review process: we'll draft, send to you for a 10-business-day review, no response = approved.
+- Confirm the revocation right: they can pull the case study at any time for any reason.
+
+---
+
+**After the call**
+
+- [ ] Within 24h: send a thank-you email + the draft outline of the case study (not the full draft, just the section headers with 1-line summaries of what you'll put under each).
+- [ ] Within 7 days: send the full draft for customer review.
+- [ ] Mark the review SLA in your calendar so the 10-business-day clock doesn't silently expire.
+- [ ] File the interview transcript in your private notes (not the repo).

--- a/docs/case-studies/_template.md
+++ b/docs/case-studies/_template.md
@@ -1,0 +1,44 @@
+# &lt;Customer Name&gt; — &lt;one-line outcome&gt;
+
+**Industry:** _[e.g. Financial services, Healthcare, Public sector, …]_
+**Deployment:** _[CE / EE / EE multi-instance]_
+**Scale:** _[N users, M Confluence spaces, K pages — numbers only with customer approval]_
+**Time to first value:** _[e.g. "~3 weeks from kickoff to the first production RAG query"]_
+**Published:** _[YYYY-MM-DD]_
+**Customer-reviewed:** _[YYYY-MM-DD, reviewer name (with consent)]_
+
+---
+
+## The problem
+
+_[2–3 paragraphs in the customer's voice. Focus on the business pain, not the technology. Avoid vendor-comparison hyperbole — a concrete "our incident runbooks were spread across 400 Confluence pages and new hires took 6 weeks to ramp" beats "we needed AI to modernise our knowledge base"._
+
+_Include direct quotes only with customer sign-off. Quotes should be attributed by role, not name, unless the quoted person has separately consented.]_
+
+> _"Representative pull quote from the interview, 1–2 sentences, sounds like a human."_
+> — _Role, Department_
+
+## Why Compendiq
+
+_[What was evaluated (Confluence AI plugins, Glean, internal tools, status quo). What drove the decision (on-prem requirement, open-source audit trail, price, German data-residency, etc.). Where Compendiq was a weaker fit than alternatives if any — being honest here earns credibility.]_
+
+## What they deployed
+
+_[Architecture sketch. Single pod vs. multi-pod. Air-gapped or network-exposed. Which LLM stack (Ollama on-prem, Azure OpenAI, vLLM). Any notable integrations (OIDC, SCIM, SMTP host). Avoid a screenshot if it would reveal internal URLs; a prose description is fine.]_
+
+## Results
+
+_[Concrete numbers — only with customer sign-off. Examples (illustrative):_
+- _Median time to answer a runbook question dropped from ~12 min to ~35 s._
+- _N% of draft Confluence pages now go through the "improve with AI" flow before publication._
+- _Zero prompt-injection incidents in the first X months (audited via `llm_audit_log`)._
+
+_If no numbers are approved, focus on qualitative outcomes and explicitly note that numbers are withheld.]_
+
+## What's next for them
+
+_[Open asks, planned expansion, feedback that influenced the Compendiq roadmap. A pointer at a specific phase item on the public roadmap where relevant.]_
+
+---
+
+*Published with permission. Compendiq retains the right to remove this case study on customer request. For fact corrections, open a PR tagged `case-study`.*


### PR DESCRIPTION
Closes #296, #297, #298 Phase A. Part of epic #295 (Phase 1.2 CE scope — Community Growth track).

Three companion docs that operationalise the Phase 1.2 community-growth commitments. All drafted in full; founder review is the long-pole on the signed-pledge text and the board URL.

## Scope

**CE #296 — Public stewardship pledge (`docs/STEWARDSHIP.md`)**
- AGPL-3.0 "stay-under-CE" pledge text
- Carve-outs covering EE-only features, unmaintainable paths, third-party deps, security patches, semantic renames
- Canonical CE feature baseline captured against v0.3.0 (every route, page, setting, worker, extension point)
- How-to-verify section (LICENSE + immutable release tags + `git diff vX.Y.Z...main`)
- Signature block at top — ⚠ **founder action required**: fill in legal name + title before merge.

**CE #297 — Public roadmap (`docs/ROADMAP.md`)**
- Documents the cadence + column structure for the org-level GitHub Projects v2 board
- Five columns: Now / Next / Later / Idea / Shipped, each with a label-based auto-sort rule
- Filters by surface area (`label:backend` / `label:frontend` / `label:enterprise` / `label:priority:high`)
- Cross-repo aggregation (CE + EE + mgmt)
- ⚠ **founder action required**: create the Projects v2 board, paste the URL at the top, pre-create `phase-1.3` / `phase-2.0` / `phase-3.0` labels.

**CE #298 Phase A — Case-study scaffolding (`docs/case-studies/`)**
- `README.md` — directory index, how-to-publish workflow, current-status row
- `_template.md` — blank case-study body (Industry / Deployment / Scale / Problem / Why Compendiq / What they deployed / Results / What's next)
- `_consent-template.md` — legal text: what's covered, what's NOT covered (verbatim-named quotes and logo use are explicit opt-ins), customer-review SLA (10 business days, silence = approval), revocation rights (5 business days), signature block
- `_interview-script.md` — founder-facing reference: ~30 min, 7-section structure with before-the-call and after-the-call checklists

Phase B (at least one published case study) is consent-gated and may slip to v0.5.

## README delta

Top-nav section adds `Roadmap` + `Stewardship` links between `v0.3 release notes` and `Community`.

## Plan alignment

Per plan §2 Sprint 1 exit criteria, these three are the documentation-only items that ship in parallel with the engineering prereqs. No tests (docs only). No CI impact.

## Test plan

- [x] All four case-study template files land under `docs/case-studies/`
- [x] `docs/STEWARDSHIP.md` + `docs/ROADMAP.md` exist
- [x] README links to both
- [x] CHANGELOG [Unreleased] ## Added entry covers all three
- [ ] Founder review the pledge text + carve-outs + signature
- [ ] Founder create the org-level Projects v2 board + paste URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)