### PR TITLE
feat: CE-side extension-hook noops for EE v0.4 AI safety features

### DIFF
--- a/backend/src/core/services/ai-review-hook.test.ts
+++ b/backend/src/core/services/ai-review-hook.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  enqueueAiReview,
+  checkPendingAiReview,
+  setAiReviewHook,
+  setPendingAiReviewCheckHook,
+  _resetAiReviewHooksForTests,
+  type EnqueueParams,
+} from './ai-review-hook.js';
+
+const baseParams: EnqueueParams = {
+  pageId: 42,
+  actionType: 'improve',
+  proposedContent: 'improved text',
+  authoredBy: '00000000-0000-0000-0000-000000000001',
+  llmAuditId: 1001,
+};
+
+afterEach(() => {
+  _resetAiReviewHooksForTests();
+});
+
+describe('ai-review-hook (CE noop + EE extension point)', () => {
+  it('enqueueAiReview returns auto-publish when no hook is installed', async () => {
+    const result = await enqueueAiReview(baseParams);
+    expect(result).toEqual({ mode: 'auto-publish' });
+  });
+
+  it('enqueueAiReview delegates to the installed hook', async () => {
+    const hook = vi.fn().mockResolvedValue({ mode: 'pending', reviewId: 'abc' });
+    setAiReviewHook(hook);
+
+    const result = await enqueueAiReview(baseParams);
+    expect(result).toEqual({ mode: 'pending', reviewId: 'abc' });
+    expect(hook).toHaveBeenCalledWith(baseParams);
+  });
+
+  it('enqueueAiReview fails open to auto-publish when hook throws', async () => {
+    setAiReviewHook(vi.fn().mockRejectedValue(new Error('queue down')));
+    const result = await enqueueAiReview(baseParams);
+    expect(result).toEqual({ mode: 'auto-publish' });
+  });
+
+  it('checkPendingAiReview returns null when no hook installed', async () => {
+    expect(await checkPendingAiReview(42)).toBeNull();
+  });
+
+  it('checkPendingAiReview delegates when hook installed', async () => {
+    const hook = vi.fn().mockResolvedValue({ id: 'review-99' });
+    setPendingAiReviewCheckHook(hook);
+    expect(await checkPendingAiReview(42)).toEqual({ id: 'review-99' });
+    expect(hook).toHaveBeenCalledWith(42);
+  });
+
+  it('checkPendingAiReview fails open to null when hook throws', async () => {
+    setPendingAiReviewCheckHook(vi.fn().mockRejectedValue(new Error('db down')));
+    expect(await checkPendingAiReview(42)).toBeNull();
+  });
+});

--- a/backend/src/core/services/ai-review-hook.ts
+++ b/backend/src/core/services/ai-review-hook.ts
@@ -1,0 +1,94 @@
+/**
+ * Extension point for the AI output review queue (EE #120).
+ *
+ * CE builds install no hook — enqueueAiReview returns `{ mode: 'auto-publish' }`
+ * so inference routes persist AI output directly, unchanged from pre-v0.4.
+ * The EE plugin registers a sync review-queue service at `registerRoutes()`
+ * time; when registered, inference routes read the decision and branch:
+ *   - 'auto-publish' → existing fast-path, persist directly
+ *   - 'pending'      → return reviewId and DO NOT persist; the admin
+ *                      review UI consumes from the `ai_output_reviews`
+ *                      table later.
+ *
+ * Mirrors the llm-audit-hook pattern, but synchronously (must decide
+ * before persistence branch).
+ */
+
+export type AiReviewAction =
+  | 'improve'
+  | 'summary'
+  | 'generate'
+  | 'auto_tag'
+  | 'apply_improvement';
+
+export type AiReviewDecision =
+  | { mode: 'auto-publish' }
+  | { mode: 'pending'; reviewId: string };
+
+export interface EnqueueParams {
+  pageId: number;
+  actionType: AiReviewAction;
+  proposedContent: string;
+  proposedHtml?: string;
+  proposedStorage?: string;
+  authoredBy: string;
+  llmAuditId: number;
+  piiFindingsId?: string;
+}
+
+type EnqueueHook = (params: EnqueueParams) => Promise<AiReviewDecision>;
+type PendingCheckHook = (pageId: number) => Promise<{ id: string } | null>;
+
+let enqueueHook: EnqueueHook | null = null;
+let pendingCheckHook: PendingCheckHook | null = null;
+
+/**
+ * Install the EE-side review-queue hook. Call from the enterprise
+ * plugin's `registerRoutes()` during startup. Pass `null` to uninstall.
+ */
+export function setAiReviewHook(fn: EnqueueHook | null): void {
+  enqueueHook = fn;
+}
+
+/**
+ * Install the publish-path gate checker. Called from the CE publish
+ * route (`POST /api/pages/:id/draft/publish`) before the upstream
+ * Confluence push. EE returns the pending review row if one exists so
+ * the CE route can 409 with a clear error.
+ */
+export function setPendingAiReviewCheckHook(fn: PendingCheckHook | null): void {
+  pendingCheckHook = fn;
+}
+
+/**
+ * Decide whether AI output should be auto-published or queued. In CE
+ * mode (no hook installed) always returns 'auto-publish'.
+ */
+export async function enqueueAiReview(params: EnqueueParams): Promise<AiReviewDecision> {
+  if (!enqueueHook) return { mode: 'auto-publish' };
+  try {
+    return await enqueueHook(params);
+  } catch {
+    // Fail-open on review-service errors — never block the user's
+    // generation because the queue misbehaved. EE service logs internally.
+    return { mode: 'auto-publish' };
+  }
+}
+
+/**
+ * Check for a pending review against this page. In CE mode returns null.
+ */
+export async function checkPendingAiReview(pageId: number): Promise<{ id: string } | null> {
+  if (!pendingCheckHook) return null;
+  try {
+    return await pendingCheckHook(pageId);
+  } catch {
+    return null;
+  }
+}
+
+/** Test helpers — reset hooks between test cases. */
+export function _resetAiReviewHooksForTests(): void {
+  enqueueHook = null;
+  pendingCheckHook = null;
+}

--- a/backend/src/core/services/pii-scan-hook.test.ts
+++ b/backend/src/core/services/pii-scan-hook.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  scanForPii,
+  setPiiScanHook,
+  _resetPiiScanHookForTests,
+  type PiiScanResult,
+} from './pii-scan-hook.js';
+
+afterEach(() => {
+  _resetPiiScanHookForTests();
+});
+
+describe('pii-scan-hook (CE noop + EE extension point)', () => {
+  it('returns null when no hook is installed (CE mode)', async () => {
+    const result = await scanForPii('some output with a@b.com', 'chat');
+    expect(result).toBeNull();
+  });
+
+  it('delegates to the installed hook when present', async () => {
+    const expected: PiiScanResult = {
+      spans: [{ start: 0, end: 5, category: 'EMAIL', confidence: 1, source: 'regex' }],
+      action: 'flag-only',
+    };
+    const hook = vi.fn().mockResolvedValue(expected);
+    setPiiScanHook(hook);
+
+    const result = await scanForPii('hello a@b.com', 'improve', { async: false });
+    expect(result).toEqual(expected);
+    expect(hook).toHaveBeenCalledWith('hello a@b.com', 'improve', { async: false });
+  });
+
+  it('fails open to null when the hook throws', async () => {
+    const hook = vi.fn().mockRejectedValue(new Error('scanner exploded'));
+    setPiiScanHook(hook);
+
+    const result = await scanForPii('text', 'chat');
+    expect(result).toBeNull();
+  });
+
+  it('setPiiScanHook(null) uninstalls', async () => {
+    setPiiScanHook(vi.fn().mockResolvedValue({ spans: [], action: 'flag-only' }));
+    setPiiScanHook(null);
+    const result = await scanForPii('text', 'chat');
+    expect(result).toBeNull();
+  });
+});

--- a/backend/src/core/services/pii-scan-hook.ts
+++ b/backend/src/core/services/pii-scan-hook.ts
@@ -1,0 +1,81 @@
+/**
+ * Extension point for PII scanning of AI output (EE #119).
+ *
+ * CE builds install no hook — scanForPii returns null and inference
+ * routes skip any PII handling (zero overhead). The EE plugin registers
+ * a synchronous scanner at `registerRoutes()` time; when registered,
+ * inference routes call `scanForPii` after generation and before
+ * persistence/audit to:
+ *   - attach detection spans to the audit entry, and
+ *   - optionally block/redact output per the admin policy.
+ *
+ * Mirrors the llm-audit-hook pattern. The sync contract (not
+ * fire-and-forget like audit) is required because redact/block modes
+ * must be able to mutate or reject the output before it is committed.
+ */
+
+/**
+ * The action type under which the scan is being performed. Matches the
+ * llm-audit-hook action taxonomy + 'auto_tag' for the pages-tags path.
+ */
+export type PiiScanAction =
+  | 'chat'
+  | 'improve'
+  | 'summary'
+  | 'generate'
+  | 'auto_tag';
+
+export interface PiiSpan {
+  start: number;
+  end: number;
+  category: string;
+  confidence: number;
+  source: 'regex' | 'ner' | 'llm-judge';
+}
+
+export interface PiiScanResult {
+  spans: PiiSpan[];
+  action: 'flag-only' | 'redacted' | 'blocked';
+  redactedText?: string;
+}
+
+type PiiScanHook = (
+  text: string,
+  action: PiiScanAction,
+  opts?: { async?: boolean },
+) => Promise<PiiScanResult>;
+
+let hook: PiiScanHook | null = null;
+
+/**
+ * Install the EE-side PII scanner. Call from the enterprise plugin's
+ * `registerRoutes()` during startup. Pass `null` to uninstall.
+ */
+export function setPiiScanHook(fn: PiiScanHook | null): void {
+  hook = fn;
+}
+
+/**
+ * Run the installed PII scanner, or return null if none is registered
+ * (CE mode). The caller treats null as "no scanning" and proceeds with
+ * the original output unmodified.
+ */
+export async function scanForPii(
+  text: string,
+  action: PiiScanAction,
+  opts?: { async?: boolean },
+): Promise<PiiScanResult | null> {
+  if (!hook) return null;
+  try {
+    return await hook(text, action, opts);
+  } catch {
+    // Fail-open on scanner errors — never block the user's request
+    // because the scanner misbehaved. The EE scanner logs internally.
+    return null;
+  }
+}
+
+/** Test helper — reset hook between test cases. */
+export function _resetPiiScanHookForTests(): void {
+  hook = null;
+}


### PR DESCRIPTION
## Summary

Two CE-side extension-point modules that the Compendiq Enterprise plugin installs real implementations against at `registerRoutes()` time. CE builds install no hook — zero runtime behaviour change.

- `core/services/pii-scan-hook.ts` — sync scan of AI output for PII (EE #119). Returns `null` in CE; when installed, returns `PiiScanResult { spans, action }` with `action ∈ {flag-only, redacted, blocked}`.
- `core/services/ai-review-hook.ts` — sync decision on auto-publish vs queue-for-review (EE #120). Returns `{ mode: 'auto-publish' }` in CE; when installed, may return `{ mode: 'pending', reviewId }`. Also exposes a `pendingCheckHook` for the publish-to-Confluence gate (blocks upstream push when a review is pending).

Both mirror the existing `llm-audit-hook.ts` / `ssrf-allowlist-bus.ts` (#306) install-once convention. Both fail open on hook errors — the scanner/queue misbehaving must never block the user's request.

## Test plan

- [x] Unit tests: install / uninstall / delegation / fail-open paths for both hooks
- [ ] Run `npm test -w backend` locally (requires `npm install` from root; skipped in the session these were authored in — test files are self-contained, no new deps)
- [ ] Typecheck green
- [ ] Lint green

## Context

Companion to the EE overlay PRs landing #119 PII detection and #120 AI output review. Plans live in `compendiq-ee:.plans/119-pii-detection.md` and `.plans/120-ai-output-review.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)