### PR TITLE
feat: extend AuditAction union with v0.4 AI-safety actions

### DIFF
--- a/backend/src/core/services/audit-service.test.ts
+++ b/backend/src/core/services/audit-service.test.ts
@@ -236,3 +236,25 @@ describe.skipIf(!dbAvailable)('Audit Service', () => {
     });
   });
 });
+
+// Pure type-level test — no DB required. Guards against accidental removal
+// of the v0.4 AI-safety action entries. If the AuditAction union no longer
+// accepts one of these literals, this file fails to compile.
+describe('AuditAction v0.4 AI safety entries', () => {
+  it('accepts PII detection actions (EE #119)', () => {
+    const actions: AuditAction[] = ['PII_DETECTED', 'PII_POLICY_CHANGED'];
+    expect(actions).toHaveLength(2);
+  });
+
+  it('accepts AI output review lifecycle actions (EE #120)', () => {
+    const actions: AuditAction[] = [
+      'AI_REVIEW_SUBMITTED',
+      'AI_REVIEW_APPROVED',
+      'AI_REVIEW_REJECTED',
+      'AI_REVIEW_EDIT_AND_APPROVED',
+      'AI_REVIEW_EXPIRED',
+      'AI_REVIEW_POLICY_CHANGED',
+    ];
+    expect(actions).toHaveLength(6);
+  });
+});

--- a/backend/src/core/services/audit-service.ts
+++ b/backend/src/core/services/audit-service.ts
@@ -21,6 +21,19 @@ import { logger } from '../utils/logger.js';
  *
  * Login metadata now carries `auth_method: 'local' | 'oidc'` (the OIDC
  * caller lives in EE).
+ *
+ * AI safety events (EE v0.4 — Compendiq/compendiq-ee#119, #120):
+ *   - PII detection:      PII_DETECTED (per-detection entry; metadata
+ *                         carries span count + categories without the
+ *                         actual text), PII_POLICY_CHANGED.
+ *   - Output review:      AI_REVIEW_SUBMITTED, AI_REVIEW_APPROVED,
+ *                         AI_REVIEW_REJECTED, AI_REVIEW_EDIT_AND_APPROVED
+ *                         (edit preserves the AI-authored original as a
+ *                         separate SUBMITTED entry for provenance),
+ *                         AI_REVIEW_EXPIRED, AI_REVIEW_POLICY_CHANGED.
+ *   Emitters all live in the EE overlay (`overlay/backend/src/enterprise/
+ *   pii-scanner.ts`, `ai-review-service.ts`); the action strings live here
+ *   so CE + EE share a single closed union.
  */
 export type AuditAction =
   | 'LOGIN'
@@ -71,7 +84,17 @@ export type AuditAction =
   | 'ACE_GRANTED'
   | 'ACE_REVOKED'
   | 'PAGE_INHERIT_PERMS_CHANGED'
-  | 'RETENTION_PRUNED';
+  | 'RETENTION_PRUNED'
+  // AI safety — EE #119 PII detection
+  | 'PII_DETECTED'
+  | 'PII_POLICY_CHANGED'
+  // AI safety — EE #120 output review workflow
+  | 'AI_REVIEW_SUBMITTED'
+  | 'AI_REVIEW_APPROVED'
+  | 'AI_REVIEW_REJECTED'
+  | 'AI_REVIEW_EDIT_AND_APPROVED'
+  | 'AI_REVIEW_EXPIRED'
+  | 'AI_REVIEW_POLICY_CHANGED';
 
 export interface AuditLogEntry {
   id: string;


### PR DESCRIPTION
## Summary

Adds 8 new entries to the closed \`AuditAction\` union so the EE overlay services (landing in Compendiq/compendiq-ee#122) that emit AI-safety audit events compile without per-call casts:

- \`PII_DETECTED\`, \`PII_POLICY_CHANGED\` (EE #119)
- \`AI_REVIEW_SUBMITTED\`, \`AI_REVIEW_APPROVED\`, \`AI_REVIEW_REJECTED\`, \`AI_REVIEW_EDIT_AND_APPROVED\`, \`AI_REVIEW_EXPIRED\`, \`AI_REVIEW_POLICY_CHANGED\` (EE #120)

The action strings live in CE so CE + EE share a single closed union; the actual \`logAuditEvent(...)\` emit sites live in the EE overlay (\`overlay/backend/src/enterprise/pii-scanner.ts\`, \`ai-review-service.ts\`).

## Scope discipline

- Zero runtime behaviour change for CE: no emit sites in this repo reference the new actions, so no audit rows with these actions get written from CE.
- Fully additive to the union — no existing entries removed or renamed.

## Test plan

- [x] Pure type-level tests added to \`audit-service.test.ts\`: if any of the 8 new entries is later removed from the union the test file fails to compile
- [ ] Existing DB-backed audit-service tests still pass (requires running test Postgres; covered by CI)

## Context

Follow-up to Compendiq/compendiq-ce#323 (noop hooks). Together they complete the CE-side surface the EE PII + review services compile against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)