### PR TITLE
feat(v0.4): redis-cache-bus + makeCachedSetting (epic §3.1 + §3.5)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -70,6 +70,7 @@ import { loadEnterprisePlugin } from './core/enterprise/loader.js';
 import { bootstrapLlmProviders } from './domains/llm/services/llm-provider-bootstrap.js';
 import { bootstrapSsrfAllowlist } from './domains/confluence/services/sync-service.js';
 import { initSsrfAllowlistBus } from './core/services/ssrf-allowlist-bus.js';
+import { initCacheBus, close as closeCacheBus } from './core/services/redis-cache-bus.js';
 
 export async function buildApp() {
   const app = Fastify({
@@ -160,6 +161,15 @@ export async function buildApp() {
   const teardownSsrfBus = await initSsrfAllowlistBus(app.redis);
   app.addHook('onClose', async () => {
     await teardownSsrfBus();
+  });
+
+  // ── Generic cache-bus (v0.4 epic §3.1) ───────────────────────────
+  // Cluster-wide invalidation channel used by cached admin_settings
+  // (see makeCachedSetting) and future hot-reload consumers. Fails soft
+  // into single-pod mode if Redis is unreachable.
+  await initCacheBus(app.redis);
+  app.addHook('onClose', async () => {
+    await closeCacheBus();
   });
 
   // ── LLM Provider Bootstrap ───────────────────────────────────────

--- a/backend/src/core/services/cached-setting.test.ts
+++ b/backend/src/core/services/cached-setting.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit tests for makeCachedSetting — the v0.4 epic §3.5 helper that wraps
+ * admin_settings reads behind an in-process cache that invalidates via the
+ * cluster-wide cache-bus.
+ *
+ * Contract:
+ *   - Async factory cold-loads from admin_settings at startup.
+ *   - The returned sync getter returns the cached value with no DB round-trip.
+ *   - A cache-bus event on the configured channel triggers re-read from DB.
+ *   - A cache-bus reconnect triggers re-read from DB (missed events are not
+ *     replayed by Redis pub/sub, so we cold-load as a recovery strategy).
+ *   - parse(null) handles the "row missing" case; defaultValue is returned
+ *     if DB errors prevent cold-load.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockQuery = vi.fn();
+vi.mock('../db/postgres.js', () => ({
+  query: (sql: string, params?: unknown[]) => mockQuery(sql, params),
+}));
+
+const mockSubscribe = vi.fn();
+const mockOnReconnect = vi.fn();
+vi.mock('./redis-cache-bus.js', () => ({
+  subscribe: (channel: string, handler: (payload: unknown) => void) =>
+    mockSubscribe(channel, handler),
+  onReconnect: (handler: () => void | Promise<void>) => mockOnReconnect(handler),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { makeCachedSetting } from './cached-setting.js';
+import { logger } from '../utils/logger.js';
+
+interface TestConfig {
+  enabled: boolean;
+  list: string[];
+}
+
+const defaultValue: TestConfig = { enabled: false, list: [] };
+
+function parse(raw: string | null): TestConfig {
+  if (!raw) return defaultValue;
+  return { ...defaultValue, ...(JSON.parse(raw) as Partial<TestConfig>) };
+}
+
+describe('makeCachedSetting', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockSubscribe.mockReset().mockReturnValue(() => {});
+    mockOnReconnect.mockReset().mockReturnValue(() => {});
+    vi.mocked(logger.warn).mockClear();
+    vi.mocked(logger.error).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('cold-load', () => {
+    it('reads the admin_settings row on startup and returns its parsed value via the sync getter', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ setting_value: JSON.stringify({ enabled: true, list: ['a', 'b'] }) }],
+      });
+
+      const get = await makeCachedSetting<TestConfig>({
+        key: 'test_setting',
+        cacheBusChannel: 'ip_allowlist:changed',
+        parse,
+        defaultValue,
+      });
+
+      expect(get()).toEqual({ enabled: true, list: ['a', 'b'] });
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('FROM admin_settings'),
+        ['test_setting'],
+      );
+    });
+
+    it('returns the parsed null-case (defaultValue) when the DB row is absent', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const get = await makeCachedSetting<TestConfig>({
+        key: 'test_setting',
+        cacheBusChannel: 'ip_allowlist:changed',
+        parse,
+        defaultValue,
+      });
+
+      expect(get()).toEqual(defaultValue);
+    });
+
+    it('falls back to defaultValue and logs a warn when the DB query rejects at cold-load', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('pool exhausted'));
+
+      const get = await makeCachedSetting<TestConfig>({
+        key: 'test_setting',
+        cacheBusChannel: 'ip_allowlist:changed',
+        parse,
+        defaultValue,
+      });
+
+      expect(get()).toEqual(defaultValue);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.any(Error), key: 'test_setting' }),
+        expect.stringContaining('cold-load failed'),
+      );
+    });
+
+    it('falls back to defaultValue and logs a warn when the parse function throws', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ setting_value: 'not-valid-json{' }],
+      });
+
+      const get = await makeCachedSetting<TestConfig>({
+        key: 'test_setting',
+        cacheBusChannel: 'ip_allowlist:changed',
+        parse,
+        defaultValue,
+      });
+
+      expect(get()).toEqual(defaultValue);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('in-process cache', () => {
+    it('subsequent getter calls do not hit the DB', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ setting_value: JSON.stringify({ enabled: true, list: ['x'] }) }],
+      });
+
+      const get = await makeCachedSetting<TestConfig>({
+        key: 'test_setting',
+        cacheBusChannel: 'ip_allowlist:changed',
+        parse,
+        defaultValue,
+      });
+
+      get();
+      get();
+      get();
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cache-bus invalidation', () => {
+    it('registers a handler on the configured channel at startup', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await makeCachedSetting<TestConfig>({
+        key: 'test_setting',
+        cacheBusChannel: 'ip_allowlist:changed',
+        parse,
+        defaultValue,
+      });
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'ip_allowlist:changed',
+        expect.any(Function),
+      );
+    });
+
+    it('re-reads the DB when the cache-bus fires and the getter reflects the new value', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ setting_value: JSON.stringify({ enabled: false, list: [] }) }],
+      });
+
+      const get = await makeCachedSetting<TestConfig>({
+        key: 'test_setting',
+        cacheBusChannel: 'ip_allowlist:changed',
+        parse,
+        defaultValue,
+      });
+      expect(get().enabled).toBe(false);
+
+      // Second DB read — the invalidation path
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ setting_value: JSON.stringify({ enabled: true, list: ['new'] }) }],
+      });
+
+      const handler = mockSubscribe.mock.calls[0][1] as (payload: unknown) => Promise<void>;
+      await handler({ at: Date.now() });
+
+      expect(get()).toEqual({ enabled: true, list: ['new'] });
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps the last-known value and logs a warn if the re-read fails', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ setting_value: JSON.stringify({ enabled: true, list: ['good'] }) }],
+      });
+
+      const get = await makeCachedSetting<TestConfig>({
+        key: 'test_setting',
+        cacheBusChannel: 'ip_allowlist:changed',
+        parse,
+        defaultValue,
+      });
+
+      mockQuery.mockRejectedValueOnce(new Error('pool exhausted'));
+      const handler = mockSubscribe.mock.calls[0][1] as (payload: unknown) => Promise<void>;
+      await handler({ at: Date.now() });
+
+      expect(get()).toEqual({ enabled: true, list: ['good'] });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.any(Error), key: 'test_setting' }),
+        expect.stringContaining('re-read failed'),
+      );
+    });
+  });
+
+  describe('reconnect', () => {
+    it('registers a reconnect handler at startup', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await makeCachedSetting<TestConfig>({
+        key: 'test_setting',
+        cacheBusChannel: 'ip_allowlist:changed',
+        parse,
+        defaultValue,
+      });
+
+      expect(mockOnReconnect).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('re-reads the DB after a cache-bus reconnect', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ setting_value: JSON.stringify({ enabled: false, list: [] }) }],
+      });
+
+      const get = await makeCachedSetting<TestConfig>({
+        key: 'test_setting',
+        cacheBusChannel: 'ip_allowlist:changed',
+        parse,
+        defaultValue,
+      });
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ setting_value: JSON.stringify({ enabled: true, list: ['reconnected'] }) }],
+      });
+
+      const onReconnectHandler = mockOnReconnect.mock.calls[0][0] as () => Promise<void>;
+      await onReconnectHandler();
+
+      expect(get()).toEqual({ enabled: true, list: ['reconnected'] });
+    });
+  });
+});

--- a/backend/src/core/services/cached-setting.ts
+++ b/backend/src/core/services/cached-setting.ts
@@ -1,0 +1,80 @@
+/**
+ * Cached-setting factory (v0.4 epic §3.5).
+ *
+ * Wraps a row in `admin_settings` behind an in-process cache that invalidates
+ * via the cluster-wide cache-bus. Intended for hot-path settings that are
+ * read on every request (e.g. IP allowlist, sync-conflict policy) where a
+ * per-request DB round-trip would be wasteful.
+ *
+ * Usage:
+ *
+ *   const getIpAllowlist = await makeCachedSetting<IpAllowlistConfig>({
+ *     key: 'ip_allowlist',
+ *     cacheBusChannel: 'ip_allowlist:changed',
+ *     parse: (raw) => raw ? { ...DEFAULT, ...JSON.parse(raw) } : DEFAULT,
+ *     defaultValue: DEFAULT,
+ *   });
+ *
+ *   // later, on every request:
+ *   const cfg = getIpAllowlist();
+ *
+ * Semantics:
+ *   - Cold-load at factory time (async): the returned getter has a fresh
+ *     value before any request runs.
+ *   - Invalidation via cache-bus: publishers (e.g. admin PUT routes) call
+ *     `publish('ip_allowlist:changed', ...)` after writing to Postgres. All
+ *     pods re-read on receipt.
+ *   - Reconnect recovery: when the cache-bus subscriber reconnects after a
+ *     transient disconnect, re-read from DB unconditionally (Redis pub/sub
+ *     does not replay missed messages).
+ *   - Soft-fail: DB errors during cold-load or re-read are logged; the
+ *     cached value stays at the last-known value (or defaultValue on first
+ *     failure). The getter never throws.
+ */
+
+import { query } from '../db/postgres.js';
+import { logger } from '../utils/logger.js';
+import { subscribe, onReconnect, type CacheBusChannel } from './redis-cache-bus.js';
+
+export interface CachedSettingOptions<T> {
+  key: string;
+  cacheBusChannel: CacheBusChannel;
+  parse: (raw: string | null) => T;
+  defaultValue: T;
+}
+
+export async function makeCachedSetting<T>(opts: CachedSettingOptions<T>): Promise<() => T> {
+  let cached: T = opts.defaultValue;
+
+  async function loadFromDb(phase: 'cold-load' | 're-read'): Promise<void> {
+    try {
+      const r = await query<{ setting_value: string }>(
+        `SELECT setting_value FROM admin_settings WHERE setting_key = $1`,
+        [opts.key],
+      );
+      const raw = r.rows[0]?.setting_value ?? null;
+      try {
+        cached = opts.parse(raw);
+      } catch (err) {
+        logger.warn(
+          { err, key: opts.key, phase },
+          'cached-setting: parse failed — keeping previous value',
+        );
+      }
+    } catch (err) {
+      logger.warn(
+        { err, key: opts.key, phase },
+        phase === 'cold-load'
+          ? 'cached-setting: cold-load failed — using defaultValue'
+          : 'cached-setting: re-read failed — keeping previous value',
+      );
+    }
+  }
+
+  await loadFromDb('cold-load');
+
+  subscribe(opts.cacheBusChannel, () => loadFromDb('re-read'));
+  onReconnect(() => loadFromDb('re-read'));
+
+  return () => cached;
+}

--- a/backend/src/core/services/redis-cache-bus.test.ts
+++ b/backend/src/core/services/redis-cache-bus.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Unit tests for redis-cache-bus.ts — a generic cluster-wide cache-bus
+ * abstraction introduced for the v0.4 epic (§3.1). Each subscriber treats
+ * received messages as invalidation advice only; payloads carry no state.
+ *
+ * Covers:
+ *   - publish JSON-encodes the payload and writes to the correct channel
+ *   - subscribe dispatches to all registered handlers on incoming messages
+ *   - unsubscribe stops dispatching
+ *   - malformed JSON does not crash the subscriber
+ *   - onReconnect fires on subsequent 'ready' events (not the first)
+ *   - soft-fail path when subscriber init fails (single-pod mode)
+ *   - close() unsubscribes, quits, and unwires the publisher
+ *   - second init while alive is a no-op
+ *   - re-init after full close works
+ *
+ * The tests mock the redis client; integration testing with a real Redis
+ * is handled at a higher layer (feature-specific tests like
+ * `ip-allowlist.multi-instance.test.ts` per the v0.4 epic).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { RedisClientType } from 'redis';
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+  initCacheBus,
+  publish,
+  subscribe,
+  onReconnect,
+  close,
+  isCacheBusActive,
+  type CacheBusChannel,
+} from './redis-cache-bus.js';
+import { logger } from '../utils/logger.js';
+
+function createMockRedis(opts?: {
+  connectRejects?: Error;
+  subscribeRejects?: Error;
+}) {
+  const channelHandlers = new Map<string, (message: string) => void>();
+  const readyListeners: Array<() => void> = [];
+  const errorListeners: Array<(err: Error) => void> = [];
+
+  const subscriber = {
+    on: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
+      if (event === 'ready') readyListeners.push(fn as () => void);
+      if (event === 'error') errorListeners.push(fn as (err: Error) => void);
+    }),
+    connect: vi.fn(async () => {
+      if (opts?.connectRejects) throw opts.connectRejects;
+    }),
+    subscribe: vi.fn(async (channel: string, handler: (message: string) => void) => {
+      if (opts?.subscribeRejects) throw opts.subscribeRejects;
+      channelHandlers.set(channel, handler);
+    }),
+    unsubscribe: vi.fn(async (channel?: string) => {
+      if (channel) channelHandlers.delete(channel);
+      else channelHandlers.clear();
+    }),
+    quit: vi.fn(async () => undefined),
+  };
+
+  const main = {
+    duplicate: vi.fn(() => subscriber),
+    publish: vi.fn(async () => 1),
+  };
+
+  return {
+    main: main as unknown as RedisClientType,
+    mainMock: main,
+    subscriber,
+    emit(channel: string, message: string) {
+      const handler = channelHandlers.get(channel);
+      if (!handler) throw new Error(`no subscriber for channel ${channel}`);
+      handler(message);
+    },
+    emitReady() {
+      for (const fn of readyListeners) fn();
+    },
+    emitError(err: Error) {
+      for (const fn of errorListeners) fn(err);
+    },
+    subscribedChannels: () => Array.from(channelHandlers.keys()),
+  };
+}
+
+describe('redis-cache-bus', () => {
+  beforeEach(() => {
+    vi.mocked(logger.warn).mockClear();
+    vi.mocked(logger.error).mockClear();
+    vi.mocked(logger.info).mockClear();
+    vi.mocked(logger.debug).mockClear();
+  });
+
+  afterEach(async () => {
+    await close();
+  });
+
+  describe('initialization', () => {
+    it('duplicates the main client, connects the subscriber, and marks the bus active', async () => {
+      const env = createMockRedis();
+
+      await initCacheBus(env.main);
+
+      expect(env.mainMock.duplicate).toHaveBeenCalledTimes(1);
+      expect(env.subscriber.connect).toHaveBeenCalledTimes(1);
+      expect(isCacheBusActive()).toBe(true);
+    });
+
+    it('second init while alive is a no-op — does not duplicate or reconnect', async () => {
+      const env = createMockRedis();
+
+      await initCacheBus(env.main);
+      await initCacheBus(env.main);
+
+      expect(env.mainMock.duplicate).toHaveBeenCalledTimes(1);
+      expect(env.subscriber.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-init after close works (simulates transient disconnect + fresh client)', async () => {
+      const envA = createMockRedis();
+      await initCacheBus(envA.main);
+      await close();
+
+      expect(isCacheBusActive()).toBe(false);
+
+      const envB = createMockRedis();
+      await initCacheBus(envB.main);
+
+      expect(envB.mainMock.duplicate).toHaveBeenCalledTimes(1);
+      expect(isCacheBusActive()).toBe(true);
+    });
+  });
+
+  describe('publish / subscribe', () => {
+    it('publish JSON-encodes the payload and writes to the correct channel on the main client', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      await publish('ip_allowlist:changed', { at: 1_700_000_000_000 });
+
+      expect(env.mainMock.publish).toHaveBeenCalledTimes(1);
+      expect(env.mainMock.publish).toHaveBeenCalledWith(
+        'ip_allowlist:changed',
+        JSON.stringify({ at: 1_700_000_000_000 }),
+      );
+    });
+
+    it('subscribe registers the channel on the redis subscriber on first handler', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      subscribe('ip_allowlist:changed', () => {});
+
+      expect(env.subscriber.subscribe).toHaveBeenCalledWith(
+        'ip_allowlist:changed',
+        expect.any(Function),
+      );
+    });
+
+    it('subscribe does NOT re-register the redis channel when a second handler is added', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      subscribe('ip_allowlist:changed', () => {});
+      subscribe('ip_allowlist:changed', () => {});
+
+      expect(env.subscriber.subscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches incoming messages to all handlers registered for the channel', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      const h1 = vi.fn();
+      const h2 = vi.fn();
+      subscribe('ip_allowlist:changed', h1);
+      subscribe('ip_allowlist:changed', h2);
+
+      env.emit('ip_allowlist:changed', JSON.stringify({ at: 42 }));
+
+      expect(h1).toHaveBeenCalledWith({ at: 42 });
+      expect(h2).toHaveBeenCalledWith({ at: 42 });
+    });
+
+    it('does not dispatch to handlers on other channels', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      const handler = vi.fn();
+      subscribe('ip_allowlist:changed', handler);
+      subscribe('license:changed', () => {});
+
+      env.emit('license:changed', JSON.stringify({ at: 1 }));
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('unsubscribe stops the handler from firing; remaining handlers still fire', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      const h1 = vi.fn();
+      const h2 = vi.fn();
+      const unsub1 = subscribe('ip_allowlist:changed', h1);
+      subscribe('ip_allowlist:changed', h2);
+
+      unsub1();
+      env.emit('ip_allowlist:changed', JSON.stringify({ at: 1 }));
+
+      expect(h1).not.toHaveBeenCalled();
+      expect(h2).toHaveBeenCalled();
+    });
+
+    it('malformed JSON on the channel does not throw — logs a warn', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      const handler = vi.fn();
+      subscribe('ip_allowlist:changed', handler);
+
+      expect(() => env.emit('ip_allowlist:changed', 'not-valid-json{')).not.toThrow();
+      expect(handler).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('a throwing handler does not prevent other handlers from firing', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      const throwing = vi.fn(() => {
+        throw new Error('boom');
+      });
+      const good = vi.fn();
+      subscribe('ip_allowlist:changed', throwing);
+      subscribe('ip_allowlist:changed', good);
+
+      expect(() =>
+        env.emit('ip_allowlist:changed', JSON.stringify({ at: 1 })),
+      ).not.toThrow();
+      expect(good).toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('onReconnect', () => {
+    it('skips the first ready event (initial connect) — onReconnect listeners do not fire', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      const handler = vi.fn();
+      onReconnect(handler);
+
+      env.emitReady();
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('fires registered handlers on a subsequent ready event (post-reconnect)', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      env.emitReady(); // "initial connect" sentinel
+
+      const handler = vi.fn();
+      onReconnect(handler);
+
+      env.emitReady(); // reconnect
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires multiple reconnect handlers independently; a throwing one does not block others', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      env.emitReady(); // skip initial
+
+      const throwing = vi.fn(() => {
+        throw new Error('boom');
+      });
+      const good = vi.fn();
+      onReconnect(throwing);
+      onReconnect(good);
+
+      env.emitReady();
+
+      expect(good).toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('onReconnect returns an unsubscribe that removes the handler', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      env.emitReady(); // skip initial
+
+      const handler = vi.fn();
+      const off = onReconnect(handler);
+      off();
+
+      env.emitReady();
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('soft-fail on Redis unavailable', () => {
+    it('logs a warn and marks bus inactive when connect() rejects', async () => {
+      const env = createMockRedis({ connectRejects: new Error('ECONNREFUSED') });
+
+      await initCacheBus(env.main);
+
+      expect(isCacheBusActive()).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.any(Error) }),
+        expect.stringContaining('single-pod mode'),
+      );
+    });
+
+    it('publish in single-pod mode is a no-op — does not throw, does not hit Redis', async () => {
+      const env = createMockRedis({ connectRejects: new Error('ECONNREFUSED') });
+      await initCacheBus(env.main);
+
+      await expect(publish('ip_allowlist:changed', { at: 1 })).resolves.toBeUndefined();
+      expect(env.mainMock.publish).not.toHaveBeenCalled();
+    });
+
+    it('subscribe in single-pod mode returns a noop unsubscribe — handler never fires', async () => {
+      const env = createMockRedis({ subscribeRejects: new Error('NOAUTH') });
+      await initCacheBus(env.main);
+
+      const handler = vi.fn();
+      const off = subscribe('ip_allowlist:changed', handler);
+
+      // Should be a callable noop
+      expect(() => off()).not.toThrow();
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('close', () => {
+    it('unsubscribes all channels, quits the subscriber, marks bus inactive', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      subscribe('ip_allowlist:changed', () => {});
+      subscribe('license:changed', () => {});
+
+      await close();
+
+      expect(env.subscriber.quit).toHaveBeenCalledTimes(1);
+      expect(isCacheBusActive()).toBe(false);
+    });
+
+    it('close while not initialised is a safe no-op', async () => {
+      await expect(close()).resolves.toBeUndefined();
+      expect(isCacheBusActive()).toBe(false);
+    });
+
+    it('publish after close is a no-op', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+      await close();
+
+      await publish('ip_allowlist:changed', { at: 1 });
+      expect(env.mainMock.publish).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('subscriber error event', () => {
+    it('logs subscriber client errors but does not crash', async () => {
+      const env = createMockRedis();
+      await initCacheBus(env.main);
+
+      env.emitError(new Error('transient redis blip'));
+
+      expect(logger.error).toHaveBeenCalled();
+      expect(isCacheBusActive()).toBe(true);
+    });
+  });
+
+  describe('type narrowing', () => {
+    it('CacheBusChannel union accepts the canonical v0.4 channels', () => {
+      // Compile-time check — if this file compiles, the type union is wide enough.
+      const channels: CacheBusChannel[] = [
+        'ip_allowlist:changed',
+        'sync_conflict_policy:changed',
+        'license:changed',
+        'admin_settings:changed',
+      ];
+      expect(channels).toHaveLength(4);
+    });
+  });
+});

--- a/backend/src/core/services/redis-cache-bus.test.ts
+++ b/backend/src/core/services/redis-cache-bus.test.ts
@@ -383,15 +383,49 @@ describe('redis-cache-bus', () => {
   });
 
   describe('type narrowing', () => {
-    it('CacheBusChannel union accepts the canonical v0.4 channels', () => {
-      // Compile-time check — if this file compiles, the type union is wide enough.
+    it('CacheBusChannel union accepts every channel named in epic §3.1', () => {
+      // Compile-time check — if this file compiles, the type union matches the plan.
       const channels: CacheBusChannel[] = [
+        'provider:cache:bump',
+        'provider:deleted',
+        'admin:llm:settings',
         'ip_allowlist:changed',
-        'sync_conflict_policy:changed',
+        'confluence:allowlist:changed',
+        'sync:conflict:policy:changed',
         'license:changed',
-        'admin_settings:changed',
       ];
-      expect(channels).toHaveLength(4);
+      expect(channels).toHaveLength(7);
+    });
+  });
+
+  describe('malformed main client', () => {
+    // Regression: previously `main.duplicate()` was called outside the try/catch,
+    // so a mock client without `duplicate()` threw a TypeError at init time
+    // (broke every test in app.test.ts). Init must soft-fail like any other
+    // subscriber-setup failure.
+    it('soft-fails to single-pod mode when main has no duplicate() method', async () => {
+      const bogusMain = { publish: vi.fn() } as unknown as RedisClientType;
+
+      await expect(initCacheBus(bogusMain)).resolves.toBeTypeOf('function');
+
+      expect(isCacheBusActive()).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.any(Error) }),
+        expect.stringContaining('single-pod mode'),
+      );
+    });
+
+    it('soft-fails when duplicate() itself throws synchronously', async () => {
+      const throwingMain = {
+        duplicate: vi.fn(() => {
+          throw new Error('synchronous boom');
+        }),
+        publish: vi.fn(),
+      } as unknown as RedisClientType;
+
+      await initCacheBus(throwingMain);
+
+      expect(isCacheBusActive()).toBe(false);
     });
   });
 });

--- a/backend/src/core/services/redis-cache-bus.ts
+++ b/backend/src/core/services/redis-cache-bus.ts
@@ -31,17 +31,17 @@
 import type { RedisClientType } from 'redis';
 import { logger } from '../utils/logger.js';
 
+// Closed union of every channel the generic cache-bus carries. Lifted
+// verbatim from epic §3.1 (.plans/v0.4-epic-2026-04.md in the EE repo);
+// future features extend this list in the same PR they add the publisher.
 export type CacheBusChannel =
-  | 'ip_allowlist:changed'
-  | 'sync_conflict_policy:changed'
-  | 'admin_settings:changed'
-  | 'license:changed'
   | 'provider:cache:bump'
   | 'provider:deleted'
   | 'admin:llm:settings'
-  | 'ai_review_policy:changed'
-  | 'pii_policy:changed'
-  | 'trusted_proxies:changed';
+  | 'ip_allowlist:changed'
+  | 'confluence:allowlist:changed'
+  | 'sync:conflict:policy:changed'
+  | 'license:changed';
 
 type Handler<T = unknown> = (payload: T) => void | Promise<void>;
 
@@ -72,45 +72,53 @@ export async function initCacheBus(main: RedisClientType): Promise<() => Promise
     return close;
   }
 
-  const subscriber = main.duplicate() as RedisClientType;
-
-  const bootState: BusState = {
-    main,
-    subscriber,
-    handlers: new Map(),
-    redisSubscribed: new Set(),
-    reconnectHandlers: new Set(),
-    readySeen: false,
-    active: false,
-  };
-
-  subscriber.on('error', (err: unknown) => {
-    logger.error({ err }, 'redis-cache-bus: subscriber client error');
-  });
-
-  subscriber.on('ready', () => {
-    if (!bootState.readySeen) {
-      bootState.readySeen = true;
-      return;
-    }
-    for (const fn of bootState.reconnectHandlers) {
-      try {
-        const res = fn();
-        if (res && typeof (res as Promise<void>).catch === 'function') {
-          (res as Promise<void>).catch((err) => {
-            logger.warn({ err }, 'redis-cache-bus: reconnect handler rejected');
-          });
-        }
-      } catch (err) {
-        logger.warn({ err }, 'redis-cache-bus: reconnect handler threw');
-      }
-    }
-  });
-
+  // All subscriber setup — including `duplicate()` and event wiring — must
+  // live inside the try/catch so a broken/mocked main client soft-fails to
+  // single-pod mode instead of throwing synchronously. Mirrors the pattern
+  // established by `ssrf-allowlist-bus.ts` (issue #306).
+  let bootState: BusState;
   try {
+    const subscriber = main.duplicate() as RedisClientType;
+
+    bootState = {
+      main,
+      subscriber,
+      handlers: new Map(),
+      redisSubscribed: new Set(),
+      reconnectHandlers: new Set(),
+      readySeen: false,
+      active: false,
+    };
+
+    subscriber.on('error', (err: unknown) => {
+      logger.error({ err }, 'redis-cache-bus: subscriber client error');
+    });
+
+    subscriber.on('ready', () => {
+      if (!bootState.readySeen) {
+        bootState.readySeen = true;
+        return;
+      }
+      for (const fn of bootState.reconnectHandlers) {
+        try {
+          const res = fn();
+          if (res && typeof (res as Promise<void>).catch === 'function') {
+            (res as Promise<void>).catch((err) => {
+              logger.warn({ err }, 'redis-cache-bus: reconnect handler rejected');
+            });
+          }
+        } catch (err) {
+          logger.warn({ err }, 'redis-cache-bus: reconnect handler threw');
+        }
+      }
+    });
+
     await subscriber.connect();
   } catch (err) {
-    logger.warn({ err }, 'redis-cache-bus: subscriber connect failed — falling back to single-pod mode');
+    logger.warn(
+      { err },
+      'redis-cache-bus: subscriber init failed — falling back to single-pod mode',
+    );
     return close;
   }
 

--- a/backend/src/core/services/redis-cache-bus.ts
+++ b/backend/src/core/services/redis-cache-bus.ts
@@ -1,0 +1,244 @@
+/**
+ * Generic cluster-wide cache-bus over Redis pub/sub (v0.4 epic §3.1).
+ *
+ * Primitives:
+ *   - publish(channel, payload)   -> writes JSON-encoded payload on `main.publish`
+ *   - subscribe(channel, handler) -> fires handler(parsed) on incoming messages;
+ *                                    returns an unsubscribe function
+ *   - onReconnect(handler)        -> fires after the subscriber reconnects
+ *                                    (NOT on initial connect), so cached settings
+ *                                    can cold-reload from Postgres
+ *   - close()                     -> unsubscribes, quits the subscriber, unwires publisher
+ *
+ * Contract (cluster semantics):
+ *   - At-most-once delivery; payloads are invalidation advice only. Subscribers
+ *     treat each event as "go re-read from the authoritative store" and never
+ *     trust state embedded in the payload.
+ *   - On startup and after reconnect, subscribers cold-load from the store
+ *     unconditionally. There is no missed-message catch-up.
+ *
+ * Soft-fail: if the subscriber cannot connect or subscribe, the bus falls back
+ * to single-pod mode. publish() becomes a no-op; subscribe() returns a noop
+ * unsubscribe. This matches the ssrf-allowlist-bus (issue #306) precedent and
+ * keeps single-pod deployments (or a Redis outage) from cascading into hard
+ * errors on every request.
+ *
+ * node-redis v5 note: a subscriber connection cannot also issue commands, so
+ * we `main.duplicate()` a dedicated subscriber. Re-subscription after a
+ * transient disconnect is handled by node-redis automatically.
+ */
+
+import type { RedisClientType } from 'redis';
+import { logger } from '../utils/logger.js';
+
+export type CacheBusChannel =
+  | 'ip_allowlist:changed'
+  | 'sync_conflict_policy:changed'
+  | 'admin_settings:changed'
+  | 'license:changed'
+  | 'provider:cache:bump'
+  | 'provider:deleted'
+  | 'admin:llm:settings'
+  | 'ai_review_policy:changed'
+  | 'pii_policy:changed'
+  | 'trusted_proxies:changed';
+
+type Handler<T = unknown> = (payload: T) => void | Promise<void>;
+
+interface BusState {
+  main: RedisClientType;
+  subscriber: RedisClientType;
+  handlers: Map<CacheBusChannel, Set<Handler>>;
+  redisSubscribed: Set<CacheBusChannel>;
+  reconnectHandlers: Set<() => void | Promise<void>>;
+  /** Skip the first 'ready' event — that's the initial connect, not a reconnect. */
+  readySeen: boolean;
+  active: boolean;
+}
+
+let state: BusState | null = null;
+
+/**
+ * Initialise the cache-bus with the given main Redis client. Returns a
+ * teardown function; also exposed as `close()` for symmetry with the epic
+ * §3.1 API.
+ *
+ * Second call while a bus is alive is a no-op and returns the original
+ * teardown.
+ */
+export async function initCacheBus(main: RedisClientType): Promise<() => Promise<void>> {
+  if (state) {
+    logger.debug('redis-cache-bus: already initialised — skipping');
+    return close;
+  }
+
+  const subscriber = main.duplicate() as RedisClientType;
+
+  const bootState: BusState = {
+    main,
+    subscriber,
+    handlers: new Map(),
+    redisSubscribed: new Set(),
+    reconnectHandlers: new Set(),
+    readySeen: false,
+    active: false,
+  };
+
+  subscriber.on('error', (err: unknown) => {
+    logger.error({ err }, 'redis-cache-bus: subscriber client error');
+  });
+
+  subscriber.on('ready', () => {
+    if (!bootState.readySeen) {
+      bootState.readySeen = true;
+      return;
+    }
+    for (const fn of bootState.reconnectHandlers) {
+      try {
+        const res = fn();
+        if (res && typeof (res as Promise<void>).catch === 'function') {
+          (res as Promise<void>).catch((err) => {
+            logger.warn({ err }, 'redis-cache-bus: reconnect handler rejected');
+          });
+        }
+      } catch (err) {
+        logger.warn({ err }, 'redis-cache-bus: reconnect handler threw');
+      }
+    }
+  });
+
+  try {
+    await subscriber.connect();
+  } catch (err) {
+    logger.warn({ err }, 'redis-cache-bus: subscriber connect failed — falling back to single-pod mode');
+    return close;
+  }
+
+  bootState.active = true;
+  state = bootState;
+
+  logger.info('redis-cache-bus: active');
+  return close;
+}
+
+export function isCacheBusActive(): boolean {
+  return state?.active === true;
+}
+
+/**
+ * Publish a JSON-encoded invalidation advice on the given channel. In
+ * single-pod mode (bus inactive), this is a no-op.
+ */
+export async function publish(channel: CacheBusChannel, payload: unknown): Promise<void> {
+  if (!state?.active) return;
+  try {
+    await state.main.publish(channel, JSON.stringify(payload));
+  } catch (err) {
+    logger.warn({ err, channel }, 'redis-cache-bus: publish failed');
+  }
+}
+
+/**
+ * Subscribe a handler to a channel. First subscription on a channel registers
+ * the Redis SUBSCRIBE; subsequent subscriptions share the same Redis channel
+ * and dispatch in-process to all registered handlers.
+ *
+ * Returns an unsubscribe function. In single-pod mode, returns a noop
+ * unsubscribe; the handler will never fire.
+ */
+export function subscribe<T = unknown>(
+  channel: CacheBusChannel,
+  handler: Handler<T>,
+): () => void {
+  if (!state?.active) return noop;
+
+  let handlers = state.handlers.get(channel);
+  if (!handlers) {
+    handlers = new Set();
+    state.handlers.set(channel, handlers);
+  }
+  handlers.add(handler as Handler);
+
+  if (!state.redisSubscribed.has(channel)) {
+    state.redisSubscribed.add(channel);
+    void state.subscriber
+      .subscribe(channel, (message: string) => dispatch(channel, message))
+      .catch((err: unknown) => {
+        logger.warn({ err, channel }, 'redis-cache-bus: subscribe failed — handler inert for this channel');
+        state?.redisSubscribed.delete(channel);
+      });
+  }
+
+  return () => {
+    const set = state?.handlers.get(channel);
+    if (set) set.delete(handler as Handler);
+  };
+}
+
+/**
+ * Register a handler to run after the subscriber reconnects. Callers use this
+ * to cold-reload cached state from Postgres once the bus is back (missed
+ * invalidation messages during the disconnect window are not replayed).
+ *
+ * Returns an unsubscribe function.
+ */
+export function onReconnect(handler: () => void | Promise<void>): () => void {
+  if (!state) return noop;
+  state.reconnectHandlers.add(handler);
+  return () => {
+    state?.reconnectHandlers.delete(handler);
+  };
+}
+
+/**
+ * Tear down the bus: unsubscribe all Redis channels, quit the subscriber,
+ * clear local state. Safe to call multiple times or when not initialised.
+ */
+export async function close(): Promise<void> {
+  const s = state;
+  if (!s) return;
+  state = null;
+
+  if (s.redisSubscribed.size > 0) {
+    try {
+      await s.subscriber.unsubscribe();
+    } catch (err) {
+      logger.warn({ err }, 'redis-cache-bus: unsubscribe failed during close');
+    }
+  }
+  try {
+    await s.subscriber.quit();
+  } catch (err) {
+    logger.warn({ err }, 'redis-cache-bus: subscriber quit failed');
+  }
+}
+
+function dispatch(channel: CacheBusChannel, message: string): void {
+  const handlers = state?.handlers.get(channel);
+  if (!handlers || handlers.size === 0) return;
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(message);
+  } catch (err) {
+    logger.warn({ err, channel, message }, 'redis-cache-bus: failed to parse event');
+    return;
+  }
+
+  for (const handler of handlers) {
+    try {
+      const res = handler(payload);
+      if (res && typeof (res as Promise<void>).catch === 'function') {
+        (res as Promise<void>).catch((err) => {
+          logger.warn({ err, channel }, 'redis-cache-bus: async handler rejected');
+        });
+      }
+    } catch (err) {
+      logger.warn({ err, channel }, 'redis-cache-bus: handler threw');
+    }
+  }
+}
+
+function noop(): void {
+  /* no-op unsubscribe for single-pod mode */
+}


### PR DESCRIPTION
## Summary

Shared infrastructure for the v0.4 epic. Lands two pre-requisite modules that unblock EE #111 (IP allowlist), EE #118 (sync conflict policy), and future cached `admin_settings` consumers.

- **`redis-cache-bus.ts`** — generic cluster-wide pub/sub wrapping a duplicated node-redis subscriber. Typed `CacheBusChannel` union, `publish` / `subscribe` / `onReconnect` / `close` primitives. At-most-once delivery; payloads are invalidation advice only (never trust state embedded in the payload). Soft-fails to single-pod mode when Redis is unreachable — matches the `ssrf-allowlist-bus` (#306) precedent.
- **`cached-setting.ts`** — `makeCachedSetting<T>()` factory that cold-loads from `admin_settings` at startup, caches in-process, and re-reads on cache-bus events or subscriber reconnects. Returns a sync getter so hot-path request handlers never touch the DB.
- **`app.ts`** — `initCacheBus` / `close` wiring alongside the existing `initSsrfAllowlistBus`.

Implements epic `§3.1` (Generic Redis cache-bus) and `§3.5` (admin-settings live-refresh pattern) from [`.plans/v0.4-epic-2026-04.md`](https://github.com/Compendiq/compendiq-ee/blob/dev/.plans/v0.4-epic-2026-04.md) in the EE repo. Tracked on the EE side under Compendiq/compendiq-ee#113 Part B-1.

## Design notes

- **Why generic over per-feature?** The PR #121 review on the EE side flagged a tension between this plan (generic single-module) and CE#306's shipped `ssrf-allowlist-bus.ts` (per-feature). The plan notes this as "pre-#113 revision work". This PR resolves it in favour of the generic design per the epic, and lets the existing `ssrf-allowlist-bus.ts` coexist unchanged for now. A follow-up can port it onto the generic bus; deliberately out of scope here to keep the PR surgical.
- **Why node-redis instead of ioredis?** The plan mentions ioredis in passing, but CE uses `redis` (node-redis v5) throughout (`redis.ts` plugin, `ssrf-allowlist-bus.ts`). Introducing a second Redis client lib would be gratuitous. The primitives are equivalent; the implementation uses `main.duplicate()` exactly like `ssrf-allowlist-bus`.
- **Reconnect semantics.** The subscriber skips the first `ready` event (initial connect) and fires local `onReconnect` handlers on subsequent ones. Subscribers — including `makeCachedSetting` consumers — use this to cold-reload from Postgres, since Redis pub/sub does not replay missed messages.

## Test plan

- [x] Unit: `redis-cache-bus.test.ts` — 23 tests covering init, publish/subscribe dispatch, unsubscribe, malformed JSON, throwing handlers, onReconnect (first-ready-is-skipped, subsequent fire, unsubscribe), soft-fail paths, close idempotency, subscriber error logging.
- [x] Unit: `cached-setting.test.ts` — 10 tests covering cold-load, null-row, DB-error fallback, parse-error fallback, in-process cache, invalidation re-read, re-read-error keeps-last-known, reconnect re-read.
- [x] Typecheck clean on touched files.
- [x] Lint clean.
- [ ] Full CE test suite — deferred to CI (local Postgres + Redis not running). Integration tests that boot the app will exercise the new `initCacheBus` wiring end-to-end; soft-fail path is already unit-tested.

## Rollback

- Revert the commit. The new modules become dead code; `ssrf-allowlist-bus` and `redisPlugin` continue as before. No schema, no runtime side effects that survive revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)