### PR TITLE
feat(v0.4): trusted-proxy helper + ipaddr.js (epic §3.4)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "fastify-plugin": "^5.0.1",
     "fastify-type-provider-zod": "^6.1.0",
     "he": "^1.2.0",
+    "ipaddr.js": "^2.3.0",
     "isomorphic-dompurify": "^3.3.0",
     "jose": "^6.0.8",
     "jsdom": "^28.1.0",

--- a/backend/src/core/utils/trusted-proxy.test.ts
+++ b/backend/src/core/utils/trusted-proxy.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for trusted-proxy.ts — epic §3.4.
+ *
+ * Exports:
+ *   - parseCidrSafe(raw): returns a parsed CIDR or null on malformed input.
+ *   - matchesAny(rawAddr, cidrs): true iff the address matches any CIDR.
+ *     Must normalise IPv4-mapped-IPv6 addresses (::ffff:1.2.3.4) to IPv4
+ *     before matching — this is the canonical allowlist-bypass (research
+ *     cluster-1 item #1).
+ *   - buildTrustProxyFn(cidrs): a Fastify `trustProxy` function. Returns
+ *     true iff the peer is in one of the given CIDRs.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parseCidrSafe,
+  matchesAny,
+  buildTrustProxyFn,
+} from './trusted-proxy.js';
+
+describe('parseCidrSafe', () => {
+  it('parses a valid IPv4 CIDR', () => {
+    expect(parseCidrSafe('10.0.0.0/8')).not.toBeNull();
+  });
+
+  it('parses a valid IPv6 CIDR', () => {
+    expect(parseCidrSafe('2001:db8::/32')).not.toBeNull();
+  });
+
+  it('returns null for malformed input', () => {
+    expect(parseCidrSafe('not-a-cidr')).toBeNull();
+    expect(parseCidrSafe('10.0.0.0')).toBeNull(); // missing prefix length
+    expect(parseCidrSafe('999.999.999.999/8')).toBeNull();
+    expect(parseCidrSafe('')).toBeNull();
+  });
+});
+
+describe('matchesAny', () => {
+  it('returns true for an IPv4 in an IPv4 CIDR', () => {
+    const cidrs = [parseCidrSafe('10.0.0.0/8')!];
+    expect(matchesAny('10.1.2.3', cidrs)).toBe(true);
+  });
+
+  it('returns false for an IPv4 outside the CIDR', () => {
+    const cidrs = [parseCidrSafe('10.0.0.0/8')!];
+    expect(matchesAny('192.168.1.1', cidrs)).toBe(false);
+  });
+
+  it('returns true for an IPv6 in an IPv6 CIDR', () => {
+    const cidrs = [parseCidrSafe('2001:db8::/32')!];
+    expect(matchesAny('2001:db8:1234::1', cidrs)).toBe(true);
+  });
+
+  it('returns false when kinds mismatch (IPv4 address vs IPv6 CIDR)', () => {
+    const cidrs = [parseCidrSafe('2001:db8::/32')!];
+    expect(matchesAny('10.1.2.3', cidrs)).toBe(false);
+  });
+
+  it('normalises IPv4-mapped-IPv6 (::ffff:a.b.c.d) and matches the IPv4 CIDR', () => {
+    // This is the canonical allowlist-bypass — Node's dual-stack sockets
+    // surface IPv4 peers as `::ffff:1.2.3.4`. Without .process() normalisation,
+    // an IPv4 CIDR wouldn't match and the peer would be incorrectly treated
+    // as untrusted (or worse, as a spoofable IPv6 address).
+    const cidrs = [parseCidrSafe('10.0.0.0/8')!];
+    expect(matchesAny('::ffff:10.1.2.3', cidrs)).toBe(true);
+  });
+
+  it('handles the loopback defaults (127.0.0.1/32 + ::1/128)', () => {
+    const cidrs = [parseCidrSafe('127.0.0.1/32')!, parseCidrSafe('::1/128')!];
+    expect(matchesAny('127.0.0.1', cidrs)).toBe(true);
+    expect(matchesAny('::1', cidrs)).toBe(true);
+    expect(matchesAny('127.0.0.2', cidrs)).toBe(false);
+  });
+
+  it('returns false for a malformed address string (soft-fail)', () => {
+    const cidrs = [parseCidrSafe('10.0.0.0/8')!];
+    expect(matchesAny('not-an-ip', cidrs)).toBe(false);
+    expect(matchesAny('', cidrs)).toBe(false);
+  });
+
+  it('returns false when the CIDR list is empty', () => {
+    expect(matchesAny('10.1.2.3', [])).toBe(false);
+  });
+
+  it('short-circuits across multiple CIDRs — any match returns true', () => {
+    const cidrs = [
+      parseCidrSafe('127.0.0.1/32')!,
+      parseCidrSafe('10.0.0.0/8')!,
+      parseCidrSafe('172.16.0.0/12')!,
+    ];
+    expect(matchesAny('172.16.5.5', cidrs)).toBe(true);
+  });
+});
+
+describe('buildTrustProxyFn', () => {
+  it('returns a function that trusts addresses inside the configured CIDR', () => {
+    const trust = buildTrustProxyFn(['10.0.0.0/8']);
+    expect(trust('10.1.2.3', 0)).toBe(true);
+    expect(trust('192.168.1.1', 0)).toBe(false);
+  });
+
+  it('the default loopback list only trusts 127.0.0.1 and ::1', () => {
+    // Intentionally NOT the "blanket" behaviour of `trustProxy: true` — this
+    // is the documented behaviour change called out in epic §3.4 + CHANGELOG.
+    const trust = buildTrustProxyFn(['127.0.0.1/32', '::1/128']);
+    expect(trust('127.0.0.1', 0)).toBe(true);
+    expect(trust('::1', 0)).toBe(true);
+    expect(trust('10.1.2.3', 0)).toBe(false);
+  });
+
+  it('drops malformed CIDRs silently — a broken config must not crash Fastify init', () => {
+    const trust = buildTrustProxyFn(['10.0.0.0/8', 'garbage', '', 'not/a/cidr']);
+    expect(trust('10.1.2.3', 0)).toBe(true);
+    expect(trust('8.8.8.8', 0)).toBe(false);
+  });
+
+  it('treats IPv4-mapped-IPv6 peers as the IPv4 they represent', () => {
+    const trust = buildTrustProxyFn(['10.0.0.0/8']);
+    expect(trust('::ffff:10.1.2.3', 0)).toBe(true);
+  });
+
+  it('returns false for an empty CIDR list (trust nothing)', () => {
+    const trust = buildTrustProxyFn([]);
+    expect(trust('127.0.0.1', 0)).toBe(false);
+    expect(trust('10.1.2.3', 0)).toBe(false);
+  });
+});

--- a/backend/src/core/utils/trusted-proxy.ts
+++ b/backend/src/core/utils/trusted-proxy.ts
@@ -1,0 +1,66 @@
+/**
+ * Trust-proxy hardening helpers (v0.4 epic §3.4).
+ *
+ * Provides:
+ *   - `parseCidrSafe`  — lenient CIDR parser that returns null on malformed input.
+ *   - `matchesAny`     — dual-stack-aware address-in-CIDR-list check.
+ *   - `buildTrustProxyFn` — Fastify `trustProxy` function factory used at
+ *     app.ts startup in place of the previous blanket `trustProxy: true`.
+ *
+ * The dual-stack normalisation step is load-bearing: Node sockets surface
+ * IPv4 peers as `::ffff:a.b.c.d` when IPv6 is available, and without
+ * `ipaddr.process()` we would fail to match them against IPv4 CIDRs —
+ * the canonical allowlist-bypass (research cluster-1 item #1).
+ *
+ * Note on hot-reload: Fastify reads `trustProxy` once at server construction
+ * and cannot have it swapped at runtime. The IP-allowlist onRequest hook
+ * therefore walks XFF itself using the live trusted-proxies list; this
+ * helper only governs Fastify's own `request.ip`. See §3.4 + the plan for
+ * #111 step 4b.
+ */
+
+import ipaddr from 'ipaddr.js';
+
+export type ParsedCidr = [ipaddr.IPv4 | ipaddr.IPv6, number];
+
+export function parseCidrSafe(raw: string): ParsedCidr | null {
+  try {
+    return ipaddr.parseCIDR(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function matchesAny(rawAddr: string, cidrs: ParsedCidr[]): boolean {
+  if (cidrs.length === 0) return false;
+  let addr: ipaddr.IPv4 | ipaddr.IPv6;
+  try {
+    addr = ipaddr.process(rawAddr);
+  } catch {
+    return false;
+  }
+  for (const cidr of cidrs) {
+    if (addr.kind() === cidr[0].kind() && addr.match(cidr)) return true;
+  }
+  return false;
+}
+
+/**
+ * Build a Fastify-compatible `trustProxy` function that trusts only addresses
+ * falling inside one of the given CIDRs. Malformed CIDRs in the input are
+ * silently dropped — a broken config must not take down Fastify startup.
+ *
+ * Pass `[]` for "trust nothing" semantics (equivalent to `trustProxy: false`);
+ * the v0.4 default when the IP-allowlist feature is disabled is
+ * `['127.0.0.1/32', '::1/128']` (loopback only), a behaviour change from the
+ * previous `trustProxy: true` blanket that MUST be flagged in CHANGELOG.
+ */
+export function buildTrustProxyFn(cidrs: string[]): (addr: string, hop: number) => boolean {
+  const parsed = cidrs
+    .map(parseCidrSafe)
+    .filter((c): c is ParsedCidr => c !== null);
+
+  return function trustProxy(addr: string): boolean {
+    return matchesAny(addr, parsed);
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "fastify-plugin": "^5.0.1",
         "fastify-type-provider-zod": "^6.1.0",
         "he": "^1.2.0",
+        "ipaddr.js": "^2.3.0",
         "isomorphic-dompurify": "^3.3.0",
         "jose": "^6.0.8",
         "jsdom": "^28.1.0",


### PR DESCRIPTION
## Summary

Standalone PR for the trusted-proxy helper prerequisite of EE #111 (IP allowlist). Separated so the dep bump + helper land reviewable in isolation; the follow-up #111 PR will wire it into \`app.ts\` and ship the full allowlist feature.

## What's in

- **\`backend/src/core/utils/trusted-proxy.ts\`**
  - \`parseCidrSafe(raw)\` — lenient CIDR parser, returns \`null\` on malformed input
  - \`matchesAny(addr, cidrs)\` — dual-stack-aware membership. Calls \`ipaddr.process()\` on the input so IPv4-mapped-IPv6 peers (\`::ffff:a.b.c.d\`) normalise to IPv4 before matching an IPv4 CIDR. **This is the canonical allowlist-bypass** (research cluster-1 item #1) and is pinned by a dedicated test case.
  - \`buildTrustProxyFn(cidrs)\` — Fastify-compatible \`trustProxy\` function factory. Silently drops malformed CIDRs so a broken config cannot fail server init.
- \`ipaddr.js@^2.3.0\` added to \`backend/package.json\` (zero-dep, TS types, dual-stack).

## What's deliberately NOT in

No \`app.ts\` wiring yet. The follow-up PR for EE #111 will:

1. Replace \`trustProxy: true\` at \`ce/backend/src/core/app.ts:73\` with \`buildTrustProxyFn(await loadTrustedProxiesFromAdminSettings())\`.
2. Flag the behaviour change in \`CHANGELOG.md\`: the Fastify default trusted list moves from blanket-trust to loopback-only (\`127.0.0.1/32\`, \`::1/128\`) when the IP-allowlist feature is off. Customers running behind a non-loopback reverse proxy must populate \`trusted_proxies\` in \`admin_settings\` explicitly.
3. Register the \`ip-allowlist-hook\` between \`redisPlugin\` and \`authPlugin\` when \`ENTERPRISE_FEATURES.IP_ALLOWLISTING\` is enabled.

Until those land, this PR is runtime-inert — the new module is dead code and \`Fastify({ trustProxy: true })\` continues as before.

## Test plan

- [x] 17/17 unit tests pass (\`npx vitest run src/core/utils/trusted-proxy.test.ts\`)
  - \`parseCidrSafe\` — IPv4, IPv6, malformed
  - \`matchesAny\` — IPv4/IPv4, IPv6/IPv6, kind-mismatch, loopback defaults, **IPv4-mapped-IPv6 normalisation**, malformed-address soft-fail, empty list, multi-CIDR short-circuit
  - \`buildTrustProxyFn\` — in-CIDR trust, loopback default, broken-CIDR soft-fail, IPv4-mapped peers, empty list
- [x] Typecheck clean on touched files (\`npx tsc --noEmit\`)
- [x] Lint clean (\`npm run lint\`; only pre-existing \`eslint-plugin-boundaries\` deprecation warning)

## Rollback

Revert the commit. The module becomes dead code and \`ipaddr.js\` remains as an unused dep — no runtime change to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)