### PR TITLE
docs(#299): traefik + caddy reverse-proxy guides, nginx SSE addendum

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,6 +1,6 @@
 # Integration Guides
 
-_Last updated: 2026-04-23_
+_Last updated: 2026-04-24_
 
 The `install.sh` quickstart assumes the easiest deployment shape — a reachable Confluence DC on a vanilla HTTPS URL with a public CA cert and unrestricted outbound internet. Real on-prem customers usually run one of three more interesting shapes. This directory documents each one end-to-end.
 
@@ -8,7 +8,9 @@ The `install.sh` quickstart assumes the easiest deployment shape — a reachable
 
 | Your environment looks like… | Guide |
 |--|--|
-| Compendiq behind a corporate reverse proxy (TLS termination, path routing, auth pass-through) | [`reverse-proxy/nginx.md`](./reverse-proxy/nginx.md) |
+| Compendiq behind corporate nginx (TLS termination, path routing, auth pass-through) | [`reverse-proxy/nginx.md`](./reverse-proxy/nginx.md) |
+| Compendiq behind Traefik v3 (Docker Swarm / Compose, label-driven routing, auto-TLS) | [`reverse-proxy/traefik.md`](./reverse-proxy/traefik.md) |
+| Compendiq behind Caddy (auto-TLS, minimal config) | [`reverse-proxy/caddy.md`](./reverse-proxy/caddy.md) |
 | Confluence DC (or the LLM upstream) uses a self-signed or private-CA cert | [`self-signed-tls/README.md`](./self-signed-tls/README.md) |
 | No outbound internet access at all (air-gapped / disconnected) | [`air-gapped/README.md`](./air-gapped/README.md) |
 

--- a/docs/integrations/reverse-proxy/caddy.md
+++ b/docs/integrations/reverse-proxy/caddy.md
@@ -48,6 +48,7 @@ compendiq.corp.example.com {
         path_regexp sse ^/api/(pages/[^/]+/presence|llm/.*)$
     }
     reverse_proxy @sse 127.0.0.1:8081 {
+        # Belt-and-suspenders: Caddy auto-streams text/event-stream anyway
         flush_interval -1
         transport http {
             read_timeout 1h

--- a/docs/integrations/reverse-proxy/caddy.md
+++ b/docs/integrations/reverse-proxy/caddy.md
@@ -1,0 +1,127 @@
+# Compendiq behind Caddy
+
+_last-verified: 2026-04-24 (draft ships with v0.4; founder VM test pending before v0.4.0 tag)_
+
+## Who this is for
+
+You like Caddy because TLS is handled automatically and the config file is five lines. You want to front Compendiq with Caddy on a public (or LAN + internal CA) hostname and keep the LLM and presence streams working — Caddy's only gotcha with Compendiq is default response buffering on long-lived connections.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    u[User browser]
+    u -->|HTTPS :443| cy[Caddy<br/>auto-TLS]
+    cy -->|HTTP :8081| cf[Compendiq frontend]
+    cf -->|HTTP :3051| cb[Compendiq backend]
+    cb --> pg[(PostgreSQL)]
+    cb --> rd[(Redis)]
+```
+
+## Prerequisites
+
+- Caddy v2.7+ installed on the host (systemd unit, Docker, or binary — all equivalent).
+- Compendiq running locally on `127.0.0.1:8081` (bundled nginx inside the frontend image; bind to loopback so only Caddy reaches it).
+- DNS record for your hostname pointing at the Caddy host. Public internet + port 80/443 open → Caddy auto-fetches a public cert. Private DNS → use Caddy's internal CA (see §2.b below).
+
+## Step-by-step
+
+### 1. Keep Compendiq bound to loopback
+
+In `docker-compose.yml`:
+
+```yaml
+frontend:
+  ports:
+    - "127.0.0.1:8081:8081"
+```
+
+### 2a. `Caddyfile` — public hostname with auto-TLS
+
+```caddyfile
+compendiq.corp.example.com {
+    # SSE streams: presence viewer list (v0.4 #301) and every LLM
+    # endpoint. `flush_interval -1` disables response buffering on
+    # THIS matcher only — everything else keeps normal buffering for
+    # best throughput on static assets.
+    @sse {
+        path_regexp sse ^/api/(pages/[^/]+/presence|llm/.*)$
+    }
+    reverse_proxy @sse 127.0.0.1:8081 {
+        flush_interval -1
+        transport http {
+            read_timeout 1h
+        }
+    }
+
+    # Everything else.
+    reverse_proxy 127.0.0.1:8081
+
+    # Raise the request body cap for diagram / image uploads.
+    request_body {
+        max_size 30MB
+    }
+}
+```
+
+Reload Caddy:
+
+```bash
+sudo caddy reload --config /etc/caddy/Caddyfile
+```
+
+Caddy auto-issues a Let's Encrypt cert on first request. No additional config needed when the hostname resolves publicly.
+
+### 2b. `Caddyfile` — internal hostname with Caddy's local CA
+
+Replace the site block's first line with:
+
+```caddyfile
+compendiq.corp.internal {
+    tls internal
+    # ...same @sse matcher + reverse_proxy blocks as above
+}
+```
+
+`tls internal` tells Caddy to issue certs from its embedded CA (`~/.local/share/caddy/pki/authorities/local/root.crt`). Distribute that root to client machines so browsers trust it.
+
+## Configuration reference
+
+| Variable | Example | Why |
+|---|---|---|
+| `FRONTEND_URL` | `https://compendiq.corp.example.com` | CORS origin + setup-wizard redirect target. Must match what Caddy serves. |
+| `FRONTEND_PORT` | `8081` | Leave as default; `reverse_proxy` targets this on loopback. |
+
+Compendiq's `trustProxy: true` honours Caddy's `X-Forwarded-*` headers (which Caddy sets automatically), so no extra env vars are needed for client-IP preservation.
+
+## Troubleshooting
+
+**1. LLM chat hangs on a spinning cursor; presence avatars never appear.**
+The `@sse` matcher isn't firing — Caddy is routing the request through the generic `reverse_proxy` which buffers. Two usual causes:
+- `path_regexp` is case-sensitive and anchored. Check your actual path: `/api/pages/abc/presence` matches, `/api/pages/abc/presence/heartbeat` (if a future backend adds it) does not.
+- The matcher block order matters in a Caddyfile. Put the `@sse` matcher **before** the catch-all `reverse_proxy` line — Caddy evaluates top-to-bottom.
+
+**2. "502 Bad Gateway" on first request.**
+Compendiq isn't bound on `127.0.0.1:8081`. Run `ss -tlnp | grep 8081` — if the bind is `0.0.0.0:8081` or missing entirely, fix the Compose `ports:` line and restart the frontend container.
+
+**3. Uploads over ~10 MB return 413.**
+`request_body max_size` defaults to 10 MB in Caddy. Raise it (see the snippet above — 30 MB is a safe starting point for a 25 MB diagram + JSON overhead).
+
+## Verification
+
+```bash
+# Reachability + cert.
+curl -I https://compendiq.corp.example.com/api/health
+# Expect: 200 OK, valid TLS (from Let's Encrypt or Caddy's internal CA).
+
+# SSE streaming (presence is the fastest sanity check — no LLM required).
+# Grab a JWT from the browser (DevTools → Application → Local Storage →
+# `compendiq-auth` → state.accessToken), substitute <TOKEN>.
+curl -N -H "Authorization: Bearer <TOKEN>" \
+     https://compendiq.corp.example.com/api/pages/<pageId>/presence
+# Expect: one `event: presence` frame every few seconds, streamed live.
+# If you get a single buffered blob at the end, `flush_interval -1` is
+# not bound to the route — revisit the @sse matcher.
+```
+
+> **Before tagging v0.4.0:** the founder should run the full verification on a fresh VM and update the `_last-verified_` stamp at the top of this file.

--- a/docs/integrations/reverse-proxy/nginx.md
+++ b/docs/integrations/reverse-proxy/nginx.md
@@ -137,7 +137,7 @@ The generic `server`-level `proxy_buffering off;` above is usually enough, but e
 ```nginx
 # Compendiq's long-lived SSE endpoints:
 #   /api/pages/{id}/presence   — live viewer list (v0.4 #301)
-#   /api/llm/ask, /chat, /summarize, /generate, /quality, /auto-tag, etc.
+#   /api/llm/*                 — all /api/llm/* streaming endpoints
 location ~ ^/api/(pages/[^/]+/presence|llm/) {
     proxy_pass http://127.0.0.1:8081;
 

--- a/docs/integrations/reverse-proxy/nginx.md
+++ b/docs/integrations/reverse-proxy/nginx.md
@@ -130,6 +130,36 @@ Raise `client_max_body_size 30m;` (or more) in the `server` block. 30 MB is enou
 **5. 502 Bad Gateway from nginx.**
 Compendiq isn't actually listening on `127.0.0.1:8081`. Run `ss -tlnp | grep 8081` on the proxy host; if the port isn't bound, fix the compose `ports:` line and restart.
 
+## Server-Sent Events (SSE) streaming routes
+
+The generic `server`-level `proxy_buffering off;` above is usually enough, but enterprises with a stricter base config often re-enable buffering globally — in which case the SSE routes need their own `location` block to be safe. Add this **above** the generic `location / { ... }` so nginx matches it first:
+
+```nginx
+# Compendiq's long-lived SSE endpoints:
+#   /api/pages/{id}/presence   — live viewer list (v0.4 #301)
+#   /api/llm/ask, /chat, /summarize, /generate, /quality, /auto-tag, etc.
+location ~ ^/api/(pages/[^/]+/presence|llm/) {
+    proxy_pass http://127.0.0.1:8081;
+
+    # Per-route overrides — critical for SSE.
+    proxy_buffering         off;
+    proxy_cache             off;
+    proxy_http_version      1.1;
+    chunked_transfer_encoding off;
+    proxy_read_timeout      3600s;   # SSE connections are long-lived.
+
+    # Preserve the same forwarded headers as the generic location.
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host  $host;
+    proxy_set_header Connection        "";
+}
+```
+
+Without this block, corporate nginx deployments with `proxy_buffering on;` in the base config will silently break both presence SSE (viewer avatars never update) and LLM streaming (chat responses arrive as one blob or time out). Adding the block is cheap insurance even if the server-level `proxy_buffering off;` is already present — the explicit location wins regardless of what other config snippets do elsewhere.
+
 ## Verification
 
 ```bash

--- a/docs/integrations/reverse-proxy/traefik.md
+++ b/docs/integrations/reverse-proxy/traefik.md
@@ -1,6 +1,6 @@
 # Compendiq behind Traefik
 
-_last-verified: 2026-04-24 (draft ships with v0.4; founder VM test pending before v0.4.0 tag)_
+_last-verified: 2026-04-24 (corrected after PR #328 review; founder VM test pending before v0.4.0 tag)_
 
 ## Who this is for
 
@@ -72,32 +72,28 @@ services:
       - "traefik.http.services.compendiq.loadBalancer.passHostHeader=true"
 
       # --- SSE-specific router ------------------------------------
-      # Separate router + service for SSE streams so we can disable
-      # response buffering WITHOUT disabling it for the rest of the
-      # app (which benefits from buffering on static assets).
+      # Traefik v3 streams responses by default — there is no
+      # "disable buffering" knob because there is no buffering to
+      # disable on the proxy path. Attaching a `buffering` middleware
+      # is what *introduces* response buffering (see Traefik issue
+      # traefik/traefik#12869 and the Buffering middleware reference
+      # docs: https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/buffering/).
+      # We keep a separate SSE router purely for clarity and higher
+      # priority, and to anchor any future streaming-specific config
+      # (HTTP/1.1 pinning, longer timeouts, etc.) without touching
+      # the main router.
       # Routes covered:
       #   /api/pages/*/presence  (live viewer list, v0.4 #301)
-      #   /api/llm/*             (ask / chat / summarize / generate / quality / auto-tag)
+      #   /api/llm/*             (all /api/llm/* streaming endpoints)
       - "traefik.http.routers.compendiq-sse.rule=Host(`compendiq.corp.example.com`) && (PathRegexp(`^/api/pages/[^/]+/presence$`) || PathPrefix(`/api/llm/`))"
       - "traefik.http.routers.compendiq-sse.entrypoints=websecure"
       - "traefik.http.routers.compendiq-sse.tls=true"
       - "traefik.http.routers.compendiq-sse.tls.certresolver=letsencrypt"
       - "traefik.http.routers.compendiq-sse.service=compendiq-sse"
-      - "traefik.http.routers.compendiq-sse.middlewares=compendiq-nobuf@docker"
       - "traefik.http.routers.compendiq-sse.priority=100"   # beats the generic router
 
       - "traefik.http.services.compendiq-sse.loadBalancer.server.port=8081"
       - "traefik.http.services.compendiq-sse.loadBalancer.passHostHeader=true"
-
-      # --- No-buffering middleware (critical for SSE) ------------
-      # maxResponseBodyBytes=0 and memResponseBodyBytes=0 together
-      # disable response buffering so SSE frames flush to the client
-      # as soon as the backend writes them. Without this, Traefik
-      # buffers the entire response and the stream only arrives when
-      # the backend closes the connection — at which point the UI
-      # spinner has long since timed out.
-      - "traefik.http.middlewares.compendiq-nobuf.buffering.maxResponseBodyBytes=0"
-      - "traefik.http.middlewares.compendiq-nobuf.buffering.memResponseBodyBytes=0"
 ```
 
 ### 3. Configure Compendiq's forwarded-headers trust
@@ -136,7 +132,7 @@ docker logs traefik 2>&1 | grep -i acme | tail -20
 ## Troubleshooting
 
 **1. LLM chat spinner never streams text; SSE presence stream cuts off after ~30 s.**
-The buffering middleware isn't bound to the SSE router, so Traefik is holding the response in memory. Verify with `docker inspect <compendiq-frontend-id> | grep nobuf` — you should see both `traefik.http.routers.compendiq-sse.middlewares=compendiq-nobuf@docker` **and** the two `buffering.*=0` middleware labels. The `@docker` provider suffix is required in v3 (in v2 it was implicit). Restart the container after fixing labels — Traefik re-reads them, but the active routing table isn't updated mid-request.
+A `buffering` middleware has been attached to the SSE router (or to the entrypoint / generic router above it) and is holding the response in memory until the backend closes the connection. Traefik v3 does **not** buffer by default — attaching a Buffering middleware is what turns buffering on, and the `maxResponseBodyBytes=0` / `memResponseBodyBytes=0` values mean "no size cap," not "disabled." Verify with `docker inspect <compendiq-frontend-id> | grep buffering` — the output should be empty for this router. If other middleware in your stack (auth, rate-limit, headers) is a `chain` that pulls in `buffering`, either drop `buffering` from the chain or exclude the `compendiq-sse` router from the chain. See the Traefik [Buffering middleware reference](https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/buffering/) and tracking issue [traefik/traefik#12869](https://github.com/traefik/traefik/issues/12869).
 
 **2. Browser DevTools shows 404 on WebSocket / EventSource connection.**
 Compendiq doesn't use WebSockets, but the EventSource (SSE) connection fails if the `compendiq-sse` router rule doesn't match. Two common misses:
@@ -161,7 +157,7 @@ Traefik v3 defaults to HTTP/2 on `websecure`. With many concurrent SSE connectio
 curl -I https://compendiq.corp.example.com/api/health
 # Expect: 200 OK, valid TLS cert
 
-# 2. SSE streaming through the no-buffer router. Grab a JWT from the
+# 2. SSE streaming through the dedicated SSE router. Grab a JWT from the
 #    browser (DevTools → Application → Local Storage → `compendiq-auth`
 #    → state.accessToken) and replace <TOKEN>. The presence route is
 #    the easiest to verify because it streams without needing an LLM.
@@ -171,6 +167,6 @@ curl -N -H "Authorization: Bearer <TOKEN>" \
 #         arriving one-by-one, NOT a single buffered blob after close.
 ```
 
-If the `curl -N` call returns a single blob rather than a stream of lines, the `compendiq-nobuf` middleware is not bound to the `compendiq-sse` router — revisit step 2. If the LLM streams work but presence hangs, check that `PathRegexp` matches your actual presence path (the leading anchor is easy to drop).
+If the `curl -N` call returns a single blob rather than a stream of lines, a `buffering` middleware is attached somewhere in the chain — see troubleshooting (#1). If the LLM streams work but presence hangs, check that `PathRegexp` matches your actual presence path (the leading anchor is easy to drop).
 
 > **Before tagging v0.4.0:** the founder should run the full step-by-step on a fresh VM, walk through the `curl` verification, and update the `_last-verified_` stamp at the top of this file with the test date.

--- a/docs/integrations/reverse-proxy/traefik.md
+++ b/docs/integrations/reverse-proxy/traefik.md
@@ -1,0 +1,176 @@
+# Compendiq behind Traefik
+
+_last-verified: 2026-04-24 (draft ships with v0.4; founder VM test pending before v0.4.0 tag)_
+
+## Who this is for
+
+Your company runs Docker Swarm or Docker Compose with Traefik v3 as the edge router — TLS terminates at Traefik, certificates come from Let's Encrypt or an internal ACME CA, and every service picks up its routing via Docker labels. You want to drop Compendiq into the same stack: one vanity hostname, auto-TLS, forwarded client IPs, and the LLM / presence streams working through the proxy without breaking.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    u[User browser]
+    u -->|HTTPS :443| tk[Traefik v3<br/>TLS terminator + ACME]
+    tk -->|HTTP :8081| cf[Compendiq frontend<br/>ghcr.io/…/ce-frontend]
+    cf -->|HTTP :3051| cb[Compendiq backend]
+    cb --> pg[(PostgreSQL<br/>internal network)]
+    cb --> rd[(Redis<br/>internal network)]
+    cb -->|HTTPS| cd[Confluence DC]
+    cb -->|HTTP| ol[Ollama]
+```
+
+Traefik attaches to the Docker socket, reads labels on the Compendiq containers, and auto-configures the router. PostgreSQL and Redis stay on the internal `compendiq` network — only the frontend is advertised to Traefik.
+
+## Prerequisites
+
+- Docker Compose v2.20+ (Swarm mode works too; the labels are the same).
+- Traefik v3.0+ already running with the Docker provider and an `websecure` entrypoint on `:443`. (Traefik v2.x works with minor label tweaks — the `.tls.certresolver` and `passHostHeader` keys are identical, but service-level middleware binding changed in v3.)
+- DNS record pointing `compendiq.corp.example.com` at the Traefik host.
+- Port 80 reachable if you use the HTTP-01 ACME challenge, or DNS credentials configured if you use DNS-01. On fully private DNS, plan on DNS-01 — see troubleshooting (#4).
+- A shared Docker network (commonly `traefik_proxy`) that Traefik and Compendiq both join.
+
+## Step-by-step
+
+### 1. Put the frontend on the shared Traefik network
+
+Compendiq's default `docker-compose.yml` puts every service on an internal `compendiq` network. Add a second network for the frontend container only:
+
+```yaml
+networks:
+  compendiq:
+    internal: true
+  traefik_proxy:
+    external: true   # already created by your Traefik stack
+```
+
+### 2. Stop exposing the frontend port publicly
+
+The bundled nginx inside the frontend image still listens on `8081`, but it should no longer be reachable from outside the Docker network. Remove the `ports:` mapping and let Traefik reach it over the shared network:
+
+```yaml
+services:
+  frontend:
+    image: ghcr.io/compendiq/compendiq-ce-frontend:<version>
+    # No `ports:` block — Traefik connects over traefik_proxy.
+    networks:
+      - compendiq
+      - traefik_proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik_proxy"
+
+      # --- Main HTTPS router ---------------------------------------
+      - "traefik.http.routers.compendiq.rule=Host(`compendiq.corp.example.com`)"
+      - "traefik.http.routers.compendiq.entrypoints=websecure"
+      - "traefik.http.routers.compendiq.tls=true"
+      - "traefik.http.routers.compendiq.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.compendiq.service=compendiq"
+
+      # --- Compendiq service target -------------------------------
+      - "traefik.http.services.compendiq.loadBalancer.server.port=8081"
+      - "traefik.http.services.compendiq.loadBalancer.passHostHeader=true"
+
+      # --- SSE-specific router ------------------------------------
+      # Separate router + service for SSE streams so we can disable
+      # response buffering WITHOUT disabling it for the rest of the
+      # app (which benefits from buffering on static assets).
+      # Routes covered:
+      #   /api/pages/*/presence  (live viewer list, v0.4 #301)
+      #   /api/llm/*             (ask / chat / summarize / generate / quality / auto-tag)
+      - "traefik.http.routers.compendiq-sse.rule=Host(`compendiq.corp.example.com`) && (PathRegexp(`^/api/pages/[^/]+/presence$`) || PathPrefix(`/api/llm/`))"
+      - "traefik.http.routers.compendiq-sse.entrypoints=websecure"
+      - "traefik.http.routers.compendiq-sse.tls=true"
+      - "traefik.http.routers.compendiq-sse.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.compendiq-sse.service=compendiq-sse"
+      - "traefik.http.routers.compendiq-sse.middlewares=compendiq-nobuf@docker"
+      - "traefik.http.routers.compendiq-sse.priority=100"   # beats the generic router
+
+      - "traefik.http.services.compendiq-sse.loadBalancer.server.port=8081"
+      - "traefik.http.services.compendiq-sse.loadBalancer.passHostHeader=true"
+
+      # --- No-buffering middleware (critical for SSE) ------------
+      # maxResponseBodyBytes=0 and memResponseBodyBytes=0 together
+      # disable response buffering so SSE frames flush to the client
+      # as soon as the backend writes them. Without this, Traefik
+      # buffers the entire response and the stream only arrives when
+      # the backend closes the connection — at which point the UI
+      # spinner has long since timed out.
+      - "traefik.http.middlewares.compendiq-nobuf.buffering.maxResponseBodyBytes=0"
+      - "traefik.http.middlewares.compendiq-nobuf.buffering.memResponseBodyBytes=0"
+```
+
+### 3. Configure Compendiq's forwarded-headers trust
+
+Set `FRONTEND_URL` on the backend service so CORS + setup-wizard redirects match the public hostname:
+
+```yaml
+services:
+  backend:
+    environment:
+      FRONTEND_URL: https://compendiq.corp.example.com
+    networks:
+      - compendiq
+```
+
+Fastify already runs with `trustProxy: true` (see `backend/src/app.ts`), so `X-Forwarded-For` and `X-Forwarded-Proto` from Traefik are honoured out of the box. `passHostHeader=true` on the service ensures the original `Host` header reaches the backend — needed for audit logs and rate-limit buckets to see the real hostname.
+
+### 4. Bring the stack up
+
+```bash
+docker compose pull
+docker compose up -d
+# Wait 30-60s for ACME to issue the cert on first boot
+docker logs traefik 2>&1 | grep -i acme | tail -20
+```
+
+## Configuration reference
+
+| Variable | Example | Why |
+|---|---|---|
+| `FRONTEND_URL` | `https://compendiq.corp.example.com` | CORS allowlist + setup-wizard redirect target. Must exactly match what Traefik exposes (scheme + host + port). |
+| `NODE_EXTRA_CA_CERTS` | `/etc/ssl/certs/corporate-ca.pem` | Only needed if Traefik presents an internal-CA cert on the backend-side leg (rare: most users terminate TLS at Traefik and speak plain HTTP on the internal network). |
+| `BACKEND_HOST_PORT` | unset | Do not expose. Keep it on the internal `compendiq` network — only Traefik reaches the frontend, and the backend is reached by the frontend. |
+| `FRONTEND_PORT` | `8081` | Leave as default; the Traefik `server.port` label targets this. |
+
+## Troubleshooting
+
+**1. LLM chat spinner never streams text; SSE presence stream cuts off after ~30 s.**
+The buffering middleware isn't bound to the SSE router, so Traefik is holding the response in memory. Verify with `docker inspect <compendiq-frontend-id> | grep nobuf` — you should see both `traefik.http.routers.compendiq-sse.middlewares=compendiq-nobuf@docker` **and** the two `buffering.*=0` middleware labels. The `@docker` provider suffix is required in v3 (in v2 it was implicit). Restart the container after fixing labels — Traefik re-reads them, but the active routing table isn't updated mid-request.
+
+**2. Browser DevTools shows 404 on WebSocket / EventSource connection.**
+Compendiq doesn't use WebSockets, but the EventSource (SSE) connection fails if the `compendiq-sse` router rule doesn't match. Two common misses:
+- The `PathRegexp` for presence requires an exact `^/api/pages/[^/]+/presence$` anchor. If your backend later adds sub-paths (e.g. `/presence/heartbeat`), extend the regex.
+- Traefik v3 path matchers are case-sensitive — `/API/llm/ask` will fall through to the generic router (which buffers).
+
+**3. Audit log shows Traefik's internal IP (`172.x.x.x`) instead of the real client IP.**
+`passHostHeader=true` is set but Traefik isn't forwarding `X-Forwarded-For`. Confirm Traefik's static config has `--entrypoints.websecure.forwardedHeaders.insecure=true` (if Traefik itself is behind another proxy) or `--entrypoints.websecure.forwardedHeaders.trustedIPs=<upstream-CIDR>`. Compendiq's `trustProxy: true` trusts whatever Traefik forwards, so the fix is upstream of Compendiq.
+
+**4. ACME certificate fails on a fully-private DNS zone.**
+HTTP-01 challenge can't reach the Traefik host from Let's Encrypt's servers. Two options:
+- Switch to DNS-01 via the `certificatesResolvers.<resolver>.acme.dnsChallenge` config — requires API credentials for your DNS provider (Route53, Cloudflare, RFC2136, etc.).
+- Use Traefik's built-in internal CA (`--providers.file ... tls.stores.default.defaultGeneratedCert`) and distribute the CA cert to client machines. Acceptable for fully-internal tools; less so for end-user browsers.
+
+**5. HTTP/2 + SSE: connection resets mid-stream on Traefik v3.**
+Traefik v3 defaults to HTTP/2 on `websecure`. With many concurrent SSE connections (several tabs per user × several users), you can hit the default `maxConcurrentStreams` cap (100) and see sporadic resets. Either pin the SSE router to HTTP/1.1 (`--entrypoints.websecure.http2.maxConcurrentStreams=-1` to disable the cap) or add a dedicated HTTP/1.1 entrypoint and route the `compendiq-sse` router there. Most deployments don't hit this until ~50 concurrent editors.
+
+## Verification
+
+```bash
+# 1. Basic reachability through the proxy (unauthenticated endpoint).
+curl -I https://compendiq.corp.example.com/api/health
+# Expect: 200 OK, valid TLS cert
+
+# 2. SSE streaming through the no-buffer router. Grab a JWT from the
+#    browser (DevTools → Application → Local Storage → `compendiq-auth`
+#    → state.accessToken) and replace <TOKEN>. The presence route is
+#    the easiest to verify because it streams without needing an LLM.
+curl -N -H "Authorization: Bearer <TOKEN>" \
+     https://compendiq.corp.example.com/api/pages/<pageId>/presence
+# Expect: a sequence of `event: presence\ndata: {...}\n\n` frames
+#         arriving one-by-one, NOT a single buffered blob after close.
+```
+
+If the `curl -N` call returns a single blob rather than a stream of lines, the `compendiq-nobuf` middleware is not bound to the `compendiq-sse` router — revisit step 2. If the LLM streams work but presence hangs, check that `PathRegexp` matches your actual presence path (the leading anchor is easy to drop).
+
+> **Before tagging v0.4.0:** the founder should run the full step-by-step on a fresh VM, walk through the `curl` verification, and update the `_last-verified_` stamp at the top of this file with the test date.


### PR DESCRIPTION
## Summary

Closes remaining work on #299. Adds the two reverse-proxy guides the issue called for (traefik must, caddy nice-to-have) and adds an SSE-buffering section to the existing nginx guide — relevant because #301 lands a new `/api/pages/:id/presence` SSE route in the same milestone.

## What's in

- **`docs/integrations/reverse-proxy/traefik.md`** (new) — full Traefik v3 Docker-Compose labels, separate SSE router bound to `PathRegexp(^/api/pages/[^/]+/presence$) \|\| PathPrefix(/api/llm/)` with `buffering.{max,mem}ResponseBodyBytes=0`, `passHostHeader=true`, ACME + private-DNS notes, top-5 troubleshooting, curl verification, `last-verified: 2026-04-24`.
- **`docs/integrations/reverse-proxy/caddy.md`** (new) — Caddyfile with `@sse` matcher + `flush_interval -1`, public auto-TLS and `tls internal` variants.
- **`docs/integrations/reverse-proxy/nginx.md`** — appended "Server-Sent Events (SSE) streaming routes" section with the exact `location ~ ^/api/(pages/[^/]+/presence\|llm/) { proxy_buffering off; ... }` block. Without this, both the new presence stream and the existing LLM streaming break behind nginx's default buffering.
- **`docs/integrations/README.md`** — linked the two new guides, bumped last-updated.

## Risk

Docs-only. Founder should re-verify the proxy configs on a fresh VM before the v0.4.0 tag per the `last-verified` banner (explicit acceptance criterion in #299).

## Test plan

- [x] Guides render cleanly
- [ ] Founder: Traefik config tested on a real VM
- [ ] Founder: Caddy config tested on a real VM
- [ ] Founder: nginx SSE block tested against a live presence/LLM stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)