### PR TITLE
docs(#297): link placeholder roadmap URL from README + STEWARDSHIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Compendiq is open-core. The Community Edition (this repo) is fully functional un
 
 Interested in Enterprise? [Open an issue](https://github.com/Compendiq/compendiq-ce/issues/new?template=enterprise-interest.md) or reach out via [GitHub Discussions](https://github.com/Compendiq/compendiq-ce/discussions).
 
+- **Public roadmap:** see what's in flight and what's next on the [Compendiq GitHub Project board](https://github.com/orgs/Compendiq/projects/TBD) <!-- TODO(#297): update to the real project URL once the board is created -->.
+
 ---
 
 ## Developer Quick Start

--- a/docs/STEWARDSHIP.md
+++ b/docs/STEWARDSHIP.md
@@ -106,6 +106,10 @@ If you believe this pledge has been violated, open an issue tagged `stewardship`
 
 ---
 
+## Open process
+
+Beyond the feature pledge, the stewardship of Compendiq is meant to be observable in public. To that end, we maintain a public [GitHub Project board](https://github.com/orgs/Compendiq/projects/TBD) <!-- TODO(#297): update to the real project URL once the board is created --> that shows what is being worked on right now, what is queued for the next phase, what is under consideration, and what has shipped in the last 90 days. If you want to understand where Compendiq is going — or influence it with an issue or a pull request — the board is the canonical answer, and it is updated alongside every release. The roadmap itself is not a commitment in the legal sense of this pledge, but publishing it is: we commit to keeping it honest, keeping it current, and not running a second, hidden roadmap that contradicts it.
+
 ## Changelog
 
 - **2026-04-23** — initial pledge drafted alongside v0.4.0 preparation (CE #296). _Founder review pending._


### PR DESCRIPTION
## Summary

Code-prep portion of #297. Adds a single README bullet and a STEWARDSHIP paragraph linking the future public Projects v2 roadmap board. Uses a `TBD` placeholder URL with an inline TODO comment — founder will create the org-level Project board separately (requires org-admin UI steps out of scope for a PR) and swap the URL in a follow-up.

## What's in

- **`README.md`** — one new bullet after the Enterprise/Discussions paragraph in the Community Edition section. No new top-level "Roadmap" section (explicit decision in #297).
- **`docs/STEWARDSHIP.md`** — new "## Open process" paragraph right before the Changelog, framed to fit the existing pledge tone.

Both link `https://github.com/orgs/Compendiq/projects/TBD` with `<!-- TODO(#297): update to the real project URL once the board is created -->`.

## Founder follow-up (NOT in this PR)

- Create the org-level Project at `Compendiq` with Now/Next/Later/Idea/Shipped columns
- Pre-create empty labels `phase-1.3` / `phase-2.0` / `phase-3.0` in CE + EE (color #0E8A16)
- Create v0.4.x / v0.5.x / v0.6.x milestones + tag open issues
- Pin the project on the org page
- Swap the two `TBD` URLs for the real Project URL

## Test plan

- [x] README bullet renders in the right section
- [x] STEWARDSHIP paragraph tone matches
- [ ] Founder: board created + URLs swapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)