### PR TITLE
feat(#301): usePresence hook + PresenceAvatarStack for real-time co-presence

### DIFF
--- a/frontend/src/features/pages/PageViewPage.test.tsx
+++ b/frontend/src/features/pages/PageViewPage.test.tsx
@@ -126,6 +126,10 @@ vi.mock('../../shared/lib/api', () => ({
   apiFetch: vi.fn().mockResolvedValue({}),
 }));
 
+vi.mock('./use-presence', () => ({
+  usePresence: () => ({ viewers: [], selfIsEditing: false, setEditing: vi.fn() }),
+}));
+
 vi.mock('../../shared/hooks/use-standalone', () => ({
   useSubmitFeedback: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useVerifyPage: () => ({ mutateAsync: vi.fn(), isPending: false }),

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -32,6 +32,8 @@ import type { TocHeading } from '../../shared/components/article/TableOfContents
 import { PageViewSkeleton } from '../../shared/components/feedback/Skeleton';
 import { TagEditor } from '../../shared/components/TagEditor';
 import { ShortcutHint } from '../../shared/components/ShortcutHint';
+import { usePresence } from './use-presence';
+import { PresenceAvatarStack } from './PresenceAvatarStack';
 
 function ImageLightbox({
   alt,
@@ -157,6 +159,13 @@ export function PageViewPage() {
   useEffect(() => {
     setStoreEditing(editing);
   }, [editing, setStoreEditing]);
+
+  // Real-time co-presence (#301). Propagates our editing flag to other viewers
+  // via a 10s heartbeat so the pencil badge toggles for them within one tick.
+  const { viewers: presenceViewers, setEditing: setPresenceEditing } = usePresence(id);
+  useEffect(() => {
+    setPresenceEditing(editing);
+  }, [editing, setPresenceEditing]);
 
   // Sync headings to the shared store (consumed by ArticleRightPane)
   useEffect(() => {
@@ -515,6 +524,7 @@ export function PageViewPage() {
           </span>
 
           <div className="flex shrink-0 items-center gap-1.5">
+            <PresenceAvatarStack viewers={presenceViewers} className="mr-1" />
             {editing ? (
               <>
                 <button

--- a/frontend/src/features/pages/PresenceAvatarStack.test.tsx
+++ b/frontend/src/features/pages/PresenceAvatarStack.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LazyMotion, domAnimation } from 'framer-motion';
+import { PresenceAvatarStack } from './PresenceAvatarStack';
+import type { PresenceViewer } from './use-presence';
+
+function wrap(ui: React.ReactElement) {
+  return render(<LazyMotion features={domAnimation}>{ui}</LazyMotion>);
+}
+
+const alice: PresenceViewer = { userId: 'u1', name: 'Alice', role: 'editor', isEditing: true };
+const bob: PresenceViewer = { userId: 'u2', name: 'Bob', role: 'viewer', isEditing: false };
+const carol: PresenceViewer = { userId: 'u3', name: 'Carol', role: 'viewer', isEditing: false };
+const dave: PresenceViewer = { userId: 'u4', name: 'Dave', role: 'viewer', isEditing: false };
+const eve: PresenceViewer = { userId: 'u5', name: 'Eve', role: 'admin', isEditing: true };
+
+describe('PresenceAvatarStack', () => {
+  it('renders nothing when there are no viewers', () => {
+    wrap(<PresenceAvatarStack viewers={[]} />);
+    expect(screen.queryByTestId('presence-avatar-stack')).toBeNull();
+  });
+
+  it('renders all viewers when count <= maxVisible', () => {
+    wrap(<PresenceAvatarStack viewers={[alice, bob]} />);
+    expect(screen.getAllByTestId('presence-avatar')).toHaveLength(2);
+    expect(screen.queryByTestId('presence-overflow')).toBeNull();
+  });
+
+  it('collapses to +N chip above maxVisible', () => {
+    wrap(<PresenceAvatarStack viewers={[alice, bob, carol, dave, eve]} />);
+    expect(screen.getAllByTestId('presence-avatar')).toHaveLength(3);
+    expect(screen.getByTestId('presence-overflow').textContent).toBe('+2');
+  });
+
+  it('shows pencil badge only on editors', () => {
+    wrap(<PresenceAvatarStack viewers={[alice, bob]} />);
+    const badges = screen.getAllByTestId('presence-editing-badge');
+    expect(badges).toHaveLength(1);
+    const editingAvatar = screen.getByText('Alice').closest('[data-testid="presence-avatar"]');
+    expect(editingAvatar?.getAttribute('data-is-editing')).toBe('true');
+  });
+
+  it('renders viewers in the order passed (caller sorts)', () => {
+    wrap(<PresenceAvatarStack viewers={[alice, bob, carol]} />);
+    const avatars = screen.getAllByTestId('presence-avatar');
+    expect(avatars[0]?.getAttribute('data-user-id')).toBe('u1');
+    expect(avatars[1]?.getAttribute('data-user-id')).toBe('u2');
+    expect(avatars[2]?.getAttribute('data-user-id')).toBe('u3');
+  });
+
+  it('shows tooltip with name and role via title attribute', () => {
+    wrap(<PresenceAvatarStack viewers={[alice, bob]} />);
+    const aliceAvatar = screen.getAllByTestId('presence-avatar')[0];
+    expect(aliceAvatar?.getAttribute('title')).toContain('Alice');
+    expect(aliceAvatar?.getAttribute('title')).toContain('editor');
+    expect(aliceAvatar?.getAttribute('title')).toContain('editing');
+    const bobAvatar = screen.getAllByTestId('presence-avatar')[1];
+    expect(bobAvatar?.getAttribute('title')).toContain('Bob');
+    expect(bobAvatar?.getAttribute('title')).not.toContain('editing');
+  });
+
+  it('respects custom maxVisible', () => {
+    wrap(<PresenceAvatarStack viewers={[alice, bob, carol, dave]} maxVisible={2} />);
+    expect(screen.getAllByTestId('presence-avatar')).toHaveLength(2);
+    expect(screen.getByTestId('presence-overflow').textContent).toBe('+2');
+  });
+});

--- a/frontend/src/features/pages/PresenceAvatarStack.tsx
+++ b/frontend/src/features/pages/PresenceAvatarStack.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from 'react';
+import { m } from 'framer-motion';
+import { Pencil } from 'lucide-react';
+import { cn } from '../../shared/lib/cn';
+import type { PresenceViewer } from './use-presence';
+
+interface PresenceAvatarStackProps {
+  viewers: PresenceViewer[];
+  maxVisible?: number;
+  className?: string;
+}
+
+function initialsOf(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return (parts[0] ?? '').slice(0, 2).toUpperCase();
+  return `${(parts[0] ?? '')[0] ?? ''}${(parts[1] ?? '')[0] ?? ''}`.toUpperCase();
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function PresenceAvatarStack({
+  viewers,
+  maxVisible = 3,
+  className,
+}: PresenceAvatarStackProps) {
+  const reduce = useMemo(prefersReducedMotion, []);
+  const visible = viewers.slice(0, maxVisible);
+  const overflow = Math.max(0, viewers.length - visible.length);
+
+  if (viewers.length === 0) return null;
+
+  const animation = reduce
+    ? { initial: false, animate: {}, exit: {} }
+    : {
+        initial: { opacity: 0, scale: 0.85 },
+        animate: { opacity: 1, scale: 1 },
+        exit: { opacity: 0, scale: 0.85 },
+      };
+
+  return (
+    <div
+      data-testid="presence-avatar-stack"
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full bg-card/80 backdrop-blur-md border border-white/10 px-2 py-1 shadow-sm',
+        className,
+      )}
+    >
+      <div className="flex items-center">
+        {visible.map((viewer, idx) => (
+          <m.span
+            key={viewer.userId}
+            {...animation}
+            transition={reduce ? { duration: 0 } : { delay: idx * 0.05, duration: 0.18 }}
+            title={`${viewer.name} (${viewer.role})${viewer.isEditing ? ' — editing' : ''}`}
+            data-testid="presence-avatar"
+            data-user-id={viewer.userId}
+            data-is-editing={viewer.isEditing ? 'true' : 'false'}
+            className={cn(
+              'relative flex h-7 w-7 items-center justify-center rounded-full border-2 border-card text-[10px] font-semibold text-foreground',
+              'bg-gradient-to-br from-primary/30 to-primary/10',
+              idx > 0 && '-ml-2',
+            )}
+            style={{ zIndex: visible.length - idx }}
+          >
+            {viewer.avatarUrl ? (
+              <img
+                src={viewer.avatarUrl}
+                alt=""
+                className="h-full w-full rounded-full object-cover"
+                aria-hidden="true"
+              />
+            ) : (
+              <span aria-hidden="true">{initialsOf(viewer.name)}</span>
+            )}
+            <span className="sr-only">{viewer.name}</span>
+            {viewer.isEditing && (
+              <span
+                data-testid="presence-editing-badge"
+                aria-label="editing"
+                className="absolute -bottom-0.5 -right-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-primary text-primary-foreground ring-2 ring-card"
+              >
+                <Pencil size={8} strokeWidth={2.5} />
+              </span>
+            )}
+          </m.span>
+        ))}
+      </div>
+      {overflow > 0 && (
+        <span
+          data-testid="presence-overflow"
+          className="ml-1 inline-flex h-6 items-center justify-center rounded-full bg-muted px-2 text-[10px] font-medium text-muted-foreground"
+        >
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/pages/use-presence.test.ts
+++ b/frontend/src/features/pages/use-presence.test.ts
@@ -180,6 +180,51 @@ describe('usePresence', () => {
     unmount();
   });
 
+  it('does not reconnect after a 401 from the SSE endpoint', async () => {
+    let sseOpens = 0;
+    let heartbeats = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : (url as URL).toString();
+      if (init?.method === 'POST' && urlStr.includes('/heartbeat')) {
+        heartbeats += 1;
+        return new Response(null, { status: 204 });
+      }
+      if (init?.method === 'DELETE') return new Response(null, { status: 204 });
+      sseOpens += 1;
+      return new Response(null, { status: 401 });
+    });
+
+    const { unmount } = renderHook(() => usePresence('page-1'));
+    await waitFor(() => expect(sseOpens).toBe(1));
+
+    // Advance past the full 30s backoff cap — no reconnect should be scheduled.
+    await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+    expect(sseOpens).toBe(1);
+    // Heartbeat interval should not fire either (auth is busted, no point spamming).
+    expect(heartbeats).toBe(0);
+
+    unmount();
+  });
+
+  it('does not reconnect after a 403 from the SSE endpoint', async () => {
+    let sseOpens = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : (url as URL).toString();
+      if (init?.method === 'POST' && urlStr.includes('/heartbeat')) return new Response(null, { status: 204 });
+      if (init?.method === 'DELETE') return new Response(null, { status: 204 });
+      sseOpens += 1;
+      return new Response(null, { status: 403 });
+    });
+
+    const { unmount } = renderHook(() => usePresence('page-1'));
+    await waitFor(() => expect(sseOpens).toBe(1));
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+    expect(sseOpens).toBe(1);
+
+    unmount();
+  });
+
   it('does not open a stream when pageId is null', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
     const { result } = renderHook(() => usePresence(null));

--- a/frontend/src/features/pages/use-presence.test.ts
+++ b/frontend/src/features/pages/use-presence.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor, cleanup } from '@testing-library/react';
+import { usePresence, type PresenceViewer } from './use-presence';
+import { useAuthStore } from '../../stores/auth-store';
+
+/**
+ * Helpers — each test builds a fresh fetch mock so we can thread a controlled
+ * ReadableStream into the hook's SSE reader loop.
+ */
+
+interface StreamHandle {
+  push: (s: string) => void;
+  close: () => void;
+  error: (err: unknown) => void;
+}
+
+function makeSseResponse(): { response: Response; handle: StreamHandle } {
+  const encoder = new TextEncoder();
+  let ctrl!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) { ctrl = c; },
+  });
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    }),
+    handle: {
+      push: (s) => ctrl.enqueue(encoder.encode(s)),
+      close: () => ctrl.close(),
+      error: (err) => ctrl.error(err),
+    },
+  };
+}
+
+function frame(viewers: PresenceViewer[], pageId = 'page-1'): string {
+  const payload = JSON.stringify({ viewers, pageId, ts: Date.now() });
+  return `event: presence\ndata: ${payload}\n\n`;
+}
+
+describe('usePresence', () => {
+  beforeEach(() => {
+    useAuthStore.getState().setAuth('token-abc', { id: 'self', username: 'me', role: 'user' });
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    // Unmount any still-mounted hooks BEFORE we restore the fetch mock, so the
+    // cleanup-path DELETE hits the spy rather than the real undici fetch (which
+    // rejects relative URLs in Node).
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    useAuthStore.getState().clearAuth();
+  });
+
+  it('opens the SSE stream, filters self out, and sorts editors first', async () => {
+    let handle: StreamHandle | null = null;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : (url as URL).toString();
+      if (init?.method === 'POST' && urlStr.includes('/heartbeat')) return new Response(null, { status: 204 });
+      if (init?.method === 'DELETE') return new Response(null, { status: 204 });
+      const { response, handle: h } = makeSseResponse();
+      handle = h;
+      return response;
+    });
+
+    const { result } = renderHook(() => usePresence('page-1'));
+
+    await waitFor(() => expect(handle).not.toBeNull());
+
+    await act(async () => {
+      handle!.push(frame([
+        { userId: 'self', name: 'Me', role: 'user', isEditing: false },
+        { userId: 'u-zed', name: 'Zed', role: 'viewer', isEditing: false },
+        { userId: 'u-alice', name: 'Alice', role: 'editor', isEditing: true },
+        { userId: 'u-bob', name: 'Bob', role: 'viewer', isEditing: false },
+      ]));
+    });
+
+    await waitFor(() => expect(result.current.viewers).toHaveLength(3));
+    // Self filtered out.
+    expect(result.current.viewers.find((v) => v.userId === 'self')).toBeUndefined();
+    // Editor first, then alphabetical.
+    expect(result.current.viewers.map((v) => v.name)).toEqual(['Alice', 'Bob', 'Zed']);
+  });
+
+  it('fires a heartbeat every 10 seconds carrying the current editing flag', async () => {
+    const heartbeats: Array<{ body: unknown }> = [];
+    let handle: StreamHandle | null = null;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : (url as URL).toString();
+      if (init?.method === 'POST' && urlStr.includes('/heartbeat')) {
+        heartbeats.push({ body: init.body ? JSON.parse(init.body as string) : null });
+        return new Response(null, { status: 204 });
+      }
+      if (init?.method === 'DELETE') return new Response(null, { status: 204 });
+      const { response, handle: h } = makeSseResponse();
+      handle = h;
+      return response;
+    });
+
+    const { result, unmount } = renderHook(() => usePresence('page-1'));
+
+    // Immediate heartbeat on connect.
+    await waitFor(() => expect(handle).not.toBeNull());
+    await waitFor(() => expect(heartbeats.length).toBeGreaterThanOrEqual(1));
+    expect(heartbeats[0]?.body).toEqual({ isEditing: false });
+
+    // Flipping editing state fires an immediate heartbeat.
+    act(() => { result.current.setEditing(true); });
+    await waitFor(() => expect(heartbeats.at(-1)?.body).toEqual({ isEditing: true }));
+
+    // The 10s interval fires again with the current flag.
+    const before = heartbeats.length;
+    await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+    expect(heartbeats.length).toBeGreaterThan(before);
+    expect(heartbeats.at(-1)?.body).toEqual({ isEditing: true });
+
+    unmount();
+  });
+
+  it('sends DELETE on unmount and stops the heartbeat interval', async () => {
+    let deletes = 0;
+    let heartbeats = 0;
+    let handle: StreamHandle | null = null;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : (url as URL).toString();
+      if (init?.method === 'POST' && urlStr.includes('/heartbeat')) {
+        heartbeats += 1;
+        return new Response(null, { status: 204 });
+      }
+      if (init?.method === 'DELETE') {
+        deletes += 1;
+        return new Response(null, { status: 204 });
+      }
+      const { response, handle: h } = makeSseResponse();
+      handle = h;
+      return response;
+    });
+
+    const { unmount } = renderHook(() => usePresence('page-1'));
+    await waitFor(() => expect(handle).not.toBeNull());
+    await waitFor(() => expect(heartbeats).toBeGreaterThanOrEqual(1));
+
+    const beforeUnmount = heartbeats;
+    unmount();
+    expect(deletes).toBeGreaterThanOrEqual(1);
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(15_000); });
+    expect(heartbeats).toBe(beforeUnmount);
+  });
+
+  it('reconnects with backoff after a stream error', async () => {
+    let sseOpens = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : (url as URL).toString();
+      if (init?.method === 'POST' && urlStr.includes('/heartbeat')) return new Response(null, { status: 204 });
+      if (init?.method === 'DELETE') return new Response(null, { status: 204 });
+      sseOpens += 1;
+      if (sseOpens === 1) {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(c) { queueMicrotask(() => c.error(new Error('boom'))); },
+          }),
+          { status: 200, headers: { 'content-type': 'text/event-stream' } },
+        );
+      }
+      const { response } = makeSseResponse();
+      return response;
+    });
+
+    const { unmount } = renderHook(() => usePresence('page-1'));
+    await waitFor(() => expect(sseOpens).toBe(1));
+
+    // Backoff is 1s for the first retry — advance past it.
+    await act(async () => { await vi.advanceTimersByTimeAsync(1_100); });
+    await waitFor(() => expect(sseOpens).toBeGreaterThanOrEqual(2));
+
+    unmount();
+  });
+
+  it('does not open a stream when pageId is null', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+    const { result } = renderHook(() => usePresence(null));
+    await act(async () => { await Promise.resolve(); });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.current.viewers).toEqual([]);
+  });
+});

--- a/frontend/src/features/pages/use-presence.ts
+++ b/frontend/src/features/pages/use-presence.ts
@@ -86,6 +86,15 @@ export function usePresence(pageId: string | null | undefined): {
           },
           signal: abort.signal,
         });
+        if (res.status === 401 || res.status === 403) {
+          // Session is broken — retrying won't help. Park until unmount.
+          cancelled = true;
+          if (heartbeatTimer) {
+            clearInterval(heartbeatTimer);
+            heartbeatTimer = null;
+          }
+          return;
+        }
         if (!res.ok || !res.body) {
           throw new Error(`Presence stream failed: ${res.status}`);
         }

--- a/frontend/src/features/pages/use-presence.ts
+++ b/frontend/src/features/pages/use-presence.ts
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAuthStore } from '../../stores/auth-store';
+
+export interface PresenceViewer {
+  userId: string;
+  name: string;
+  role: string;
+  isEditing: boolean;
+  avatarUrl?: string;
+}
+
+interface PresenceEvent {
+  viewers: PresenceViewer[];
+  pageId: string;
+  ts: number;
+}
+
+const HEARTBEAT_MS = 10_000;
+const BACKOFF_CAP_MS = 30_000;
+
+function sortViewers(viewers: PresenceViewer[]): PresenceViewer[] {
+  return [...viewers].sort((a, b) => {
+    if (a.isEditing !== b.isEditing) return a.isEditing ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export function usePresence(pageId: string | null | undefined): {
+  viewers: PresenceViewer[];
+  selfIsEditing: boolean;
+  setEditing: (v: boolean) => void;
+} {
+  const [viewers, setViewers] = useState<PresenceViewer[]>([]);
+  const [selfIsEditing, setSelfIsEditingState] = useState(false);
+  const selfIsEditingRef = useRef(false);
+  const selfUserId = useAuthStore((s) => s.user?.id);
+
+  const sendHeartbeat = useCallback(async (isEditing: boolean) => {
+    if (!pageId) return;
+    const { accessToken } = useAuthStore.getState();
+    try {
+      await fetch(`/api/pages/${encodeURIComponent(pageId)}/presence/heartbeat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
+        body: JSON.stringify({ isEditing }),
+      });
+    } catch {
+      // Heartbeat is best-effort; the server will evict us via ZRANGEBYSCORE.
+    }
+  }, [pageId]);
+
+  const setEditing = useCallback((v: boolean) => {
+    selfIsEditingRef.current = v;
+    setSelfIsEditingState(v);
+    void sendHeartbeat(v);
+  }, [sendHeartbeat]);
+
+  useEffect(() => {
+    if (!pageId) return;
+
+    const abort = new AbortController();
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let backoffMs = 1000;
+    let cancelled = false;
+
+    const applyEvent = (ev: PresenceEvent) => {
+      const withoutSelf = selfUserId
+        ? ev.viewers.filter((v) => v.userId !== selfUserId)
+        : ev.viewers;
+      setViewers(sortViewers(withoutSelf));
+    };
+
+    const connect = async () => {
+      if (cancelled) return;
+      try {
+        const { accessToken } = useAuthStore.getState();
+        const res = await fetch(`/api/pages/${encodeURIComponent(pageId)}/presence`, {
+          method: 'GET',
+          headers: {
+            Accept: 'text/event-stream',
+            ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+          },
+          signal: abort.signal,
+        });
+        if (!res.ok || !res.body) {
+          throw new Error(`Presence stream failed: ${res.status}`);
+        }
+
+        // Connected — reset backoff and fire an immediate heartbeat.
+        backoffMs = 1000;
+        void sendHeartbeat(selfIsEditingRef.current);
+        if (heartbeatTimer) clearInterval(heartbeatTimer);
+        heartbeatTimer = setInterval(() => {
+          void sendHeartbeat(selfIsEditingRef.current);
+        }, HEARTBEAT_MS);
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const frames = buffer.split('\n\n');
+          buffer = frames.pop() ?? '';
+          for (const frame of frames) {
+            const dataLine = frame.split('\n').find((l) => l.startsWith('data: '));
+            if (!dataLine) continue;
+            try {
+              applyEvent(JSON.parse(dataLine.slice(6)) as PresenceEvent);
+            } catch {
+              // Skip malformed frames.
+            }
+          }
+        }
+        throw new Error('stream closed');
+      } catch (err) {
+        if (cancelled || (err instanceof DOMException && err.name === 'AbortError')) return;
+        if (heartbeatTimer) {
+          clearInterval(heartbeatTimer);
+          heartbeatTimer = null;
+        }
+        const delay = backoffMs;
+        backoffMs = Math.min(backoffMs * 2, BACKOFF_CAP_MS);
+        reconnectTimer = setTimeout(() => { void connect(); }, delay);
+      }
+    };
+
+    void connect();
+
+    const handleBeforeUnload = () => {
+      const { accessToken } = useAuthStore.getState();
+      try {
+        void fetch(`/api/pages/${encodeURIComponent(pageId)}/presence`, {
+          method: 'DELETE',
+          headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
+          keepalive: true,
+        });
+      } catch {
+        // Best-effort; the server's 20s ZRANGEBYSCORE filter will evict us anyway.
+      }
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      cancelled = true;
+      abort.abort();
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      handleBeforeUnload();
+    };
+  }, [pageId, selfUserId, sendHeartbeat]);
+
+  return useMemo(
+    () => ({ viewers, selfIsEditing, setEditing }),
+    [viewers, selfIsEditing, setEditing],
+  );
+}


### PR DESCRIPTION
## Summary

Frontend half of #301 (ghost avatars for real-time co-presence). The backend half lands in a companion PR — this PR can be reviewed independently because the SSE contract is locked in the issue body and the hook is mocked in the PageViewPage test.

## What's in

- **`frontend/src/features/pages/use-presence.ts`** (+ test) — fetch-stream SSE consumer matching the existing LLM SSE pattern so bearer auth flows correctly. 10 s heartbeat via \`setInterval\`, exponential-backoff reconnect (1s → 2s → 4s, cap 30s), \`beforeunload\` + unmount DELETE via \`fetch({ keepalive: true })\` (sendBeacon doesn't support DELETE). Self is filtered out of the viewers list; editors sort first, then alphabetical.
- **`frontend/src/features/pages/PresenceAvatarStack.tsx`** (+ test) — Framer Motion staggered entrance, respects \`prefers-reduced-motion\`, up to 3 avatars + \`+N\` overflow chip, pencil badge for editors, \`title\`-attribute tooltip (matches the existing QualityScoreBadge pattern — no Radix Avatar/Tooltip in the repo today), glassmorphic \`bg-card/80 backdrop-blur-md border-white/10\` per ADR-010.
- **`frontend/src/features/pages/PageViewPage.tsx`** — wires the avatar stack into the action strip top-right of the title bar.
- **`frontend/src/features/pages/PageViewPage.test.tsx`** — adds \`vi.mock('./use-presence')\` so the existing diagram/fetch-count assertions aren't affected by the new hook's fetch calls.

## Acceptance criteria mapping (from #301)

- [x] Editing toggle + 10s heartbeat fires POST with \`isEditing\`
- [x] Unmount + \`beforeunload\` call DELETE
- [x] Reconnect on stream error with backoff
- [x] Editors sort first
- [x] \`prefers-reduced-motion\` respected
- [ ] 2 tabs see each other ≤10s — covered by backend PR + manual QA
- [ ] 2 pods behind LB broadcast correctly — covered by multi-pod integration test after both halves merge

## Test plan

- [x] \`npm run test -w frontend\` → 1862/1862 green
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [ ] Manual: open two tabs, verify avatar appears after backend PR merges
- [ ] Visual: glassmorphic + reduced-motion both look right

🤖 Generated with [Claude Code](https://claude.com/claude-code)