### PR TITLE
chore(#301): multi-pod presence smoke test + v0.4 verification report

### DIFF
--- a/docs/releases/v0.4-presence-multipod-smoke.md
+++ b/docs/releases/v0.4-presence-multipod-smoke.md
@@ -1,0 +1,91 @@
+# v0.4 presence — multi-pod smoke test
+
+Post-merge verification that the real-time presence service (issue [#301](https://github.com/Compendiq/compendiq-ce/issues/301)) satisfies its acceptance criterion **"Two backend pods behind a load balancer correctly broadcast presence to clients on different pods."** Backend code shipped in PR #331 (`003a0b1`), frontend in PR #330 (`aec50ed`).
+
+Unit tests exercise the in-process listener map; they don't cross process boundaries. This smoke test spins up **two real backend processes** against one shared Postgres + Redis and confirms Redis pub/sub fans heartbeats to SSE subscribers on the peer pod.
+
+## Topology
+
+```
+ client A ──SSE─▶ pod A (:3100) ─┐                ┌─ pod B (:3101) ◀─HB─ client B
+                                 ├─ postgres :5433 (shared test DB)
+                                 └─ redis :6380   (shared, throwaway)
+```
+
+- Postgres: `compendiq-test-postgres-test-1` (existing compose), `kb_creator_test` on `:5433`.
+- Redis: throwaway `compendiq-smoke-redis` (image `redis:8-alpine`) on `:6380` — kept off the EE/CE prod port.
+- Two Node processes launched via `tsx backend/src/index.ts`, same env except `BACKEND_PORT`.
+
+## Env vars (both pods)
+
+```
+POSTGRES_URL=postgresql://kb_user:changeme-postgres@localhost:5433/kb_creator_test
+REDIS_URL=redis://localhost:6380
+JWT_SECRET=smoke-test-secret-at-least-32-chars-long
+PAT_ENCRYPTION_KEY=smoke-test-pat-key-at-least-32-chars
+NODE_ENV=development
+USE_BULLMQ=false            # setInterval workers — no bullmq queue noise
+BACKEND_PORT=3100           # pod A (3101 for pod B)
+```
+
+## Seed
+
+```sql
+-- two users, role='admin' so userCanAccessPage short-circuits via the system-admin bypass
+INSERT INTO users (id, username, password_hash, role, display_name) VALUES
+  ('aaaaaaaa-0000-0000-0000-000000000001', 'smoke_user_a', 'not-used', 'admin', 'Alice Smoke'),
+  ('aaaaaaaa-0000-0000-0000-000000000002', 'smoke_user_b', 'not-used', 'admin', 'Bob Smoke');
+
+-- one standalone/shared page (visibility rule also short-circuits userCanAccessPage)
+INSERT INTO pages (title, source, visibility, inherit_perms)
+VALUES ('smoke-test-page', 'standalone', 'shared', true)
+RETURNING id;   -- => 2687
+```
+
+JWTs are minted directly against `JWT_SECRET` with `jose` (HS256, issuer `compendiq`, 2h expiry). No login route call needed.
+
+## Script
+
+`scripts/smoke-presence-multipod.mjs`. Opens an SSE stream on one pod, posts `POST /api/pages/:id/presence/heartbeat` on the **other** pod as a different user, and resolves when a `presence` event carrying the heartbeating user's id arrives on the SSE stream. Runs both directions back-to-back.
+
+## Output
+
+```
+[smoke] multi-pod presence smoke test
+  pod A = http://127.0.0.1:3100, pod B = http://127.0.0.1:3101, pageId = 2687
+
+=== DIRECTION 1: SSE on A, heartbeat on B (expect user B in A's stream) ===
+  SSE on http://127.0.0.1:3100, heartbeat on http://127.0.0.1:3101, expect viewer aaaaaaaa-0000-0000-0000-000000000002
+  heartbeat posted to http://127.0.0.1:3101
+  received 2 SSE event(s)
+    event: viewers=[]
+    event: viewers=[aaaaaaaa-0000-0000-0000-000000000002]
+  DIRECTION 1: SSE on A, heartbeat on B (expect user B in A's stream): PASS
+
+=== DIRECTION 2: SSE on B, heartbeat on A (expect user A in B's stream) ===
+  SSE on http://127.0.0.1:3101, heartbeat on http://127.0.0.1:3100, expect viewer aaaaaaaa-0000-0000-0000-000000000001
+  heartbeat posted to http://127.0.0.1:3100
+  received 2 SSE event(s)
+    event: viewers=[aaaaaaaa-0000-0000-0000-000000000002]
+    event: viewers=[aaaaaaaa-0000-0000-0000-000000000001,aaaaaaaa-0000-0000-0000-000000000002]
+  DIRECTION 2: SSE on B, heartbeat on A (expect user A in B's stream): PASS
+
+=== SUMMARY ===
+  direction 1 (A sees B): PASS
+  direction 2 (B sees A): PASS
+  overall: PASS
+```
+
+## Verdict
+
+| direction                                        | verdict |
+| ------------------------------------------------ | :-----: |
+| pod A's SSE stream sees a heartbeat from pod B   | **PASS** |
+| pod B's SSE stream sees a heartbeat from pod A   | **PASS** |
+
+Cross-pod Redis pub/sub fan-out (`PSUBSCRIBE presence:page:*`) is wired correctly on both pods. Issue #301's multi-pod acceptance criterion is satisfied on the current `dev` tip.
+
+## Notes
+
+- Direction 2 snapshot contains user B because the ZSET entry from direction 1 is still within the 20 s `ACTIVE_WINDOW_SEC`. Expected and harmless.
+- Redis was thrown away (`docker rm -f compendiq-smoke-redis`) after the run; the test postgres is shared with other suites and stayed up.

--- a/scripts/smoke-presence-multipod.mjs
+++ b/scripts/smoke-presence-multipod.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Multi-pod presence smoke test (issue #301 acceptance criterion).
+ *
+ * Setup (done externally, see docs/releases/v0.4-presence-multipod-smoke.md):
+ *   - One shared Postgres (test DB) + one shared Redis
+ *   - Two backend processes: pod A on :3100, pod B on :3101 using the same
+ *     POSTGRES_URL + REDIS_URL.
+ *   - Two seeded users (A, B) with role='admin' and one standalone page with
+ *     visibility='shared' so userCanAccessPage() resolves true for both.
+ *
+ * Env inputs (required):
+ *   POD_A_URL       e.g. http://127.0.0.1:3100
+ *   POD_B_URL       e.g. http://127.0.0.1:3101
+ *   JWT_A           access token for user A (HS256, matches backend JWT_SECRET)
+ *   JWT_B           access token for user B
+ *   USER_A_ID       uuid of user A (used to assert viewers contains A)
+ *   USER_B_ID       uuid of user B
+ *   PAGE_ID         integer pages.id used in the presence routes
+ *   SSE_WAIT_MS     optional, default 6000 (ms to wait for the fan-out event)
+ *
+ * Exits 0 on PASS (both directions), 1 on FAIL.
+ */
+
+const POD_A_URL = mustEnv('POD_A_URL');
+const POD_B_URL = mustEnv('POD_B_URL');
+const JWT_A = mustEnv('JWT_A');
+const JWT_B = mustEnv('JWT_B');
+const USER_A_ID = mustEnv('USER_A_ID');
+const USER_B_ID = mustEnv('USER_B_ID');
+const PAGE_ID = mustEnv('PAGE_ID');
+const SSE_WAIT_MS = parseInt(process.env.SSE_WAIT_MS ?? '6000', 10);
+
+function mustEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`[smoke] missing required env ${name}`);
+    process.exit(2);
+  }
+  return v;
+}
+
+/**
+ * Open an SSE stream on `baseUrl` for `pageId`, collect presence events,
+ * and resolve when `predicate(viewers)` matches or the deadline fires.
+ *
+ * Returns { matched: boolean, events: Event[], error?: Error }.
+ */
+async function waitForPresenceEvent(baseUrl, jwt, pageId, predicate, timeoutMs) {
+  const controller = new AbortController();
+  const events = [];
+  let matched = false;
+  let settled = false;
+
+  const url = `${baseUrl}/api/pages/${pageId}/presence`;
+  const deadline = setTimeout(() => {
+    if (!settled) controller.abort();
+  }, timeoutMs);
+
+  try {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${jwt}`, Accept: 'text/event-stream' },
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      clearTimeout(deadline);
+      return { matched: false, events, error: new Error(`SSE HTTP ${res.status}`) };
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+
+      // Split on SSE event boundaries (double newline).
+      let idx;
+      while ((idx = buf.indexOf('\n\n')) !== -1) {
+        const raw = buf.slice(0, idx);
+        buf = buf.slice(idx + 2);
+        const dataLine = raw.split('\n').find((l) => l.startsWith('data: '));
+        if (!dataLine) continue;
+        let parsed;
+        try {
+          parsed = JSON.parse(dataLine.slice(6));
+        } catch (err) {
+          continue;
+        }
+        events.push(parsed);
+        if (predicate(parsed.viewers ?? [])) {
+          matched = true;
+          settled = true;
+          controller.abort();
+          break;
+        }
+      }
+      if (matched) break;
+    }
+  } catch (err) {
+    if (!matched && err.name !== 'AbortError') {
+      clearTimeout(deadline);
+      return { matched: false, events, error: err };
+    }
+  }
+  clearTimeout(deadline);
+  return { matched, events };
+}
+
+async function postHeartbeat(baseUrl, jwt, pageId, isEditing) {
+  const res = await fetch(`${baseUrl}/api/pages/${pageId}/presence/heartbeat`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ isEditing }),
+  });
+  if (res.status !== 204) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`heartbeat HTTP ${res.status}: ${body}`);
+  }
+}
+
+async function runDirection(label, ssePod, sseJwt, hbPod, hbJwt, expectUserId) {
+  console.log(`\n=== ${label} ===`);
+  console.log(`  SSE on ${ssePod}, heartbeat on ${hbPod}, expect viewer ${expectUserId}`);
+
+  // Open SSE first, wait a tick so the subscribe is registered, then heartbeat.
+  const ssePromise = waitForPresenceEvent(
+    ssePod,
+    sseJwt,
+    PAGE_ID,
+    (viewers) => viewers.some((v) => v.userId === expectUserId),
+    SSE_WAIT_MS,
+  );
+
+  // Small delay so the SSE stream has issued its initial snapshot and the
+  // subscribeToPage() listener is registered before we publish.
+  await new Promise((r) => setTimeout(r, 400));
+
+  try {
+    await postHeartbeat(hbPod, hbJwt, PAGE_ID, false);
+    console.log(`  heartbeat posted to ${hbPod}`);
+  } catch (err) {
+    console.log(`  heartbeat FAILED: ${err.message}`);
+    return false;
+  }
+
+  const { matched, events, error } = await ssePromise;
+  if (error) {
+    console.log(`  SSE error: ${error.message}`);
+  }
+  console.log(`  received ${events.length} SSE event(s)`);
+  for (const e of events) {
+    const vs = (e.viewers ?? []).map((v) => v.userId).join(',');
+    console.log(`    event: viewers=[${vs}]`);
+  }
+  console.log(`  ${label}: ${matched ? 'PASS' : 'FAIL'}`);
+  return matched;
+}
+
+async function main() {
+  console.log('[smoke] multi-pod presence smoke test');
+  console.log(`  pod A = ${POD_A_URL}, pod B = ${POD_B_URL}, pageId = ${PAGE_ID}`);
+
+  const fwd = await runDirection(
+    'DIRECTION 1: SSE on A, heartbeat on B (expect user B in A\'s stream)',
+    POD_A_URL,
+    JWT_A,
+    POD_B_URL,
+    JWT_B,
+    USER_B_ID,
+  );
+
+  // Small gap so the Redis TTLs for the previous heartbeat don't interfere.
+  await new Promise((r) => setTimeout(r, 500));
+
+  const rev = await runDirection(
+    'DIRECTION 2: SSE on B, heartbeat on A (expect user A in B\'s stream)',
+    POD_B_URL,
+    JWT_B,
+    POD_A_URL,
+    JWT_A,
+    USER_A_ID,
+  );
+
+  console.log('\n=== SUMMARY ===');
+  console.log(`  direction 1 (A sees B): ${fwd ? 'PASS' : 'FAIL'}`);
+  console.log(`  direction 2 (B sees A): ${rev ? 'PASS' : 'FAIL'}`);
+  const ok = fwd && rev;
+  console.log(`  overall: ${ok ? 'PASS' : 'FAIL'}`);
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('[smoke] unexpected error', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Post-merge smoke test for issue #301's "two pods broadcast across a load balancer" acceptance criterion.
- Adds `scripts/smoke-presence-multipod.mjs` — spins up two SSE streams and cross-pod heartbeats, asserts the expected viewer shows up in each stream via Redis pub/sub.
- Adds `docs/releases/v0.4-presence-multipod-smoke.md` with topology, env, seed, and raw PASS/FAIL output.

Backend (#331, `003a0b1`) and frontend (#330, `aec50ed`) are already merged into `dev`; this PR is verification-only, no production code changed.

## Result

| direction | verdict |
| --- | :---: |
| pod A sees heartbeat from pod B | **PASS** |
| pod B sees heartbeat from pod A | **PASS** |

## Test plan

- [x] `scripts/smoke-presence-multipod.mjs` run against two live backends + throwaway Redis (`:6380`) + shared test Postgres (`:5433`)
- [x] Both SSE streams received the expected `presence` event within the 6 s wait window
- [x] Both pods + smoke Redis torn down cleanly after the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)