### PR TITLE
feat(v0.4,#114): emit webhook events from page CRUD, sync, AI workers

### DIFF
--- a/backend/src/domains/confluence/services/sync-service-webhooks.test.ts
+++ b/backend/src/domains/confluence/services/sync-service-webhooks.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Webhook emit-call-site tests for sync-service (#114).
+ *
+ * Verifies that `emitWebhookEvent` fires `sync.completed` once per synced
+ * space on the success path with the expected aggregate counters, and is NOT
+ * called when the sync errors before the syncSpace finalisation block runs.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { QueryResult } from 'pg';
+import type { RedisClientType } from 'redis';
+
+// ── Mocks (mirror sync-service.test.ts so the module-under-test loads) ───────
+
+vi.mock('../../../core/utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../../core/db/postgres.js', () => ({
+  query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+}));
+
+vi.mock('../../../core/services/rbac-service.js', () => ({
+  getUserAccessibleSpaces: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../../core/utils/crypto.js', () => ({
+  decryptPat: vi.fn().mockReturnValue('decrypted-pat'),
+}));
+
+vi.mock('../../../core/utils/ssrf-guard.js', () => ({
+  addAllowedBaseUrlSilent: vi.fn(),
+}));
+
+const mockConfluenceClientInstance: Record<string, ReturnType<typeof vi.fn>> = {
+  getAllSpaces: vi.fn().mockResolvedValue([]),
+  getAllPagesInSpace: vi.fn().mockResolvedValue([]),
+  getModifiedPages: vi.fn().mockResolvedValue([]),
+  getPage: vi.fn(),
+  getPageAttachments: vi.fn().mockResolvedValue({ results: [] }),
+};
+
+vi.mock('./confluence-client.js', () => ({
+  ConfluenceClient: vi.fn(function (this: Record<string, ReturnType<typeof vi.fn>>) {
+    Object.assign(this, mockConfluenceClientInstance);
+  }),
+}));
+
+vi.mock('../../../core/services/content-converter.js', () => ({
+  confluenceToHtml: vi.fn().mockReturnValue('<p>html</p>'),
+  htmlToText: vi.fn().mockReturnValue('text'),
+}));
+
+vi.mock('./attachment-handler.js', () => ({
+  syncDrawioAttachments: vi.fn(),
+  syncImageAttachments: vi.fn(),
+  cleanPageAttachments: vi.fn(),
+  getMissingAttachments: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../../core/services/version-snapshot.js', () => ({
+  saveVersionSnapshot: vi.fn(),
+}));
+
+vi.mock('../../llm/services/embedding-service.js', () => ({
+  processDirtyPages: vi.fn().mockResolvedValue({ processed: 0, errors: 0 }),
+}));
+
+const mockEmitWebhookEvent = vi.fn();
+vi.mock('../../../core/services/webhook-emit-hook.js', () => ({
+  emitWebhookEvent: (...args: unknown[]) => mockEmitWebhookEvent(...args),
+}));
+
+const mockRedisSet = vi.fn();
+const mockRedisGet = vi.fn();
+const mockRedisEval = vi.fn();
+
+let mockRedisClient: RedisClientType | null = null;
+
+function createMockRedis() {
+  return {
+    get: mockRedisGet,
+    set: mockRedisSet,
+    del: vi.fn(),
+    eval: mockRedisEval,
+    exists: vi.fn(),
+    scan: vi.fn(),
+    incr: vi.fn(),
+    expire: vi.fn(),
+    setEx: vi.fn(),
+    ping: vi.fn(),
+  } as unknown as RedisClientType;
+}
+
+vi.mock('../../../core/services/redis-cache.js', () => ({
+  getRedisClient: () => mockRedisClient,
+  recordAttachmentFailure: vi.fn(),
+  getAttachmentFailureCount: vi.fn().mockResolvedValue(0),
+  clearAttachmentFailures: vi.fn(),
+  MAX_ATTACHMENT_FAILURES: 3,
+}));
+
+// Now import the module under test
+import { syncUser } from './sync-service.js';
+import { query } from '../../../core/db/postgres.js';
+import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Configure mocks for a single-space full-sync run.
+ *
+ * @param confluencePages — pages reported by Confluence for the space
+ * @param dbPages         — confluence_ids already in the local DB
+ */
+function setupSyncMocks(opts: {
+  confluencePages: Array<{ id: string; title: string; version?: number }>;
+  dbPages?: string[];
+  rbacUserCount?: number;
+}) {
+  const { confluencePages, dbPages = [], rbacUserCount = 1 } = opts;
+
+  mockConfluenceClientInstance.getAllSpaces.mockResolvedValue([
+    { key: 'TEST', name: 'Test Space', homepage: null },
+  ]);
+  mockConfluenceClientInstance.getAllPagesInSpace.mockResolvedValue(
+    confluencePages.map((p) => ({ id: p.id, title: p.title, status: 'current' })),
+  );
+  mockConfluenceClientInstance.getModifiedPages.mockResolvedValue([]);
+  mockConfluenceClientInstance.getPage.mockImplementation((id: string) => {
+    const summary = confluencePages.find((p) => p.id === id);
+    return Promise.resolve({
+      id,
+      title: summary?.title ?? `Page ${id}`,
+      body: { storage: { value: '<p>content</p>' } },
+      version: {
+        number: summary?.version ?? 1,
+        when: '2025-01-01T00:00:00Z',
+        by: { displayName: 'Author' },
+      },
+      metadata: { labels: { results: [] } },
+      ancestors: [],
+    });
+  });
+  mockConfluenceClientInstance.getPageAttachments.mockResolvedValue({ results: [] });
+
+  vi.mocked(getUserAccessibleSpaces).mockResolvedValue(['TEST']);
+
+  vi.mocked(query).mockImplementation(async (sql: string, _params?: unknown[]) => {
+    const sqlStr = typeof sql === 'string' ? sql : '';
+    const empty = { rows: [], rowCount: 0, command: '', oid: 0, fields: [] };
+
+    if (sqlStr.includes('confluence_url') && sqlStr.includes('user_settings')) {
+      return {
+        rows: [{ confluence_url: 'https://confluence.test', confluence_pat: 'enc' }],
+        rowCount: 1, command: '', oid: 0, fields: [],
+      } as QueryResult;
+    }
+    if (sqlStr.includes('INSERT INTO spaces')) return empty as QueryResult;
+    if (sqlStr.includes('last_synced') && sqlStr.includes('FROM spaces')) {
+      // null → forces full sync (so detectDeletedPages runs)
+      return { rows: [{ last_synced: null }], rowCount: 1, command: '', oid: 0, fields: [] } as QueryResult;
+    }
+    // syncPage: SELECT version, title, body_html, body_text FROM pages WHERE confluence_id = $1
+    if (sqlStr.includes('SELECT version') && sqlStr.includes('FROM pages')) {
+      return empty as QueryResult; // fresh create for every page in confluencePages
+    }
+    if (sqlStr.includes('INSERT INTO pages')) return empty as QueryResult;
+    // detectDeletedPages: COUNT(DISTINCT principal_id)
+    if (sqlStr.includes('COUNT(DISTINCT principal_id)')) {
+      return {
+        rows: [{ count: String(rbacUserCount) }],
+        rowCount: 1, command: '', oid: 0, fields: [],
+      } as QueryResult;
+    }
+    // detectDeletedPages: SELECT confluence_id FROM pages WHERE space_key = $1 AND deleted_at IS NULL
+    if (sqlStr.includes('SELECT confluence_id FROM pages') && sqlStr.includes('deleted_at IS NULL')) {
+      return {
+        rows: dbPages.map((id) => ({ confluence_id: id })),
+        rowCount: dbPages.length, command: '', oid: 0, fields: [],
+      } as QueryResult;
+    }
+    // detectDeletedPages: soft-delete UPDATE
+    if (sqlStr.includes('UPDATE pages SET deleted_at = NOW()')) {
+      return { rows: [], rowCount: 1, command: 'UPDATE', oid: 0, fields: [] } as QueryResult;
+    }
+    // purgeDeletedPages: DELETE old soft-deleted
+    if (sqlStr.includes('DELETE FROM pages') && sqlStr.includes('deleted_at <')) {
+      return { rows: [], rowCount: 0, command: 'DELETE', oid: 0, fields: [] } as QueryResult;
+    }
+    if (sqlStr.includes('UPDATE spaces SET last_synced')) return empty as QueryResult;
+    return empty as QueryResult;
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('sync-service webhook emit call-sites', () => {
+  beforeEach(() => {
+    mockRedisClient = createMockRedis();
+    mockRedisSet.mockResolvedValue('OK');
+    mockRedisGet.mockResolvedValue(null);
+    mockRedisEval.mockResolvedValue(1);
+    mockEmitWebhookEvent.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('emits sync.completed once per space with aggregate counts', async () => {
+    setupSyncMocks({
+      confluencePages: [
+        { id: 'p1', title: 'Page 1' },
+        { id: 'p2', title: 'Page 2' },
+      ],
+      dbPages: [], // both pages are fresh creates
+    });
+
+    await syncUser('user-1');
+
+    const completedCalls = mockEmitWebhookEvent.mock.calls.filter(
+      (c) => c[0]?.eventType === 'sync.completed',
+    );
+    expect(completedCalls).toHaveLength(1);
+
+    const event = completedCalls[0]![0];
+    expect(event.payload).toMatchObject({
+      spaceKey: 'TEST',
+      pagesCreated: 2,
+      pagesUpdated: 0,
+      pagesDeleted: 0,
+    });
+    expect(typeof event.payload.durationMs).toBe('number');
+    expect(event.payload.durationMs).toBeGreaterThanOrEqual(0);
+    expect(typeof event.payload.completedAt).toBe('string');
+  });
+
+  it('counts soft-deletes from detectDeletedPages in pagesDeleted', async () => {
+    // DB has p1 + p2; Confluence reports only p1 → p2 must be soft-deleted.
+    setupSyncMocks({
+      confluencePages: [{ id: 'p1', title: 'Page 1' }],
+      dbPages: ['p1', 'p2'],
+    });
+
+    await syncUser('user-1');
+
+    const completedCalls = mockEmitWebhookEvent.mock.calls.filter(
+      (c) => c[0]?.eventType === 'sync.completed',
+    );
+    expect(completedCalls).toHaveLength(1);
+
+    expect(completedCalls[0]![0].payload).toMatchObject({
+      spaceKey: 'TEST',
+      pagesCreated: 1, // p1 was a fresh create
+      pagesDeleted: 1, // p2 was soft-deleted
+    });
+  });
+
+  it('does NOT emit per-page page.created/updated/deleted from sync (one event per run)', async () => {
+    setupSyncMocks({
+      confluencePages: [{ id: 'p1', title: 'Page 1' }],
+      dbPages: ['p1', 'p2'],
+    });
+
+    await syncUser('user-1');
+
+    // Only sync.completed should be emitted; per-page events would
+    // double-fire alongside the aggregate counters.
+    const types = mockEmitWebhookEvent.mock.calls.map((c) => c[0]?.eventType);
+    expect(types.every((t) => t === 'sync.completed')).toBe(true);
+    expect(types).not.toContain('page.created');
+    expect(types).not.toContain('page.updated');
+    expect(types).not.toContain('page.deleted');
+  });
+
+  it('does NOT emit sync.completed when getAllSpaces throws before syncSpace finalises', async () => {
+    setupSyncMocks({ confluencePages: [] });
+    mockConfluenceClientInstance.getAllSpaces.mockRejectedValue(new Error('Confluence down'));
+
+    await expect(syncUser('user-1')).rejects.toThrow('Confluence down');
+
+    expect(mockEmitWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it('does NOT emit sync.completed when no spaces are accessible (sync skipped)', async () => {
+    setupSyncMocks({ confluencePages: [] });
+    vi.mocked(getUserAccessibleSpaces).mockResolvedValue([]);
+
+    await syncUser('user-1');
+
+    expect(mockEmitWebhookEvent).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/domains/confluence/services/sync-service.ts
+++ b/backend/src/domains/confluence/services/sync-service.ts
@@ -13,6 +13,7 @@ import { saveVersionSnapshot } from '../../../core/services/version-snapshot.js'
 import { processDirtyPages } from '../../llm/services/embedding-service.js';
 import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
 import { logAuditEvent } from '../../../core/services/audit-service.js';
+import { emitWebhookEvent } from '../../../core/services/webhook-emit-hook.js';
 import { decryptPat } from '../../../core/utils/crypto.js';
 import { addAllowedBaseUrlSilent } from '../../../core/utils/ssrf-guard.js';
 import { logger } from '../../../core/utils/logger.js';
@@ -195,6 +196,18 @@ export async function syncUser(userId: string): Promise<void> {
   }
 }
 
+/**
+ * Per-space counters for the `sync.completed` webhook event (#114).
+ * Mutated in-place by `syncPage` / `detectDeletedPages` so the totals visible
+ * to `emitWebhookEvent` cover every page touched in this sync run for this
+ * space.
+ */
+interface SyncSpaceCounts {
+  pagesCreated: number;
+  pagesUpdated: number;
+  pagesDeleted: number;
+}
+
 async function syncSpace(
   client: ConfluenceClient,
   userId: string,
@@ -203,6 +216,9 @@ async function syncSpace(
   syncRunStartedAt: Date,
   ancestorCache: Map<string, ConfluenceRestriction[]>,
 ): Promise<void> {
+  const spaceStartedAt = Date.now();
+  const counts: SyncSpaceCounts = { pagesCreated: 0, pagesUpdated: 0, pagesDeleted: 0 };
+
   logger.info({ userId, spaceKey }, 'Syncing space');
 
   // Upsert shared space metadata (no user_id)
@@ -245,7 +261,7 @@ async function syncSpace(
     });
 
     const page = pages[i]!;
-    await syncPage(client, userId, spaceKey, page, syncRunStartedAt, ancestorCache);
+    await syncPage(client, userId, spaceKey, page, syncRunStartedAt, ancestorCache, counts);
   }
 
   // During incremental sync, also check for pages with missing attachments
@@ -257,7 +273,7 @@ async function syncSpace(
 
   // Detect deleted pages (only during full sync)
   if (!lastSynced || (Date.now() - lastSynced.getTime()) >= 24 * 60 * 60 * 1000) {
-    await detectDeletedPages(client, spaceKey, pages);
+    await detectDeletedPages(client, spaceKey, pages, counts);
   }
 
   // Purge pages that have been soft-deleted for more than 30 days
@@ -268,6 +284,21 @@ async function syncSpace(
     'UPDATE spaces SET last_synced = NOW() WHERE space_key = $1',
     [spaceKey],
   );
+
+  // Emit sync.completed webhook for this space (#114). Aggregate counters
+  // mean receivers don't need per-page page.created/updated/deleted from
+  // sync (those would double-fire alongside this event).
+  emitWebhookEvent({
+    eventType: 'sync.completed',
+    payload: {
+      spaceKey,
+      pagesCreated: counts.pagesCreated,
+      pagesUpdated: counts.pagesUpdated,
+      pagesDeleted: counts.pagesDeleted,
+      durationMs: Date.now() - spaceStartedAt,
+      completedAt: new Date().toISOString(),
+    },
+  });
 }
 
 async function syncPage(
@@ -277,6 +308,7 @@ async function syncPage(
   pageSummary: ConfluencePage,
   syncRunStartedAt: Date,
   ancestorCache: Map<string, ConfluenceRestriction[]>,
+  counts: SyncSpaceCounts,
 ): Promise<void> {
   // Fetch full page content
   const page = await client.getPage(pageSummary.id);
@@ -387,6 +419,7 @@ async function syncPage(
          WHERE confluence_id = $1`,
         [page.id, page.title, bodyStorage, bodyHtml, bodyText, parentId, labels, author, lastModified],
       );
+      counts.pagesUpdated++;
     }
 
     // Version-unchanged branch: still re-evaluate restrictions. See note at
@@ -423,6 +456,7 @@ async function syncPage(
   // Upsert page (shared table, no user_id)
   // deleted_at = NULL restores pages that were previously soft-deleted
   // (e.g. page was restored from Confluence trash)
+  const wasFreshCreate = existing.rows.length === 0;
   await query(
     `INSERT INTO pages
        (confluence_id, space_key, title, body_storage, body_html, body_text,
@@ -450,6 +484,11 @@ async function syncPage(
     [page.id, spaceKey, page.title, bodyStorage, bodyHtml, bodyText,
      page.version.number, parentId, labels, author, lastModified],
   );
+  if (wasFreshCreate) {
+    counts.pagesCreated++;
+  } else {
+    counts.pagesUpdated++;
+  }
 
   // Sync Confluence view restrictions → access_control_entries. Runs after
   // the page upsert so `pages.id` is guaranteed to exist (the ACE foreign
@@ -849,6 +888,7 @@ async function detectDeletedPages(
   _client: ConfluenceClient,
   spaceKey: string,
   currentPages: ConfluencePage[],
+  counts: SyncSpaceCounts,
 ): Promise<void> {
   // Only delete pages when exactly one user has this space assigned via RBAC.
   // If multiple users share the space, one user's limited-permission sync
@@ -880,6 +920,7 @@ async function detectDeletedPages(
       );
       await cleanPageAttachments('', confluence_id);
       await clearPageFailures(confluence_id);
+      counts.pagesDeleted++;
     }
   }
 }

--- a/backend/src/domains/knowledge/services/quality-worker.test.ts
+++ b/backend/src/domains/knowledge/services/quality-worker.test.ts
@@ -52,6 +52,13 @@ vi.mock('../../llm/services/llm-provider-resolver.js', () => ({
   }),
 }));
 
+// Webhook emit-call-site (#114). The hook is a CE-side no-op; we mock it
+// to assert call shape from the worker's success path.
+const mockEmitWebhookEvent = vi.fn();
+vi.mock('../../../core/services/webhook-emit-hook.js', () => ({
+  emitWebhookEvent: (...args: unknown[]) => mockEmitWebhookEvent(...args),
+}));
+
 describe('parseQualityScores', () => {
   it('parses a complete well-formed quality report', () => {
     const text = `
@@ -311,6 +318,52 @@ describe.skipIf(!dbAvailable)('Quality Worker (DB)', () => {
       // LLM mock returns valid scores, so page should be analyzed
       expect(result.rows[0].quality_status).toBe('analyzed');
       expect(result.rows[0].quality_retry_count).toBe(0); // reset on success
+    });
+
+    describe('ai.quality.complete webhook emit (#114)', () => {
+      beforeEach(() => {
+        mockEmitWebhookEvent.mockReset();
+      });
+
+      it('emits ai.quality.complete with the parsed score on success', async () => {
+        const longContent = 'This is a sufficiently long article body that exceeds the fifty character minimum threshold for quality analysis processing.';
+        const insertResult = await query<{ id: number }>(
+          `INSERT INTO pages (confluence_id, space_key, title, body_text, body_html, quality_status)
+           VALUES ('w1', $1, 'Webhook Page', $2, $3, 'pending')
+           RETURNING id`,
+          [testSpaceKey, longContent, `<p>${longContent}</p>`],
+        );
+        const pageId = insertResult.rows[0].id;
+
+        await processBatch();
+
+        const completedCalls = mockEmitWebhookEvent.mock.calls.filter(
+          (c) => c[0]?.eventType === 'ai.quality.complete',
+        );
+        expect(completedCalls).toHaveLength(1);
+        const event = completedCalls[0]![0];
+        expect(event.payload).toMatchObject({
+          pageId,
+          score: 75,
+        });
+        expect(typeof event.payload.summary).toBe('string');
+        expect(typeof event.payload.completedAt).toBe('string');
+      });
+
+      it('does NOT emit ai.quality.complete when content is too short (skipped)', async () => {
+        await query(
+          `INSERT INTO pages (confluence_id, space_key, title, body_text, body_html, quality_status)
+           VALUES ('w-short', $1, 'Short Page', 'tiny', '<p>tiny</p>', 'pending')`,
+          [testSpaceKey],
+        );
+
+        await processBatch();
+
+        const completedCalls = mockEmitWebhookEvent.mock.calls.filter(
+          (c) => c[0]?.eventType === 'ai.quality.complete',
+        );
+        expect(completedCalls).toHaveLength(0);
+      });
     });
 
     it('should analyze standalone pages with NULL confluence_id', async () => {

--- a/backend/src/domains/knowledge/services/quality-worker.ts
+++ b/backend/src/domains/knowledge/services/quality-worker.ts
@@ -27,6 +27,7 @@
  */
 
 import { query } from '../../../core/db/postgres.js';
+import { emitWebhookEvent } from '../../../core/services/webhook-emit-hook.js';
 import { getSystemPrompt } from '../../llm/services/prompts.js';
 import { resolveUsecase } from '../../llm/services/llm-provider-resolver.js';
 import {
@@ -221,6 +222,16 @@ async function analyzePageQuality(
         scores.summary,
       ],
     );
+
+    emitWebhookEvent({
+      eventType: 'ai.quality.complete',
+      payload: {
+        pageId,
+        score: scores.overall,
+        summary: scores.summary,
+        completedAt: new Date().toISOString(),
+      },
+    });
 
     logger.info({ pageId, score: scores.overall }, 'Quality analysis complete');
   } catch (err) {

--- a/backend/src/domains/knowledge/services/summary-worker.test.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.test.ts
@@ -51,6 +51,13 @@ vi.mock('../../llm/services/llm-provider-resolver.js', () => ({
   }),
 }));
 
+// Webhook emit-call-site (#114). The hook is a CE-side no-op; we mock it
+// to assert call shape from the worker's success path.
+const mockEmitWebhookEvent = vi.fn();
+vi.mock('../../../core/services/webhook-emit-hook.js', () => ({
+  emitWebhookEvent: (...args: unknown[]) => mockEmitWebhookEvent(...args),
+}));
+
 describe.skipIf(!dbAvailable)('Summary Worker', () => {
   let testUserId: string;
   const testSpaceKey = 'TEST';
@@ -365,6 +372,52 @@ describe.skipIf(!dbAvailable)('Summary Worker', () => {
       expect(result.rows[0].summary_status).toBe('summarized');
       expect(result.rows[0].summary_text).toBeTruthy();
       expect(result.rows[0].summary_model).toBe('test-model');
+    });
+  });
+
+  describe('ai.summary.complete webhook emit (#114)', () => {
+    beforeEach(() => {
+      mockEmitWebhookEvent.mockReset();
+    });
+
+    it('emits ai.summary.complete with the generated summary on success', async () => {
+      const longContent = 'D'.repeat(200);
+      const insertResult = await query<{ id: number }>(
+        `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status)
+         VALUES ('w-summary', $1, 'Summary Webhook Page', $2, 'pending')
+         RETURNING id`,
+        [testSpaceKey, longContent],
+      );
+      const pageId = insertResult.rows[0].id;
+
+      const { processed, errors } = await runSummaryBatch('test-model');
+      expect(processed).toBe(1);
+      expect(errors).toBe(0);
+
+      const completedCalls = mockEmitWebhookEvent.mock.calls.filter(
+        (c) => c[0]?.eventType === 'ai.summary.complete',
+      );
+      expect(completedCalls).toHaveLength(1);
+      const event = completedCalls[0]![0];
+      expect(event.payload).toMatchObject({ pageId });
+      expect(typeof event.payload.summary).toBe('string');
+      expect(event.payload.summary.length).toBeGreaterThan(0);
+      expect(typeof event.payload.completedAt).toBe('string');
+    });
+
+    it('does NOT emit ai.summary.complete when content is too short (skipped)', async () => {
+      await query(
+        `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status)
+         VALUES ('w-summary-short', $1, 'Short Page', 'tiny', 'pending')`,
+        [testSpaceKey],
+      );
+
+      await runSummaryBatch('test-model');
+
+      const completedCalls = mockEmitWebhookEvent.mock.calls.filter(
+        (c) => c[0]?.eventType === 'ai.summary.complete',
+      );
+      expect(completedCalls).toHaveLength(0);
     });
   });
 

--- a/backend/src/domains/knowledge/services/summary-worker.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.ts
@@ -29,6 +29,7 @@
 
 import crypto from 'node:crypto';
 import { query } from '../../../core/db/postgres.js';
+import { emitWebhookEvent } from '../../../core/services/webhook-emit-hook.js';
 import { getSystemPrompt } from '../../llm/services/prompts.js';
 import { resolveUsecase } from '../../llm/services/llm-provider-resolver.js';
 import {
@@ -280,6 +281,15 @@ async function summarizePage(
        WHERE id = $5`,
       [summaryText, summaryHtml, contentHash, model, id],
     );
+
+    emitWebhookEvent({
+      eventType: 'ai.summary.complete',
+      payload: {
+        pageId: id,
+        summary: summaryText,
+        completedAt: new Date().toISOString(),
+      },
+    });
 
     logger.info({ pageId: id, title, model }, 'Summary generated');
   } catch (err) {

--- a/backend/src/routes/knowledge/pages-crud-webhooks.test.ts
+++ b/backend/src/routes/knowledge/pages-crud-webhooks.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Webhook emit-call-site tests for pages-crud (#114).
+ *
+ * Verifies that `emitWebhookEvent` fires with the expected event shape on the
+ * success path AND is NOT called when the route bails before the canonical
+ * mutation (validation, RBAC, not-found, conflict). The hook itself is a
+ * no-op in CE — these tests just check that the route is wired to it.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+import { ZodError } from 'zod';
+import { pagesCrudRoutes } from './pages-crud.js';
+
+// --- Mocks (mirror pages-crud-create.test.ts so imports resolve identically) ---
+
+vi.mock('../../core/services/redis-cache.js', () => ({
+  RedisCache: class MockRedisCache {
+    get = vi.fn().mockResolvedValue(null);
+    set = vi.fn().mockResolvedValue(undefined);
+    invalidate = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('../../core/services/audit-service.js', () => ({
+  logAuditEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../core/utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const mockGetClientForUser = vi.fn();
+vi.mock('../../domains/confluence/services/sync-service.js', () => ({
+  getClientForUser: (...args: unknown[]) => mockGetClientForUser(...args),
+}));
+
+vi.mock('../../core/services/content-converter.js', () => ({
+  htmlToConfluence: vi.fn((html: string) => html),
+  confluenceToHtml: vi.fn((html: string) => html),
+  htmlToText: vi.fn((html: string) => html.replace(/<[^>]*>/g, '')),
+}));
+
+vi.mock('../../domains/confluence/services/attachment-handler.js', () => ({
+  cleanPageAttachments: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../domains/llm/services/embedding-service.js', () => ({
+  processDirtyPages: vi.fn().mockResolvedValue(undefined),
+  isProcessingUser: vi.fn().mockReturnValue(false),
+}));
+
+const mockGetUserAccessibleSpaces = vi.fn();
+vi.mock('../../core/services/rbac-service.js', () => ({
+  getUserAccessibleSpaces: (...args: unknown[]) => mockGetUserAccessibleSpaces(...args),
+}));
+
+const mockEmitWebhookEvent = vi.fn();
+vi.mock('../../core/services/webhook-emit-hook.js', () => ({
+  emitWebhookEvent: (...args: unknown[]) => mockEmitWebhookEvent(...args),
+}));
+
+const mockQueryFn = vi.fn();
+vi.mock('../../core/db/postgres.js', () => ({
+  query: (...args: unknown[]) => mockQueryFn(...args),
+  getPool: vi.fn().mockReturnValue({}),
+  runMigrations: vi.fn(),
+  closePool: vi.fn(),
+}));
+
+const TEST_USER = 'user-1';
+
+describe('pages-crud webhook emit call-sites', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.setErrorHandler((error: Error & { statusCode?: number }, _request, reply) => {
+      if (error instanceof ZodError) {
+        return reply.status(400).send({ error: 'Validation failed', details: error.issues });
+      }
+      const statusCode = error.statusCode ?? 500;
+      return reply.status(statusCode).send({ error: error.message });
+    });
+
+    app.decorate(
+      'authenticate',
+      async (request: { userId: string; username: string; userRole: string }) => {
+        request.userId = TEST_USER;
+        request.username = 'testuser';
+        request.userRole = 'user';
+      },
+    );
+    app.decorate(
+      'requireAdmin',
+      async (request: { userId: string; username: string; userRole: string }) => {
+        request.userId = TEST_USER;
+        request.username = 'testuser';
+        request.userRole = 'admin';
+      },
+    );
+    app.decorate('redis', {});
+
+    await app.register(pagesCrudRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+  });
+
+  // ── page.created ────────────────────────────────────────────────────────────
+
+  describe('POST /api/pages — page.created', () => {
+    it('emits page.created with isLocal=true on standalone create success', async () => {
+      // INSERT returns new page
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ id: 42, title: 'Hello', version: 1 }] });
+      // Path/depth UPDATE
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages',
+        payload: { title: 'Hello', bodyHtml: '<p>Hello</p>', source: 'standalone' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockEmitWebhookEvent).toHaveBeenCalledTimes(1);
+      const event = mockEmitWebhookEvent.mock.calls[0]![0];
+      expect(event.eventType).toBe('page.created');
+      expect(event.payload).toMatchObject({
+        pageId: 42,
+        title: 'Hello',
+        isLocal: true,
+        spaceKey: null,
+      });
+      expect(typeof event.payload.createdAt).toBe('string');
+    });
+
+    it('emits page.created with isLocal=false on Confluence create success', async () => {
+      // Space lookup: confluence
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ source: 'confluence' }] });
+      // INSERT (cache row) — UPDATE doesn't return rows for INSERT ... ON CONFLICT
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      mockGetClientForUser.mockResolvedValue({
+        createPage: vi.fn().mockResolvedValue({
+          id: 'conf-1',
+          title: 'Hello',
+          version: { number: 1 },
+          body: { storage: { value: '<p>Hello</p>' } },
+        }),
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages',
+        payload: { title: 'Hello', bodyHtml: '<p>Hello</p>', spaceKey: 'DEV', source: 'confluence' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockEmitWebhookEvent).toHaveBeenCalledTimes(1);
+      const event = mockEmitWebhookEvent.mock.calls[0]![0];
+      expect(event.eventType).toBe('page.created');
+      expect(event.payload).toMatchObject({
+        pageId: 'conf-1',
+        title: 'Hello',
+        isLocal: false,
+        spaceKey: 'DEV',
+      });
+    });
+
+    it('does NOT emit page.created when validation fails', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages',
+        payload: { /* missing title */ bodyHtml: '<p>Hello</p>' },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(mockEmitWebhookEvent).not.toHaveBeenCalled();
+    });
+
+    it('does NOT emit page.created when parentId does not exist', async () => {
+      // Parent lookup returns nothing
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages',
+        payload: {
+          title: 'Child',
+          bodyHtml: '<p>Hello</p>',
+          source: 'standalone',
+          parentId: '999',
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(mockEmitWebhookEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── page.updated ────────────────────────────────────────────────────────────
+
+  describe('PUT /api/pages/:id — page.updated', () => {
+    it('emits page.updated on standalone update success', async () => {
+      // SELECT existing page (standalone)
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{
+          id: 7, version: 3, space_key: null, source: 'standalone',
+          created_by_user_id: TEST_USER, visibility: 'shared',
+          confluence_id: null, deleted_at: null, page_type: 'page',
+        }],
+      });
+      // UPDATE
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/7',
+        payload: { title: 'New title', bodyHtml: '<p>updated</p>', version: 3 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockEmitWebhookEvent).toHaveBeenCalledTimes(1);
+      const event = mockEmitWebhookEvent.mock.calls[0]![0];
+      expect(event.eventType).toBe('page.updated');
+      expect(event.payload).toMatchObject({
+        pageId: 7,
+        title: 'New title',
+        spaceKey: null,
+      });
+      expect(typeof event.payload.updatedAt).toBe('string');
+    });
+
+    it('emits page.updated on Confluence update success', async () => {
+      // SELECT existing page (confluence)
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{
+          id: 9, version: 5, space_key: 'OPS', source: 'confluence',
+          created_by_user_id: null, visibility: 'shared',
+          confluence_id: 'conf-9', deleted_at: null, page_type: 'page',
+        }],
+      });
+      // UPDATE local cache after Confluence push
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      mockGetClientForUser.mockResolvedValue({
+        updatePage: vi.fn().mockResolvedValue({
+          version: { number: 6 },
+          body: { storage: { value: '<p>updated</p>' } },
+        }),
+      });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/conf-9',
+        payload: { title: 'New title', bodyHtml: '<p>updated</p>', version: 5 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockEmitWebhookEvent).toHaveBeenCalledTimes(1);
+      const event = mockEmitWebhookEvent.mock.calls[0]![0];
+      expect(event.eventType).toBe('page.updated');
+      expect(event.payload).toMatchObject({
+        pageId: 9,
+        title: 'New title',
+        spaceKey: 'OPS',
+      });
+    });
+
+    it('does NOT emit page.updated when version conflict occurs', async () => {
+      // SELECT existing page with newer version than supplied
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{
+          id: 7, version: 10, space_key: null, source: 'standalone',
+          created_by_user_id: TEST_USER, visibility: 'shared',
+          confluence_id: null, deleted_at: null, page_type: 'page',
+        }],
+      });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/7',
+        payload: { title: 'Stale', bodyHtml: '<p>stale</p>', version: 3 },
+      });
+
+      expect(response.statusCode).toBe(409);
+      expect(mockEmitWebhookEvent).not.toHaveBeenCalled();
+    });
+
+    it('does NOT emit page.updated when page is not found', async () => {
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/99',
+        payload: { title: 'Whatever', bodyHtml: '<p>x</p>' },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(mockEmitWebhookEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── page.deleted ────────────────────────────────────────────────────────────
+
+  describe('DELETE /api/pages/:id — page.deleted', () => {
+    it('emits page.deleted with isHardDelete=false on standalone soft-delete', async () => {
+      // SELECT existing page
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{
+          id: 11, source: 'standalone', created_by_user_id: TEST_USER,
+          confluence_id: null, space_key: null,
+        }],
+      });
+      // UPDATE deleted_at
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/pages/11',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockEmitWebhookEvent).toHaveBeenCalledTimes(1);
+      const event = mockEmitWebhookEvent.mock.calls[0]![0];
+      expect(event.eventType).toBe('page.deleted');
+      expect(event.payload).toEqual({ pageId: 11, isHardDelete: false });
+    });
+
+    it('emits page.deleted with isHardDelete=true on standalone permanent delete', async () => {
+      // SELECT existing page
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{
+          id: 12, source: 'standalone', created_by_user_id: TEST_USER,
+          confluence_id: null, space_key: null,
+        }],
+      });
+      // DELETE FROM pinned_pages, DELETE FROM pages
+      mockQueryFn.mockResolvedValue({ rows: [] });
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/pages/12?permanent=true',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockEmitWebhookEvent).toHaveBeenCalledTimes(1);
+      const event = mockEmitWebhookEvent.mock.calls[0]![0];
+      expect(event.eventType).toBe('page.deleted');
+      expect(event.payload).toEqual({ pageId: 12, isHardDelete: true });
+    });
+
+    it('emits page.deleted with isHardDelete=true on Confluence delete success', async () => {
+      // SELECT existing page (confluence)
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{
+          id: 13, source: 'confluence', created_by_user_id: null,
+          confluence_id: 'conf-13', space_key: 'DEV',
+        }],
+      });
+      // DELETE FROM pinned_pages, DELETE FROM pages
+      mockQueryFn.mockResolvedValue({ rows: [] });
+
+      mockGetClientForUser.mockResolvedValue({
+        deletePage: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/pages/conf-13',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockEmitWebhookEvent).toHaveBeenCalledTimes(1);
+      const event = mockEmitWebhookEvent.mock.calls[0]![0];
+      expect(event.eventType).toBe('page.deleted');
+      expect(event.payload).toEqual({ pageId: 13, isHardDelete: true });
+    });
+
+    it('does NOT emit page.deleted when page is not found', async () => {
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/pages/999',
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(mockEmitWebhookEvent).not.toHaveBeenCalled();
+    });
+
+    it('does NOT emit page.deleted when caller is not the standalone owner', async () => {
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{
+          id: 15, source: 'standalone', created_by_user_id: 'someone-else',
+          confluence_id: null, space_key: null,
+        }],
+      });
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/pages/15',
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(mockEmitWebhookEvent).not.toHaveBeenCalled();
+    });
+
+    it('does NOT emit page.deleted when Confluence space access is denied', async () => {
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{
+          id: 16, source: 'confluence', created_by_user_id: null,
+          confluence_id: 'conf-16', space_key: 'HR',
+        }],
+      });
+      mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/pages/conf-16',
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(mockEmitWebhookEvent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -6,6 +6,7 @@ import { getClientForUser } from '../../domains/confluence/services/sync-service
 import { htmlToConfluence, confluenceToHtml } from '../../core/services/content-converter.js';
 import { cleanPageAttachments, writeAttachmentCache } from '../../domains/confluence/services/attachment-handler.js';
 import { logAuditEvent } from '../../core/services/audit-service.js';
+import { emitWebhookEvent } from '../../core/services/webhook-emit-hook.js';
 import { processDirtyPages, isProcessingUser } from '../../domains/llm/services/embedding-service.js';
 import { getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
 import { PageListQuerySchema, PageTreeQuerySchema, CreatePageSchema, UpdatePageSchema, SaveDraftSchema } from '@compendiq/contracts';
@@ -922,6 +923,17 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       await logAuditEvent(userId, 'PAGE_CREATED', 'page', String(newPage.id),
         { source: 'standalone', title: body.title, visibility: body.visibility ?? 'shared', spaceKey, pageType }, request);
 
+      emitWebhookEvent({
+        eventType: 'page.created',
+        payload: {
+          pageId: newPage.id,
+          title: newPage.title,
+          spaceKey,
+          isLocal: true,
+          createdAt: new Date().toISOString(),
+        },
+      });
+
       return { id: newPage.id, title: newPage.title, version: newPage.version, source: 'standalone', pageType };
     }
 
@@ -971,6 +983,17 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     await cache.invalidate(userId, 'spaces');
 
     await logAuditEvent(userId, 'PAGE_CREATED', 'page', page.id, { spaceKey: body.spaceKey, title: body.title }, request);
+
+    emitWebhookEvent({
+      eventType: 'page.created',
+      payload: {
+        pageId: page.id,
+        title: page.title,
+        spaceKey: body.spaceKey ?? null,
+        isLocal: false,
+        createdAt: new Date().toISOString(),
+      },
+    });
 
     return { id: page.id, title: page.title, version: page.version.number, source: 'confluence' };
   });
@@ -1053,6 +1076,16 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       await cache.invalidate(userId, 'pages');
       await logAuditEvent(userId, 'PAGE_UPDATED', 'page', String(id), { source: 'standalone', title: body.title }, request);
 
+      emitWebhookEvent({
+        eventType: 'page.updated',
+        payload: {
+          pageId: existingPage.id,
+          title: body.title,
+          spaceKey: existingPage.space_key,
+          updatedAt: new Date().toISOString(),
+        },
+      });
+
       return { id: existingPage.id, title: body.title, version: newVersion, source: 'standalone' };
     }
 
@@ -1108,6 +1141,16 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
 
     await logAuditEvent(userId, 'PAGE_UPDATED', 'page', String(id), { title: body.title }, request);
 
+    emitWebhookEvent({
+      eventType: 'page.updated',
+      payload: {
+        pageId: existingPage.id,
+        title: body.title,
+        spaceKey: existingPage.space_key,
+        updatedAt: new Date().toISOString(),
+      },
+    });
+
     return { id: existingPage.id, title: body.title, version: confPage.version.number, source: 'confluence' };
   });
 
@@ -1154,6 +1197,14 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       await logAuditEvent(userId, 'PAGE_DELETED', 'page', String(id),
         { source: 'standalone', permanent: queryParams.permanent === 'true' }, request);
 
+      emitWebhookEvent({
+        eventType: 'page.deleted',
+        payload: {
+          pageId: existingPage.id,
+          isHardDelete: queryParams.permanent === 'true',
+        },
+      });
+
       return { message: queryParams.permanent === 'true' ? 'Page permanently deleted' : 'Page moved to trash' };
     }
 
@@ -1185,6 +1236,14 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     await cache.invalidate(userId, 'spaces');
 
     await logAuditEvent(userId, 'PAGE_DELETED', 'page', String(id), {}, request);
+
+    emitWebhookEvent({
+      eventType: 'page.deleted',
+      payload: {
+        pageId: existingPage.id,
+        isHardDelete: true,
+      },
+    });
 
     return { message: 'Page deleted' };
   });
@@ -1270,10 +1329,10 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       id: number; version: number; title: string;
       body_html: string | null; body_text: string | null; body_storage: string | null;
       source: string; created_by_user_id: string | null;
-      visibility: string; confluence_id: string | null;
+      visibility: string; confluence_id: string | null; space_key: string | null;
       draft_body_html: string | null; draft_body_storage: string | null;
     }>(
-      `SELECT id, version, title, body_html, body_text, body_storage, source, created_by_user_id, visibility, confluence_id, draft_body_html, draft_body_storage FROM pages WHERE id = $1 AND deleted_at IS NULL`,
+      `SELECT id, version, title, body_html, body_text, body_storage, source, created_by_user_id, visibility, confluence_id, space_key, draft_body_html, draft_body_storage FROM pages WHERE id = $1 AND deleted_at IS NULL`,
       [pageId],
     );
     if (!existing.rows.length) throw fastify.httpErrors.notFound('Page not found');
@@ -1346,6 +1405,16 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     await cache.invalidate(userId, 'pages');
     await logAuditEvent(userId, 'DRAFT_PUBLISHED', 'page', String(page.id),
       { version: page.version + 1 }, request);
+
+    emitWebhookEvent({
+      eventType: 'page.updated',
+      payload: {
+        pageId: page.id,
+        title: page.title,
+        spaceKey: page.space_key,
+        updatedAt: new Date().toISOString(),
+      },
+    });
 
     return { id: page.id, version: page.version + 1, published: true };
   });
@@ -1425,6 +1494,13 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
         query('UPDATE pages SET deleted_at = NOW() WHERE id = ANY($1::int[])', [standaloneNumericIds]),
         query('DELETE FROM pinned_pages WHERE user_id = $1 AND page_id = ANY($2::int[])', [userId, standaloneNumericIds]),
       ]);
+      // Bulk delete is a soft-delete (move to trash) for standalone pages.
+      for (const pageId of standaloneNumericIds) {
+        emitWebhookEvent({
+          eventType: 'page.deleted',
+          payload: { pageId, isHardDelete: false },
+        });
+      }
     }
     const standaloneSucceeded = standaloneNumericIds.length;
 
@@ -1466,6 +1542,13 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
             query('DELETE FROM pages WHERE confluence_id = ANY($1)', [deletedConfluenceIds]),
           ]);
           await Promise.allSettled(deletedConfluenceIds.map((id) => bulkLimit(() => cleanPageAttachments(userId, id))));
+          // Confluence bulk delete is always a hard delete (Confluence API + local row removal).
+          for (const pageId of deletedConfluenceNumericIds) {
+            emitWebhookEvent({
+              eventType: 'page.deleted',
+              payload: { pageId, isHardDelete: true },
+            });
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Completes the webhook push feature loop (#114). CE infrastructure (#336) and the EE outbox+delivery overlay (Compendiq/compendiq-ee#123) are both merged; this PR wires the CE-side `emitWebhookEvent` call-sites so events actually fire from page CRUD, Confluence sync, and the AI workers.

The emit hook is a no-op in CE-only deployments (zero overhead). The EE plugin registers the real outbox-writing implementation at startup, so every call-site here fires for real in EE deployments.

## Files modified — and which event types each fires

| File | Events fired |
|---|---|
| `backend/src/routes/knowledge/pages-crud.ts` | `page.created` (POST /api/pages — both standalone & Confluence branches), `page.updated` (PUT /api/pages/:id — both branches + draft publish flow), `page.deleted` (DELETE /api/pages/:id — both branches; bulk delete fires per-page) |
| `backend/src/domains/confluence/services/sync-service.ts` | `sync.completed` (one event per `syncSpace` at finalisation, with `pagesCreated/Updated/Deleted` aggregate counters threaded through `syncPage` and `detectDeletedPages`) |
| `backend/src/domains/knowledge/services/quality-worker.ts` | `ai.quality.complete` (after a successful quality-score write to `pages.quality_score`) |
| `backend/src/domains/knowledge/services/summary-worker.ts` | `ai.summary.complete` (after a successful summary write to `pages.summary_text`) |

### New test files

- `backend/src/routes/knowledge/pages-crud-webhooks.test.ts` — 14 tests covering all three CRUD events, success + failure paths.
- `backend/src/domains/confluence/services/sync-service-webhooks.test.ts` — 5 tests covering the per-space `sync.completed` aggregate counters and that the sync path does NOT fire per-page events (only the aggregate).

### Existing test files extended

- `backend/src/domains/knowledge/services/quality-worker.test.ts` — added `ai.quality.complete` describe block (success path emits, short-content/skipped path does NOT emit). DB-backed, follows the existing `describe.skipIf(!dbAvailable)` pattern.
- `backend/src/domains/knowledge/services/summary-worker.test.ts` — same shape for `ai.summary.complete`.

## Design decisions worth flagging

1. **Multiple `INSERT INTO pages` candidates for `page.created`.** `routes/knowledge/pages-crud.ts` has two distinct fresh-create insertion sites for `POST /api/pages` — the standalone branch (line ~901) and the Confluence branch (line ~958, `INSERT … ON CONFLICT DO UPDATE`). They are mutually exclusive within a single request and represent two separate user-facing creation flows, so I emit from **both** with `isLocal: true|false` to distinguish. The other `INSERT INTO pages` in this file is actually inside the upsert path that runs from sync code (handled by the sync-side emit logic, not pages-crud).

2. **`page.updated` only fires for body/title changes.** Skipped emit-on-update sites that are metadata-only or internal: `path/depth` bookkeeping after create, `inherit_perms` / `embedding_dirty` flag flips, draft save (not yet live), draft discard, label updates, restore-from-trash (deleted_at = NULL only). Draft publish DOES fire because that's the canonical "draft becomes live" content flip from the user's perspective.

3. **`sync.completed` granularity is per-space, not per-run.** Each `syncSpace()` call emits exactly one `sync.completed` event with that space's `spaceKey` and aggregate counters, threaded through `SyncSpaceCounts { pagesCreated, pagesUpdated, pagesDeleted }`. A user-level "sync run" syncing N spaces produces N `sync.completed` events — this matches the payload shape (single `spaceKey` field) and lets receivers attribute churn to the correct space without rebundling. Per the brief: no per-page `page.created/updated/deleted` from sync to avoid double-fire alongside the aggregates.

4. **No transaction context passed to emit calls.** None of these call-sites currently run inside a `pg.PoolClient` transaction (the closest is the draft-publish atomic swap which uses `txClient` for the page_versions snapshot + page UPDATE, then releases the client before emitting). Emitting outside the tx gives up exactly-once-on-commit semantics — acceptable for now per the hook's documented contract, can be tightened later by passing the active client when present.

5. **Test mock pattern.** Each test file mocks `../../core/services/webhook-emit-hook.js` (path adjusted to the file's location) to a single `vi.fn()` and asserts the call shape. This is the same boundary pattern used for `logAuditEvent` mocks elsewhere in the codebase.

## Verification

- `cd backend && npx tsc --noEmit` — clean. The closed `WebhookEventType` union catches typos at compile time.
- `cd backend && npx vitest run <8 touched test files + 1 webhook-emit-hook.test.ts>` — 95/95 pass.
- `cd backend && npm run lint` — clean (only the pre-existing legacy `eslint-plugin-boundaries` selector-syntax warning, unrelated).

## What this PR does NOT change

- The `webhook-emit-hook.ts` contract itself (fixed by #336).
- Event types (stuck to the 6 enumerated by `WebhookEventType`).
- Routes/services beyond the emit calls + their tests.
- No EE PR — this is CE-only.

## Test plan

- [x] `npx tsc --noEmit` in backend
- [x] `npx vitest run` on all 8 touched test files + the existing `webhook-emit-hook.test.ts` — 95/95 pass
- [x] `npm run lint -w backend`
- [ ] CI to run the full backend suite against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)