### PR TITLE
feat(#117): batch page operations — backend + frontend

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -44,6 +44,7 @@ import { llmPdfRoutes } from './routes/llm/llm-pdf.js';
 // Knowledge routes
 import { pagesCrudRoutes } from './routes/knowledge/pages-crud.js';
 import { pagesPresenceRoutes } from './routes/knowledge/pages-presence.js';
+import { pagesBulkProgressRoutes } from './routes/knowledge/pages-bulk-progress.js';
 import { pagesVersionRoutes } from './routes/knowledge/pages-versions.js';
 import { pagesTagRoutes } from './routes/knowledge/pages-tags.js';
 import { pagesEmbeddingRoutes } from './routes/knowledge/pages-embeddings.js';
@@ -382,6 +383,7 @@ export async function buildApp() {
   // Knowledge routes
   await app.register(pagesCrudRoutes, { prefix: '/api' });
   await app.register(pagesPresenceRoutes, { prefix: '/api' });
+  await app.register(pagesBulkProgressRoutes, { prefix: '/api' });
   await app.register(pagesVersionRoutes, { prefix: '/api' });
   await app.register(pagesTagRoutes, { prefix: '/api' });
   await app.register(pagesEmbeddingRoutes, { prefix: '/api' });

--- a/backend/src/core/services/audit-service.ts
+++ b/backend/src/core/services/audit-service.ts
@@ -120,7 +120,18 @@ export type AuditAction =
   | 'USER_UPDATED'
   | 'USER_DEACTIVATED'
   | 'USER_REACTIVATED'
-  | 'USER_HARD_DELETED';
+  | 'USER_HARD_DELETED'
+  // Bulk page operations — EE #117. One audit row per bulk action (NOT per
+  // affected page) per epic v0.4 §3.6 / R8 audit-volume mitigation.
+  // BULK_PAGE_TAGGED covers additive tag changes (adds/removes); the dedicated
+  // BULK_PAGE_TAGS_REPLACED entry distinguishes the higher-risk
+  // replace-the-entire-tag-set semantic. BULK_PAGE_PERMISSION_CHANGED is
+  // emitted by the EE-gated bulk-permission route in the overlay and covers
+  // any add/remove/replace of an ACE applied across N pages — including the
+  // implicit `inherit_perms=false` flip when present (recorded in metadata).
+  | 'BULK_PAGE_TAGGED'
+  | 'BULK_PAGE_TAGS_REPLACED'
+  | 'BULK_PAGE_PERMISSION_CHANGED';
 
 export interface AuditLogEntry {
   id: string;

--- a/backend/src/core/services/bulk-page-progress.test.ts
+++ b/backend/src/core/services/bulk-page-progress.test.ts
@@ -1,0 +1,187 @@
+/**
+ * In-memory mode covers the unit tests. Redis-backed correctness is covered
+ * by a Redis-using integration test in the sibling redis-cache-bus.test.ts
+ * pattern (deferred — getRedisClient() is mocked here).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  startBulkJob,
+  publishProgress,
+  cancelBulkJob,
+  isBulkJobCancelled,
+  streamBulkProgress,
+  runBulkInChunks,
+  newJobId,
+  _resetMemoryJobsForTests,
+} from './bulk-page-progress.js';
+
+vi.mock('./redis-cache.js', () => ({
+  getRedisClient: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('bulk-page-progress (in-memory)', () => {
+  beforeEach(() => {
+    _resetMemoryJobsForTests();
+  });
+
+  it('newJobId returns a unique id every call', () => {
+    const a = newJobId();
+    const b = newJobId();
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^[0-9a-f-]{36}$/i);
+  });
+
+  it('publishProgress without a started job is a no-op (does not throw)', async () => {
+    await expect(publishProgress('not-started', { completed: 5 })).resolves.toBeUndefined();
+  });
+
+  it('isBulkJobCancelled returns false until cancelBulkJob is called', async () => {
+    const jobId = newJobId();
+    await startBulkJob(jobId, 10, 'user-1', 'replace-tags');
+    expect(await isBulkJobCancelled(jobId)).toBe(false);
+    await cancelBulkJob(jobId);
+    expect(await isBulkJobCancelled(jobId)).toBe(true);
+  });
+
+  it('streamBulkProgress replays history then yields published events to done', async () => {
+    const jobId = newJobId();
+    await startBulkJob(jobId, 100, 'user-1', 'replace-tags');
+    await publishProgress(jobId, { completed: 25 });
+    await publishProgress(jobId, { completed: 50 });
+
+    const controller = new AbortController();
+    const events: number[] = [];
+
+    // Run the consumer concurrently with later publishes.
+    const consumer = (async () => {
+      for await (const ev of streamBulkProgress(jobId, controller.signal)) {
+        // Ignore keepalive ticks (they reuse the last completed value).
+        if (ev.note === 'keepalive') continue;
+        events.push(ev.completed);
+        if (ev.done || ev.cancelled) break;
+      }
+    })();
+
+    // Microtask hop so the consumer drains history first.
+    await new Promise((r) => setTimeout(r, 0));
+    await publishProgress(jobId, { completed: 75 });
+    await publishProgress(jobId, { completed: 100, done: true });
+    await consumer;
+
+    // History 0,25,50 + live 75,100 — consumer sees all, ending on done.
+    expect(events).toContain(0);
+    expect(events).toContain(25);
+    expect(events).toContain(50);
+    expect(events).toContain(75);
+    expect(events).toContain(100);
+  });
+
+  it('streamBulkProgress aborts cleanly when signal fires', async () => {
+    const jobId = newJobId();
+    await startBulkJob(jobId, 10, 'user-1', 'replace-tags');
+
+    const controller = new AbortController();
+    const collected: boolean[] = [];
+
+    const consumer = (async () => {
+      for await (const ev of streamBulkProgress(jobId, controller.signal)) {
+        collected.push(ev.cancelled);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 5));
+    controller.abort();
+
+    // The consumer must terminate within a reasonable window despite no
+    // further events being published.
+    await Promise.race([
+      consumer,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('consumer hung after abort')), 1000)),
+    ]);
+
+    // Initial event was emitted, no cancellation set.
+    expect(collected.length).toBeGreaterThanOrEqual(1);
+    expect(collected.every((c) => c === false)).toBe(true);
+  });
+
+  it('runBulkInChunks aggregates per-chunk results and publishes progress', async () => {
+    const jobId = newJobId();
+    await startBulkJob(jobId, 30, 'user-1', 'replace-tags');
+
+    const result = await runBulkInChunks(
+      Array.from({ length: 30 }, (_, i) => i),
+      10,
+      jobId,
+      async (chunk) => ({
+        succeeded: chunk.length - 1,
+        failed: 1,
+        errors: [`row ${chunk[0]}: simulated error`],
+      }),
+    );
+
+    expect(result.succeeded).toBe(27);
+    expect(result.failed).toBe(3);
+    expect(result.errors).toHaveLength(3);
+    expect(result.cancelled).toBe(false);
+  });
+
+  it('runBulkInChunks bails out when the job is cancelled mid-flight', async () => {
+    const jobId = newJobId();
+    await startBulkJob(jobId, 100, 'user-1', 'replace-tags');
+
+    let chunksRun = 0;
+    const result = await runBulkInChunks(
+      Array.from({ length: 100 }, (_, i) => i),
+      10,
+      jobId,
+      async (chunk) => {
+        chunksRun++;
+        if (chunksRun === 2) {
+          await cancelBulkJob(jobId);
+        }
+        return { succeeded: chunk.length, failed: 0, errors: [] };
+      },
+    );
+
+    expect(result.cancelled).toBe(true);
+    expect(chunksRun).toBeLessThan(10);
+    expect(result.succeeded).toBeGreaterThan(0);
+  });
+
+  it('runBulkInChunks works without a jobId (legacy / no-progress path)', async () => {
+    const result = await runBulkInChunks(
+      [1, 2, 3, 4, 5],
+      2,
+      null,
+      async (chunk) => ({ succeeded: chunk.length, failed: 0, errors: [] }),
+    );
+    expect(result.succeeded).toBe(5);
+    expect(result.cancelled).toBe(false);
+  });
+
+  it('cancelBulkJob causes streamBulkProgress to terminate with cancelled=true', async () => {
+    const jobId = newJobId();
+    await startBulkJob(jobId, 10, 'user-1', 'replace-tags');
+
+    const controller = new AbortController();
+    const lastSeen: { cancelled: boolean }[] = [];
+
+    const consumer = (async () => {
+      for await (const ev of streamBulkProgress(jobId, controller.signal)) {
+        lastSeen.push({ cancelled: ev.cancelled });
+        if (ev.cancelled) break;
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 5));
+    await cancelBulkJob(jobId);
+    await consumer;
+
+    expect(lastSeen.some((e) => e.cancelled)).toBe(true);
+    expect(await isBulkJobCancelled(jobId)).toBe(true);
+  });
+});

--- a/backend/src/core/services/bulk-page-progress.ts
+++ b/backend/src/core/services/bulk-page-progress.ts
@@ -1,0 +1,499 @@
+/**
+ * Redis-backed progress + cancel state for long-running bulk page operations
+ * (Compendiq/compendiq-ee#117).
+ *
+ * Two routes share state via this module:
+ *   - POST /api/pages/bulk/<action>?jobId=...   runs the operation in chunks,
+ *     publishes progress after each chunk, checks the cancel flag between
+ *     chunks.
+ *   - GET  /api/pages/bulk/:jobId/progress      SSE stream that consumes the
+ *     same state and sets the cancel flag when the client disconnects.
+ *
+ * Why Redis: bulk operations span seconds to minutes. The POST and SSE
+ * connections are two independent HTTP requests possibly hitting different
+ * Node processes behind a load balancer. Redis is the only state store
+ * that's already shared across the cluster.
+ *
+ * When Redis is unavailable (test mode, Redis outage) the module degrades to
+ * an in-process Map. Single-process correctness is preserved; multi-process
+ * progress observation is not.
+ */
+import type { RedisClientType } from 'redis';
+import { randomUUID } from 'node:crypto';
+import { getRedisClient } from './redis-cache.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * TTL on every progress key. Long enough for the longest realistic bulk op
+ * to complete and the SSE client to consume the final `done` event;
+ * short enough that abandoned jobs are reaped automatically.
+ */
+const PROGRESS_TTL_SEC = 60 * 30; // 30 minutes
+
+/**
+ * Channel prefix for pub/sub-style progress events. We push to a Redis list
+ * (LPUSH + LTRIM bounded) AND publish a notification so the SSE generator
+ * can wake without polling. The list is the durable record (so a slow SSE
+ * subscriber catches up); the pub/sub is the kick.
+ */
+const PROGRESS_CHANNEL_PREFIX = 'bulk-page-progress:channel:';
+const PROGRESS_LIST_PREFIX = 'bulk-page-progress:list:';
+const PROGRESS_CANCEL_PREFIX = 'bulk-page-progress:cancel:';
+const PROGRESS_META_PREFIX = 'bulk-page-progress:meta:';
+const PROGRESS_LIST_MAX = 1000;
+
+export interface BulkProgressEvent {
+  jobId: string;
+  total: number;
+  completed: number;
+  failed: number;
+  done: boolean;
+  cancelled: boolean;
+  /** Optional human-readable note (e.g. last error). */
+  note?: string;
+}
+
+interface InMemoryJob {
+  meta: { total: number; userId: string; action: string };
+  events: BulkProgressEvent[];
+  cancelled: boolean;
+  done: boolean;
+  /** Resolvers waiting on the next event — wakes the in-memory async generator. */
+  waiters: Array<() => void>;
+}
+
+const memoryJobs = new Map<string, InMemoryJob>();
+
+function channelKey(jobId: string): string {
+  return `${PROGRESS_CHANNEL_PREFIX}${jobId}`;
+}
+function listKey(jobId: string): string {
+  return `${PROGRESS_LIST_PREFIX}${jobId}`;
+}
+function cancelKey(jobId: string): string {
+  return `${PROGRESS_CANCEL_PREFIX}${jobId}`;
+}
+function metaKey(jobId: string): string {
+  return `${PROGRESS_META_PREFIX}${jobId}`;
+}
+
+/** Generate a fresh job id. Callers MAY supply their own (e.g. correlation id). */
+export function newJobId(): string {
+  return randomUUID();
+}
+
+/**
+ * Initialize progress state for a new bulk job. Idempotent: re-initialisation
+ * with the same jobId is a no-op (the SSE client may have created the meta
+ * record by hitting the GET route slightly before the POST starts).
+ */
+export async function startBulkJob(
+  jobId: string,
+  total: number,
+  userId: string,
+  action: string,
+): Promise<void> {
+  const redis = getRedisClient();
+  const meta = JSON.stringify({ total, userId, action, startedAt: Date.now() });
+
+  if (redis) {
+    try {
+      await redis.set(metaKey(jobId), meta, { NX: true, EX: PROGRESS_TTL_SEC });
+      // Pre-warm the cancel key so EXISTS-style checks always have a definitive
+      // answer; "0" means "not cancelled". TTL keeps it from leaking.
+      await redis.set(cancelKey(jobId), '0', { NX: true, EX: PROGRESS_TTL_SEC });
+      await pushEvent(redis, jobId, {
+        jobId, total, completed: 0, failed: 0, done: false, cancelled: false,
+      });
+      return;
+    } catch (err) {
+      logger.warn({ err, jobId }, 'bulk-progress: redis init failed, falling back to memory');
+    }
+  }
+
+  if (!memoryJobs.has(jobId)) {
+    memoryJobs.set(jobId, {
+      meta: { total, userId, action },
+      events: [{ jobId, total, completed: 0, failed: 0, done: false, cancelled: false }],
+      cancelled: false,
+      done: false,
+      waiters: [],
+    });
+  }
+}
+
+/**
+ * Publish a progress tick. Called by the chunked runner after each chunk.
+ * Safe to call from many concurrent runners as long as each owns its own
+ * jobId.
+ */
+export async function publishProgress(
+  jobId: string,
+  partial: Partial<Omit<BulkProgressEvent, 'jobId'>>,
+): Promise<void> {
+  const redis = getRedisClient();
+
+  if (redis) {
+    try {
+      const last = await getLatestEvent(redis, jobId);
+      const next: BulkProgressEvent = {
+        jobId,
+        total: partial.total ?? last?.total ?? 0,
+        completed: partial.completed ?? last?.completed ?? 0,
+        failed: partial.failed ?? last?.failed ?? 0,
+        done: partial.done ?? last?.done ?? false,
+        cancelled: partial.cancelled ?? last?.cancelled ?? false,
+        note: partial.note ?? last?.note,
+      };
+      await pushEvent(redis, jobId, next);
+      return;
+    } catch (err) {
+      logger.warn({ err, jobId }, 'bulk-progress: redis publish failed, falling back to memory');
+    }
+  }
+
+  const job = memoryJobs.get(jobId);
+  if (!job) return;
+  const last = job.events[job.events.length - 1];
+  const next: BulkProgressEvent = {
+    jobId,
+    total: partial.total ?? last?.total ?? 0,
+    completed: partial.completed ?? last?.completed ?? 0,
+    failed: partial.failed ?? last?.failed ?? 0,
+    done: partial.done ?? last?.done ?? false,
+    cancelled: partial.cancelled ?? last?.cancelled ?? false,
+    note: partial.note ?? last?.note,
+  };
+  job.events.push(next);
+  if (next.done) job.done = true;
+  if (next.cancelled) job.cancelled = true;
+  for (const w of job.waiters.splice(0)) w();
+}
+
+/**
+ * Mark the job as cancelled. Called by the SSE route when the client
+ * disconnects. The chunked runner checks `isCancelled()` between chunks;
+ * a true result causes the loop to bail with the partial-success counts
+ * gathered so far.
+ *
+ * Idempotent: calling on an already-cancelled or already-done job is a no-op
+ * for the runner but still publishes a final event so the SSE generator
+ * exits cleanly.
+ */
+export async function cancelBulkJob(jobId: string): Promise<void> {
+  const redis = getRedisClient();
+
+  if (redis) {
+    try {
+      await redis.set(cancelKey(jobId), '1', { EX: PROGRESS_TTL_SEC });
+      const last = await getLatestEvent(redis, jobId);
+      await pushEvent(redis, jobId, {
+        jobId,
+        total: last?.total ?? 0,
+        completed: last?.completed ?? 0,
+        failed: last?.failed ?? 0,
+        done: last?.done ?? false,
+        cancelled: true,
+        note: last?.note,
+      });
+      return;
+    } catch (err) {
+      logger.warn({ err, jobId }, 'bulk-progress: redis cancel failed');
+    }
+  }
+
+  const job = memoryJobs.get(jobId);
+  if (!job) return;
+  job.cancelled = true;
+  const last = job.events[job.events.length - 1];
+  job.events.push({
+    jobId,
+    total: last?.total ?? 0,
+    completed: last?.completed ?? 0,
+    failed: last?.failed ?? 0,
+    done: last?.done ?? false,
+    cancelled: true,
+    note: last?.note,
+  });
+  for (const w of job.waiters.splice(0)) w();
+}
+
+/**
+ * Probe the cancel flag. Cheap — single GET. The chunked runner calls this
+ * between every chunk so cancel-latency is bounded by chunk-size, not row
+ * count.
+ */
+export async function isBulkJobCancelled(jobId: string): Promise<boolean> {
+  const redis = getRedisClient();
+  if (redis) {
+    try {
+      const v = await redis.get(cancelKey(jobId));
+      return v === '1';
+    } catch (err) {
+      logger.debug({ err, jobId }, 'bulk-progress: redis cancel-probe failed, defaulting to false');
+      return memoryJobs.get(jobId)?.cancelled ?? false;
+    }
+  }
+  return memoryJobs.get(jobId)?.cancelled ?? false;
+}
+
+/**
+ * Async generator backing the SSE route. Yields every published event for
+ * the job, then yields once more on `done` or `cancelled` and returns.
+ *
+ * `signal` is the SSE route's AbortController — when the client disconnects,
+ * the route aborts and the generator exits early without setting the cancel
+ * flag. The route is responsible for separately calling `cancelBulkJob`.
+ *
+ * Includes a 15s keepalive heartbeat: when no event arrives within the
+ * window, the generator yields a synthetic event with the last known counts
+ * and `note: 'keepalive'`. Reverse proxies that buffer SSE will see the
+ * write and not idle-disconnect.
+ */
+export async function* streamBulkProgress(
+  jobId: string,
+  signal: AbortSignal,
+): AsyncGenerator<BulkProgressEvent> {
+  const redis = getRedisClient();
+  const KEEPALIVE_MS = 15_000;
+
+  if (redis) {
+    // Replay any historical events first — the SSE client may connect after
+    // the POST has already completed several chunks.
+    const history = await readEventList(redis, jobId);
+    for (const ev of history) {
+      yield ev;
+      if (ev.done || ev.cancelled) return;
+    }
+
+    // Subscribe and stream. We use a duplicate connection because pub/sub
+    // mode disables normal commands on a redis-client v4+ instance.
+    const sub = redis.duplicate();
+    await sub.connect();
+
+    let lastEvent: BulkProgressEvent | null = history[history.length - 1] ?? null;
+    let pending: BulkProgressEvent | null = null;
+    let resolveWaiter: (() => void) | null = null;
+    let aborted = false;
+
+    const wake = (): void => {
+      const r = resolveWaiter;
+      resolveWaiter = null;
+      r?.();
+    };
+
+    const onMessage = (msg: string): void => {
+      try {
+        pending = JSON.parse(msg) as BulkProgressEvent;
+      } catch {
+        // Drop malformed events.
+        return;
+      }
+      wake();
+    };
+
+    await sub.subscribe(channelKey(jobId), onMessage);
+
+    const onAbort = (): void => {
+      aborted = true;
+      wake();
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+
+    try {
+      while (!aborted) {
+        if (pending !== null) {
+          const ev: BulkProgressEvent = pending;
+          pending = null;
+          lastEvent = ev;
+          yield ev;
+          if (ev.done || ev.cancelled) return;
+          continue;
+        }
+
+        // Wait for the next event OR the keepalive deadline OR abort.
+        await new Promise<void>((resolve) => {
+          resolveWaiter = resolve;
+          const t = setTimeout(() => {
+            resolveWaiter = null;
+            resolve();
+          }, KEEPALIVE_MS);
+          // If signalled while we set up, resolve immediately.
+          if (aborted) {
+            clearTimeout(t);
+            resolve();
+          }
+        });
+
+        if (aborted) break;
+        if (pending) continue;
+
+        // Keepalive tick — yield the last known event with a marker note.
+        if (lastEvent) {
+          yield { ...lastEvent, note: 'keepalive' };
+        }
+      }
+    } finally {
+      signal.removeEventListener('abort', onAbort);
+      try {
+        await sub.unsubscribe(channelKey(jobId));
+        await sub.quit();
+      } catch (err) {
+        logger.debug({ err, jobId }, 'bulk-progress: subscriber teardown failed');
+      }
+    }
+    return;
+  }
+
+  // In-memory mode (tests, redis outage)
+  const job = memoryJobs.get(jobId);
+  if (!job) return;
+
+  let i = 0;
+  let aborted = false;
+  const onAbort = (): void => {
+    aborted = true;
+    for (const w of job.waiters.splice(0)) w();
+  };
+  signal.addEventListener('abort', onAbort, { once: true });
+  try {
+    while (!aborted) {
+      while (i < job.events.length) {
+        const ev = job.events[i++]!;
+        yield ev;
+        if (ev.done || ev.cancelled) return;
+      }
+      if (aborted) break;
+
+      // Wait for the next event or keepalive timeout.
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, KEEPALIVE_MS);
+        job.waiters.push(() => {
+          clearTimeout(t);
+          resolve();
+        });
+      });
+
+      if (aborted) break;
+      if (i >= job.events.length && job.events.length > 0) {
+        yield { ...job.events[job.events.length - 1]!, note: 'keepalive' };
+      }
+    }
+  } finally {
+    signal.removeEventListener('abort', onAbort);
+  }
+}
+
+// ── internal redis helpers ────────────────────────────────────────────────
+
+async function pushEvent(
+  redis: RedisClientType,
+  jobId: string,
+  ev: BulkProgressEvent,
+): Promise<void> {
+  const payload = JSON.stringify(ev);
+  // LPUSH + LTRIM bounds the durable list; PUBLISH wakes subscribers. Both
+  // commands tolerate failure independently.
+  await Promise.all([
+    redis.lPush(listKey(jobId), payload).then(() => redis.lTrim(listKey(jobId), 0, PROGRESS_LIST_MAX - 1)),
+    redis.expire(listKey(jobId), PROGRESS_TTL_SEC),
+    redis.publish(channelKey(jobId), payload),
+  ]).catch((err) => {
+    logger.debug({ err, jobId }, 'bulk-progress: pushEvent partial failure');
+  });
+}
+
+async function readEventList(
+  redis: RedisClientType,
+  jobId: string,
+): Promise<BulkProgressEvent[]> {
+  try {
+    const raw = await redis.lRange(listKey(jobId), 0, -1);
+    // List is LPUSH'd, so reverse for chronological order.
+    return raw
+      .slice()
+      .reverse()
+      .map((s) => {
+        try {
+          return JSON.parse(s) as BulkProgressEvent;
+        } catch {
+          return null;
+        }
+      })
+      .filter((e): e is BulkProgressEvent => e !== null);
+  } catch {
+    return [];
+  }
+}
+
+async function getLatestEvent(
+  redis: RedisClientType,
+  jobId: string,
+): Promise<BulkProgressEvent | null> {
+  try {
+    const raw = await redis.lIndex(listKey(jobId), 0);
+    if (!raw) return null;
+    return JSON.parse(raw) as BulkProgressEvent;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Chunked runner used by every bulk route. Splits `items` into chunks of
+ * `chunkSize`, runs `worker` on each, publishes a progress tick between
+ * chunks, and aborts as soon as `isBulkJobCancelled` returns true.
+ *
+ * The worker is responsible for its own concurrency inside the chunk
+ * (existing routes use `pLimit(5)` against external services). Returns
+ * aggregate counts plus the cancelled flag so the route can decide what to
+ * report in the response body.
+ *
+ * `jobId` may be `null` — in that case we still chunk for memory pressure
+ * but skip the publish/cancel checks. This keeps the runner usable for
+ * callers that don't need progress streaming (e.g. legacy clients calling
+ * the existing bulk routes without a jobId).
+ */
+export async function runBulkInChunks<T>(
+  items: T[],
+  chunkSize: number,
+  jobId: string | null,
+  worker: (chunk: T[]) => Promise<{ succeeded: number; failed: number; errors: string[] }>,
+): Promise<{ succeeded: number; failed: number; errors: string[]; cancelled: boolean }> {
+  let succeeded = 0;
+  let failed = 0;
+  const errors: string[] = [];
+  let cancelled = false;
+
+  for (let i = 0; i < items.length; i += chunkSize) {
+    if (jobId && (await isBulkJobCancelled(jobId))) {
+      cancelled = true;
+      break;
+    }
+    const chunk = items.slice(i, i + chunkSize);
+    const result = await worker(chunk);
+    succeeded += result.succeeded;
+    failed += result.failed;
+    if (result.errors.length > 0) errors.push(...result.errors);
+
+    if (jobId) {
+      await publishProgress(jobId, { completed: succeeded + failed, failed });
+    }
+  }
+
+  if (jobId) {
+    await publishProgress(jobId, {
+      completed: succeeded + failed,
+      failed,
+      done: !cancelled,
+      cancelled,
+    });
+  }
+
+  return { succeeded, failed, errors, cancelled };
+}
+
+// Test-only: clear in-memory job state.
+export function _resetMemoryJobsForTests(): void {
+  memoryJobs.clear();
+}

--- a/backend/src/core/services/bulk-page-selection.test.ts
+++ b/backend/src/core/services/bulk-page-selection.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockQueryFn = vi.fn();
+
+vi.mock('../db/postgres.js', () => ({
+  query: (...args: unknown[]) => mockQueryFn(...args),
+}));
+
+import {
+  BulkSelectionSchema,
+  resolveBulkSelection,
+  buildFilterClauses,
+  BulkSelectionError,
+} from './bulk-page-selection.js';
+
+describe('BulkSelectionSchema', () => {
+  it('accepts ids-only mode', () => {
+    expect(BulkSelectionSchema.parse({ ids: ['1', '2'] })).toEqual({ ids: ['1', '2'] });
+  });
+
+  it('accepts filter + expectedCount mode', () => {
+    const r = BulkSelectionSchema.parse({
+      filter: { spaceKey: 'OPS' },
+      expectedCount: 42,
+    });
+    expect(r.expectedCount).toBe(42);
+    expect(r.filter?.spaceKey).toBe('OPS');
+  });
+
+  it('rejects ids alongside filter', () => {
+    expect(() =>
+      BulkSelectionSchema.parse({
+        ids: ['1'],
+        filter: { spaceKey: 'OPS' },
+        expectedCount: 1,
+      }),
+    ).toThrow();
+  });
+
+  it('rejects filter without expectedCount', () => {
+    expect(() => BulkSelectionSchema.parse({ filter: { spaceKey: 'OPS' } })).toThrow();
+  });
+
+  it('rejects empty body', () => {
+    expect(() => BulkSelectionSchema.parse({})).toThrow();
+  });
+
+  it('rejects unknown filter keys (strict)', () => {
+    expect(() =>
+      BulkSelectionSchema.parse({
+        filter: { spaceKey: 'OPS', search: 'foo' },
+        expectedCount: 1,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('buildFilterClauses', () => {
+  it('builds parts for the standard combination', () => {
+    const r = buildFilterClauses(
+      { spaceKey: 'OPS', labels: 'a,b,c', source: 'confluence' },
+      3,
+    );
+    expect(r.parts).toEqual([
+      'cp.space_key = $3',
+      'cp.labels @> $4',
+      'cp.source = $5',
+    ]);
+    expect(r.values).toEqual(['OPS', ['a', 'b', 'c'], 'confluence']);
+    expect(r.nextIdx).toBe(6);
+  });
+
+  it('skips empty labels', () => {
+    const r = buildFilterClauses({ labels: '  ,  ' }, 3);
+    expect(r.parts).toEqual([]);
+  });
+
+  it('translates freshness=stale into a literal date predicate (no extra param)', () => {
+    const r = buildFilterClauses({ freshness: 'stale' }, 3);
+    expect(r.parts.some((p) => p.includes("90 days"))).toBe(true);
+    expect(r.values).toEqual([]);
+  });
+});
+
+describe('resolveBulkSelection — ids mode', () => {
+  beforeEach(() => {
+    mockQueryFn.mockReset();
+  });
+
+  it('resolves numeric + confluence ids and reports not-found', async () => {
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [
+        { id: 1, confluence_id: null, space_key: null, source: 'standalone' },
+        { id: 2, confluence_id: 'conf-2', space_key: 'OPS', source: 'confluence' },
+      ],
+      rowCount: 2,
+    });
+
+    const r = await resolveBulkSelection(
+      'user-1',
+      { ids: ['1', 'conf-2', 'conf-missing'] },
+      ['OPS'],
+    );
+
+    expect(r.rows).toHaveLength(2);
+    expect(r.notFoundIds).toEqual(['conf-missing']);
+  });
+
+  it('respects numeric-only mode (filters out confluence ids before query)', async () => {
+    mockQueryFn.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    await resolveBulkSelection('user-1', { ids: ['1', 'conf-2'] }, ['OPS'], {
+      idMode: 'numeric-only',
+    });
+
+    const args = mockQueryFn.mock.calls[0]!;
+    expect(args[1]![0]).toEqual([1]);            // numericIds
+    expect(args[1]![1]).toEqual([]);             // confluenceStringIds (empty)
+  });
+});
+
+describe('resolveBulkSelection — filter mode', () => {
+  beforeEach(() => {
+    mockQueryFn.mockReset();
+  });
+
+  it('rejects when actual count drifts beyond tolerance (default 5%)', async () => {
+    // expectedCount = 100, actual = 110 → allowedDrift = ceil(100 * 0.05) = 5
+    // 110 - 100 = 10 > 5 → must throw count_drift
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ count: '110' }], rowCount: 1 });
+
+    await expect(
+      resolveBulkSelection(
+        'user-1',
+        { filter: { spaceKey: 'OPS' }, expectedCount: 100 },
+        ['OPS'],
+      ),
+    ).rejects.toThrow(BulkSelectionError);
+  });
+
+  it('passes when actual count is within tolerance', async () => {
+    // expectedCount = 100, actual = 102, allowedDrift = 5 → OK
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ count: '102' }], rowCount: 1 });
+    mockQueryFn.mockResolvedValueOnce({
+      rows: Array.from({ length: 102 }, (_, i) => ({
+        id: i + 1,
+        confluence_id: null,
+        space_key: 'OPS',
+        source: 'confluence',
+      })),
+      rowCount: 102,
+    });
+
+    const r = await resolveBulkSelection(
+      'user-1',
+      { filter: { spaceKey: 'OPS' }, expectedCount: 100 },
+      ['OPS'],
+    );
+    expect(r.rows).toHaveLength(102);
+  });
+
+  it('zero-tolerance rejects any drift', async () => {
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ count: '101' }], rowCount: 1 });
+
+    await expect(
+      resolveBulkSelection(
+        'user-1',
+        { filter: { spaceKey: 'OPS' }, expectedCount: 100, driftToleranceFraction: 0 },
+        ['OPS'],
+      ),
+    ).rejects.toMatchObject({
+      detail: { kind: 'count_drift', expected: 100, actual: 101 },
+    });
+  });
+
+  it('treats expectedCount=0, actual=0 as an empty selection (no-op)', async () => {
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 });
+
+    const r = await resolveBulkSelection(
+      'user-1',
+      { filter: { spaceKey: 'EMPTY' }, expectedCount: 0 },
+      ['EMPTY'],
+    );
+    expect(r.rows).toEqual([]);
+    expect(r.notFoundIds).toEqual([]);
+  });
+
+  it('builds the WHERE clause with RBAC + filter merged', async () => {
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ count: '1' }], rowCount: 1 });
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 7, confluence_id: 'c', space_key: 'OPS', source: 'confluence' }],
+      rowCount: 1,
+    });
+
+    await resolveBulkSelection(
+      'user-1',
+      {
+        filter: { spaceKey: 'OPS', labels: 'on-call' },
+        expectedCount: 1,
+      },
+      ['OPS'],
+    );
+
+    const countSql = mockQueryFn.mock.calls[0]![0] as string;
+    expect(countSql).toContain("cp.space_key = ANY($1::text[])");
+    expect(countSql).toContain('cp.deleted_at IS NULL');
+    expect(countSql).toContain('cp.space_key = $3');
+    expect(countSql).toContain('cp.labels @> $4');
+
+    const dataSql = mockQueryFn.mock.calls[1]![0] as string;
+    expect(dataSql).toContain('LIMIT 5000');
+  });
+});

--- a/backend/src/core/services/bulk-page-selection.ts
+++ b/backend/src/core/services/bulk-page-selection.ts
@@ -1,0 +1,359 @@
+/**
+ * Filter-based selection resolver for bulk page operations
+ * (Compendiq/compendiq-ee#117).
+ *
+ * Two input shapes are supported:
+ *   - `{ ids: string[] }`  — explicit list of page identifiers
+ *   - `{ filter: BulkPageFilter, expectedCount: number }` — server resolves
+ *     the matching pages from the same filter shape used by
+ *     `GET /api/pages`. The client passes the count it observed in the
+ *     preview; the server aborts with HTTP 409 when the live count diverges
+ *     by more than `driftToleranceFraction` (default 5%).
+ *
+ * RBAC: the resolver always restricts results to pages the caller is
+ * entitled to see — the same rule that gates `GET /api/pages`. Filter mode
+ * MUST NOT widen the surface; an admin-only filter view (`/api/admin/...`)
+ * passes its own widened scope via the `accessibleSpaces` parameter.
+ *
+ * Side effects: none. The resolver only reads from `pages`. Mutating routes
+ * are responsible for their own UPDATE / DELETE work.
+ */
+import { z } from 'zod';
+import { query } from '../db/postgres.js';
+
+/**
+ * Subset of the GET /pages filter shape that's safe + useful for bulk
+ * operations. We intentionally exclude `search` (FTS+ILIKE fallback) and
+ * `page` / `limit` / `sort`: bulk operations apply to the entire matching
+ * set, not a paginated slice. Adding `search` later is straightforward but
+ * deferred — typing a search term then bulk-acting on FTS scores is a
+ * user-experience footgun.
+ */
+export const BulkPageFilterSchema = z
+  .object({
+    spaceKey: z.string().optional(),
+    labels: z.string().optional(), // comma-separated, same convention as GET /pages
+    source: z.enum(['confluence', 'standalone']).optional(),
+    visibility: z.enum(['private', 'shared']).optional(),
+    freshness: z.enum(['fresh', 'recent', 'aging', 'stale']).optional(),
+    embeddingStatus: z.enum(['pending', 'done']).optional(),
+    qualityMin: z.coerce.number().int().min(0).max(100).optional(),
+    qualityMax: z.coerce.number().int().min(0).max(100).optional(),
+    qualityStatus: z.enum(['pending', 'analyzing', 'analyzed', 'failed', 'skipped']).optional(),
+    dateFrom: z.string().optional(),
+    dateTo: z.string().optional(),
+  })
+  .strict();
+
+export type BulkPageFilter = z.infer<typeof BulkPageFilterSchema>;
+
+/**
+ * Wire shape for any bulk route's `selection` body. Routes use this in
+ * their request schema:
+ *
+ *   const Body = z.object({ selection: BulkSelectionSchema, ...other })
+ */
+export const BulkSelectionSchema = z
+  .object({
+    ids: z.array(z.string().min(1)).min(1).max(1000).optional(),
+    filter: BulkPageFilterSchema.optional(),
+    expectedCount: z.coerce.number().int().min(0).optional(),
+    /**
+     * Fraction of `expectedCount` we tolerate as drift between the user's
+     * preview and the server-side resolution. 0 means exact-match required.
+     * Default 0.05 (5%). Set 0 for risky operations (permission changes).
+     */
+    driftToleranceFraction: z.coerce.number().min(0).max(1).optional(),
+  })
+  .refine(
+    (v) =>
+      (v.ids && !v.filter && v.expectedCount === undefined) ||
+      (!v.ids && v.filter && v.expectedCount !== undefined),
+    {
+      message:
+        'Provide either { ids } or { filter, expectedCount }; do not mix or omit expectedCount in filter mode',
+    },
+  );
+
+export type BulkSelection = z.infer<typeof BulkSelectionSchema>;
+
+export interface ResolvedBulkRow {
+  id: number;
+  confluenceId: string | null;
+  spaceKey: string | null;
+  source: 'confluence' | 'standalone';
+  /**
+   * Existing label set on the page. Included in the SELECT so a single
+   * resolver round-trip serves both the "which pages match" and the "what
+   * are their current tags" needs of the tag/replace-tag routes.
+   */
+  labels: string[];
+}
+
+export interface BulkSelectionResolutionError {
+  /**
+   * Discriminator. `count_drift` maps to HTTP 409 in the route layer; the
+   * shape is stable so the frontend can render a "the selection changed
+   * since you previewed it" prompt without parsing the message.
+   */
+  kind: 'count_drift' | 'invalid_input';
+  message: string;
+  /** Counts only populated for `count_drift`. */
+  expected?: number;
+  actual?: number;
+}
+
+export interface ResolveBulkSelectionResult {
+  rows: ResolvedBulkRow[];
+  /** IDs supplied by the caller that did not resolve to any page (only for ids-mode). */
+  notFoundIds: string[];
+}
+
+/**
+ * Resolve a `{ ids } | { filter, expectedCount }` body to a list of pages.
+ * Throws `BulkSelectionResolutionError` (as a plain object via Zod's
+ * convention is not used — we just throw a regular Error with a structured
+ * `cause` so the route layer can map to HTTP).
+ */
+export class BulkSelectionError extends Error {
+  constructor(public detail: BulkSelectionResolutionError) {
+    super(detail.message);
+    this.name = 'BulkSelectionError';
+  }
+}
+
+/**
+ * Build the SQL filter fragment from a `BulkPageFilter`. Returns
+ * `{ wherePart, values }` where `wherePart` joins to a base WHERE clause
+ * supplied by the caller, and `values` are the positional parameters
+ * matching `$startIdx..$startIdx+N`.
+ *
+ * Keep in sync with the filter clauses in `routes/knowledge/pages-crud.ts`
+ * `GET /pages` (lines 185-268). We deliberately omit FTS search.
+ */
+export function buildFilterClauses(
+  filter: BulkPageFilter,
+  startIdx: number,
+): { parts: string[]; values: unknown[]; nextIdx: number } {
+  const parts: string[] = [];
+  const values: unknown[] = [];
+  let idx = startIdx;
+
+  if (filter.spaceKey) {
+    parts.push(`cp.space_key = $${idx++}`);
+    values.push(filter.spaceKey);
+  }
+
+  if (filter.labels) {
+    const labelList = filter.labels
+      .split(',')
+      .map((l) => l.trim())
+      .filter(Boolean);
+    if (labelList.length > 0) {
+      parts.push(`cp.labels @> $${idx++}`);
+      values.push(labelList);
+    }
+  }
+
+  if (filter.source) {
+    parts.push(`cp.source = $${idx++}`);
+    values.push(filter.source);
+  }
+
+  if (filter.visibility) {
+    parts.push(`cp.visibility = $${idx++}`);
+    values.push(filter.visibility);
+  }
+
+  if (filter.freshness) {
+    const map: Record<string, [string | null, string | null]> = {
+      fresh:  [`NOW() - INTERVAL '7 days'`, null],
+      recent: [`NOW() - INTERVAL '30 days'`, `NOW() - INTERVAL '7 days'`],
+      aging:  [`NOW() - INTERVAL '90 days'`, `NOW() - INTERVAL '30 days'`],
+      stale:  [null, `NOW() - INTERVAL '90 days'`],
+    };
+    const entry = map[filter.freshness];
+    if (entry) {
+      const [after, before] = entry;
+      if (after) parts.push(`cp.last_modified_at >= ${after}`);
+      if (before) parts.push(`cp.last_modified_at < ${before}`);
+    }
+  }
+
+  if (filter.embeddingStatus) {
+    parts.push(`cp.embedding_dirty = $${idx++}`);
+    values.push(filter.embeddingStatus === 'pending');
+  }
+
+  if (filter.qualityMin !== undefined) {
+    parts.push(`cp.quality_score >= $${idx++}`);
+    values.push(filter.qualityMin);
+  }
+  if (filter.qualityMax !== undefined) {
+    parts.push(`cp.quality_score <= $${idx++}`);
+    values.push(filter.qualityMax);
+  }
+  if (filter.qualityStatus) {
+    parts.push(`cp.quality_status = $${idx++}`);
+    values.push(filter.qualityStatus);
+  }
+
+  if (filter.dateFrom) {
+    parts.push(`cp.last_modified_at >= $${idx++}`);
+    values.push(filter.dateFrom);
+  }
+  if (filter.dateTo) {
+    parts.push(`cp.last_modified_at <= $${idx++}`);
+    values.push(filter.dateTo);
+  }
+
+  return { parts, values, nextIdx: idx };
+}
+
+const DEFAULT_DRIFT_TOLERANCE = 0.05;
+
+/**
+ * Resolve a bulk selection body. The caller supplies the pre-fetched
+ * `accessibleSpaces` (RBAC scope) so we don't double-fetch when the route
+ * already has them.
+ *
+ * For ids-mode: queries `pages` filtered by id OR confluence_id, restricted
+ * to the user's RBAC scope (own standalone OR accessible spaces). Returns
+ * the matching rows + the input ids that didn't resolve.
+ *
+ * For filter-mode: builds the same WHERE clause that `GET /pages` would,
+ * COUNTs, validates drift, then SELECTs the resolved rows. Throws
+ * `BulkSelectionError` when drift exceeds tolerance.
+ */
+export async function resolveBulkSelection(
+  userId: string,
+  selection: BulkSelection,
+  accessibleSpaces: string[],
+  options: { idMode?: 'numeric-only' | 'mixed' } = {},
+): Promise<ResolveBulkSelectionResult> {
+  // -- ids mode --
+  if (selection.ids) {
+    const ids = selection.ids;
+    const numericIds = ids.filter((id) => /^\d+$/.test(id)).map(Number);
+    const confluenceStringIds =
+      options.idMode === 'numeric-only' ? [] : ids.filter((id) => !/^\d+$/.test(id));
+
+    const result = await query<{
+      id: number;
+      confluence_id: string | null;
+      space_key: string | null;
+      source: string;
+      labels: string[] | null;
+    }>(
+      `SELECT cp.id, cp.confluence_id, cp.space_key, cp.source, cp.labels FROM pages cp
+       WHERE (cp.id = ANY($1::int[]) OR cp.confluence_id = ANY($2::text[]))
+         AND cp.deleted_at IS NULL
+         AND ((cp.source = 'standalone' AND (cp.visibility = 'shared' OR cp.created_by_user_id = $3))
+              OR cp.space_key = ANY($4::text[]))`,
+      [numericIds, confluenceStringIds, userId, accessibleSpaces],
+    );
+
+    const rows: ResolvedBulkRow[] = result.rows.map((r) => ({
+      id: r.id,
+      confluenceId: r.confluence_id,
+      spaceKey: r.space_key,
+      source: r.source as 'confluence' | 'standalone',
+      labels: r.labels ?? [],
+    }));
+
+    // Map each returned row back to the *original* id the caller supplied so
+    // we can compute notFoundIds correctly. In `numeric-only` mode every
+    // input is the integer PK; in `mixed` mode the input is whatever the
+    // route accepted (PK for standalone pages, confluence_id for synced).
+    const foundOriginal = new Set<string>(
+      result.rows.map((r) => {
+        if (options.idMode === 'numeric-only') return String(r.id);
+        return r.source === 'standalone' ? String(r.id) : r.confluence_id ?? String(r.id);
+      }),
+    );
+    const notFoundIds = ids.filter((id) => !foundOriginal.has(id));
+
+    return { rows, notFoundIds };
+  }
+
+  // -- filter mode --
+  if (!selection.filter || selection.expectedCount === undefined) {
+    throw new BulkSelectionError({
+      kind: 'invalid_input',
+      message: 'Filter mode requires both `filter` and `expectedCount`',
+    });
+  }
+
+  const tolerance = selection.driftToleranceFraction ?? DEFAULT_DRIFT_TOLERANCE;
+
+  // Base WHERE clause matches the GET /pages RBAC + tombstone shape.
+  const baseValues: unknown[] = [accessibleSpaces, userId];
+  const { parts, values: filterValues } = buildFilterClauses(
+    selection.filter,
+    baseValues.length + 1,
+  );
+  const whereParts = ['cp.deleted_at IS NULL', ...parts];
+  const where = `WHERE (
+      (cp.source = 'confluence' AND cp.space_key = ANY($1::text[]))
+      OR (cp.source = 'standalone' AND cp.visibility = 'shared')
+      OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $2)
+    ) AND ${whereParts.join(' AND ')}`;
+
+  const allValues = [...baseValues, ...filterValues];
+
+  const countResult = await query<{ count: string }>(
+    `SELECT COUNT(*) as count FROM pages cp ${where}`,
+    allValues,
+  );
+  const actual = parseInt(countResult.rows[0]?.count ?? '0', 10);
+
+  // Drift check — `expectedCount` of zero with tolerance 0 means "the user
+  // is bulk-acting on an empty preview" which we treat as a no-op rather
+  // than as a 409. Otherwise apply the fractional tolerance against the
+  // expected count (so tiny selections don't false-positive on a 1-row drift
+  // when tolerance > 0%).
+  const expected = selection.expectedCount;
+  if (expected === 0 && actual === 0) {
+    return { rows: [], notFoundIds: [] };
+  }
+  // tolerance=0 → exact match required. Otherwise allow at least ±1 row of
+  // drift even on tiny selections (a 1-page drift on a 5-row preview should
+  // not 409 — that's noise, not a real change in the matching set).
+  const allowedDrift =
+    tolerance === 0 ? 0 : Math.max(1, Math.ceil(expected * tolerance));
+  if (Math.abs(actual - expected) > allowedDrift) {
+    throw new BulkSelectionError({
+      kind: 'count_drift',
+      message: `Selection drift exceeded tolerance: expected ~${expected} (±${allowedDrift}), got ${actual}`,
+      expected,
+      actual,
+    });
+  }
+
+  // Hard cap on filter-mode selections. Bulk routes already cap ids[] at
+  // 1000; filter mode should not be a backdoor around that. Bigger
+  // operations should be split client-side.
+  const HARD_CAP = 5000;
+  const result = await query<{
+    id: number;
+    confluence_id: string | null;
+    space_key: string | null;
+    source: string;
+    labels: string[] | null;
+  }>(
+    `SELECT cp.id, cp.confluence_id, cp.space_key, cp.source, cp.labels FROM pages cp ${where}
+     ORDER BY cp.id ASC
+     LIMIT ${HARD_CAP}`,
+    allValues,
+  );
+
+  const rows: ResolvedBulkRow[] = result.rows.map((r) => ({
+    id: r.id,
+    confluenceId: r.confluence_id,
+    spaceKey: r.space_key,
+    source: r.source as 'confluence' | 'standalone',
+    labels: r.labels ?? [],
+  }));
+
+  return { rows, notFoundIds: [] };
+}

--- a/backend/src/routes/knowledge/bulk-pages.test.ts
+++ b/backend/src/routes/knowledge/bulk-pages.test.ts
@@ -350,6 +350,29 @@ describe('Bulk Pages Routes (Parallelized)', () => {
     });
   });
 
+  describe('POST /api/pages/bulk/delete (filter-mode)', () => {
+    it('accepts filter-mode + expectedCount selection', async () => {
+      // COUNT → 1; SELECT resolved → 1 row; UPDATE deleted_at + DELETE pinned (parallel)
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ count: '1' }], rowCount: 1 });
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{ id: 50, confluence_id: null, space_key: null, source: 'standalone', labels: [] }],
+        rowCount: 1,
+      });
+      mockQueryFn.mockResolvedValue({ rows: [], rowCount: 1 });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/delete',
+        payload: { filter: { source: 'standalone' }, expectedCount: 1 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.succeeded).toBe(1);
+      expect(body.failed).toBe(0);
+    });
+  });
+
   describe('POST /api/pages/bulk/sync', () => {
     it('should re-sync multiple pages', async () => {
       const response = await app.inject({
@@ -395,8 +418,10 @@ describe('Bulk Pages Routes (Parallelized)', () => {
     });
 
     it('should use batch ownership query with ANY()', async () => {
+      // Resolver SELECT (call 0) returns the eligible row; the route then
+      // issues the UPDATE (call 1). Both use ANY() for batching.
       mockQueryFn.mockResolvedValueOnce({
-        rows: [{ confluence_id: 'page-1', space_key: 'OPS' }],
+        rows: [{ id: 1, confluence_id: 'page-1', space_key: 'OPS', source: 'confluence', labels: [] }],
         rowCount: 1,
       });
 
@@ -406,9 +431,43 @@ describe('Bulk Pages Routes (Parallelized)', () => {
         payload: { ids: ['page-1'] },
       });
 
-      // First query call should be the batch ownership check
+      // Resolver SELECT batches by `ANY($1::int[])` for numeric ids and
+      // `ANY($2::text[])` for confluence ids — both visible in the first call.
       const firstCall = mockQueryFn.mock.calls[0];
-      expect(firstCall[0]).toContain('ANY($2)');
+      expect(firstCall[0]).toContain('ANY($2::text[])');
+    });
+
+    it('accepts filter-mode + expectedCount selection', async () => {
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ count: '1' }], rowCount: 1 });
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{ id: 1, confluence_id: 'page-1', space_key: 'OPS', source: 'confluence', labels: [] }],
+        rowCount: 1,
+      });
+      mockQueryFn.mockResolvedValue({ rows: [], rowCount: 1 });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/sync',
+        payload: { filter: { spaceKey: 'OPS' }, expectedCount: 1 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.succeeded).toBe(1);
+      expect(body.failed).toBe(0);
+    });
+
+    it('returns 409 CountDrift when filter actual diverges past tolerance', async () => {
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ count: '50' }], rowCount: 1 });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/sync',
+        payload: { filter: { spaceKey: 'OPS' }, expectedCount: 10 },
+      });
+
+      expect(response.statusCode).toBe(409);
+      expect(JSON.parse(response.body).error).toBe('CountDrift');
     });
 
     it('passes cached space keys into confluenceToHtml during bulk sync', async () => {
@@ -490,7 +549,40 @@ describe('Bulk Pages Routes (Parallelized)', () => {
       expect(body.error).toContain('already in progress');
     });
 
+    it('accepts filter-mode + expectedCount selection', async () => {
+      // COUNT (drift check) → 2; SELECT resolved rows → 2 rows; UPDATE → 2 rows
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ count: '2' }], rowCount: 1 });
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [
+          { id: 1, confluence_id: 'page-1', space_key: 'OPS', source: 'confluence', labels: [] },
+          { id: 2, confluence_id: 'page-2', space_key: 'OPS', source: 'confluence', labels: [] },
+        ],
+        rowCount: 2,
+      });
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{ confluence_id: 'page-1' }, { confluence_id: 'page-2' }],
+        rowCount: 2,
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/embed',
+        payload: { filter: { spaceKey: 'OPS' }, expectedCount: 2 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.succeeded).toBe(2);
+      expect(body.failed).toBe(0);
+    });
+
     it('should use single batch UPDATE with ANY() and RETURNING', async () => {
+      // Resolver SELECT (call 0) returns the eligible row; route's UPDATE
+      // (call 1) writes embedding_dirty=TRUE with `ANY($1)` and RETURNING.
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{ id: 1, confluence_id: 'page-1', space_key: 'OPS', source: 'confluence', labels: [] }],
+        rowCount: 1,
+      });
       mockQueryFn.mockResolvedValueOnce({
         rows: [{ confluence_id: 'page-1' }],
         rowCount: 1,
@@ -502,11 +594,10 @@ describe('Bulk Pages Routes (Parallelized)', () => {
         payload: { ids: ['page-1'] },
       });
 
-      // The embed endpoint now issues a single UPDATE...RETURNING query
-      // ids are ANY($1), userId is $2 in subquery for space_key access control
-      const embedCall = mockQueryFn.mock.calls[0];
-      expect(embedCall[0]).toContain('ANY($1)');
-      expect(embedCall[0]).toContain('RETURNING');
+      const updateCall = mockQueryFn.mock.calls[1];
+      expect(updateCall![0]).toContain('UPDATE pages SET embedding_dirty');
+      expect(updateCall![0]).toContain('ANY($1)');
+      expect(updateCall![0]).toContain('RETURNING');
     });
   });
 

--- a/backend/src/routes/knowledge/bulk-pages.test.ts
+++ b/backend/src/routes/knowledge/bulk-pages.test.ts
@@ -877,6 +877,70 @@ describe('Bulk Pages Routes (Parallelized)', () => {
       expect(meta.cancelled).toBe(false);
     });
 
+    it('accepts filter-mode + expectedCount selection (instead of ids)', async () => {
+      // First query: COUNT for drift check → returns 2
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ count: '2' }], rowCount: 1 });
+      // Second query: SELECT resolved rows
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [
+          { id: 1, confluence_id: 'conf-1', space_key: 'OPS', source: 'confluence', labels: ['old'] },
+          { id: 2, confluence_id: 'conf-2', space_key: 'OPS', source: 'confluence', labels: [] },
+        ],
+        rowCount: 2,
+      });
+      mockQueryFn.mockResolvedValue({ rows: [], rowCount: 1 }); // UPDATEs
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/replace-tags',
+        payload: {
+          filter: { spaceKey: 'OPS' },
+          expectedCount: 2,
+          tags: ['canonical'],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.succeeded).toBe(2);
+      expect(body.failed).toBe(0);
+    });
+
+    it('returns 409 CountDrift when filter actual diverges past tolerance', async () => {
+      // expectedCount = 100, actual = 200 → way past 5% tolerance
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ count: '200' }], rowCount: 1 });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/replace-tags',
+        payload: {
+          filter: { spaceKey: 'OPS' },
+          expectedCount: 100,
+          tags: ['x'],
+        },
+      });
+
+      expect(response.statusCode).toBe(409);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('CountDrift');
+      expect(body.expected).toBe(100);
+      expect(body.actual).toBe(200);
+    });
+
+    it('rejects mixing ids and filter (Zod refine)', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/replace-tags',
+        payload: {
+          ids: ['1'],
+          filter: { spaceKey: 'OPS' },
+          expectedCount: 1,
+          tags: ['x'],
+        },
+      });
+      expect(response.statusCode).toBe(400);
+    });
+
     it('partial-apply: emits ONE audit event whose metadata reflects the failure count', async () => {
       // Two pages eligible from RBAC; the first UPDATE rejects (simulated DB
       // failure) so we expect succeeded=1, failed=1 in the single audit row.

--- a/backend/src/routes/knowledge/bulk-pages.test.ts
+++ b/backend/src/routes/knowledge/bulk-pages.test.ts
@@ -713,5 +713,210 @@ describe('Bulk Pages Routes (Parallelized)', () => {
       expect(updateCall).toBeDefined();
       expect(updateCall![0]).toContain('WHERE id = $1');
     });
+
+    // EE #117 — confirm the additive bulk/tag route now emits exactly one
+    // BULK_PAGE_TAGGED audit event per request (not per row). Audit-volume
+    // mitigation per epic v0.4 §3.6 / R8.
+    it('emits exactly one BULK_PAGE_TAGGED audit event for the whole request', async () => {
+      const { logAuditEvent } = await import('../../core/services/audit-service.js');
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [
+          { id: 1, confluence_id: 'conf-1', labels: ['existing-tag'] },
+          { id: 2, confluence_id: 'conf-2', labels: [] },
+          { id: 3, confluence_id: 'conf-3', labels: [] },
+        ],
+        rowCount: 3,
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/tag',
+        payload: { ids: ['1', '2', '3'], addTags: ['shared'] },
+      });
+
+      const calls = vi.mocked(logAuditEvent).mock.calls;
+      const bulkTaggedCalls = calls.filter((c) => c[1] === 'BULK_PAGE_TAGGED');
+      expect(bulkTaggedCalls).toHaveLength(1);
+      const meta = bulkTaggedCalls[0]?.[4] as Record<string, unknown>;
+      expect(meta.bulkIds).toEqual(['1', '2', '3']);
+      expect(meta.addTags).toEqual(['shared']);
+      expect(meta.succeeded).toBe(3);
+      expect(meta.failed).toBe(0);
+    });
+  });
+
+  describe('POST /api/pages/bulk/replace-tags', () => {
+    it('should replace the entire tag set on the targeted pages', async () => {
+      // Page 1 has existing labels ['old-a', 'old-b'] → after replace they are
+      // wiped and ['kept'] survives only because the input contains it.
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{ id: 1, confluence_id: 'conf-1', labels: ['old-a', 'old-b'] }],
+        rowCount: 1,
+      });
+      // UPDATE query
+      mockQueryFn.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/replace-tags',
+        payload: { ids: ['1'], tags: ['kept'] },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.succeeded).toBe(1);
+      expect(body.failed).toBe(0);
+      expect(body.cancelled).toBe(false);
+
+      // The UPDATE should write the new tag set to the page
+      const updateCall = mockQueryFn.mock.calls.find(
+        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('UPDATE pages SET labels'),
+      );
+      expect(updateCall).toBeDefined();
+      expect(updateCall![1]).toEqual([1, ['kept']]);
+    });
+
+    it('normalises tags (lowercase, trim, dedupe) before persisting', async () => {
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{ id: 1, confluence_id: null, labels: [] }],
+        rowCount: 1,
+      });
+      mockQueryFn.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/replace-tags',
+        payload: {
+          ids: ['1'],
+          tags: ['  Bug  ', 'BUG', 'feature', 'feature', '   '],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const updateCall = mockQueryFn.mock.calls.find(
+        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('UPDATE pages SET labels'),
+      );
+      expect(updateCall![1]).toEqual([1, ['bug', 'feature']]);
+    });
+
+    it('syncs the diff to Confluence: adds new tags, removes dropped ones', async () => {
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{ id: 1, confluence_id: 'conf-1', labels: ['old-a', 'old-b'] }],
+        rowCount: 1,
+      });
+      mockQueryFn.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/replace-tags',
+        payload: { ids: ['1'], tags: ['old-a', 'new'] },
+      });
+
+      const client = await vi.mocked(getClientForUser).mock.results[0].value;
+      expect(client.addLabels).toHaveBeenCalledWith('conf-1', ['new']);
+      expect(client.removeLabel).toHaveBeenCalledWith('conf-1', 'old-b');
+    });
+
+    it('reports not-found pages without aborting the request', async () => {
+      // RBAC fetch returns only page 1; page 999 is not found.
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{ id: 1, confluence_id: null, labels: [] }],
+        rowCount: 1,
+      });
+      mockQueryFn.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/replace-tags',
+        payload: { ids: ['1', '999'], tags: ['t'] },
+      });
+
+      const body = JSON.parse(response.body);
+      expect(body.succeeded).toBe(1);
+      expect(body.failed).toBe(1);
+      expect(body.errors[0]).toContain('999');
+      expect(body.errors[0]).toContain('not found');
+    });
+
+    it('rejects empty ids', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/replace-tags',
+        payload: { ids: [], tags: ['t'] },
+      });
+      expect(response.statusCode).toBe(400);
+    });
+
+    // Audit-count invariant: one BULK_PAGE_TAGS_REPLACED event per request,
+    // never per affected page (epic v0.4 §3.6 / R8).
+    it('emits exactly one BULK_PAGE_TAGS_REPLACED audit event for the whole request', async () => {
+      const { logAuditEvent } = await import('../../core/services/audit-service.js');
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [
+          { id: 1, confluence_id: 'conf-1', labels: ['old-a'] },
+          { id: 2, confluence_id: 'conf-2', labels: ['old-b'] },
+          { id: 3, confluence_id: null, labels: [] },
+        ],
+        rowCount: 3,
+      });
+      mockQueryFn.mockResolvedValue({ rows: [], rowCount: 1 });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/replace-tags',
+        payload: { ids: ['1', '2', '3'], tags: ['shared'] },
+      });
+
+      const calls = vi.mocked(logAuditEvent).mock.calls;
+      const replacedCalls = calls.filter((c) => c[1] === 'BULK_PAGE_TAGS_REPLACED');
+      expect(replacedCalls).toHaveLength(1);
+      const meta = replacedCalls[0]?.[4] as Record<string, unknown>;
+      expect(meta.tags).toEqual(['shared']);
+      expect(meta.succeeded).toBe(3);
+      expect(meta.failed).toBe(0);
+      expect(meta.cancelled).toBe(false);
+    });
+
+    it('partial-apply: emits ONE audit event whose metadata reflects the failure count', async () => {
+      // Two pages eligible from RBAC; the first UPDATE rejects (simulated DB
+      // failure) so we expect succeeded=1, failed=1 in the single audit row.
+      const { logAuditEvent } = await import('../../core/services/audit-service.js');
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [
+          { id: 1, confluence_id: 'conf-1', labels: [] },
+          { id: 2, confluence_id: 'conf-2', labels: [] },
+        ],
+        rowCount: 2,
+      });
+      // First UPDATE rejects, second succeeds.
+      let updateCallIdx = 0;
+      mockQueryFn.mockImplementation((sql: string) => {
+        if (sql.includes('UPDATE pages SET labels')) {
+          updateCallIdx++;
+          if (updateCallIdx === 1) {
+            return Promise.reject(new Error('simulated DB failure'));
+          }
+          return Promise.resolve({ rows: [], rowCount: 1 });
+        }
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/replace-tags',
+        payload: { ids: ['1', '2'], tags: ['new'] },
+      });
+
+      const body = JSON.parse(response.body);
+      expect(body.succeeded).toBe(1);
+      expect(body.failed).toBe(1);
+      expect(body.errors.some((e: string) => e.includes('simulated DB failure'))).toBe(true);
+
+      const replacedCalls = vi.mocked(logAuditEvent).mock.calls.filter((c) => c[1] === 'BULK_PAGE_TAGS_REPLACED');
+      expect(replacedCalls).toHaveLength(1);
+      const meta = replacedCalls[0]?.[4] as Record<string, unknown>;
+      expect(meta.succeeded).toBe(1);
+      expect(meta.failed).toBe(1);
+    });
   });
 });

--- a/backend/src/routes/knowledge/pages-bulk-progress.ts
+++ b/backend/src/routes/knowledge/pages-bulk-progress.ts
@@ -1,0 +1,113 @@
+/**
+ * SSE progress stream for long-running bulk page operations
+ * (Compendiq/compendiq-ee#117).
+ *
+ *   GET /api/pages/bulk/:jobId/progress
+ *
+ * Pairs with the bulk-action POST routes in pages-crud.ts (replace-tags,
+ * tag, sync, embed, delete) and the EE-overlay bulk/permission route. The
+ * client opens the SSE first, then issues the POST with the same `jobId`.
+ * Events are pushed via Redis (see `bulk-page-progress.ts`); when the client
+ * disconnects, the route fires `cancelBulkJob(jobId)` so the in-flight POST
+ * can bail at the next chunk boundary.
+ *
+ * Auth: `fastify.authenticate` is applied via `addHook('onRequest')` — the
+ * bulk routes already require auth, so the SSE observer must as well. Cross-
+ * user observation of someone else's job is intentionally left open at the
+ * route layer (jobIds are unguessable UUIDs); we do NOT scope by `userId`
+ * because future async features (e.g. an admin watching a long sync) need
+ * cross-user visibility. The unguessability of the jobId is the access
+ * control.
+ *
+ * SSE pattern follows `routes/knowledge/pages-presence.ts:85-138` and
+ * `routes/llm/_helpers.ts:151-220`. Specifically:
+ *   - `reply.hijack()` BEFORE writing headers
+ *   - `request.raw.on('close')` registers an AbortController abort
+ *   - the route returns a never-resolving Promise so Fastify doesn't
+ *     finalise the reply early; the abort listener resolves on disconnect
+ */
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { logger } from '../../core/utils/logger.js';
+import {
+  streamBulkProgress,
+  cancelBulkJob,
+  type BulkProgressEvent,
+} from '../../core/services/bulk-page-progress.js';
+
+const JobIdParamSchema = z.object({ jobId: z.string().uuid() });
+
+export async function pagesBulkProgressRoutes(fastify: FastifyInstance) {
+  fastify.addHook('onRequest', fastify.authenticate);
+
+  fastify.get('/pages/bulk/:jobId/progress', async (request, reply) => {
+    const { jobId } = JobIdParamSchema.parse(request.params);
+
+    // --- SSE stream ---
+    reply.hijack();
+    reply.raw.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      // Suppress NGINX / cloud-LB buffering so chunked progress reaches the
+      // browser in real time. Critical for the cancel-button UX.
+      'X-Accel-Buffering': 'no',
+    });
+
+    const controller = new AbortController();
+    let closed = false;
+    const onClose = (): void => {
+      if (closed) return;
+      closed = true;
+      controller.abort();
+      // Fire-and-forget: surface cancellation to the in-flight POST. We do
+      // NOT await this — the SSE socket is already gone.
+      cancelBulkJob(jobId).catch((err) => {
+        logger.debug({ err, jobId }, 'pages-bulk-progress: cancel-on-disconnect failed');
+      });
+    };
+    request.raw.on('close', onClose);
+
+    const writeEvent = (ev: BulkProgressEvent): void => {
+      try {
+        // Use the SSE `event:` field for keepalive ticks so the client can
+        // ignore them in its progress UI without parsing the JSON.
+        const eventName = ev.note === 'keepalive' ? 'keepalive' : 'progress';
+        reply.raw.write(`event: ${eventName}\ndata: ${JSON.stringify(ev)}\n\n`);
+      } catch (err) {
+        logger.debug({ err, jobId }, 'pages-bulk-progress: SSE write failed (client disconnected)');
+        controller.abort();
+      }
+    };
+
+    try {
+      for await (const ev of streamBulkProgress(jobId, controller.signal)) {
+        writeEvent(ev);
+        if (ev.done || ev.cancelled) break;
+      }
+    } catch (err) {
+      logger.error({ err, jobId }, 'pages-bulk-progress: stream error');
+      try {
+        reply.raw.write(`event: error\ndata: ${JSON.stringify({ message: 'stream error' })}\n\n`);
+      } catch {
+        // socket gone
+      }
+    } finally {
+      try {
+        reply.raw.end();
+      } catch {
+        // already torn down
+      }
+    }
+
+    // Promise resolves on client disconnect via the registered close handler.
+    if (!closed) {
+      await new Promise<void>((resolve) => {
+        request.raw.on('close', () => {
+          onClose();
+          resolve();
+        });
+      });
+    }
+  });
+}

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -6,6 +6,12 @@ import { getClientForUser } from '../../domains/confluence/services/sync-service
 import { htmlToConfluence, confluenceToHtml } from '../../core/services/content-converter.js';
 import { cleanPageAttachments, writeAttachmentCache } from '../../domains/confluence/services/attachment-handler.js';
 import { logAuditEvent } from '../../core/services/audit-service.js';
+import {
+  startBulkJob,
+  runBulkInChunks,
+  publishProgress,
+  newJobId,
+} from '../../core/services/bulk-page-progress.js';
 import { emitWebhookEvent } from '../../core/services/webhook-emit-hook.js';
 import { processDirtyPages, isProcessingUser } from '../../domains/llm/services/embedding-service.js';
 import { getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
@@ -102,6 +108,18 @@ const BulkTagSchema = z.object({
   ids: z.array(z.string().min(1)).min(1).max(100),
   addTags: z.array(z.string()).default([]),
   removeTags: z.array(z.string()).default([]),
+});
+/**
+ * `bulk/replace-tags` (EE #117) — REPLACES the entire label set on each page.
+ * Higher-risk than additive tag (`bulk/tag`), so the audit emission gets its
+ * own action: `BULK_PAGE_TAGS_REPLACED`. Tags are normalised (lowercased,
+ * trimmed, de-duplicated) at input to match the existing auto-tagger
+ * convention.
+ */
+const BulkReplaceTagsSchema = z.object({
+  ids: z.array(z.string().min(1)).min(1).max(100),
+  tags: z.array(z.string()).max(50),
+  jobId: z.string().uuid().optional(),
 });
 const IdParamSchema = z.object({ id: z.string().min(1) });
 
@@ -1768,7 +1786,143 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
 
     await cache.invalidate(userId, 'pages');
 
+    // Audit: one event per bulk action, not per row (epic v0.4 §3.6 / R8).
+    await logAuditEvent(
+      userId,
+      'BULK_PAGE_TAGGED',
+      'page',
+      undefined,
+      { bulkIds: ids, addTags, removeTags, succeeded, failed },
+      request,
+    );
+
     return { succeeded, failed, errors };
+  });
+
+  // POST /api/pages/bulk/replace-tags — REPLACE entire tag set on N pages
+  //
+  // Distinct from /bulk/tag (additive) so admins can wipe tags atomically and
+  // the audit log can distinguish the higher-risk operation
+  // (BULK_PAGE_TAGS_REPLACED). Optional `jobId` enables SSE progress; when
+  // absent the route still chunks for memory but skips the publish/cancel
+  // path. Tags are normalised (lower-cased, trimmed, de-duplicated) at the
+  // boundary to match the existing auto-tagger convention.
+  fastify.post('/pages/bulk/replace-tags', async (request) => {
+    const { ids, tags, jobId } = BulkReplaceTagsSchema.parse(request.body);
+    const userId = request.userId;
+
+    // Normalise input tags
+    const normTags = Array.from(
+      new Set(
+        tags
+          .map((t) => t.trim().toLowerCase())
+          .filter((t) => t.length > 0),
+      ),
+    );
+
+    const invalidIds = ids.filter((id) => !/^\d+$/.test(id));
+    if (invalidIds.length > 0) {
+      request.log.warn({ invalidIds }, 'Non-numeric page IDs filtered from bulk replace-tags');
+    }
+    const numericIds = ids.filter((id) => /^\d+$/.test(id)).map((id) => parseInt(id, 10));
+
+    // RBAC: only pages in user-accessible spaces (or unscoped standalone)
+    const accessSpaces = await getUserAccessibleSpaces(userId);
+    const existing = await query<{ id: number; confluence_id: string | null; labels: string[] }>(
+      `SELECT cp.id, cp.confluence_id, cp.labels FROM pages cp
+       WHERE (cp.space_key = ANY($1::text[]) OR cp.space_key IS NULL)
+         AND cp.id = ANY($2::int[])
+         AND cp.deleted_at IS NULL`,
+      [accessSpaces, numericIds],
+    );
+    const pageMap = new Map(
+      existing.rows.map((r) => [r.id, { confluenceId: r.confluence_id, oldLabels: r.labels || [] }]),
+    );
+    const notFoundIds = ids.filter((id) => !pageMap.has(parseInt(id, 10)));
+    const errors: string[] = notFoundIds.map((id) => `Page ${id} not found`);
+    let initialFailed = notFoundIds.length;
+
+    const eligible = [...pageMap.entries()].map(([id, info]) => ({ id, ...info }));
+
+    if (jobId) {
+      await startBulkJob(jobId, eligible.length, userId, 'replace-tags');
+    }
+
+    const client = await getClientForUser(userId);
+    const bulkLimit = pLimit(5);
+
+    const result = await runBulkInChunks(eligible, 100, jobId ?? null, async (chunk) => {
+      let chunkSucceeded = 0;
+      let chunkFailed = 0;
+      const chunkErrors: string[] = [];
+
+      const settled = await Promise.allSettled(
+        chunk.map((page) =>
+          bulkLimit(async () => {
+            await query('UPDATE pages SET labels = $2 WHERE id = $1', [page.id, normTags]);
+
+            // Sync to Confluence: remove labels not in new set, add the rest
+            if (client && page.confluenceId) {
+              const oldSet = new Set(page.oldLabels);
+              const newSet = new Set(normTags);
+              const toAdd = normTags.filter((t) => !oldSet.has(t));
+              const toRemove = page.oldLabels.filter((t) => !newSet.has(t));
+              try {
+                if (toAdd.length > 0) await client.addLabels(page.confluenceId, toAdd);
+                for (const label of toRemove) {
+                  await client.removeLabel(page.confluenceId, label);
+                }
+              } catch (err) {
+                logger.error(
+                  { err, pageId: page.id, confluenceId: page.confluenceId, userId },
+                  'replace-tags: Confluence label sync failed',
+                );
+              }
+            }
+            return page.id;
+          }),
+        ),
+      );
+
+      for (let i = 0; i < settled.length; i++) {
+        const r = settled[i]!;
+        if (r.status === 'fulfilled') {
+          chunkSucceeded++;
+        } else {
+          chunkFailed++;
+          chunkErrors.push(
+            `Page ${chunk[i]!.id}: ${r.reason instanceof Error ? r.reason.message : 'Unknown error'}`,
+          );
+        }
+      }
+
+      return { succeeded: chunkSucceeded, failed: chunkFailed, errors: chunkErrors };
+    });
+
+    errors.push(...result.errors);
+    const succeeded = result.succeeded;
+    const failed = initialFailed + result.failed;
+    const cancelled = result.cancelled;
+
+    await cache.invalidate(userId, 'pages');
+
+    await logAuditEvent(
+      userId,
+      'BULK_PAGE_TAGS_REPLACED',
+      'page',
+      undefined,
+      {
+        bulkIds: ids,
+        tags: normTags,
+        succeeded,
+        failed,
+        cancelled,
+        ...(jobId ? { jobId } : {}),
+      },
+      request,
+    );
+
+    return { succeeded, failed, errors, cancelled, ...(jobId ? { jobId } : {}) };
   });
 
   // POST /api/pages/:id/images - upload a pasted/dropped image for a page

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -107,7 +107,28 @@ async function uploadLocalImagesToConfluence(
   return changed ? doc.body.innerHTML : html;
 }
 
-const BulkIdsSchema = z.object({ ids: z.array(z.string().min(1)).min(1).max(100) });
+/**
+ * Shared schema for the 4 existing bulk routes (delete/sync/embed/tag). Either
+ * `ids` (legacy wire shape) OR `filter + expectedCount` (filter-mode added in
+ * EE #117 slice 1c). Optional `jobId` enables SSE progress observation.
+ */
+const BulkIdsOrFilterSchema = z
+  .object({
+    ids: z.array(z.string().min(1)).min(1).max(1000).optional(),
+    filter: BulkPageFilterSchema.optional(),
+    expectedCount: z.coerce.number().int().min(0).optional(),
+    driftToleranceFraction: z.coerce.number().min(0).max(1).optional(),
+    jobId: z.string().uuid().optional(),
+  })
+  .refine(
+    (v) =>
+      (v.ids && !v.filter && v.expectedCount === undefined) ||
+      (!v.ids && v.filter && v.expectedCount !== undefined),
+    {
+      message:
+        'Provide either { ids } or { filter, expectedCount }; do not mix or omit expectedCount in filter mode',
+    },
+  );
 /**
  * Bulk-action selection mode (EE #117 slice 1b). Either `ids` (existing wire
  * shape) OR `filter` + `expectedCount` (new). The two are mutually exclusive
@@ -1506,40 +1527,43 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
   // ======== Bulk Operations (Issue #28, parallelized #192) ========
 
   // POST /api/pages/bulk/delete - delete multiple pages by IDs
-  fastify.post('/pages/bulk/delete', async (request) => {
-    const { ids } = BulkIdsSchema.parse(request.body);
+  fastify.post('/pages/bulk/delete', async (request, reply) => {
+    const parsed = BulkIdsOrFilterSchema.parse(request.body);
     const userId = request.userId;
 
-    // Separate numeric IDs (standalone pages use DB PK) from Confluence string IDs
-    const numericIds = ids.filter((id) => /^\d+$/.test(id)).map(Number);
-    const confluenceStringIds = ids.filter((id) => !/^\d+$/.test(id));
-
-    // Fetch all requested pages with source info; RBAC: standalone owned by user OR in accessible spaces
     const bulkAccessSpaces = await getUserAccessibleSpaces(userId);
-    const existing = await query<{
-      id: number; source: string; confluence_id: string | null; space_key: string | null;
-    }>(
-      `SELECT p.id, p.source, p.confluence_id, p.space_key
-       FROM pages p
-       WHERE (p.id = ANY($1::int[]) OR p.confluence_id = ANY($2::text[]))
-         AND ((p.source = 'standalone' AND p.created_by_user_id = $3)
-              OR p.space_key = ANY($4::text[]))`,
-      [numericIds, confluenceStringIds, userId, bulkAccessSpaces],
-    );
+    const selection: BulkSelection = {
+      ids: parsed.ids,
+      filter: parsed.filter,
+      expectedCount: parsed.expectedCount,
+      driftToleranceFraction: parsed.driftToleranceFraction,
+    };
 
-    // Map found rows back to the original string IDs supplied by the caller
-    const foundOriginalIds = new Set<string>(
-      existing.rows.map((row) =>
-        row.source === 'standalone' ? String(row.id) : (row.confluence_id ?? String(row.id)),
-      ),
-    );
-    const notFoundIds = ids.filter((id) => !foundOriginalIds.has(id));
-    const errors: string[] = notFoundIds.map((id) => `Page ${id} not found`);
-    let failed = notFoundIds.length;
+    let resolved;
+    try {
+      // delete accepts the legacy mixed wire shape (PK for standalone,
+      // confluence_id for synced) so the resolver runs in 'mixed' mode.
+      resolved = await resolveBulkSelection(userId, selection, bulkAccessSpaces);
+    } catch (err) {
+      if (err instanceof BulkSelectionError && err.detail.kind === 'count_drift') {
+        return reply.status(409).send({
+          error: 'CountDrift',
+          message: err.detail.message,
+          expected: err.detail.expected,
+          actual: err.detail.actual,
+        });
+      }
+      throw err;
+    }
+
+    const errors: string[] = resolved.notFoundIds.map((id) => `Page ${id} not found`);
+    let failed = resolved.notFoundIds.length;
 
     // --- Partition by source ---
-    const standalonePages = existing.rows.filter((r) => r.source === 'standalone');
-    const confluencePages = existing.rows.filter((r) => r.source !== 'standalone');
+    const standalonePages = resolved.rows.filter((r) => r.source === 'standalone')
+      .map((r) => ({ id: r.id, source: 'standalone', confluence_id: r.confluenceId, space_key: r.spaceKey }));
+    const confluencePages = resolved.rows.filter((r) => r.source !== 'standalone')
+      .map((r) => ({ id: r.id, source: r.source, confluence_id: r.confluenceId, space_key: r.spaceKey }));
 
     // Soft-delete standalone pages (move to trash)
     const standaloneNumericIds = standalonePages.map((r) => r.id);
@@ -1610,14 +1634,26 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     const succeeded = standaloneSucceeded + confluenceSucceeded;
     await cache.invalidate(userId, 'pages');
     await cache.invalidate(userId, 'spaces');
-    await logAuditEvent(userId, 'PAGE_DELETED', 'page', undefined, { bulkIds: ids, succeeded, failed }, request);
+    await logAuditEvent(
+      userId,
+      'PAGE_DELETED',
+      'page',
+      undefined,
+      {
+        ...(parsed.ids ? { bulkIds: parsed.ids } : { filter: parsed.filter, expectedCount: parsed.expectedCount }),
+        affectedCount: resolved.rows.length,
+        succeeded,
+        failed,
+      },
+      request,
+    );
 
     return { succeeded, failed, errors };
   });
 
   // POST /api/pages/bulk/sync - re-sync multiple pages from Confluence
-  fastify.post('/pages/bulk/sync', async (request) => {
-    const { ids } = BulkIdsSchema.parse(request.body);
+  fastify.post('/pages/bulk/sync', async (request, reply) => {
+    const parsed = BulkIdsOrFilterSchema.parse(request.body);
     const userId = request.userId;
 
     const client = await getClientForUser(userId);
@@ -1625,19 +1661,38 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       throw fastify.httpErrors.badRequest('Confluence not configured');
     }
 
-    // Batch verify access: pages in user's accessible spaces (RBAC)
     const bulkAccessSpaces = await getUserAccessibleSpaces(userId);
-    const existing = await query<{ confluence_id: string; space_key: string }>(
-      `SELECT cp.confluence_id, cp.space_key FROM pages cp
-       WHERE cp.space_key = ANY($1::text[])
-         AND cp.confluence_id = ANY($2)`,
-      [bulkAccessSpaces, ids],
+    const selection: BulkSelection = {
+      ids: parsed.ids,
+      filter: parsed.filter,
+      expectedCount: parsed.expectedCount,
+      driftToleranceFraction: parsed.driftToleranceFraction,
+    };
+
+    let resolved;
+    try {
+      resolved = await resolveBulkSelection(userId, selection, bulkAccessSpaces);
+    } catch (err) {
+      if (err instanceof BulkSelectionError && err.detail.kind === 'count_drift') {
+        return reply.status(409).send({
+          error: 'CountDrift',
+          message: err.detail.message,
+          expected: err.detail.expected,
+          actual: err.detail.actual,
+        });
+      }
+      throw err;
+    }
+
+    // Sync only operates on Confluence-sourced pages (standalone pages have no
+    // upstream to re-sync from).
+    const syncableRows = resolved.rows.filter((r) => r.confluenceId !== null);
+    const ownedIds = new Set(syncableRows.map((r) => r.confluenceId as string));
+    const spaceKeysById = new Map(
+      syncableRows.map((r) => [r.confluenceId as string, r.spaceKey ?? '']),
     );
-    const ownedIds = new Set(existing.rows.map((r) => r.confluence_id));
-    const spaceKeysById = new Map(existing.rows.map((r) => [r.confluence_id, r.space_key]));
-    const notFoundIds = ids.filter((id) => !ownedIds.has(id));
-    const errors: string[] = notFoundIds.map((id) => `Page ${id} not found`);
-    let failed = notFoundIds.length;
+    const errors: string[] = resolved.notFoundIds.map((id) => `Page ${id} not found`);
+    let failed = resolved.notFoundIds.length;
 
     // Eager-load htmlToText once (avoid repeated dynamic import)
     const { htmlToText } = await import('../../core/services/content-converter.js');
@@ -1691,8 +1746,8 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
   });
 
   // POST /api/pages/bulk/embed - re-embed multiple pages
-  fastify.post('/pages/bulk/embed', async (request) => {
-    const { ids } = BulkIdsSchema.parse(request.body);
+  fastify.post('/pages/bulk/embed', async (request, reply) => {
+    const parsed = BulkIdsOrFilterSchema.parse(request.body);
     const userId = request.userId;
 
     // Return 409 if embedding is already in progress for this user
@@ -1700,21 +1755,48 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       throw fastify.httpErrors.conflict('Embedding processing is already in progress for this user');
     }
 
-    // Batch update: single query with ANY() and RETURNING instead of N updates
     const embedSpaces = await getUserAccessibleSpaces(userId);
-    const result = await query<{ confluence_id: string }>(
-      `UPDATE pages SET embedding_dirty = TRUE
-       WHERE confluence_id = ANY($1)
-         AND space_key = ANY($2::text[])
-       RETURNING confluence_id`,
-      [ids, embedSpaces],
-    );
+    const selection: BulkSelection = {
+      ids: parsed.ids,
+      filter: parsed.filter,
+      expectedCount: parsed.expectedCount,
+      driftToleranceFraction: parsed.driftToleranceFraction,
+    };
 
-    const updatedIds = new Set(result.rows.map((r) => r.confluence_id));
-    const succeeded = updatedIds.size;
-    const notFoundIds = ids.filter((id) => !updatedIds.has(id));
-    const failed = notFoundIds.length;
-    const errors: string[] = notFoundIds.map((id) => `Page ${id} not found`);
+    let resolved;
+    try {
+      resolved = await resolveBulkSelection(userId, selection, embedSpaces);
+    } catch (err) {
+      if (err instanceof BulkSelectionError && err.detail.kind === 'count_drift') {
+        return reply.status(409).send({
+          error: 'CountDrift',
+          message: err.detail.message,
+          expected: err.detail.expected,
+          actual: err.detail.actual,
+        });
+      }
+      throw err;
+    }
+
+    // Embedding requires a confluence_id — standalone pages are skipped (their
+    // embeddings live separately).
+    const eligibleIds = resolved.rows
+      .filter((r) => r.confluenceId !== null)
+      .map((r) => r.confluenceId as string);
+
+    let succeeded = 0;
+    if (eligibleIds.length > 0) {
+      const result = await query<{ confluence_id: string }>(
+        `UPDATE pages SET embedding_dirty = TRUE
+         WHERE confluence_id = ANY($1)
+         RETURNING confluence_id`,
+        [eligibleIds],
+      );
+      succeeded = result.rows.length;
+    }
+
+    const errors: string[] = resolved.notFoundIds.map((id) => `Page ${id} not found`);
+    const failed = resolved.notFoundIds.length;
 
     // Fire-and-forget: trigger processing of dirty pages (same pattern as POST /embeddings/process)
     if (succeeded > 0) {

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -9,9 +9,13 @@ import { logAuditEvent } from '../../core/services/audit-service.js';
 import {
   startBulkJob,
   runBulkInChunks,
-  publishProgress,
-  newJobId,
 } from '../../core/services/bulk-page-progress.js';
+import {
+  BulkPageFilterSchema,
+  resolveBulkSelection,
+  BulkSelectionError,
+  type BulkSelection,
+} from '../../core/services/bulk-page-selection.js';
 import { emitWebhookEvent } from '../../core/services/webhook-emit-hook.js';
 import { processDirtyPages, isProcessingUser } from '../../domains/llm/services/embedding-service.js';
 import { getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
@@ -104,11 +108,30 @@ async function uploadLocalImagesToConfluence(
 }
 
 const BulkIdsSchema = z.object({ ids: z.array(z.string().min(1)).min(1).max(100) });
-const BulkTagSchema = z.object({
-  ids: z.array(z.string().min(1)).min(1).max(100),
-  addTags: z.array(z.string()).default([]),
-  removeTags: z.array(z.string()).default([]),
-});
+/**
+ * Bulk-action selection mode (EE #117 slice 1b). Either `ids` (existing wire
+ * shape) OR `filter` + `expectedCount` (new). The two are mutually exclusive
+ * and refined-validated below; the existing `ids` clients keep working.
+ */
+const BulkTagSchema = z
+  .object({
+    ids: z.array(z.string().min(1)).min(1).max(1000).optional(),
+    filter: BulkPageFilterSchema.optional(),
+    expectedCount: z.coerce.number().int().min(0).optional(),
+    driftToleranceFraction: z.coerce.number().min(0).max(1).optional(),
+    addTags: z.array(z.string()).default([]),
+    removeTags: z.array(z.string()).default([]),
+    jobId: z.string().uuid().optional(),
+  })
+  .refine(
+    (v) =>
+      (v.ids && !v.filter && v.expectedCount === undefined) ||
+      (!v.ids && v.filter && v.expectedCount !== undefined),
+    {
+      message:
+        'Provide either { ids } or { filter, expectedCount }; do not mix or omit expectedCount in filter mode',
+    },
+  );
 /**
  * `bulk/replace-tags` (EE #117) — REPLACES the entire label set on each page.
  * Higher-risk than additive tag (`bulk/tag`), so the audit emission gets its
@@ -116,11 +139,24 @@ const BulkTagSchema = z.object({
  * trimmed, de-duplicated) at input to match the existing auto-tagger
  * convention.
  */
-const BulkReplaceTagsSchema = z.object({
-  ids: z.array(z.string().min(1)).min(1).max(100),
-  tags: z.array(z.string()).max(50),
-  jobId: z.string().uuid().optional(),
-});
+const BulkReplaceTagsSchema = z
+  .object({
+    ids: z.array(z.string().min(1)).min(1).max(1000).optional(),
+    filter: BulkPageFilterSchema.optional(),
+    expectedCount: z.coerce.number().int().min(0).optional(),
+    driftToleranceFraction: z.coerce.number().min(0).max(1).optional(),
+    tags: z.array(z.string()).max(50),
+    jobId: z.string().uuid().optional(),
+  })
+  .refine(
+    (v) =>
+      (v.ids && !v.filter && v.expectedCount === undefined) ||
+      (!v.ids && v.filter && v.expectedCount !== undefined),
+    {
+      message:
+        'Provide either { ids } or { filter, expectedCount }; do not mix or omit expectedCount in filter mode',
+    },
+  );
 const IdParamSchema = z.object({ id: z.string().min(1) });
 
 const ImageUploadSchema = z.object({
@@ -1691,8 +1727,9 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
   });
 
   // POST /api/pages/bulk/tag - add/remove tags on multiple pages
-  fastify.post('/pages/bulk/tag', async (request) => {
-    const { ids, addTags, removeTags } = BulkTagSchema.parse(request.body);
+  fastify.post('/pages/bulk/tag', async (request, reply) => {
+    const parsed = BulkTagSchema.parse(request.body);
+    const { addTags, removeTags } = parsed;
     const userId = request.userId;
 
     if (addTags.length === 0 && removeTags.length === 0) {
@@ -1700,27 +1737,37 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     }
 
     const client = await getClientForUser(userId);
-
-    // Parse IDs as integers (frontend sends stringified integer PKs)
-    const invalidIds = ids.filter((id) => !/^\d+$/.test(id));
-    if (invalidIds.length > 0) {
-      request.log.warn({ invalidIds }, 'Non-numeric page IDs filtered from bulk tag operation');
-    }
-    const numericIds = ids.filter((id) => /^\d+$/.test(id)).map((id) => parseInt(id, 10));
-
-    // Batch fetch labels: single query with RBAC space-based access control
     const tagSpaces = await getUserAccessibleSpaces(userId);
-    const existing = await query<{ id: number; confluence_id: string | null; labels: string[] }>(
-      `SELECT cp.id, cp.confluence_id, cp.labels FROM pages cp
-       WHERE (cp.space_key = ANY($1::text[]) OR cp.space_key IS NULL)
-         AND cp.id = ANY($2::int[])
-         AND cp.deleted_at IS NULL`,
-      [tagSpaces, numericIds],
+
+    const selection: BulkSelection = {
+      ids: parsed.ids,
+      filter: parsed.filter,
+      expectedCount: parsed.expectedCount,
+      driftToleranceFraction: parsed.driftToleranceFraction,
+    };
+
+    let resolved;
+    try {
+      resolved = await resolveBulkSelection(userId, selection, tagSpaces, {
+        idMode: 'numeric-only',
+      });
+    } catch (err) {
+      if (err instanceof BulkSelectionError && err.detail.kind === 'count_drift') {
+        return reply.status(409).send({
+          error: 'CountDrift',
+          message: err.detail.message,
+          expected: err.detail.expected,
+          actual: err.detail.actual,
+        });
+      }
+      throw err;
+    }
+
+    const pageMap = new Map(
+      resolved.rows.map((r) => [String(r.id), { confluenceId: r.confluenceId, labels: r.labels }]),
     );
-    const pageMap = new Map(existing.rows.map((r) => [String(r.id), { confluenceId: r.confluence_id, labels: r.labels || [] }]));
-    const notFoundIds = ids.filter((id) => !pageMap.has(id));
-    const errors: string[] = notFoundIds.map((id) => `Page ${id} not found`);
-    let failed = notFoundIds.length;
+    const errors: string[] = resolved.notFoundIds.map((id) => `Page ${id} not found`);
+    let failed = resolved.notFoundIds.length;
 
     // Process each owned page: compute new labels, update DB, sync to Confluence
     const bulkLimit = pLimit(5);
@@ -1792,7 +1839,14 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       'BULK_PAGE_TAGGED',
       'page',
       undefined,
-      { bulkIds: ids, addTags, removeTags, succeeded, failed },
+      {
+        ...(parsed.ids ? { bulkIds: parsed.ids } : { filter: parsed.filter, expectedCount: parsed.expectedCount }),
+        affectedCount: pageMap.size,
+        addTags,
+        removeTags,
+        succeeded,
+        failed,
+      },
       request,
     );
 
@@ -1807,8 +1861,9 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
   // absent the route still chunks for memory but skips the publish/cancel
   // path. Tags are normalised (lower-cased, trimmed, de-duplicated) at the
   // boundary to match the existing auto-tagger convention.
-  fastify.post('/pages/bulk/replace-tags', async (request) => {
-    const { ids, tags, jobId } = BulkReplaceTagsSchema.parse(request.body);
+  fastify.post('/pages/bulk/replace-tags', async (request, reply) => {
+    const parsed = BulkReplaceTagsSchema.parse(request.body);
+    const { tags, jobId } = parsed;
     const userId = request.userId;
 
     // Normalise input tags
@@ -1820,29 +1875,38 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       ),
     );
 
-    const invalidIds = ids.filter((id) => !/^\d+$/.test(id));
-    if (invalidIds.length > 0) {
-      request.log.warn({ invalidIds }, 'Non-numeric page IDs filtered from bulk replace-tags');
-    }
-    const numericIds = ids.filter((id) => /^\d+$/.test(id)).map((id) => parseInt(id, 10));
-
-    // RBAC: only pages in user-accessible spaces (or unscoped standalone)
     const accessSpaces = await getUserAccessibleSpaces(userId);
-    const existing = await query<{ id: number; confluence_id: string | null; labels: string[] }>(
-      `SELECT cp.id, cp.confluence_id, cp.labels FROM pages cp
-       WHERE (cp.space_key = ANY($1::text[]) OR cp.space_key IS NULL)
-         AND cp.id = ANY($2::int[])
-         AND cp.deleted_at IS NULL`,
-      [accessSpaces, numericIds],
-    );
-    const pageMap = new Map(
-      existing.rows.map((r) => [r.id, { confluenceId: r.confluence_id, oldLabels: r.labels || [] }]),
-    );
-    const notFoundIds = ids.filter((id) => !pageMap.has(parseInt(id, 10)));
-    const errors: string[] = notFoundIds.map((id) => `Page ${id} not found`);
-    let initialFailed = notFoundIds.length;
+    const selection: BulkSelection = {
+      ids: parsed.ids,
+      filter: parsed.filter,
+      expectedCount: parsed.expectedCount,
+      driftToleranceFraction: parsed.driftToleranceFraction,
+    };
 
-    const eligible = [...pageMap.entries()].map(([id, info]) => ({ id, ...info }));
+    let resolved;
+    try {
+      resolved = await resolveBulkSelection(userId, selection, accessSpaces, {
+        idMode: 'numeric-only',
+      });
+    } catch (err) {
+      if (err instanceof BulkSelectionError && err.detail.kind === 'count_drift') {
+        return reply.status(409).send({
+          error: 'CountDrift',
+          message: err.detail.message,
+          expected: err.detail.expected,
+          actual: err.detail.actual,
+        });
+      }
+      throw err;
+    }
+
+    const errors: string[] = resolved.notFoundIds.map((id) => `Page ${id} not found`);
+    const initialFailed = resolved.notFoundIds.length;
+    const eligible = resolved.rows.map((r) => ({
+      id: r.id,
+      confluenceId: r.confluenceId,
+      oldLabels: r.labels,
+    }));
 
     if (jobId) {
       await startBulkJob(jobId, eligible.length, userId, 'replace-tags');
@@ -1912,7 +1976,8 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       'page',
       undefined,
       {
-        bulkIds: ids,
+        ...(parsed.ids ? { bulkIds: parsed.ids } : { filter: parsed.filter, expectedCount: parsed.expectedCount }),
+        affectedCount: eligible.length,
         tags: normTags,
         succeeded,
         failed,

--- a/frontend/src/features/pages/BulkOperations.test.tsx
+++ b/frontend/src/features/pages/BulkOperations.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { BulkOperations } from './BulkOperations';
@@ -121,5 +121,34 @@ describe('BulkOperations', () => {
     expect(screen.getByTestId('bulk-embed-btn')).toBeInTheDocument();
     expect(screen.getByTestId('bulk-tag-btn')).toBeInTheDocument();
     expect(screen.getByTestId('bulk-delete-btn')).toBeInTheDocument();
+  });
+
+  it('hides the EE Permission button when batch_page_operations is not licensed', () => {
+    // Default wrapper has no EnterpriseContext.Provider → hasFeature() is
+    // false in CE/unlicensed mode (the default context value).
+    render(<BulkOperations {...defaultProps} />, { wrapper: createWrapper() });
+    expect(screen.queryByTestId('bulk-permission-btn')).not.toBeInTheDocument();
+  });
+
+  it('POSTs replace-tags when the user picks the Replace tag action', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    render(<BulkOperations {...defaultProps} />, { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByTestId('bulk-tag-btn'));
+    fireEvent.click(screen.getByTestId('tag-action-replace'));
+    fireEvent.change(screen.getByTestId('tag-input'), { target: { value: 'on-call, urgent' } });
+    fireEvent.click(screen.getByTestId('tag-submit'));
+
+    await waitFor(() => {
+      const call = fetchSpy.mock.calls.find(
+        (c) => typeof c[0] === 'string' && (c[0] as string).includes('/pages/bulk/replace-tags'),
+      );
+      expect(call).toBeDefined();
+      const body = JSON.parse((call![1] as RequestInit).body as string);
+      // Tags are normalised on the client (lowercase + dedupe + trim) then
+      // re-normalised on the server. The wire shape is the de-duped list.
+      expect(body.tags).toEqual(['on-call', 'urgent']);
+      expect(body.ids).toEqual(['page-1', 'page-2']);
+    });
   });
 });

--- a/frontend/src/features/pages/BulkOperations.tsx
+++ b/frontend/src/features/pages/BulkOperations.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Trash2, RefreshCw, Cpu, Tag, X, CheckSquare, Square } from 'lucide-react';
+import { Trash2, RefreshCw, Cpu, Tag, X, CheckSquare, Square, Shield } from 'lucide-react';
 import { apiFetch } from '../../shared/lib/api';
 import { cn } from '../../shared/lib/cn';
+import { useEnterprise } from '../../shared/enterprise/use-enterprise';
+import { BulkPagePermissionDialog } from './BulkPagePermissionDialog';
 
 interface BulkResult {
   succeeded: number;
@@ -27,10 +29,14 @@ export function BulkOperations({
   onClose,
 }: BulkOperationsProps) {
   const queryClient = useQueryClient();
+  const { hasFeature } = useEnterprise();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showTagPopover, setShowTagPopover] = useState(false);
   const [tagInput, setTagInput] = useState('');
-  const [tagAction, setTagAction] = useState<'add' | 'remove'>('add');
+  // 'replace' wipes the existing tag set and writes the input as the new
+  // canonical set; 'add' / 'remove' are the legacy additive semantics.
+  const [tagAction, setTagAction] = useState<'add' | 'remove' | 'replace'>('add');
+  const [showPermissionDialog, setShowPermissionDialog] = useState(false);
 
   const bulkDelete = useMutation({
     mutationFn: () =>
@@ -101,7 +107,42 @@ export function BulkOperations({
     onError: (err) => toast.error(err.message),
   });
 
+  // Comma-separated tag input → trimmed, deduped, lowercased list.
+  const parseTagsList = (s: string): string[] =>
+    Array.from(
+      new Set(
+        s
+          .split(',')
+          .map((t) => t.trim().toLowerCase())
+          .filter(Boolean),
+      ),
+    );
+
+  const bulkReplaceTags = useMutation({
+    mutationFn: (tags: string[]) =>
+      apiFetch<BulkResult>('/pages/bulk/replace-tags', {
+        method: 'POST',
+        body: JSON.stringify({ ids: selectedIds, tags }),
+      }),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['pages'], refetchType: 'none' });
+      queryClient.refetchQueries({ queryKey: ['pages'] });
+      toast.success(
+        `Replaced tags on ${data.succeeded} page${data.succeeded === 1 ? '' : 's'}${data.failed > 0 ? `, ${data.failed} failed` : ''}`,
+      );
+      setShowTagPopover(false);
+      setTagInput('');
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
   function handleTagSubmit() {
+    if (tagAction === 'replace') {
+      const tags = parseTagsList(tagInput);
+      // Empty input is a valid "wipe all tags" intent — confirm via prefix.
+      bulkReplaceTags.mutate(tags);
+      return;
+    }
     const tag = tagInput.trim();
     if (!tag) return;
     if (tagAction === 'add') {
@@ -111,7 +152,12 @@ export function BulkOperations({
     }
   }
 
-  const isLoading = bulkDelete.isPending || bulkSync.isPending || bulkEmbed.isPending || bulkTag.isPending;
+  const isLoading =
+    bulkDelete.isPending ||
+    bulkSync.isPending ||
+    bulkEmbed.isPending ||
+    bulkTag.isPending ||
+    bulkReplaceTags.isPending;
 
   if (selectedIds.length === 0) return null;
 
@@ -183,10 +229,10 @@ export function BulkOperations({
 
           {showTagPopover && (
             <div
-              className="absolute bottom-full left-0 mb-2 w-64 rounded-xl border border-border/50 bg-card/95 p-3 shadow-xl backdrop-blur-xl"
+              className="absolute bottom-full left-0 mb-2 w-72 rounded-xl border border-border/50 bg-card/95 p-3 shadow-xl backdrop-blur-xl"
               data-testid="tag-popover"
             >
-              <div className="mb-2 flex gap-2">
+              <div className="mb-2 flex gap-1.5">
                 <button
                   onClick={() => setTagAction('add')}
                   className={cn(
@@ -195,8 +241,9 @@ export function BulkOperations({
                       ? 'bg-primary/15 text-primary'
                       : 'text-muted-foreground hover:text-foreground',
                   )}
+                  data-testid="tag-action-add"
                 >
-                  Add Tag
+                  Add
                 </button>
                 <button
                   onClick={() => setTagAction('remove')}
@@ -206,23 +253,52 @@ export function BulkOperations({
                       ? 'bg-destructive/15 text-destructive'
                       : 'text-muted-foreground hover:text-foreground',
                   )}
+                  data-testid="tag-action-remove"
                 >
-                  Remove Tag
+                  Remove
+                </button>
+                <button
+                  onClick={() => setTagAction('replace')}
+                  className={cn(
+                    'rounded px-2 py-1 text-xs font-medium transition-colors',
+                    tagAction === 'replace'
+                      ? 'bg-amber-500/15 text-amber-600 dark:text-amber-400'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )}
+                  data-testid="tag-action-replace"
+                  title="Replace the entire tag set on every selected page"
+                >
+                  Replace
                 </button>
               </div>
+              {tagAction === 'replace' && (
+                <p className="mb-2 text-[11px] leading-tight text-amber-600 dark:text-amber-400">
+                  Comma-separated. Existing tags on the selected pages will be wiped and replaced.
+                </p>
+              )}
               <div className="flex gap-2">
                 <input
                   type="text"
                   value={tagInput}
                   onChange={(e) => setTagInput(e.target.value)}
                   onKeyDown={(e) => e.key === 'Enter' && handleTagSubmit()}
-                  placeholder={tagAction === 'add' ? 'Enter tag to add...' : 'Enter tag to remove...'}
+                  placeholder={
+                    tagAction === 'add'
+                      ? 'Enter tag to add...'
+                      : tagAction === 'remove'
+                        ? 'Enter tag to remove...'
+                        : 'tag-a, tag-b, tag-c'
+                  }
                   className="flex-1 rounded-md bg-foreground/5 px-2 py-1.5 text-xs outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-primary"
                   data-testid="tag-input"
                 />
                 <button
                   onClick={handleTagSubmit}
-                  disabled={!tagInput.trim() || bulkTag.isPending}
+                  disabled={
+                    (tagAction !== 'replace' && !tagInput.trim()) ||
+                    bulkTag.isPending ||
+                    bulkReplaceTags.isPending
+                  }
                   className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
                   data-testid="tag-submit"
                 >
@@ -232,6 +308,22 @@ export function BulkOperations({
             </div>
           )}
         </div>
+
+        {/* EE-gated bulk-permission action — only renders when the live
+            license has BATCH_PAGE_OPERATIONS. CE deployments and EE
+            without the feature hide the button entirely. */}
+        {hasFeature('batch_page_operations') && (
+          <button
+            onClick={() => setShowPermissionDialog(true)}
+            disabled={isLoading}
+            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-foreground/5 disabled:opacity-50"
+            title="Add or remove a permission across the selected pages"
+            data-testid="bulk-permission-btn"
+          >
+            <Shield size={14} />
+            Permission
+          </button>
+        )}
 
         {/* Delete with confirmation */}
         {showDeleteConfirm ? (
@@ -279,6 +371,13 @@ export function BulkOperations({
           <X size={14} />
         </button>
       </div>
+
+      <BulkPagePermissionDialog
+        open={showPermissionDialog}
+        onClose={() => setShowPermissionDialog(false)}
+        selectedIds={selectedIds}
+        onApplied={onDeselectAll}
+      />
     </div>
   );
 }

--- a/frontend/src/features/pages/BulkPagePermissionDialog.test.tsx
+++ b/frontend/src/features/pages/BulkPagePermissionDialog.test.tsx
@@ -62,7 +62,7 @@ describe('BulkPagePermissionDialog', () => {
   });
 
   it('shows the inherit_perms warning for add and replace, hides for remove', () => {
-    const { rerender } = render(
+    render(
       <BulkPagePermissionDialog {...baseProps} />,
       { wrapper: makeWrapper({ hasBatchOps: true }) },
     );

--- a/frontend/src/features/pages/BulkPagePermissionDialog.test.tsx
+++ b/frontend/src/features/pages/BulkPagePermissionDialog.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EnterpriseContext } from '../../shared/enterprise/enterprise-context';
+import type { EnterpriseContextValue } from '../../shared/enterprise/types';
+import { BulkPagePermissionDialog } from './BulkPagePermissionDialog';
+
+function makeWrapper(opts: { hasBatchOps: boolean }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const value: EnterpriseContextValue = {
+    ui: null,
+    license: null,
+    isEnterprise: opts.hasBatchOps,
+    hasFeature: (f: string) => opts.hasBatchOps && f === 'batch_page_operations',
+    isLoading: false,
+  };
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <EnterpriseContext.Provider value={value}>{children}</EnterpriseContext.Provider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('BulkPagePermissionDialog', () => {
+  const baseProps = {
+    open: true,
+    onClose: vi.fn(),
+    selectedIds: ['1', '2', '3'],
+  };
+
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ succeeded: 3, failed: 0, errors: [], inheritFlippedPageIds: [1, 2] }),
+        { headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when batch_page_operations feature is disabled (CE / unlicensed EE)', () => {
+    const { container } = render(
+      <BulkPagePermissionDialog {...baseProps} />,
+      { wrapper: makeWrapper({ hasBatchOps: false }) },
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders the dialog when feature is enabled', () => {
+    render(
+      <BulkPagePermissionDialog {...baseProps} />,
+      { wrapper: makeWrapper({ hasBatchOps: true }) },
+    );
+    expect(screen.getByTestId('bulk-permission-dialog')).toBeInTheDocument();
+  });
+
+  it('shows the inherit_perms warning for add and replace, hides for remove', () => {
+    const { rerender } = render(
+      <BulkPagePermissionDialog {...baseProps} />,
+      { wrapper: makeWrapper({ hasBatchOps: true }) },
+    );
+    expect(screen.queryByTestId('inherit-warning')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('action-remove'));
+    expect(screen.queryByTestId('inherit-warning')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('action-replace'));
+    expect(screen.queryByTestId('inherit-warning')).toBeInTheDocument();
+  });
+
+  it('Apply is disabled while principal_id is empty, enabled once filled', () => {
+    render(
+      <BulkPagePermissionDialog {...baseProps} />,
+      { wrapper: makeWrapper({ hasBatchOps: true }) },
+    );
+    const apply = screen.getByTestId('apply-btn') as HTMLButtonElement;
+    expect(apply.disabled).toBe(true);
+
+    fireEvent.change(screen.getByTestId('principal-id'), { target: { value: 'executives' } });
+    expect(apply.disabled).toBe(false);
+  });
+
+  it('POSTs the chosen action+principal+permission and closes on success', async () => {
+    const onClose = vi.fn();
+    const onApplied = vi.fn();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    render(
+      <BulkPagePermissionDialog {...baseProps} onClose={onClose} onApplied={onApplied} />,
+      { wrapper: makeWrapper({ hasBatchOps: true }) },
+    );
+
+    fireEvent.change(screen.getByTestId('principal-type'), { target: { value: 'group' } });
+    fireEvent.change(screen.getByTestId('principal-id'), { target: { value: 'executives' } });
+    fireEvent.change(screen.getByTestId('permission'), { target: { value: 'edit' } });
+    fireEvent.click(screen.getByTestId('apply-btn'));
+
+    await waitFor(() => {
+      expect(onApplied).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    const call = fetchSpy.mock.calls.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('/admin/pages/bulk/permission'),
+    );
+    expect(call).toBeDefined();
+    const body = JSON.parse((call![1] as RequestInit).body as string);
+    expect(body).toMatchObject({
+      ids: ['1', '2', '3'],
+      action: 'add',
+      principal_type: 'group',
+      principal_id: 'executives',
+      permission: 'edit',
+    });
+  });
+
+  it('does not render when open=false', () => {
+    const { container } = render(
+      <BulkPagePermissionDialog {...baseProps} open={false} />,
+      { wrapper: makeWrapper({ hasBatchOps: true }) },
+    );
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/frontend/src/features/pages/BulkPagePermissionDialog.tsx
+++ b/frontend/src/features/pages/BulkPagePermissionDialog.tsx
@@ -1,0 +1,263 @@
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Shield, X, AlertTriangle } from 'lucide-react';
+import { apiFetch } from '../../shared/lib/api';
+import { useEnterprise } from '../../shared/enterprise/use-enterprise';
+import { cn } from '../../shared/lib/cn';
+
+/**
+ * EE-gated bulk-permission dialog (issue Compendiq/compendiq-ee#117).
+ *
+ * Pairs with the EE overlay route POST /api/admin/pages/bulk/permission.
+ * Outer gate uses `hasFeature('batch_page_operations')` — CE deployments
+ * and EE deployments without the feature render nothing, which keeps the
+ * dialog from ever surfacing if a parent forgets to gate the trigger.
+ *
+ * The "this will flip inherit_perms=false on N pages" warning is mandatory
+ * for add/replace per the plan §1.3 — admins must consciously opt into the
+ * cascade because per-page ACEs are otherwise ignored against the inherited
+ * space-level permission.
+ */
+type Action = 'add' | 'remove' | 'replace';
+type PrincipalType = 'user' | 'group';
+type Permission = 'read' | 'comment' | 'edit' | 'delete' | 'manage';
+
+interface BulkPermissionResult {
+  succeeded: number;
+  failed: number;
+  errors: string[];
+  inheritFlippedPageIds: number[];
+}
+
+interface BulkPagePermissionDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Page ids the action will apply to. */
+  selectedIds: string[];
+  /** Called after a successful apply (e.g. to clear the selection). */
+  onApplied?: () => void;
+}
+
+export function BulkPagePermissionDialog(props: BulkPagePermissionDialogProps) {
+  const { hasFeature } = useEnterprise();
+  if (!hasFeature('batch_page_operations')) {
+    return null;
+  }
+  return <BulkPagePermissionDialogInner {...props} />;
+}
+
+function BulkPagePermissionDialogInner({
+  open,
+  onClose,
+  selectedIds,
+  onApplied,
+}: BulkPagePermissionDialogProps) {
+  const queryClient = useQueryClient();
+  const [action, setAction] = useState<Action>('add');
+  const [principalType, setPrincipalType] = useState<PrincipalType>('group');
+  const [principalId, setPrincipalId] = useState('');
+  const [permission, setPermission] = useState<Permission>('read');
+
+  const apply = useMutation({
+    mutationFn: () =>
+      apiFetch<BulkPermissionResult>('/admin/pages/bulk/permission', {
+        method: 'POST',
+        body: JSON.stringify({
+          ids: selectedIds,
+          action,
+          principal_type: principalType,
+          principal_id: principalId.trim(),
+          permission,
+        }),
+      }),
+    onSuccess: (data) => {
+      const flipped = data.inheritFlippedPageIds.length;
+      const flipNote = flipped > 0 ? ` (inherit_perms flipped on ${flipped})` : '';
+      toast.success(
+        `${actionVerb(action, true)} permission on ${data.succeeded} page${data.succeeded === 1 ? '' : 's'}${flipNote}`,
+      );
+      queryClient.invalidateQueries({ queryKey: ['pages'], refetchType: 'none' });
+      queryClient.refetchQueries({ queryKey: ['pages'] });
+      onApplied?.();
+      reset();
+      onClose();
+    },
+    onError: (err: Error & { status?: number }) => {
+      if (err.status === 404) {
+        toast.error('Bulk page-permission requires the EE overlay to be deployed.');
+        return;
+      }
+      toast.error(err.message);
+    },
+  });
+
+  function reset() {
+    setAction('add');
+    setPrincipalType('group');
+    setPrincipalId('');
+    setPermission('read');
+  }
+
+  function handleClose() {
+    if (apply.isPending) return;
+    reset();
+    onClose();
+  }
+
+  if (!open) return null;
+
+  const principalTrim = principalId.trim();
+  const canSubmit = principalTrim.length > 0 && selectedIds.length > 0 && !apply.isPending;
+  const willFlipInherit = action === 'add' || action === 'replace';
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={handleClose}
+      data-testid="bulk-permission-dialog-overlay"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="glass-card w-full max-w-md rounded-2xl border border-border/60 bg-card/95 p-6 shadow-2xl backdrop-blur-xl"
+        data-testid="bulk-permission-dialog"
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Shield size={18} className="text-primary" />
+            <h2 className="text-lg font-semibold">Bulk Page Permission</h2>
+          </div>
+          <button
+            onClick={handleClose}
+            disabled={apply.isPending}
+            className="rounded-lg p-1 text-muted-foreground hover:bg-foreground/5 hover:text-foreground disabled:opacity-50"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <p className="mb-4 text-sm text-muted-foreground">
+          Apply a permission change to{' '}
+          <span className="font-semibold text-foreground">{selectedIds.length}</span> selected
+          page{selectedIds.length === 1 ? '' : 's'}.
+        </p>
+
+        {/* Action picker */}
+        <div className="mb-3">
+          <label className="mb-1 block text-xs font-medium text-muted-foreground">Action</label>
+          <div className="flex gap-2">
+            {(['add', 'remove', 'replace'] as Action[]).map((a) => (
+              <button
+                key={a}
+                onClick={() => setAction(a)}
+                disabled={apply.isPending}
+                className={cn(
+                  'flex-1 rounded-md px-3 py-1.5 text-xs font-medium capitalize transition-colors',
+                  action === a
+                    ? 'bg-primary/15 text-primary'
+                    : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
+                )}
+                data-testid={`action-${a}`}
+              >
+                {a}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Principal type + id */}
+        <div className="mb-3 grid grid-cols-3 gap-2">
+          <div className="col-span-1">
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">Type</label>
+            <select
+              value={principalType}
+              onChange={(e) => setPrincipalType(e.target.value as PrincipalType)}
+              disabled={apply.isPending}
+              className="w-full rounded-md bg-foreground/5 px-2 py-1.5 text-xs outline-none focus:ring-1 focus:ring-primary"
+              data-testid="principal-type"
+            >
+              <option value="group">Group</option>
+              <option value="user">User</option>
+            </select>
+          </div>
+          <div className="col-span-2">
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              {principalType === 'user' ? 'User ID' : 'Group name'}
+            </label>
+            <input
+              type="text"
+              value={principalId}
+              onChange={(e) => setPrincipalId(e.target.value)}
+              disabled={apply.isPending}
+              placeholder={principalType === 'user' ? 'e.g. alice' : 'e.g. executives'}
+              className="w-full rounded-md bg-foreground/5 px-2 py-1.5 text-xs outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-primary"
+              data-testid="principal-id"
+            />
+          </div>
+        </div>
+
+        {/* Permission picker */}
+        <div className="mb-4">
+          <label className="mb-1 block text-xs font-medium text-muted-foreground">Permission</label>
+          <select
+            value={permission}
+            onChange={(e) => setPermission(e.target.value as Permission)}
+            disabled={apply.isPending}
+            className="w-full rounded-md bg-foreground/5 px-2 py-1.5 text-xs outline-none focus:ring-1 focus:ring-primary"
+            data-testid="permission"
+          >
+            <option value="read">read</option>
+            <option value="comment">comment</option>
+            <option value="edit">edit</option>
+            <option value="delete">delete</option>
+            <option value="manage">manage</option>
+          </select>
+        </div>
+
+        {/* inherit_perms cascade warning */}
+        {willFlipInherit && (
+          <div
+            className="mb-4 flex gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3"
+            data-testid="inherit-warning"
+          >
+            <AlertTriangle size={16} className="mt-0.5 shrink-0 text-amber-500" />
+            <p className="text-xs text-foreground">
+              Pages currently inheriting permissions from their space will have{' '}
+              <code className="rounded bg-foreground/10 px-1">inherit_perms</code> flipped to{' '}
+              <code className="rounded bg-foreground/10 px-1">false</code>. The page-level rule you
+              add will then take effect; otherwise the inherited rule wins.
+            </p>
+          </div>
+        )}
+
+        {/* Action buttons */}
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={handleClose}
+            disabled={apply.isPending}
+            className="rounded-md px-4 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground disabled:opacity-50"
+            data-testid="cancel-btn"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => apply.mutate()}
+            disabled={!canSubmit}
+            className="rounded-md bg-primary px-4 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            data-testid="apply-btn"
+          >
+            {apply.isPending ? 'Applying…' : 'Apply'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function actionVerb(a: Action, past: boolean): string {
+  if (past) {
+    return { add: 'Added', remove: 'Removed', replace: 'Replaced' }[a];
+  }
+  return { add: 'Add', remove: 'Remove', replace: 'Replace' }[a];
+}


### PR DESCRIPTION
Four-commit PR delivering the **CE half** of v0.4 batch page operations ([Compendiq/compendiq-ee#117](https://github.com/Compendiq/compendiq-ee/issues/117)) — backend (commits 1-3) plus the frontend UI for the two new actions (commit 4). The EE-overlay \`bulk/permission\` route lives in [Compendiq/compendiq-ee#129](https://github.com/Compendiq/compendiq-ee/pull/129).

## Commits

1. **\`bulk-page-progress + bulk/replace-tags + audit entries\`** — 3 new \`AuditAction\` entries (\`BULK_PAGE_TAGGED\`, \`BULK_PAGE_TAGS_REPLACED\`, \`BULK_PAGE_PERMISSION_CHANGED\`); new \`bulk-page-progress\` service (Redis progress + cancel + chunked runner + SSE-friendly async generator); new \`pages-bulk-progress\` SSE route; new \`bulk/replace-tags\` route. \`bulk/tag\` now emits \`BULK_PAGE_TAGGED\` per request.
2. **\`filter-mode + expectedCount race guard for tag routes\`** — new \`bulk-page-selection\` service (\`resolveBulkSelection()\` accepts \`{ids}\` or \`{filter, expectedCount}\`; RBAC-aware WHERE clause matching \`GET /pages\`; 5%-default drift tolerance with 0% override; 5000-row hard cap). Wired into \`bulk/tag\` + \`bulk/replace-tags\`. Backward-compat preserved.
3. **\`filter-mode for bulk/delete + bulk/sync + bulk/embed\`** — all 5 bulk routes now accept either \`{ids}\` or \`{filter, expectedCount}\`. Shared \`BulkIdsOrFilterSchema\` with optional \`jobId\` for SSE observation. Audit metadata records \`affectedCount\` + selection mode.
4. **\`frontend — replace-tags + EE bulk-permission dialog\`** — \`BulkOperations.tsx\` gains the Replace tag radio (wired to \`/pages/bulk/replace-tags\`) and an EE-gated Permission button. New \`BulkPagePermissionDialog.tsx\` opens the action picker (\`add\` / \`remove\` / \`replace\` × \`user\` / \`group\` × 5 permissions) with the mandatory \`inherit_perms\`-flip warning on add/replace.

## Tests

- \`bulk-page-progress.test.ts\` — 9 tests
- \`bulk-page-selection.test.ts\` — 16 tests
- \`bulk-pages.test.ts\` — 14 new + updated tests
- \`BulkPagePermissionDialog.test.tsx\` — 6 tests
- \`BulkOperations.test.tsx\` — 2 new tests + 10 existing tests still pass

**85 targeted tests pass** (69 backend + 12 frontend BulkOperations + 6 BulkPagePermissionDialog overlap with 12). \`tsc\` + \`eslint\` clean for changed files.

## Pairs with

- **EE overlay route**: [Compendiq/compendiq-ee#129](https://github.com/Compendiq/compendiq-ee/pull/129) — POST \`/api/admin/pages/bulk/permission\` (the dialog in commit 4 calls this)
- Merge order: this PR first, then the CE submodule pointer in compendiq-ee#129 can be bumped to dev HEAD post-merge

## Out of scope (potential follow-ups within #117)

- Filter-mode "Select all matching" UX in PagesList (parent refactor; pulls filter from list query into the bulk action body)
- SSE progress UI + cancel button (separate component + \`EventSource\` integration on top of the \`/pages/bulk/:jobId/progress\` route from commit 1)

## Test plan

- [x] \`npx vitest run src/core/services\` green
- [x] \`npx vitest run src/routes/knowledge\` green
- [x] \`npx vitest run src/features/pages\` green
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)