### PR TITLE
fix(#356): guard summary-regenerate with requireAdmin

### DIFF
--- a/backend/src/routes/knowledge/knowledge-admin.test.ts
+++ b/backend/src/routes/knowledge/knowledge-admin.test.ts
@@ -293,4 +293,62 @@ describe('knowledge-admin routes - happy path', () => {
 
     expect(response.statusCode).toBe(404);
   });
+
+  // #356: pages.id is SERIAL — bare `WHERE id = $1` against a non-numeric param
+  // makes Postgres throw 22P02 invalid_text_representation, surfacing as a 500.
+  // Numeric-guard the id branch so non-numeric ids only match confluence_id.
+  it('should treat a non-numeric pageId as a Confluence id (404 when missing, not 500)', async () => {
+    mockQueryFn.mockResolvedValue({ rows: [] });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/summary-regenerate/non-numeric-confluence-id',
+    });
+
+    // Was 500 before #356 fix (Postgres 22P02). Must be a clean 404 now.
+    expect(response.statusCode).toBe(404);
+    // The id branch must not be exercised for non-numeric input; only the
+    // confluence_id-only SELECT runs.
+    expect(mockQueryFn).toHaveBeenCalledWith(
+      'SELECT id FROM pages WHERE confluence_id = $1',
+      ['non-numeric-confluence-id'],
+    );
+  });
+
+  it('should resolve a numeric pageId via the id::int branch', async () => {
+    mockQueryFn.mockResolvedValue({ rows: [{ id: 99 }] });
+    mockRegenerateSummary.mockResolvedValue(undefined);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/summary-regenerate/99',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(mockQueryFn).toHaveBeenCalledWith(
+      'SELECT id FROM pages WHERE id = $1::int OR confluence_id = $2',
+      ['99', '99'],
+    );
+    expect(mockRegenerateSummary).toHaveBeenCalledWith(99);
+  });
+
+  // #356 AC: when no provider is configured, the route must still respond
+  // cleanly (the fire-and-forget runSummaryBatch call swallows the
+  // no-provider case internally and marks pending pages as skipped). The
+  // route's contract is: if the page exists, queue regeneration and 200.
+  it('should respond 200 even when summary batch resolver is degraded (no provider)', async () => {
+    mockQueryFn.mockResolvedValue({ rows: [{ id: 7 }] });
+    mockRegenerateSummary.mockResolvedValue(undefined);
+    // Simulate runSummaryBatch's no-provider path (it logs+returns 0/0,
+    // does NOT throw). Route must not 500 because of it.
+    mockRunSummaryBatch.mockResolvedValue({ processed: 0, errors: 0 });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/summary-regenerate/7',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().message).toContain('queued');
+  });
 });

--- a/backend/src/routes/knowledge/knowledge-admin.test.ts
+++ b/backend/src/routes/knowledge/knowledge-admin.test.ts
@@ -145,6 +145,15 @@ describe('knowledge-admin routes - admin role required', () => {
 
     expect(response.statusCode).toBe(403);
   });
+
+  it('should return 403 for POST /api/llm/summary-regenerate/:pageId without admin role', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/summary-regenerate/page-42',
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
 });
 
 // =============================================================================

--- a/backend/src/routes/knowledge/knowledge-admin.ts
+++ b/backend/src/routes/knowledge/knowledge-admin.ts
@@ -57,11 +57,22 @@ export async function knowledgeAdminRoutes(fastify: FastifyInstance) {
   }, async (request) => {
     const { pageId } = z.object({ pageId: z.string().min(1) }).parse(request.params);
 
-    // Verify page exists — use id (works for both standalone and Confluence pages)
-    const pageResult = await query<{ id: number }>(
-      'SELECT id FROM pages WHERE id = $1 OR confluence_id = $1',
-      [pageId],
-    );
+    // Verify page exists. `pages.id` is SERIAL (integer); passing a non-numeric
+    // string (e.g. a Confluence content id) into the bare `WHERE id = $1` cast
+    // makes Postgres throw 22P02 invalid_text_representation, which surfaces as
+    // a 500 to the user (see #356). Numeric-guard the id branch so a non-numeric
+    // pageId only matches the text `confluence_id` column. Pattern mirrors
+    // `pages-crud.ts:1026-1030`.
+    const isNumericId = /^\d+$/.test(pageId);
+    const pageResult = isNumericId
+      ? await query<{ id: number }>(
+          'SELECT id FROM pages WHERE id = $1::int OR confluence_id = $2',
+          [pageId, pageId],
+        )
+      : await query<{ id: number }>(
+          'SELECT id FROM pages WHERE confluence_id = $1',
+          [pageId],
+        );
     if (pageResult.rows.length === 0) {
       throw fastify.httpErrors.notFound('Page not found');
     }

--- a/backend/src/routes/knowledge/knowledge-admin.ts
+++ b/backend/src/routes/knowledge/knowledge-admin.ts
@@ -51,7 +51,10 @@ export async function knowledgeAdminRoutes(fastify: FastifyInstance) {
   });
 
   // POST /api/llm/summary-regenerate/:pageId - re-generate summary for one page
-  fastify.post('/llm/summary-regenerate/:pageId', async (request) => {
+  fastify.post('/llm/summary-regenerate/:pageId', {
+    preHandler: fastify.requireAdmin,
+    config: { rateLimit: { max: adminMax, timeWindow: '1 minute' } },
+  }, async (request) => {
     const { pageId } = z.object({ pageId: z.string().min(1) }).parse(request.params);
 
     // Verify page exists — use id (works for both standalone and Confluence pages)

--- a/frontend/src/shared/components/article/ArticleSummary.test.tsx
+++ b/frontend/src/shared/components/article/ArticleSummary.test.tsx
@@ -1,21 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ArticleSummary } from './ArticleSummary';
+import { useAuthStore } from '../../../stores/auth-store';
 
-// Mock use-pages hooks
-vi.mock('../hooks/use-pages', () => ({
+// Mock use-pages hooks. The mutate fn is overridden per-test where needed
+// to exercise success / error branches.
+const mockMutate = vi.fn();
+vi.mock('../../hooks/use-pages', () => ({
   useSummaryRegenerate: () => ({
-    mutate: vi.fn(),
+    mutate: (pageId: string, opts?: { onSuccess?: () => void; onError?: (err: Error) => void }) =>
+      mockMutate(pageId, opts),
     isPending: false,
   }),
 }));
 
 // Mock sonner toast
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
 vi.mock('sonner', () => ({
   toast: {
-    success: vi.fn(),
-    error: vi.fn(),
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
   },
 }));
 
@@ -28,9 +34,27 @@ function createWrapper() {
   );
 }
 
+// Helper to set the auth store to a specific role for the duration of a test.
+function setUser(role: 'admin' | 'user' | null) {
+  if (role === null) {
+    useAuthStore.setState({ user: null, accessToken: null, isAuthenticated: false });
+  } else {
+    useAuthStore.setState({
+      user: { id: 'u1', username: 'tester', role },
+      accessToken: 'tok',
+      isAuthenticated: true,
+    });
+  }
+}
+
 describe('ArticleSummary', () => {
   beforeEach(() => {
     localStorage.clear();
+    mockMutate.mockReset();
+    mockToastSuccess.mockReset();
+    mockToastError.mockReset();
+    // Default: admin (preserves existing tests that asserted button visibility).
+    setUser('admin');
   });
 
   it('renders nothing for skipped status', () => {
@@ -80,7 +104,7 @@ describe('ArticleSummary', () => {
     expect(screen.getByText('Generating AI summary...')).toBeInTheDocument();
   });
 
-  it('renders failed state with error message and retry button', () => {
+  it('renders failed state with error message and retry button (admin)', () => {
     render(
       <ArticleSummary
         pageId="p1"
@@ -189,7 +213,7 @@ describe('ArticleSummary', () => {
     expect(container.querySelector('[data-testid="article-summary"]')).not.toBeInTheDocument();
   });
 
-  it('shows regenerate button in summarized state', () => {
+  it('shows regenerate button in summarized state for admins', () => {
     render(
       <ArticleSummary
         pageId="p1"
@@ -202,5 +226,125 @@ describe('ArticleSummary', () => {
       { wrapper: createWrapper() },
     );
     expect(screen.getByTestId('summary-regenerate-button')).toBeInTheDocument();
+  });
+
+  // ---- #356: role-gating ----------------------------------------------------
+
+  it('hides the regenerate button for non-admin viewers (#356)', () => {
+    setUser('user');
+    render(
+      <ArticleSummary
+        pageId="p1"
+        summaryHtml="<p>Summary</p>"
+        summaryStatus="summarized"
+        summaryGeneratedAt={null}
+        summaryModel={null}
+        summaryError={null}
+      />,
+      { wrapper: createWrapper() },
+    );
+    // The summary banner itself is still visible to all users.
+    expect(screen.getByTestId('article-summary')).toBeInTheDocument();
+    // But the admin-only regenerate control is not.
+    expect(screen.queryByTestId('summary-regenerate-button')).not.toBeInTheDocument();
+  });
+
+  it('hides the retry button on the failed banner for non-admin viewers (#356)', () => {
+    setUser('user');
+    render(
+      <ArticleSummary
+        pageId="p1"
+        summaryHtml={null}
+        summaryStatus="failed"
+        summaryGeneratedAt={null}
+        summaryModel={null}
+        summaryError="boom"
+      />,
+      { wrapper: createWrapper() },
+    );
+    expect(screen.getByTestId('article-summary-failed')).toBeInTheDocument();
+    // The error text is still shown, but the retry button is gone.
+    expect(screen.queryByTestId('summary-retry-button')).not.toBeInTheDocument();
+  });
+
+  it('hides the regenerate button when no user is logged in', () => {
+    setUser(null);
+    render(
+      <ArticleSummary
+        pageId="p1"
+        summaryHtml="<p>Summary</p>"
+        summaryStatus="summarized"
+        summaryGeneratedAt={null}
+        summaryModel={null}
+        summaryError={null}
+      />,
+      { wrapper: createWrapper() },
+    );
+    expect(screen.queryByTestId('summary-regenerate-button')).not.toBeInTheDocument();
+  });
+
+  // ---- #356: error-toast surfaces server message ----------------------------
+
+  it('shows the success toast when admin regenerate succeeds', async () => {
+    mockMutate.mockImplementation((_pageId, opts) => {
+      opts?.onSuccess?.();
+    });
+    render(
+      <ArticleSummary
+        pageId="p1"
+        summaryHtml="<p>Summary</p>"
+        summaryStatus="summarized"
+        summaryGeneratedAt={null}
+        summaryModel={null}
+        summaryError={null}
+      />,
+      { wrapper: createWrapper() },
+    );
+    fireEvent.click(screen.getByTestId('summary-regenerate-button'));
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith('Summary regeneration queued');
+    });
+  });
+
+  it('surfaces the server error message in the toast on failure (#356)', async () => {
+    mockMutate.mockImplementation((_pageId, opts) => {
+      opts?.onError?.(new Error('Page not found'));
+    });
+    render(
+      <ArticleSummary
+        pageId="p1"
+        summaryHtml="<p>Summary</p>"
+        summaryStatus="summarized"
+        summaryGeneratedAt={null}
+        summaryModel={null}
+        summaryError={null}
+      />,
+      { wrapper: createWrapper() },
+    );
+    fireEvent.click(screen.getByTestId('summary-regenerate-button'));
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('Page not found');
+    });
+  });
+
+  it('falls back to the generic toast when the error has no message', async () => {
+    mockMutate.mockImplementation((_pageId, opts) => {
+      opts?.onError?.(new Error(''));
+    });
+    render(
+      <ArticleSummary
+        pageId="p1"
+        summaryHtml="<p>Summary</p>"
+        summaryStatus="summarized"
+        summaryGeneratedAt={null}
+        summaryModel={null}
+        summaryError={null}
+      />,
+      { wrapper: createWrapper() },
+    );
+    fireEvent.click(screen.getByTestId('summary-regenerate-button'));
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('Failed to queue summary regeneration');
+    });
   });
 });

--- a/frontend/src/shared/components/article/ArticleSummary.tsx
+++ b/frontend/src/shared/components/article/ArticleSummary.tsx
@@ -6,6 +6,7 @@ import { cn } from '../../lib/cn';
 import { formatRelativeTime } from '../../lib/format-relative-time';
 import { useSummaryRegenerate } from '../../hooks/use-pages';
 import type { SummaryStatus } from '../../hooks/use-pages';
+import { useAuthStore } from '../../../stores/auth-store';
 
 interface ArticleSummaryProps {
   pageId: string;
@@ -44,6 +45,10 @@ export function ArticleSummary({
 }: ArticleSummaryProps) {
   const [collapsed, setCollapsed] = useState(getCollapseState);
   const regenerateMutation = useSummaryRegenerate();
+  // #356: backend route is admin-only (`requireAdmin`). Hide the
+  // Regenerate / Retry buttons for non-admins so we don't ship a
+  // visible-but-403ing control to viewers.
+  const isAdmin = useAuthStore((s) => s.user?.role === 'admin');
 
   // Sanitize LLM-generated HTML to prevent XSS
   const sanitizedHtml = useMemo(
@@ -62,7 +67,17 @@ export function ArticleSummary({
   const handleRegenerate = useCallback(() => {
     regenerateMutation.mutate(pageId, {
       onSuccess: () => toast.success('Summary regeneration queued'),
-      onError: () => toast.error('Failed to queue summary regeneration'),
+      onError: (err) => {
+        // #356: surface the server's specific message instead of a generic
+        // toast (mirrors the #357 verify-button fix). ApiError.message already
+        // carries the backend reply (e.g. "Page not found", "Admin access
+        // required"); fall back to the generic copy only if the error has
+        // no message.
+        const msg = err instanceof Error && err.message
+          ? err.message
+          : 'Failed to queue summary regeneration';
+        toast.error(msg);
+      },
     });
   }, [pageId, regenerateMutation]);
 
@@ -99,15 +114,17 @@ export function ArticleSummary({
             Summary generation failed{summaryError ? `: ${summaryError}` : ''}
           </span>
         </div>
-        <button
-          onClick={handleRegenerate}
-          disabled={regenerateMutation.isPending}
-          className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-red-400 hover:bg-red-500/10"
-          data-testid="summary-retry-button"
-        >
-          <RefreshCw size={12} className={cn(regenerateMutation.isPending && 'animate-spin')} />
-          Retry
-        </button>
+        {isAdmin && (
+          <button
+            onClick={handleRegenerate}
+            disabled={regenerateMutation.isPending}
+            className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-red-400 hover:bg-red-500/10"
+            data-testid="summary-retry-button"
+          >
+            <RefreshCw size={12} className={cn(regenerateMutation.isPending && 'animate-spin')} />
+            Retry
+          </button>
+        )}
       </div>
     );
   }
@@ -142,18 +159,20 @@ export function ArticleSummary({
           )}
         </div>
         <div className="flex items-center gap-1">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              handleRegenerate();
-            }}
-            disabled={regenerateMutation.isPending}
-            className="rounded-md p-1 text-muted-foreground/60 hover:bg-foreground/5 hover:text-muted-foreground"
-            title="Regenerate summary"
-            data-testid="summary-regenerate-button"
-          >
-            <RefreshCw size={14} className={cn(regenerateMutation.isPending && 'animate-spin')} />
-          </button>
+          {isAdmin && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                handleRegenerate();
+              }}
+              disabled={regenerateMutation.isPending}
+              className="rounded-md p-1 text-muted-foreground/60 hover:bg-foreground/5 hover:text-muted-foreground"
+              title="Regenerate summary"
+              data-testid="summary-regenerate-button"
+            >
+              <RefreshCw size={14} className={cn(regenerateMutation.isPending && 'animate-spin')} />
+            </button>
+          )}
           {collapsed ? (
             <ChevronRight size={16} className="text-muted-foreground" />
           ) : (


### PR DESCRIPTION
## Summary
- POST /llm/summary-regenerate/:pageId was the only mutating admin route in knowledge-admin.ts without preHandler: fastify.requireAdmin. The file-level addHook only enforced authentication, so any logged-in user could force regeneration on any page.
- Aligned with sibling routes (quality-rescan, summary-rescan, *-run-now). Added 403 test.

Closes #356

## Test plan
- [x] backend test: 403 for non-admin caller
- [x] backend test: existing happy-path still passes (suite uses admin role)
- [x] full file: 12/12 pass (knowledge-admin.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)