### PR TITLE
fix(#348): drop labels macro instead of leaking placeholder text

### DIFF
--- a/backend/src/core/services/content-converter.test.ts
+++ b/backend/src/core/services/content-converter.test.ts
@@ -187,6 +187,20 @@ describe('content-converter', () => {
       expect(html).toContain('Embedded widget');
     });
 
+    it('drops the labels macro and never leaks "[Confluence macro: labels]" (#348)', () => {
+      const xhtml = `<p>Before</p>
+        <ac:structured-macro ac:name="labels" ac:schema-version="1">
+          <ac:parameter ac:name="showLabels">true</ac:parameter>
+        </ac:structured-macro>
+        <p>After</p>`;
+      const html = confluenceToHtml(xhtml);
+      expect(html).not.toContain('[Confluence macro: labels]');
+      expect(html).not.toContain('confluence-macro-unknown');
+      expect(html).not.toContain('ac:structured-macro');
+      expect(html).toContain('Before');
+      expect(html).toContain('After');
+    });
+
     it('preserves user mentions as @username spans (#300)', () => {
       const html = confluenceToHtml(USER_MENTIONS_PAGE);
       // Raw `<ri:user>` is rewritten into `<span class="confluence-user-mention">`.

--- a/backend/src/core/services/content-converter.ts
+++ b/backend/src/core/services/content-converter.ts
@@ -442,6 +442,16 @@ export function confluenceToHtml(storageXhtml: string, pageId?: string, spaceKey
     layout.replaceWith(div);
   }
 
+  // Drop labels macro (#348). Labels are page metadata fetched via
+  // expand=metadata.labels — never parse them out of the body. The macro is
+  // a rendering placeholder with no body, so dropping it (rather than
+  // round-tripping) is safe; htmlToConfluence's "labels" output is currently
+  // unused.
+  for (const macro of byTag(doc, 'ac:structured-macro')) {
+    if (getMacroName(macro) !== 'labels') continue;
+    macro.remove();
+  }
+
   // Remove remaining unknown macros - preserve as data attributes
   for (const macro of byTag(doc, 'ac:structured-macro')) {
     const name = getMacroName(macro) || 'unknown';

--- a/docs/architecture/11-content-pipeline.md
+++ b/docs/architecture/11-content-pipeline.md
@@ -57,6 +57,7 @@ Custom turndown rules handle Confluence-specific macros:
 | `ac:structured-macro[include]`       | `<div class="confluence-include-macro" data-page-title="…">[Include: …]</div>` | `[Include: …]` placeholder |
 | `ac:structured-macro[excerpt-include]` | `<div class="confluence-include-macro" data-macro-name="excerpt-include">[Excerpt: …]</div>` | `[Excerpt: …]` placeholder |
 | `ac:structured-macro[toc]`           | `<div class="confluence-toc" data-maxlevel="…">[Table of Contents]</div>` | `[Table of Contents]` placeholder |
+| `ac:structured-macro[labels]`        | dropped on import (page metadata, no body)                   | — (not rendered)              |
 
 ### Round-trip notes (issue #300)
 


### PR DESCRIPTION
## Summary
- The Confluence labels macro had no dedicated handler in content-converter.ts, so it fell through to the generic unknown-macro fallback at line 445 and surfaced as "[Confluence macro: labels]" inside body_html.
- Labels are page metadata fetched via expand=metadata.labels — never parse them out of the body. Drop the macro element entirely.

Closes #348

## Test plan
- [x] new unit test on conversion fixture
- [x] full converter suite: 118/118 pass
- [x] no regression in existing macro handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)