### PR TITLE
feat(#350): focus AI ask input on mount + 4 clickable example prompts

### DIFF
--- a/backend/src/core/services/webhook-outbox-poller.test.ts
+++ b/backend/src/core/services/webhook-outbox-poller.test.ts
@@ -494,6 +494,17 @@ describe.skipIf(!canRun)('webhook-outbox-poller', () => {
       // subsequent tests still have a working queue handle.
       const fresh = getWebhookDeliveryQueue();
       expect(fresh).toBeInstanceOf(Queue);
+
+      // Wait for the rebuilt queue's ioredis client + subscriber connections
+      // to fully establish before we close them. Otherwise `afterAll`'s
+      // `__closeWebhookDeliveryQueueForTests()` races against in-flight
+      // ioredis handshake commands and the close handler rejects them with
+      // `Error: Connection is closed.` — which surfaces as an unhandled
+      // rejection that fails the whole vitest run (see Compendiq/compendiq-ce
+      // PRs #365, #373, #377). Owning the cleanup inside the test that
+      // built the queue eliminates the race entirely.
+      await fresh.waitUntilReady();
+      await __closeWebhookDeliveryQueueForTests();
     });
   });
 });

--- a/frontend/src/features/ai/AiAssistantPage.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.tsx
@@ -14,7 +14,7 @@ import { SourceCitations } from './SourceCitations';
 import { CitationChips } from './CitationChips';
 import { AiProvider, useAiContext, type Mode, type Message } from './AiContext';
 import {
-  AskModeInput, ASK_EMPTY_TITLE, ASK_EMPTY_SUBTITLE,
+  AskModeInput, AskExamplePrompts, ASK_EMPTY_TITLE, ASK_EMPTY_SUBTITLE,
   ImproveTypeSelector, ImproveDiffView, ImproveModeInput, IMPROVE_EMPTY_TITLE, improveEmptySubtitle,
   GenerateModeInput, GENERATE_EMPTY_TITLE, GENERATE_EMPTY_SUBTITLE,
   SummarizeModeInput, SUMMARIZE_EMPTY_TITLE, summarizeEmptySubtitle,
@@ -319,6 +319,7 @@ function AiAssistantInner() {
               <Bot size={44} className="mb-4 text-muted-foreground/50" />
               <p className="text-base font-medium">{getEmptyTitle(mode)}</p>
               <p className="mt-1 max-w-sm text-sm text-muted-foreground">{getEmptySubtitle(mode, page)}</p>
+              {mode === 'ask' && <AskExamplePrompts />}
             </div>
           )}
 

--- a/frontend/src/features/ai/modes/AskMode.test.tsx
+++ b/frontend/src/features/ai/modes/AskMode.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LazyMotion, domAnimation } from 'framer-motion';
-import { AskModeInput, ASK_EMPTY_TITLE, ASK_EMPTY_SUBTITLE } from './AskMode';
+import { AskModeInput, AskExamplePrompts, ASK_EMPTY_TITLE, ASK_EMPTY_SUBTITLE, ASK_EXAMPLE_PROMPTS } from './AskMode';
 import { AiProvider } from '../AiContext';
 import { useAuthStore } from '../../../stores/auth-store';
 
@@ -88,6 +88,35 @@ describe('AskMode', () => {
     render(<AskModeInput />, { wrapper: createWrapper() });
     expect(screen.getByPlaceholderText('Ask a question...')).toBeInTheDocument();
     expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('focuses the input on mount (#350)', async () => {
+    render(<AskModeInput />, { wrapper: createWrapper() });
+    const input = screen.getByPlaceholderText('Ask a question...');
+    await waitFor(() => {
+      expect(document.activeElement).toBe(input);
+    });
+  });
+
+  it('renders 4 example prompts and clicking one fills the input (#350)', async () => {
+    const Composed = () => (
+      <>
+        <AskExamplePrompts />
+        <AskModeInput />
+      </>
+    );
+    render(<Composed />, { wrapper: createWrapper() });
+
+    const items = screen.getAllByTestId('ask-example-prompt');
+    expect(items).toHaveLength(4);
+    expect(ASK_EXAMPLE_PROMPTS).toHaveLength(4);
+
+    const input = screen.getByPlaceholderText('Ask a question...') as HTMLInputElement;
+    fireEvent.click(items[0]!);
+
+    await waitFor(() => {
+      expect(input.value).toBe(ASK_EXAMPLE_PROMPTS[0]);
+    });
   });
 
   it('disables send button when input is empty', () => {

--- a/frontend/src/features/ai/modes/AskMode.test.tsx
+++ b/frontend/src/features/ai/modes/AskMode.test.tsx
@@ -3,7 +3,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LazyMotion, domAnimation } from 'framer-motion';
-import { AskModeInput, AskExamplePrompts, ASK_EMPTY_TITLE, ASK_EMPTY_SUBTITLE, ASK_EXAMPLE_PROMPTS } from './AskMode';
+import { AskModeInput, AskExamplePrompts, ASK_EMPTY_TITLE, ASK_EMPTY_SUBTITLE } from './AskMode';
+import { ASK_EXAMPLE_PROMPTS } from './ask-example-prompts';
 import { AiProvider } from '../AiContext';
 import { useAuthStore } from '../../../stores/auth-store';
 

--- a/frontend/src/features/ai/modes/AskMode.tsx
+++ b/frontend/src/features/ai/modes/AskMode.tsx
@@ -4,6 +4,7 @@ import { useAiContext, nextMessageId } from '../AiContext';
 import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '../../../shared/lib/api';
+import { ASK_EXAMPLE_PROMPTS } from './ask-example-prompts';
 
 interface McpDocsSettings {
   enabled: boolean;
@@ -191,15 +192,6 @@ export function AskModeInput() {
 export const ASK_EMPTY_TITLE = 'Ask questions about your knowledge base';
 export const ASK_EMPTY_SUBTITLE = 'Your questions will be answered using RAG over your Confluence pages';
 
-// #350: clickable example prompts shown on the empty state. Each fills the
-// input rather than auto-submits — auto-submit would surprise the user.
-export const ASK_EXAMPLE_PROMPTS: readonly string[] = [
-  'Summarise the most-edited pages in the last 30 days',
-  'Find pages that look like duplicates of each other',
-  'Draft a how-to from pages tagged "onboarding"',
-  'What changed in the engineering space in the last 7 days?',
-];
-
 export function AskExamplePrompts() {
   const { setInput } = useAiContext();
 
@@ -212,31 +204,34 @@ export function AskExamplePrompts() {
     });
   };
 
+  // Use real <ul>/<li> elements so each <button> keeps its implicit "button"
+  // role for assistive tech. Previously we set role="listitem" on the buttons,
+  // which stripped the button role and made screen readers announce
+  // "listitem" instead of "button".
   return (
-    <div
-      role="list"
+    <ul
       aria-label="Example prompts"
-      className="mt-6 grid w-full max-w-xl grid-cols-1 gap-2 sm:grid-cols-2"
+      className="mt-6 grid w-full max-w-xl grid-cols-1 gap-2 sm:grid-cols-2 list-none p-0"
     >
       {ASK_EXAMPLE_PROMPTS.map((prompt) => (
-        <button
-          key={prompt}
-          role="listitem"
-          type="button"
-          onClick={() => pick(prompt)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              pick(prompt);
-            }
-          }}
-          className="nm-card-interactive flex items-start gap-2 rounded-lg p-3 text-left text-xs text-foreground/80 hover:text-foreground"
-          data-testid="ask-example-prompt"
-        >
-          <Sparkles size={14} className="mt-0.5 shrink-0 text-primary" />
-          <span>{prompt}</span>
-        </button>
+        <li key={prompt}>
+          <button
+            type="button"
+            onClick={() => pick(prompt)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                pick(prompt);
+              }
+            }}
+            className="nm-card-interactive flex w-full items-start gap-2 rounded-lg p-3 text-left text-xs text-foreground/80 hover:text-foreground"
+            data-testid="ask-example-prompt"
+          >
+            <Sparkles size={14} className="mt-0.5 shrink-0 text-primary" />
+            <span>{prompt}</span>
+          </button>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 }

--- a/frontend/src/features/ai/modes/AskMode.tsx
+++ b/frontend/src/features/ai/modes/AskMode.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useState } from 'react';
-import { Send, Loader2, Link2, X, Plus } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Send, Loader2, Link2, X, Plus, Sparkles } from 'lucide-react';
 import { useAiContext, nextMessageId } from '../AiContext';
 import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
@@ -55,6 +55,15 @@ export function AskModeInput() {
   const removeUrl = (url: string) => {
     setExternalUrls((prev) => prev.filter((u) => u !== url));
   };
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // #350: focus input on mount so the user can type immediately. Use a ref +
+  // useEffect rather than autoFocus so it survives StrictMode double-mount and
+  // route transitions reliably.
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
 
   const handleAsk = useCallback(async () => {
     if (!input.trim() || isStreaming) return;
@@ -157,12 +166,14 @@ export function AskModeInput() {
           </button>
         )}
         <input
+          ref={inputRef}
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && handleSubmit()}
           placeholder="Ask a question..."
           disabled={isStreaming}
           className="flex-1 bg-transparent px-2 py-1.5 text-sm outline-none placeholder:text-muted-foreground/70 disabled:opacity-50"
+          data-testid="ask-input"
         />
         <button
           onClick={handleSubmit}
@@ -179,3 +190,53 @@ export function AskModeInput() {
 
 export const ASK_EMPTY_TITLE = 'Ask questions about your knowledge base';
 export const ASK_EMPTY_SUBTITLE = 'Your questions will be answered using RAG over your Confluence pages';
+
+// #350: clickable example prompts shown on the empty state. Each fills the
+// input rather than auto-submits — auto-submit would surprise the user.
+export const ASK_EXAMPLE_PROMPTS: readonly string[] = [
+  'Summarise the most-edited pages in the last 30 days',
+  'Find pages that look like duplicates of each other',
+  'Draft a how-to from pages tagged "onboarding"',
+  'What changed in the engineering space in the last 7 days?',
+];
+
+export function AskExamplePrompts() {
+  const { setInput } = useAiContext();
+
+  const pick = (prompt: string) => {
+    setInput(prompt);
+    // Defer focus to next tick so the input mounts before we focus it.
+    requestAnimationFrame(() => {
+      const el = document.querySelector<HTMLInputElement>('[data-testid="ask-input"]');
+      el?.focus();
+    });
+  };
+
+  return (
+    <div
+      role="list"
+      aria-label="Example prompts"
+      className="mt-6 grid w-full max-w-xl grid-cols-1 gap-2 sm:grid-cols-2"
+    >
+      {ASK_EXAMPLE_PROMPTS.map((prompt) => (
+        <button
+          key={prompt}
+          role="listitem"
+          type="button"
+          onClick={() => pick(prompt)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              pick(prompt);
+            }
+          }}
+          className="nm-card-interactive flex items-start gap-2 rounded-lg p-3 text-left text-xs text-foreground/80 hover:text-foreground"
+          data-testid="ask-example-prompt"
+        >
+          <Sparkles size={14} className="mt-0.5 shrink-0 text-primary" />
+          <span>{prompt}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/ai/modes/ask-example-prompts.ts
+++ b/frontend/src/features/ai/modes/ask-example-prompts.ts
@@ -1,0 +1,13 @@
+// #350: clickable example prompts shown on the empty state of the Ask mode.
+// Extracted from AskMode.tsx so the file only exports React components, which
+// keeps `react-refresh/only-export-components` happy (the rule's
+// `allowConstantExport` option only whitelists primitives, not arrays).
+//
+// Each prompt fills the input rather than auto-submits — auto-submit would
+// surprise the user.
+export const ASK_EXAMPLE_PROMPTS: readonly string[] = [
+  'Summarise the most-edited pages in the last 30 days',
+  'Find pages that look like duplicates of each other',
+  'Draft a how-to from pages tagged "onboarding"',
+  'What changed in the engineering space in the last 7 days?',
+];

--- a/frontend/src/features/ai/modes/index.ts
+++ b/frontend/src/features/ai/modes/index.ts
@@ -1,4 +1,4 @@
-export { AskModeInput, ASK_EMPTY_TITLE, ASK_EMPTY_SUBTITLE } from './AskMode';
+export { AskModeInput, AskExamplePrompts, ASK_EMPTY_TITLE, ASK_EMPTY_SUBTITLE, ASK_EXAMPLE_PROMPTS } from './AskMode';
 export { ImproveTypeSelector, ImproveDiffView, ImproveModeInput, IMPROVE_EMPTY_TITLE, improveEmptySubtitle } from './ImproveMode';
 export { GenerateModeInput, GenerateSavePanel, GENERATE_EMPTY_TITLE, GENERATE_EMPTY_SUBTITLE } from './GenerateMode';
 export { SummarizeModeInput, SUMMARIZE_EMPTY_TITLE, summarizeEmptySubtitle } from './SummarizeMode';

--- a/frontend/src/features/ai/modes/index.ts
+++ b/frontend/src/features/ai/modes/index.ts
@@ -1,4 +1,5 @@
-export { AskModeInput, AskExamplePrompts, ASK_EMPTY_TITLE, ASK_EMPTY_SUBTITLE, ASK_EXAMPLE_PROMPTS } from './AskMode';
+export { AskModeInput, AskExamplePrompts, ASK_EMPTY_TITLE, ASK_EMPTY_SUBTITLE } from './AskMode';
+export { ASK_EXAMPLE_PROMPTS } from './ask-example-prompts';
 export { ImproveTypeSelector, ImproveDiffView, ImproveModeInput, IMPROVE_EMPTY_TITLE, improveEmptySubtitle } from './ImproveMode';
 export { GenerateModeInput, GenerateSavePanel, GENERATE_EMPTY_TITLE, GENERATE_EMPTY_SUBTITLE } from './GenerateMode';
 export { SummarizeModeInput, SUMMARIZE_EMPTY_TITLE, summarizeEmptySubtitle } from './SummarizeMode';


### PR DESCRIPTION
## Summary
- useRef + useEffect so focus survives StrictMode double-mount and route transitions (autoFocus would lose to those).
- 4 example prompts on the empty state of Ask mode; clicking one fills the input rather than auto-submitting.
- Examples are keyboard-accessible (Enter/Space) and exported as ASK_EXAMPLE_PROMPTS for testability and easy edits.

Closes #350

## Test plan
- [x] focus-on-mount RTL test
- [x] example-prompt click test (4 prompts, fills input)
- [x] full AskMode suite: 10/10 pass; AiAssistantPage: 37/37 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)