### PR TITLE
feat(#354): keep AI-Tagging available in article edit mode

### DIFF
--- a/frontend/src/shared/components/article/ArticleRightPane.test.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.test.tsx
@@ -171,6 +171,23 @@ describe('ArticleRightPane', () => {
     expect(screen.queryByText('AI Improve')).not.toBeInTheDocument();
   });
 
+  it('keeps AI-Tagging available in edit mode (#354)', () => {
+    useArticleViewStore.setState({ editing: true });
+
+    render(<ArticleRightPane />, { wrapper: createWrapper() });
+
+    // The read-mode action panel is hidden, but AI-Tagging is rendered
+    // in its own edit-mode wrapper.
+    expect(screen.queryByTestId('article-actions')).not.toBeInTheDocument();
+    const editPanel = screen.getByTestId('article-actions-edit');
+    expect(editPanel).toBeInTheDocument();
+
+    // AutoTagger mock attaches data-* attrs identical to the read-mode case.
+    const autoTagger = screen.getByTestId('auto-tagger');
+    expect(autoTagger).toBeInTheDocument();
+    expect(autoTagger).toHaveAttribute('data-page-id', 'page-1');
+  });
+
   it('navigates to AI Improve when the button is clicked', () => {
     render(<ArticleRightPane />, { wrapper: createWrapper() });
 

--- a/frontend/src/shared/components/article/ArticleRightPane.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.tsx
@@ -438,6 +438,22 @@ export function ArticleRightPane() {
       {/* Divider */}
       <div className="mx-3 h-px bg-[var(--glass-sidebar-divider)]" />
 
+      {/* AI-Tagging — available in BOTH read and edit mode (#354).
+          Authors want to apply labels while editing without leaving the
+          editor; readers want to discover labels for re-tagging. The other
+          actions (Improve, Export, Delete) stay read-mode-only because they
+          act on the saved page state. */}
+      {page && id && activeModel && editing && (
+        <div className="p-2 space-y-0.5" data-testid="article-actions-edit">
+          <AutoTagger
+            pageId={id}
+            currentLabels={page?.labels ?? []}
+            model={activeModel}
+            className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-sm text-muted-foreground transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background hover:bg-[var(--glass-pill-hover)] hover:text-foreground"
+          />
+        </div>
+      )}
+
       {/* Action buttons — glass button style */}
       {!editing && page && (
         <div className="p-2 space-y-0.5" data-testid="article-actions">


### PR DESCRIPTION
## Summary
The AI-Tagging button was rendered inside the {!editing && page} block, so it disappeared whenever the article entered edit mode. Authors want to apply labels while editing without leaving the editor.

Render an additional AutoTagger block gated on editing && page so the button is present in both modes. The other read-mode actions (AI Improve, Export PDF, Pin, Open in Confluence, Delete) stay read-only because they act on saved page state.

Closes #354

## Test plan
- [x] new RTL test asserts AI-Tagging is rendered in edit mode
- [x] existing test asserts other actions are still hidden in edit
- [x] full ArticleRightPane suite: 17/17 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)