### PR TITLE
feat(#355): pre-fill AI chat with admin-configured chat use-case default

### DIFF
--- a/backend/src/routes/llm/llm-usecases.test.ts
+++ b/backend/src/routes/llm/llm-usecases.test.ts
@@ -114,3 +114,81 @@ describe.skipIf(!dbAvailable)('GET /api/admin/llm-usecases', () => {
     });
   });
 });
+
+describe.skipIf(!dbAvailable)('GET /api/llm/usecase-default', () => {
+  it('returns the resolved chat default for any authenticated user (#355)', async () => {
+    const p = await app.inject({
+      method: 'POST',
+      url: '/api/admin/llm-providers',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({
+        name: 'Chat Provider',
+        baseUrl: 'http://a/v1',
+        authType: 'none',
+        verifySsl: true,
+        defaultModel: 'gpt-4o',
+      }),
+    });
+    const providerId: string = p.json().id;
+    await app.inject({
+      method: 'POST',
+      url: `/api/admin/llm-providers/${providerId}/set-default`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+
+    // Even a non-admin token should be able to read the default — this route
+    // is auth-gated but not admin-gated.
+    const userResult = await query<{ id: string }>(
+      `INSERT INTO users (username, password_hash, role)
+       VALUES ('chat_default_user', 'fakehash', 'user') RETURNING id`,
+    );
+    const userId = userResult.rows[0]!.id;
+    await query('INSERT INTO user_settings (user_id) VALUES ($1)', [userId]);
+    const userToken = await generateAccessToken({
+      sub: userId,
+      username: 'chat_default_user',
+      role: 'user',
+    });
+
+    const r = await app.inject({
+      method: 'GET',
+      url: '/api/llm/usecase-default?usecase=chat',
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(r.statusCode).toBe(200);
+    expect(r.json()).toMatchObject({
+      usecase: 'chat',
+      providerId,
+      providerName: 'Chat Provider',
+      model: 'gpt-4o',
+    });
+  });
+
+  it('rejects an invalid usecase with 400', async () => {
+    const r = await app.inject({
+      method: 'GET',
+      url: '/api/llm/usecase-default?usecase=bogus',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(r.statusCode).toBe(400);
+  });
+
+  it('returns 401 without auth', async () => {
+    const r = await app.inject({
+      method: 'GET',
+      url: '/api/llm/usecase-default?usecase=chat',
+    });
+    expect(r.statusCode).toBe(401);
+  });
+
+  it('surfaces 404 with a specific message when no provider is configured', async () => {
+    // No provider has been created — resolveUsecase('chat') should reject.
+    const r = await app.inject({
+      method: 'GET',
+      url: '/api/llm/usecase-default?usecase=chat',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(r.statusCode).toBe(404);
+    expect(r.json().error).toMatch(/Settings → LLM/);
+  });
+});

--- a/backend/src/routes/llm/llm-usecases.ts
+++ b/backend/src/routes/llm/llm-usecases.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
-import { UpdateUsecaseAssignmentsInputSchema, type LlmUsecase } from '@compendiq/contracts';
+import { z } from 'zod';
+import { LlmUsecaseSchema, UpdateUsecaseAssignmentsInputSchema, type LlmUsecase } from '@compendiq/contracts';
 import { query, getPool } from '../../core/db/postgres.js';
 import { resolveUsecase } from '../../domains/llm/services/llm-provider-resolver.js';
 import { bumpProviderCacheVersion } from '../../domains/llm/services/cache-bus.js';
@@ -14,6 +15,27 @@ const USECASES: readonly LlmUsecase[] = ['chat', 'summary', 'quality', 'auto_tag
 
 export async function llmUsecaseRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
+
+  // GET /llm/usecase-default?usecase=chat — non-admin: resolved default for a
+  // single use case. Used by the AI chat input pane to pre-fill its model
+  // selector with the admin-configured chat default (#355). Returns the same
+  // shape that resolveUsecase produces, excluding the raw assignment row.
+  fastify.get('/llm/usecase-default', async (req, reply) => {
+    const { usecase } = z.object({ usecase: LlmUsecaseSchema }).parse(req.query);
+    try {
+      const resolved = await resolveUsecase(usecase);
+      return {
+        usecase,
+        providerId: resolved.config.providerId,
+        providerName: resolved.config.name,
+        model: resolved.model,
+      };
+    } catch {
+      return reply.code(404).send({
+        error: `No provider resolved for use case "${usecase}". Configure one in Settings → LLM.`,
+      });
+    }
+  });
 
   // GET /admin/llm-usecases — return all 5 use-cases with raw + resolved values.
   fastify.get(

--- a/frontend/src/features/ai/AiAssistantPage.test.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LazyMotion, domAnimation } from 'framer-motion';
@@ -53,6 +53,28 @@ function createWrapper(initialEntries = ['/ai']) {
       </QueryClientProvider>
     );
   };
+}
+
+/**
+ * Variant that exposes the QueryClient so the test can manipulate cache state
+ * directly (used by the #355 chat-default-prefill tests below to simulate an
+ * admin-side change without round-tripping through a real PUT).
+ */
+function createWrapperWithClient(initialEntries = ['/ai']): {
+  Wrapper: ({ children }: { children: React.ReactNode }) => React.ReactElement;
+  queryClient: QueryClient;
+} {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <LazyMotion features={domAnimation}>{children}</LazyMotion>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+  return { Wrapper, queryClient };
 }
 
 describe('AiAssistantPage', () => {
@@ -1072,6 +1094,259 @@ describe('AiAssistantPage', () => {
       // (this would fail with index-based keys if React rebinds elements)
       const userMessage = screen.getByText('My question');
       expect(userMessage.closest('.bg-primary\\/10')).toBeTruthy();
+    });
+  });
+
+  // #355 — admin-configured chat use-case default
+  // (Findings 1, 2, 4 from the PR review).
+  describe('chat use-case default pre-fill (#355)', () => {
+    it('pre-fills the model selector from /llm/usecase-default?usecase=chat on mount', async () => {
+      // Arrange: backend returns a chat use-case default that differs from
+      // the legacy /settings.ollamaModel value. The pre-fill must come from
+      // the use-case default, not /settings.
+      apiFetchMock.mockImplementation((path: string) => {
+        if (path === '/llm/usecase-default?usecase=chat') {
+          return Promise.resolve({
+            usecase: 'chat',
+            providerId: '11111111-1111-4111-8111-111111111111',
+            providerName: 'Ollama',
+            model: 'qwen3:8b',
+          });
+        }
+        if (path === '/settings') {
+          // Legacy fallback — should NOT be reached because chat default exists.
+          return Promise.resolve({
+            llmProvider: 'ollama',
+            ollamaModel: 'legacy-llama3',
+            openaiModel: null,
+          });
+        }
+        if (path.startsWith('/ollama/models')) {
+          return Promise.resolve([
+            { name: 'qwen3:8b' },
+            { name: 'llama3' },
+            { name: 'gpt-4o-mini' },
+          ]);
+        }
+        if (path === '/llm/conversations') return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+
+      render(<AiAssistantPage />, { wrapper: createWrapper() });
+
+      // Wait for the model dropdown to render (i.e. models loaded).
+      await waitFor(() => {
+        expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
+      });
+
+      const select = document.querySelector('select') as HTMLSelectElement | null;
+      expect(select).not.toBeNull();
+      expect(select!.value).toBe('qwen3:8b');
+    });
+
+    it('queries /ollama/models with ?usecase=chat (Finding 4 — not ?provider=…)', async () => {
+      apiFetchMock.mockImplementation((path: string) => {
+        if (path === '/llm/usecase-default?usecase=chat') {
+          return Promise.resolve({
+            usecase: 'chat',
+            providerId: '11111111-1111-4111-8111-111111111111',
+            providerName: 'Ollama',
+            model: 'qwen3:8b',
+          });
+        }
+        if (path.startsWith('/ollama/models')) {
+          return Promise.resolve([{ name: 'qwen3:8b' }]);
+        }
+        if (path === '/llm/conversations') return Promise.resolve([]);
+        if (path === '/settings') return Promise.resolve({ llmProvider: 'ollama', ollamaModel: '', openaiModel: null });
+        return Promise.resolve([]);
+      });
+
+      render(<AiAssistantPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        const modelsCalls = apiFetchMock.mock.calls
+          .map((args) => args[0])
+          .filter((p): p is string => typeof p === 'string' && p.startsWith('/ollama/models'));
+        expect(modelsCalls.length).toBeGreaterThan(0);
+      });
+
+      const modelsCalls = apiFetchMock.mock.calls
+        .map((args) => args[0])
+        .filter((p): p is string => typeof p === 'string' && p.startsWith('/ollama/models'));
+
+      // Backend route at backend/src/routes/llm/llm-models.ts only parses
+      // ?usecase=… — sending ?provider=… silently returns the wrong models.
+      expect(modelsCalls.every((p) => p.includes('usecase=chat'))).toBe(true);
+      expect(modelsCalls.some((p) => p.includes('provider='))).toBe(false);
+    });
+
+    it('falls back to /settings model when chat use-case default is unavailable (404)', async () => {
+      apiFetchMock.mockImplementation((path: string) => {
+        if (path === '/llm/usecase-default?usecase=chat') {
+          // Simulate the 404 the backend returns when no provider is configured.
+          return Promise.reject(new Error('No provider resolved for use case "chat"'));
+        }
+        if (path === '/settings') {
+          return Promise.resolve({
+            llmProvider: 'ollama',
+            ollamaModel: 'legacy-llama3',
+            openaiModel: null,
+          });
+        }
+        if (path.startsWith('/ollama/models')) {
+          return Promise.resolve([{ name: 'legacy-llama3' }]);
+        }
+        if (path === '/llm/conversations') return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+
+      render(<AiAssistantPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
+      });
+
+      const select = document.querySelector('select') as HTMLSelectElement | null;
+      expect(select).not.toBeNull();
+      expect(select!.value).toBe('legacy-llama3');
+    });
+
+    it('propagates an admin-side change to the chat UI without remount (Finding 1, AC-3)', async () => {
+      // First load: chat default is qwen3:8b.
+      let currentChatDefault = {
+        usecase: 'chat',
+        providerId: '11111111-1111-4111-8111-111111111111',
+        providerName: 'Ollama',
+        model: 'qwen3:8b',
+      };
+      let currentModels = [{ name: 'qwen3:8b' }, { name: 'llama3' }];
+
+      apiFetchMock.mockImplementation((path: string) => {
+        if (path === '/llm/usecase-default?usecase=chat') {
+          return Promise.resolve(currentChatDefault);
+        }
+        if (path.startsWith('/ollama/models')) {
+          return Promise.resolve(currentModels);
+        }
+        if (path === '/llm/conversations') return Promise.resolve([]);
+        if (path === '/settings') {
+          return Promise.resolve({ llmProvider: 'ollama', ollamaModel: '', openaiModel: null });
+        }
+        return Promise.resolve([]);
+      });
+
+      const { Wrapper, queryClient } = createWrapperWithClient();
+      render(<AiAssistantPage />, { wrapper: Wrapper });
+
+      // Initial state: dropdown shows qwen3:8b.
+      await waitFor(() => {
+        const select = document.querySelector('select') as HTMLSelectElement | null;
+        expect(select?.value).toBe('qwen3:8b');
+      });
+
+      // Verify dropdown options reflect the initial models list.
+      const initialOptions = Array.from(document.querySelectorAll('select option')).map(
+        (o) => o.textContent,
+      );
+      expect(initialOptions).toEqual(['qwen3:8b', 'llama3']);
+
+      // Admin changes the chat assignment to a different provider+model.
+      // Simulate by updating what the API returns and invalidating the
+      // relevant query keys (which is what LlmTab's save handler does
+      // after a successful PUT /admin/llm-usecases).
+      currentChatDefault = {
+        usecase: 'chat',
+        providerId: '22222222-2222-4222-8222-222222222222',
+        providerName: 'OpenAI',
+        model: 'gpt-4o-mini',
+      };
+      currentModels = [{ name: 'gpt-4o-mini' }, { name: 'gpt-4o' }];
+
+      await act(async () => {
+        await queryClient.invalidateQueries({ queryKey: ['llm', 'usecase-default'] });
+        await queryClient.invalidateQueries({ queryKey: ['llm', 'models'] });
+      });
+
+      // Models dropdown should now reflect the new provider's models —
+      // proving the admin change propagated without a remount.
+      await waitFor(() => {
+        const opts = Array.from(document.querySelectorAll('select option')).map(
+          (o) => o.textContent,
+        );
+        expect(opts).toEqual(['gpt-4o-mini', 'gpt-4o']);
+      });
+    });
+
+    it('startNewConversation resets model to the current chat default (Finding 2, AC-4)', async () => {
+      apiFetchMock.mockImplementation((path: string, opts?: RequestInit) => {
+        if (path === '/llm/usecase-default?usecase=chat') {
+          return Promise.resolve({
+            usecase: 'chat',
+            providerId: '11111111-1111-4111-8111-111111111111',
+            providerName: 'Ollama',
+            model: 'qwen3:8b',
+          });
+        }
+        if (path.startsWith('/ollama/models')) {
+          return Promise.resolve([
+            { name: 'qwen3:8b' },
+            { name: 'llama3' },
+            { name: 'gpt-4o-mini' },
+          ]);
+        }
+        if (path === '/llm/conversations') return Promise.resolve([]);
+        if (path === '/llm/conversations/conv-1' && (!opts || !opts.method)) {
+          // Loading an old conversation that was created with a different model —
+          // this simulates the per-conversation override that previously leaked.
+          return Promise.resolve({
+            id: 'conv-1',
+            model: 'llama3',
+            messages: [
+              { role: 'user', content: 'old question' },
+              { role: 'assistant', content: 'old answer' },
+            ],
+          });
+        }
+        if (path === '/settings') {
+          return Promise.resolve({ llmProvider: 'ollama', ollamaModel: '', openaiModel: null });
+        }
+        return Promise.resolve([]);
+      });
+
+      // Render the AiContext provider directly so we can call its
+      // startNewConversation() and inspect model state.
+      const { AiProvider, useAiContext } = await import('./AiContext');
+      let captured: ReturnType<typeof useAiContext> | null = null;
+      function Capture() {
+        captured = useAiContext();
+        return null;
+      }
+
+      render(
+        <AiProvider>
+          <Capture />
+        </AiProvider>,
+        { wrapper: createWrapper() },
+      );
+
+      // Wait for chat default to load and pre-fill model.
+      await waitFor(() => {
+        expect(captured?.model).toBe('qwen3:8b');
+      });
+
+      // Simulate the user picking a different model for the current conversation.
+      await act(async () => {
+        captured!.setModel('gpt-4o-mini');
+      });
+      expect(captured?.model).toBe('gpt-4o-mini');
+
+      // Start a new conversation — model must reset to the chat default,
+      // not stay on the per-conversation override.
+      await act(async () => {
+        captured!.startNewConversation();
+      });
+      expect(captured?.model).toBe('qwen3:8b');
     });
   });
 });

--- a/frontend/src/features/ai/AiContext.tsx
+++ b/frontend/src/features/ai/AiContext.tsx
@@ -228,36 +228,52 @@ export function AiProvider({ children }: { children: ReactNode }) {
     };
   }, [isThinking]);
 
-  // Load settings, models and conversations on mount
+  // Load settings, models and conversations on mount.
+  // #355: prefer the admin-configured chat use-case default (resolveUsecase
+  // 'chat') over the legacy per-user settings.ollamaModel/openaiModel. The
+  // settings model remains a fallback so the input never shows empty if the
+  // chat use-case isn't configured.
   useEffect(() => {
-    apiFetch<{ llmProvider: string; ollamaModel: string; openaiModel: string | null }>('/settings')
-      .then((settings) => {
-        const provider = settings.llmProvider ?? 'ollama';
-        const preferredModel = provider === 'openai'
-          ? settings.openaiModel ?? ''
-          : settings.ollamaModel ?? '';
+    const loadSettingsFallback = () =>
+      apiFetch<{ llmProvider: string; ollamaModel: string; openaiModel: string | null }>('/settings')
+        .then((settings) => {
+          const provider = settings.llmProvider ?? 'ollama';
+          const fallback = provider === 'openai'
+            ? settings.openaiModel ?? ''
+            : settings.ollamaModel ?? '';
+          return { provider, fallback };
+        })
+        .catch(() => ({ provider: 'ollama', fallback: '' }));
 
-        apiFetch<Array<{ name: string }>>(`/ollama/models?provider=${provider}`)
-          .then((m) => {
-            setModels(m);
-            if (preferredModel) {
-              setModel(preferredModel);
-            } else if (m.length > 0) {
-              setModel((prev) => prev || (m[0]?.name ?? ''));
-            }
-          })
-          .catch(() => {
-            if (preferredModel) setModel(preferredModel);
-          });
-      })
-      .catch(() => {
-        apiFetch<Array<{ name: string }>>('/ollama/models')
-          .then((m) => {
-            setModels(m);
-            if (m.length > 0) setModel((prev) => prev || (m[0]?.name ?? ''));
-          })
-          .catch(() => {});
-      });
+    (async () => {
+      // Try the chat use-case default first.
+      let preferred = '';
+      let provider = 'ollama';
+      try {
+        const def = await apiFetch<{ providerId: string; providerName: string; model: string }>(
+          '/llm/usecase-default?usecase=chat',
+        );
+        preferred = def.model ?? '';
+        // The provider name is informational; we still load models via the
+        // legacy /ollama/models endpoint scoped to llm-provider type.
+      } catch {
+        const fb = await loadSettingsFallback();
+        provider = fb.provider;
+        preferred = fb.fallback;
+      }
+
+      try {
+        const m = await apiFetch<Array<{ name: string }>>(`/ollama/models?provider=${provider}`);
+        setModels(m);
+        if (preferred) {
+          setModel(preferred);
+        } else if (m.length > 0) {
+          setModel((prev) => prev || (m[0]?.name ?? ''));
+        }
+      } catch {
+        if (preferred) setModel(preferred);
+      }
+    })();
 
     apiFetch<Conversation[]>('/llm/conversations')
       .then(setConversations)

--- a/frontend/src/features/ai/AiContext.tsx
+++ b/frontend/src/features/ai/AiContext.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useState, useRef, useEffect, useCallback, type ReactNode } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type { UsecaseDefault } from '@compendiq/contracts';
 import { apiFetch } from '../../shared/lib/api';
 import { streamSSE } from '../../shared/lib/sse';
 import { usePage, useEmbeddingStatus, type EmbeddingStatusData } from '../../shared/hooks/use-pages';
@@ -162,7 +163,6 @@ export function AiProvider({ children }: { children: ReactNode }) {
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [model, setModel] = useState('');
-  const [models, setModels] = useState<Array<{ name: string }>>([]);
   const [includeSubPages, setIncludeSubPages] = useState(false);
   const [thinkingMode, setThinkingModeState] = useState(() => localStorage.getItem('ai-thinking-mode') === 'true');
   const handleSetThinkingMode = useCallback((v: boolean) => {
@@ -233,52 +233,90 @@ export function AiProvider({ children }: { children: ReactNode }) {
   // 'chat') over the legacy per-user settings.ollamaModel/openaiModel. The
   // settings model remains a fallback so the input never shows empty if the
   // chat use-case isn't configured.
+  //
+  // Refactored to TanStack Query (Finding 1, AC-3) so admin-side changes to
+  // the chat use-case assignment propagate to the chat UI without a hard
+  // reload. LlmTab's save handler invalidates ['llm', 'usecase-default'] and
+  // ['llm', 'models'], which causes these queries to refetch automatically.
+  const chatDefaultQuery = useQuery<UsecaseDefault>({
+    queryKey: ['llm', 'usecase-default', 'chat'],
+    queryFn: () => apiFetch<UsecaseDefault>('/llm/usecase-default?usecase=chat'),
+    // Returns 404 when no provider is configured for chat — that's a legitimate
+    // "no default" signal that we should fall through to the legacy /settings
+    // path; do not retry it as an error.
+    retry: false,
+    staleTime: 30_000,
+  });
+  const chatDefault = chatDefaultQuery.data;
+  const isChatDefaultSettled = !chatDefaultQuery.isLoading;
+
+  // Legacy fallback only consulted when the chat use-case has no configured
+  // default. Skipped while the primary query is still in flight so we don't
+  // race-set the wrong model.
+  const settingsFallbackQuery = useQuery<{
+    llmProvider: string;
+    ollamaModel: string;
+    openaiModel: string | null;
+  }>({
+    queryKey: ['settings', 'llm-fallback'],
+    queryFn: () =>
+      apiFetch('/settings'),
+    enabled: isChatDefaultSettled && !chatDefault?.model,
+    retry: false,
+    staleTime: 30_000,
+  });
+
+  // Models for the chat use case. Finding 4: the backend route at
+  // backend/src/routes/llm/llm-models.ts only parses ?usecase=… — it ignores
+  // ?provider=… entirely. Calling with the wrong query param silently returned
+  // the default provider's models, which broke when chat was assigned to a
+  // non-default provider.
+  const modelsQuery = useQuery<Array<{ name: string }>>({
+    queryKey: ['llm', 'models', 'chat'],
+    queryFn: () => apiFetch<Array<{ name: string }>>('/ollama/models?usecase=chat'),
+    retry: false,
+    staleTime: 30_000,
+  });
+  const models = modelsQuery.data ?? [];
+
+  const conversationsQuery = useQuery<Conversation[]>({
+    queryKey: ['llm', 'conversations'],
+    queryFn: () => apiFetch<Conversation[]>('/llm/conversations'),
+    retry: false,
+    staleTime: 30_000,
+  });
   useEffect(() => {
-    const loadSettingsFallback = () =>
-      apiFetch<{ llmProvider: string; ollamaModel: string; openaiModel: string | null }>('/settings')
-        .then((settings) => {
-          const provider = settings.llmProvider ?? 'ollama';
-          const fallback = provider === 'openai'
-            ? settings.openaiModel ?? ''
-            : settings.ollamaModel ?? '';
-          return { provider, fallback };
-        })
-        .catch(() => ({ provider: 'ollama', fallback: '' }));
+    if (conversationsQuery.data) setConversations(conversationsQuery.data);
+  }, [conversationsQuery.data]);
 
-    (async () => {
-      // Try the chat use-case default first.
-      let preferred = '';
-      let provider = 'ollama';
-      try {
-        const def = await apiFetch<{ providerId: string; providerName: string; model: string }>(
-          '/llm/usecase-default?usecase=chat',
-        );
-        preferred = def.model ?? '';
-        // The provider name is informational; we still load models via the
-        // legacy /ollama/models endpoint scoped to llm-provider type.
-      } catch {
-        const fb = await loadSettingsFallback();
-        provider = fb.provider;
-        preferred = fb.fallback;
+  // Initial model selection. Runs once when the resolved default (or its
+  // fallback chain) becomes available. Subsequent admin-side changes update
+  // the dropdown options live, but the *selected* model only resets on the
+  // next startNewConversation() call — see Finding 2.
+  const modelInitializedRef = useRef(false);
+  useEffect(() => {
+    if (modelInitializedRef.current) return;
+    if (chatDefault?.model) {
+      setModel(chatDefault.model);
+      modelInitializedRef.current = true;
+      return;
+    }
+    if (settingsFallbackQuery.data) {
+      const s = settingsFallbackQuery.data;
+      const provider = s.llmProvider ?? 'ollama';
+      const fb = provider === 'openai' ? s.openaiModel ?? '' : s.ollamaModel ?? '';
+      if (fb) {
+        setModel(fb);
+        modelInitializedRef.current = true;
+        return;
       }
-
-      try {
-        const m = await apiFetch<Array<{ name: string }>>(`/ollama/models?provider=${provider}`);
-        setModels(m);
-        if (preferred) {
-          setModel(preferred);
-        } else if (m.length > 0) {
-          setModel((prev) => prev || (m[0]?.name ?? ''));
-        }
-      } catch {
-        if (preferred) setModel(preferred);
-      }
-    })();
-
-    apiFetch<Conversation[]>('/llm/conversations')
-      .then(setConversations)
-      .catch(() => {});
-  }, []);
+    }
+    const modelsList = modelsQuery.data;
+    if (modelsList && modelsList.length > 0) {
+      setModel((prev) => prev || (modelsList[0]?.name ?? ''));
+      modelInitializedRef.current = true;
+    }
+  }, [chatDefault, settingsFallbackQuery.data, modelsQuery.data]);
 
   useEffect(() => {
     if (messages.length === 0) return;
@@ -299,7 +337,15 @@ export function AiProvider({ children }: { children: ReactNode }) {
     setMessages([]);
     setConversationId(null);
     setInput('');
-  }, []);
+    // #355 (Finding 2, AC-4): reset the model selector to the current chat
+    // default so a per-conversation override (set via loadConversation or the
+    // dropdown) doesn't leak into newly-started conversations. We read from
+    // the live TanStack Query result so admin-side changes are picked up
+    // without remounting.
+    if (chatDefault?.model) {
+      setModel(chatDefault.model);
+    }
+  }, [chatDefault]);
 
   const loadConversation = useCallback(async (id: string) => {
     try {

--- a/frontend/src/features/settings/panels/LlmTab.test.tsx
+++ b/frontend/src/features/settings/panels/LlmTab.test.tsx
@@ -13,6 +13,22 @@ function createWrapper() {
   };
 }
 
+/** Wrapper variant that exposes the QueryClient so assertions can observe
+ *  cache invalidations triggered by mutations. Used by the #355 invalidation
+ *  test (Finding 1, AC-3). */
+function createWrapperWithClient(): {
+  Wrapper: ({ children }: { children: React.ReactNode }) => React.ReactElement;
+  qc: QueryClient;
+} {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return { Wrapper, qc };
+}
+
 const providerA = {
   id: '11111111-1111-4111-8111-111111111111',
   name: 'Ollama',
@@ -173,6 +189,40 @@ describe('LlmTab', () => {
       expect(putCall).toBeTruthy();
       const body = JSON.parse((putCall![1] as RequestInit).body as string);
       expect(body.chat.providerId).toBe(providerB.id);
+    });
+  });
+
+  // #355 Finding 1, AC-3: saving the use-case assignments must invalidate
+  // the chat-default + use-case-scoped models query keys so the AI chat
+  // input pane (AiContext.tsx) refetches without a hard reload.
+  it('invalidates [llm, usecase-default] and [llm, models] after a successful save', async () => {
+    const { Wrapper, qc } = createWrapperWithClient();
+    mockRoutes();
+
+    // Pre-seed the cache with stale data on the keys we expect to be
+    // invalidated. After save.onSuccess fires, both should be refetched
+    // (i.e. their queryState should be marked invalid/stale).
+    qc.setQueryData(['llm', 'usecase-default', 'chat'], {
+      usecase: 'chat',
+      providerId: providerA.id,
+      providerName: 'Ollama',
+      model: 'qwen3:4b',
+    });
+    qc.setQueryData(['llm', 'models', 'chat'], [{ name: 'qwen3:4b' }]);
+
+    render(<LlmTab />, { wrapper: Wrapper });
+    await screen.findByText('Use case assignments');
+    fireEvent.change(screen.getByTestId('usecase-chat-provider'), {
+      target: { value: providerB.id },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save use-case assignments/i }));
+
+    // After the mutation succeeds, both seeded entries must be invalidated.
+    await waitFor(() => {
+      const usecaseEntry = qc.getQueryState(['llm', 'usecase-default', 'chat']);
+      const modelsEntry = qc.getQueryState(['llm', 'models', 'chat']);
+      expect(usecaseEntry?.isInvalidated).toBe(true);
+      expect(modelsEntry?.isInvalidated).toBe(true);
     });
   });
 

--- a/frontend/src/features/settings/panels/LlmTab.tsx
+++ b/frontend/src/features/settings/panels/LlmTab.tsx
@@ -86,6 +86,13 @@ export function LlmTab() {
       apiFetch('/admin/llm-usecases', { method: 'PUT', body: JSON.stringify(diff) }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['llm-usecases'] });
+      // #355 (Finding 1, AC-3): cascade the change to consumers of the
+      // resolved per-use-case default (notably the AI chat input pane in
+      // AiContext.tsx) and the use-case-scoped models list. Prefix-match on
+      // ['llm', 'usecase-default'] and ['llm', 'models'] invalidates every
+      // use-case-keyed entry so dropdowns refresh without a hard reload.
+      qc.invalidateQueries({ queryKey: ['llm', 'usecase-default'] });
+      qc.invalidateQueries({ queryKey: ['llm', 'models'] });
       toast.success('Use-case assignments saved');
     },
     onError: (e: Error) => toast.error(e.message),

--- a/packages/contracts/src/llm.ts
+++ b/packages/contracts/src/llm.ts
@@ -70,6 +70,21 @@ export const UpdateUsecaseAssignmentsInputSchema = z.object({
 });
 export type UpdateUsecaseAssignmentsInput = z.infer<typeof UpdateUsecaseAssignmentsInputSchema>;
 
+// ─── Read-side resolver output for non-admin callers (#355) ─────────────────
+/**
+ * Shape returned by `GET /llm/usecase-default?usecase=…` — the resolved
+ * provider+model for a given use case, suitable for non-admin UI surfaces
+ * (chat input pane, etc.). Excludes the raw assignment row to avoid leaking
+ * the admin-internal "unset / inherits default" distinction.
+ */
+export const UsecaseDefaultSchema = z.object({
+  usecase: LlmUsecaseSchema,
+  providerId: z.string().uuid(),
+  providerName: z.string(),
+  model: z.string(),
+});
+export type UsecaseDefault = z.infer<typeof UsecaseDefaultSchema>;
+
 // ─── DEPRECATED: old two-slot enum kept for transitional typing only ──────
 /** @deprecated use `LlmProvider.id` (uuid). Removed after Task 36. */
 export const LlmProviderTypeSchema = z.enum(['ollama', 'openai']);


### PR DESCRIPTION
## Summary
**Backend**: new GET /llm/usecase-default?usecase=… (auth required, no admin) returns the resolved provider+model for a single use case. Wraps resolveUsecase, so it follows the same fallback chain (assignment → provider default → seed env vars). Returns 404 with a specific message when no provider is configured. Schema in @compendiq/contracts as UsecaseDefaultSchema.

**Frontend**: AiContext now reads /llm/usecase-default?usecase=chat on mount and uses that model as the input default. Falls back to the legacy /settings.ollamaModel/openaiModel only if the use-case lookup fails, so the input is never empty if either path resolves.

Closes #355

## Test plan
- [x] backend tests for the 4 paths (200, 400 invalid, 401, 404 no-provider) — DB-skipped locally; CI runs them
- [x] frontend AI suite: 165/165 pass with the new lookup
- [x] type-check: contracts + backend + frontend all clean
- [ ] manual: open AI chat, confirm input model matches Settings → LLM → chat use-case

🤖 Generated with [Claude Code](https://claude.com/claude-code)