### PR TITLE
fix(#357): align Verify button to backend POST route

### DIFF
--- a/backend/src/routes/knowledge/verification.ts
+++ b/backend/src/routes/knowledge/verification.ts
@@ -46,11 +46,15 @@ export async function verificationRoutes(fastify: FastifyInstance) {
 
     const pageId = await assertPageAccess(id, userId);
 
+    // #357: clamp review_interval_days defensively. The column is NOT NULL
+    // DEFAULT 90, but if a future bug or partial-migration ever leaves a
+    // 0 or NULL behind, the bare `(col || ' days')::INTERVAL` cast would
+    // throw on the request path. GREATEST + COALESCE keeps verify usable.
     const result = await query(
       `UPDATE pages SET
         verified_by = $1,
         verified_at = NOW(),
-        next_review_at = NOW() + (review_interval_days || ' days')::INTERVAL
+        next_review_at = NOW() + (GREATEST(COALESCE(review_interval_days, 90), 1) || ' days')::INTERVAL
        WHERE id = $2
        RETURNING id`,
       [userId, pageId],

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -793,10 +793,13 @@ function VerifyButton({ pageId }: { pageId: string | undefined }) {
   const handleVerify = async () => {
     if (!pageId) return;
     try {
-      await verifyMutation.mutateAsync({ pageId: Number(pageId), verified: true });
-      toast.success('Page verified');
-    } catch {
-      toast.error('Failed to verify page');
+      await verifyMutation.mutateAsync({ pageId: Number(pageId) });
+      toast.success('Page verified — next review reminder rescheduled');
+    } catch (err) {
+      // #357: surface the server's specific message instead of a generic
+      // toast. ApiError.message already carries the backend reply.
+      const msg = err instanceof Error && err.message ? err.message : 'Failed to verify page';
+      toast.error(msg);
     }
   };
 
@@ -804,6 +807,8 @@ function VerifyButton({ pageId }: { pageId: string | undefined }) {
     <button
       onClick={handleVerify}
       disabled={verifyMutation.isPending}
+      title="Mark this page as up-to-date. Resets the next review reminder based on the configured review interval."
+      aria-label="Mark page as verified"
       className="rounded-md px-2.5 py-1 text-xs text-emerald-500 transition-colors hover:bg-emerald-500/10 disabled:opacity-50"
       data-testid="verify-btn"
     >

--- a/frontend/src/shared/hooks/use-standalone.test.ts
+++ b/frontend/src/shared/hooks/use-standalone.test.ts
@@ -224,13 +224,15 @@ describe('use-standalone hooks', () => {
   // ---- Verification ----
 
   describe('useVerifyPage', () => {
-    it('sends verify request', async () => {
-      const mock = mockFetch({ message: 'verified' });
+    it('sends POST verify request without body (#357)', async () => {
+      const mock = mockFetch({ success: true });
       const { result } = renderHook(() => useVerifyPage(), { wrapper: createWrapper() });
-      await result.current.mutateAsync({ pageId: 42, verified: true });
+      await result.current.mutateAsync({ pageId: 42 });
       const [url, opts] = mock.mock.calls[0] as [string, RequestInit];
       expect(url).toContain('/pages/42/verify');
-      expect(opts.method).toBe('PUT');
+      expect(opts.method).toBe('POST');
+      // Backend ignores the body; we don't send one.
+      expect(opts.body).toBeUndefined();
     });
   });
 

--- a/frontend/src/shared/hooks/use-standalone.ts
+++ b/frontend/src/shared/hooks/use-standalone.ts
@@ -231,14 +231,17 @@ export function useMarkAllRead() {
 
 // ======== Verification ========
 
+/**
+ * Mark a page as human-reviewed (#357). Backend exposes POST
+ * /api/pages/:id/verify and ignores the body — the previous PUT call with a
+ * `{ verified: boolean }` body was the source of the generic "Failed to
+ * verify page" toast (404 from Fastify, no PUT route registered).
+ */
 export function useVerifyPage() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ pageId, verified }: { pageId: number; verified: boolean }) =>
-      apiFetch(`/pages/${pageId}/verify`, {
-        method: 'PUT',
-        body: JSON.stringify({ verified }),
-      }),
+    mutationFn: ({ pageId }: { pageId: number }) =>
+      apiFetch(`/pages/${pageId}/verify`, { method: 'POST' }),
     onSuccess: (_data, { pageId }) => {
       queryClient.invalidateQueries({ queryKey: ['pages', String(pageId)] });
     },


### PR DESCRIPTION
## Summary
**Root cause** (reproduced in the running container stack): useVerifyPage called PUT /api/pages/:id/verify but the backend registers POST. Fastify returned 404 for the PUT, the frontend swallowed that into a generic "Failed to verify page" toast. Confirmed live: PUT 404 vs POST 401.

- Frontend: switch the mutation to POST and drop the body. The backend already ignores any body — there's no unverify path. Surface the server's error message verbatim instead of a generic toast.
- Frontend: tooltip explaining what Verify does ("Mark this page as up-to-date. Resets the next review reminder…") so users know before clicking.
- Backend: defensive clamp on the SQL interval cast (GREATEST(COALESCE(review_interval_days, 90), 1)) so a future partial-migration leaving NULL/0 in the column can't crash the request path. Belt-and-suspenders — not the bug, but cheap and permanent insurance.

Closes #357

## Test plan
- [x] hook test asserts POST + no body
- [x] live container smoke: POST returns 401 (route exists), PUT 404 (correct: that route doesn't exist)
- [ ] manual: click Verify on a synced page, observe success toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)