### PR TITLE
feat(#358): graph empty-state plumbing + admin recompute (slice 351a)

### DIFF
--- a/backend/src/routes/knowledge/pages-embeddings.ts
+++ b/backend/src/routes/knowledge/pages-embeddings.ts
@@ -23,7 +23,14 @@ export async function pagesEmbeddingRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
   const cache = new RedisCache(fastify.redis);
 
-  // GET /api/pages/graph - nodes (pages) + edges (relationships) for knowledge graph
+  // GET /api/pages/graph - nodes (pages) + edges (relationships) for knowledge graph.
+  // Response shape:
+  //   { nodes, edges, meta: { pagesTotal, pagesEmbedded, relationshipsTotal,
+  //     relationshipsByType: { embedding_similarity, label_overlap, explicit_link?, parent_child? } } }
+  // The meta block is what powers the differentiated empty states in #358:
+  // - pagesTotal === 0  → "No accessible pages in selected spaces"
+  // - pagesEmbedded === 0 (with pagesTotal > 0)  → "Pages not embedded yet"
+  // - relationshipsTotal === 0 (with pagesEmbedded > 0)  → "Embedded but no relationships yet"
   fastify.get('/pages/graph', async (request) => {
     const userId = request.userId;
     const { view, spaceKey: filterSpaceKey } = GraphQuerySchema.parse(request.query);
@@ -39,7 +46,11 @@ export async function pagesEmbeddingRoutes(fastify: FastifyInstance) {
       : graphSpaces;
 
     if (effectiveSpaces.length === 0) {
-      return { nodes: [], edges: [] };
+      return {
+        nodes: [],
+        edges: [],
+        meta: { pagesTotal: 0, pagesEmbedded: 0, relationshipsTotal: 0, relationshipsByType: {} },
+      };
     }
 
     if (view === 'clustered') {
@@ -123,7 +134,26 @@ export async function pagesEmbeddingRoutes(fastify: FastifyInstance) {
         score: row.score,
       }));
 
-    const response = { nodes, edges };
+    // #358: meta counts so the UI can differentiate empty states without
+    // a second roundtrip. pagesEmbedded counts pages that have at least
+    // one row in page_embeddings; relationshipsByType breaks the edge
+    // count down per relationship_type for diagnostics.
+    const pagesEmbedded = embeddingCountMap.size;
+    const relationshipsByType: Record<string, number> = {};
+    for (const e of edges) {
+      relationshipsByType[e.type] = (relationshipsByType[e.type] ?? 0) + 1;
+    }
+
+    const response = {
+      nodes,
+      edges,
+      meta: {
+        pagesTotal: nodes.length,
+        pagesEmbedded,
+        relationshipsTotal: edges.length,
+        relationshipsByType,
+      },
+    };
     await cache.set(userId, 'pages', cacheKey, response, GRAPH_CACHE_TTL);
     return response;
   });

--- a/backend/src/routes/knowledge/pages-graph.test.ts
+++ b/backend/src/routes/knowledge/pages-graph.test.ts
@@ -208,6 +208,14 @@ describe('Knowledge Graph API', () => {
       expect(body.edges[0].target).toBe('2');
       expect(body.edges[0].type).toBe('embedding_similarity');
       expect(body.edges[0].score).toBe(0.85);
+
+      // #358: meta block powers the differentiated empty states.
+      expect(body.meta).toEqual({
+        pagesTotal: 2,
+        pagesEmbedded: 2,
+        relationshipsTotal: 1,
+        relationshipsByType: { embedding_similarity: 1 },
+      });
     });
 
     it('should return empty arrays when no pages exist', async () => {

--- a/backend/src/routes/knowledge/pages-graph.test.ts
+++ b/backend/src/routes/knowledge/pages-graph.test.ts
@@ -3,6 +3,7 @@ import Fastify from 'fastify';
 import sensible from '@fastify/sensible';
 import { ZodError } from 'zod';
 import { pagesEmbeddingRoutes } from './pages-embeddings.js';
+import { getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
 
 // Track cache set calls to verify TTL
 const mockCacheSet = vi.fn().mockResolvedValue(undefined);
@@ -235,6 +236,44 @@ describe('Knowledge Graph API', () => {
       const body = JSON.parse(response.body);
       expect(body.nodes).toHaveLength(0);
       expect(body.edges).toHaveLength(0);
+
+      // #358: meta block must be present (with zeros) so the UI can render
+      // the differentiated empty state without a second roundtrip.
+      expect(body.meta).toEqual({
+        pagesTotal: 0,
+        pagesEmbedded: 0,
+        relationshipsTotal: 0,
+        relationshipsByType: {},
+      });
+    });
+
+    it('should short-circuit with zero-meta when RBAC grants no spaces', async () => {
+      // #358: when getUserAccessibleSpaces returns [] (user has no granted
+      // spaces), the route must skip the main query path entirely and emit
+      // the same meta-block contract the UI expects for the
+      // "No accessible pages in your spaces" empty state.
+      vi.mocked(getUserAccessibleSpaces).mockResolvedValueOnce([]);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/pages/graph',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.nodes).toEqual([]);
+      expect(body.edges).toEqual([]);
+      expect(body.meta).toEqual({
+        pagesTotal: 0,
+        pagesEmbedded: 0,
+        relationshipsTotal: 0,
+        relationshipsByType: {},
+      });
+
+      // The short-circuit must NOT hit the database — no nodes/edges/embeddings
+      // queries should run, otherwise we are leaking work for users with
+      // zero accessible spaces.
+      expect(mockQueryFn).not.toHaveBeenCalled();
     });
 
     it('should default embeddingCount to 0 for pages without embeddings', async () => {

--- a/frontend/src/features/graph/GraphPage.test.tsx
+++ b/frontend/src/features/graph/GraphPage.test.tsx
@@ -124,6 +124,73 @@ describe('GraphPage', () => {
     });
   });
 
+  // ---------- #358 differentiated empty states + admin recompute ----------
+
+  it('shows the "no spaces accessible" empty state when meta.pagesTotal===0', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({
+        nodes: [],
+        edges: [],
+        meta: { pagesTotal: 0, pagesEmbedded: 0, relationshipsTotal: 0, relationshipsByType: {} },
+      }),
+    } as Response);
+
+    render(<GraphPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText(/No accessible pages in your spaces/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows the "pages not embedded yet" state when pagesTotal>0 but pagesEmbedded===0', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({
+        nodes: [{ id: '1', spaceKey: 'DEV', title: 't', labels: [], embeddingStatus: 'pending', embeddingCount: 0, lastModifiedAt: null }],
+        edges: [],
+        meta: { pagesTotal: 1, pagesEmbedded: 0, relationshipsTotal: 0, relationshipsByType: {} },
+      }),
+    } as Response);
+
+    render(<GraphPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Pages not embedded yet/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows "no relationships computed yet" with admin recompute button when admin', async () => {
+    // Set admin role on the auth store
+    const { useAuthStore } = await import('../../stores/auth-store');
+    useAuthStore.setState({ user: { id: '1', username: 'a', role: 'admin' }, accessToken: 'tok' });
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({
+        nodes: [{ id: '1', spaceKey: 'DEV', title: 't', labels: [], embeddingStatus: 'embedded', embeddingCount: 1, lastModifiedAt: null }],
+        edges: [],
+        meta: { pagesTotal: 1, pagesEmbedded: 1, relationshipsTotal: 0, relationshipsByType: {} },
+      }),
+    } as Response);
+
+    render(<GraphPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText(/no relationships computed yet/i)).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('graph-recompute-btn')).toBeInTheDocument();
+
+    // Reset role to avoid leaking into other tests.
+    useAuthStore.setState({ user: null, accessToken: null });
+  });
+
   it('renders error state with error message when fetch fails', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
       ok: false,

--- a/frontend/src/features/graph/GraphPage.test.tsx
+++ b/frontend/src/features/graph/GraphPage.test.tsx
@@ -191,6 +191,82 @@ describe('GraphPage', () => {
     useAuthStore.setState({ user: null, accessToken: null });
   });
 
+  it('admin recompute click fires POST /api/pages/graph/refresh and triggers re-fetch (AC-3)', async () => {
+    // AC-3: clicking Recompute must (a) call POST /api/pages/graph/refresh
+    // and (b) invalidate the graph query so the UI re-fetches the new data.
+    const { useAuthStore } = await import('../../stores/auth-store');
+    useAuthStore.setState({ user: { id: '1', username: 'a', role: 'admin' }, accessToken: 'tok' });
+
+    const initialEmpty = {
+      nodes: [{ id: '1', spaceKey: 'DEV', title: 't', labels: [], embeddingStatus: 'embedded', embeddingCount: 1, lastModifiedAt: null }],
+      edges: [],
+      meta: { pagesTotal: 1, pagesEmbedded: 1, relationshipsTotal: 0, relationshipsByType: {} },
+    };
+    const recomputed = {
+      nodes: [{ id: '1', spaceKey: 'DEV', title: 't', labels: [], embeddingStatus: 'embedded', embeddingCount: 1, lastModifiedAt: null }],
+      edges: [{ source: '1', target: '1', type: 'embedding_similarity', score: 0.9 }],
+      meta: { pagesTotal: 1, pagesEmbedded: 1, relationshipsTotal: 1, relationshipsByType: { embedding_similarity: 1 } },
+    };
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      // 1) initial GET — empty relationships, button visible
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => initialEmpty,
+      } as Response)
+      // 2) POST /api/pages/graph/refresh from useRefreshGraph mutation
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ message: 'Graph relationships refreshed', edges: 1 }),
+      } as Response)
+      // 3) re-fetch GET triggered by queryClient.invalidateQueries
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => recomputed,
+      } as Response);
+
+    render(<GraphPage />, { wrapper: createWrapper() });
+
+    // Wait for the empty-state Recompute button to render.
+    const button = await screen.findByRole('button', { name: /recompute/i });
+    expect(button).toBeInTheDocument();
+
+    // Click the button — fires the mutation.
+    fireEvent.click(button);
+
+    // Assert the POST to /api/pages/graph/refresh was made with method=POST.
+    await waitFor(() => {
+      const refreshCall = fetchSpy.mock.calls.find(
+        ([url]) => typeof url === 'string' && url.includes('/api/pages/graph/refresh'),
+      );
+      expect(refreshCall).toBeDefined();
+      expect((refreshCall![1] as RequestInit | undefined)?.method).toBe('POST');
+    });
+
+    // Assert cache invalidation triggered a re-fetch — the GET to
+    // /api/pages/graph runs again (so the count is at least 2 across the
+    // initial + the post-invalidation reload).
+    await waitFor(() => {
+      const getCalls = fetchSpy.mock.calls.filter(
+        ([url, init]) => {
+          const method = (init as RequestInit | undefined)?.method ?? 'GET';
+          return typeof url === 'string' && url.includes('/api/pages/graph') && !url.includes('/refresh') && method === 'GET';
+        },
+      );
+      expect(getCalls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    // Reset role to avoid leaking into other tests.
+    useAuthStore.setState({ user: null, accessToken: null });
+  });
+
   it('renders error state with error message when fetch fails', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
       ok: false,

--- a/frontend/src/features/graph/GraphPage.tsx
+++ b/frontend/src/features/graph/GraphPage.tsx
@@ -2,9 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { m } from 'framer-motion';
 import ForceGraph2D from 'react-force-graph-2d';
-import { ZoomIn, ZoomOut, Maximize, RefreshCw, Info, Layers, Grid3x3, Filter } from 'lucide-react';
+import { toast } from 'sonner';
+import { ZoomIn, ZoomOut, Maximize, RefreshCw, Info, Layers, Grid3x3, Filter, Settings, Loader2 } from 'lucide-react';
 import { cn } from '../../shared/lib/cn';
-import { useGraphData, useLocalGraphData } from './graph-hooks';
+import { useAuthStore } from '../../stores/auth-store';
+import { useGraphData, useLocalGraphData, useRefreshGraph } from './graph-hooks';
 
 // ---------- Types ----------
 
@@ -303,16 +305,10 @@ export function GraphPage() {
     );
   }
 
-  // Empty state
-  if (!data || data.nodes.length === 0) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <div className="nm-card flex flex-col items-center gap-4 p-8 text-center">
-          <Info className="h-8 w-8 text-muted-foreground" />
-          <p className="text-muted-foreground">No pages found. Sync and embed pages to see the knowledge graph.</p>
-        </div>
-      </div>
-    );
+  // #358: differentiate empty states using meta counts so users get an
+  // actionable message instead of a generic "no pages found".
+  if (!data || data.nodes.length === 0 || (data.meta && data.meta.relationshipsTotal === 0)) {
+    return <GraphEmptyState meta={data?.meta} />;
   }
 
   return (
@@ -512,5 +508,86 @@ export function GraphPage() {
         )}
       </div>
     </m.div>
+  );
+}
+
+
+// ---------- Empty-state branches (#358) ----------
+
+interface GraphEmptyStateProps {
+  meta: import('./graph-hooks').GraphMeta | undefined;
+}
+
+/**
+ * Differentiated empty state for the knowledge graph. Picks a message based
+ * on the meta counts so users know which step they're stuck at:
+ *   - no spaces accessible (RBAC)            → check sync settings
+ *   - no pages embedded yet                  → embed pages from Settings → LLM
+ *   - embedded but no relationships computed → admin can press Recompute
+ * Falls back to a generic message if meta is missing (older backend).
+ */
+function GraphEmptyState({ meta }: GraphEmptyStateProps) {
+  const role = useAuthStore((s) => s.user?.role);
+  const isAdmin = role === 'admin';
+  const refresh = useRefreshGraph();
+
+  const onRecompute = async () => {
+    try {
+      const res = await refresh.mutateAsync();
+      toast.success(`Graph relationships recomputed — ${res.edges} edges`);
+    } catch (err) {
+      const msg = err instanceof Error && err.message ? err.message : 'Failed to recompute graph';
+      toast.error(msg);
+    }
+  };
+
+  let title = 'No pages found';
+  let body =
+    'Sync a Confluence space and run embeddings to see the knowledge graph.';
+
+  if (meta) {
+    if (meta.pagesTotal === 0) {
+      title = 'No accessible pages in your spaces';
+      body =
+        'Sync a Confluence space or check that your role grants access to at least one space, then return here.';
+    } else if (meta.pagesEmbedded === 0) {
+      title = 'Pages not embedded yet';
+      body =
+        'Pages exist but no embeddings have been generated. Configure an embedding provider in Settings → LLM, then run an embedding pass.';
+    } else if (meta.relationshipsTotal === 0) {
+      title = 'Embedded — but no relationships computed yet';
+      body = isAdmin
+        ? 'Press Recompute below to build the relationship graph from current embeddings.'
+        : 'Ask an admin to recompute the relationship graph (Settings → Knowledge → Graph).';
+    }
+  }
+
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="nm-card flex flex-col items-center gap-4 p-8 text-center max-w-md" data-testid="graph-empty-state">
+        <Info className="h-8 w-8 text-muted-foreground" />
+        <p className="font-medium">{title}</p>
+        <p className="text-sm text-muted-foreground">{body}</p>
+        {meta && (
+          <p className="text-xs text-muted-foreground/70">
+            {meta.pagesTotal} pages · {meta.pagesEmbedded} embedded · {meta.relationshipsTotal} relationships
+          </p>
+        )}
+        {isAdmin && meta && meta.pagesEmbedded > 0 && meta.relationshipsTotal === 0 && (
+          <button
+            onClick={onRecompute}
+            disabled={refresh.isPending}
+            className="nm-button-primary inline-flex items-center gap-2 px-4 py-2 text-sm"
+            data-testid="graph-recompute-btn"
+          >
+            {refresh.isPending ? (
+              <><Loader2 size={14} className="animate-spin" /> Recomputing…</>
+            ) : (
+              <><Settings size={14} /> Recompute relationships</>
+            )}
+          </button>
+        )}
+      </div>
+    </div>
   );
 }

--- a/frontend/src/features/graph/graph-hooks.ts
+++ b/frontend/src/features/graph/graph-hooks.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '../../shared/lib/api';
 
 // ---------- Types ----------
@@ -39,10 +39,24 @@ interface GraphEdge {
   score: number;
 }
 
+/**
+ * #358: meta block on the graph response. The UI uses this to differentiate
+ * empty states ("no spaces accessible" vs "no pages embedded yet" vs
+ * "embedded but no relationships computed yet"). All counts are scoped to the
+ * caller's accessible pages — same RBAC as the nodes/edges arrays.
+ */
+export interface GraphMeta {
+  pagesTotal: number;
+  pagesEmbedded: number;
+  relationshipsTotal: number;
+  relationshipsByType: Record<string, number>;
+}
+
 interface GraphData {
   nodes: (GraphNode | ClusterNode)[];
   edges: GraphEdge[];
   centerId?: string;
+  meta?: GraphMeta;
 }
 
 type ViewMode = 'individual' | 'clustered';
@@ -65,5 +79,20 @@ export function useLocalGraphData(pageId: string | undefined, hops = 2) {
     queryFn: () => apiFetch(`/pages/${pageId}/graph/local?hops=${hops}`),
     staleTime: 60_000,
     enabled: !!pageId,
+  });
+}
+
+/**
+ * #358: admin trigger to recompute page_relationships rows. Wraps the
+ * existing POST /api/pages/graph/refresh; returns the new edge count.
+ * On success invalidates the global+local graph queries so the UI re-reads.
+ */
+export function useRefreshGraph() {
+  const queryClient = useQueryClient();
+  return useMutation<{ message: string; edges: number }>({
+    mutationFn: () => apiFetch('/pages/graph/refresh', { method: 'POST' }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pages', 'graph'] });
+    },
   });
 }


### PR DESCRIPTION
## Summary
**Backend**: GET /api/pages/graph now includes a meta block — { pagesTotal, pagesEmbedded, relationshipsTotal, relationshipsByType } — so the UI can pick a specific empty-state branch without a second roundtrip. RBAC-scoped exactly like the nodes/edges arrays.

**Frontend**: GraphPage uses meta to differentiate three empty states:
- pagesTotal === 0  → "No accessible pages in your spaces"
- pagesEmbedded === 0 (with pagesTotal > 0) → "Pages not embedded yet"
- relationshipsTotal === 0 (with pagesEmbedded > 0) → admin-only Recompute button wired to the existing POST /api/pages/graph/refresh

Diagnostic-first per the plan: differentiate before any rebuild work (slices 351b-e). No new dependencies. **Unblocks #359, #360, #361, #362.**

Closes #358 · part of #351

## Test plan
- [x] backend test: meta shape on populated response
- [x] 3 frontend tests for the empty-state branches + admin Recompute button
- [x] full graph + graph-route suites pass (14 + 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)