### PR TITLE
feat(#359): explicit_link edges from internal page links (slice 351b)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -72,6 +72,7 @@ import { APP_VERSION } from './core/utils/version.js';
 import { loadEnterprisePlugin, setCurrentLicense } from './core/enterprise/loader.js';
 import { bootstrapLlmProviders } from './domains/llm/services/llm-provider-bootstrap.js';
 import { bootstrapSsrfAllowlist } from './domains/confluence/services/sync-service.js';
+import { registerKnowledgeRelationshipProducers } from './domains/knowledge/services/relationship-producers.js';
 import { initSsrfAllowlistBus } from './core/services/ssrf-allowlist-bus.js';
 import { initPresenceBus } from './core/services/presence-service.js';
 import { initCacheBus, close as closeCacheBus } from './core/services/redis-cache-bus.js';
@@ -260,6 +261,13 @@ export async function buildApp() {
   // the pub/sub channel with N redundant add events (other pods already
   // populated their sets from the same DB rows on their own boot).
   await bootstrapSsrfAllowlist();
+
+  // ── Knowledge Relationship Producers (issue #359) ───────────────
+  // Register cross-domain edge producers (e.g. explicit_link from
+  // body_html anchors) into the embedding-service registry so they run
+  // inside `computePageRelationships()`'s transaction. Idempotent: safe
+  // to call once per process.
+  registerKnowledgeRelationshipProducers();
 
   // Known Fastify HTTP error names that are safe to expose to clients.
   // Anything not in this set could leak internal details (e.g. TypeError, RangeError).

--- a/backend/src/domains/knowledge/services/link-extractor.test.ts
+++ b/backend/src/domains/knowledge/services/link-extractor.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { extractInternalLinks } from './link-extractor.js';
+import { describe, it, expect, afterEach } from 'vitest';
+import { extractInternalLinks, getInternalHosts } from './link-extractor.js';
 
 describe('extractInternalLinks', () => {
   it('returns [] for empty/null html', () => {
@@ -55,5 +55,93 @@ describe('extractInternalLinks', () => {
   it('rejects /pages/:id when :id is non-numeric', () => {
     const html = `<a href="/pages/new">new page form</a>`;
     expect(extractInternalLinks(html, new Map())).toEqual([]);
+  });
+
+  // ── #359 absolute-URL matching against the configured deployment host ──
+
+  it('matches absolute URLs whose host is in internalHosts', () => {
+    const hosts = new Set(['kb.example.com']);
+    const html = `<a href="https://kb.example.com/pages/123">x</a>`;
+    expect(extractInternalLinks(html, new Map(), hosts)).toEqual([
+      { targetPageId: 123 },
+    ]);
+  });
+
+  it('rejects absolute URLs whose host is NOT in internalHosts (foreign host)', () => {
+    const hosts = new Set(['kb.example.com']);
+    const html = `<a href="https://other.example.com/pages/123">x</a>`;
+    expect(extractInternalLinks(html, new Map(), hosts)).toEqual([]);
+  });
+
+  it('treats absolute URL host case-insensitively', () => {
+    const hosts = new Set(['kb.example.com']);
+    const html = `<a href="https://KB.Example.COM/pages/9">x</a>`;
+    expect(extractInternalLinks(html, new Map(), hosts)).toEqual([
+      { targetPageId: 9 },
+    ]);
+  });
+
+  it('matches absolute URLs across multiple internal hosts (comma-separated FRONTEND_URL)', () => {
+    const hosts = new Set(['kb.example.com', 'staging.example.com']);
+    const html = `
+      <a href="https://kb.example.com/pages/1">a</a>
+      <a href="https://staging.example.com/pages/2">b</a>
+    `;
+    expect(extractInternalLinks(html, new Map(), hosts)).toEqual([
+      { targetPageId: 1 },
+      { targetPageId: 2 },
+    ]);
+  });
+
+  it('rejects absolute URLs to internal host that do not point at /pages/:id', () => {
+    const hosts = new Set(['kb.example.com']);
+    const html = `<a href="https://kb.example.com/spaces/DEV">x</a>`;
+    expect(extractInternalLinks(html, new Map(), hosts)).toEqual([]);
+  });
+
+  it('still rejects absolute URLs when internalHosts is empty (default)', () => {
+    const html = `<a href="https://kb.example.com/pages/1">x</a>`;
+    expect(extractInternalLinks(html, new Map())).toEqual([]);
+  });
+
+  it('dedupes a relative /pages/:id and an absolute internal URL to the same id', () => {
+    const hosts = new Set(['kb.example.com']);
+    const html = `
+      <a href="/pages/42">rel</a>
+      <a href="https://kb.example.com/pages/42">abs</a>
+    `;
+    expect(extractInternalLinks(html, new Map(), hosts)).toEqual([
+      { targetPageId: 42 },
+    ]);
+  });
+});
+
+describe('getInternalHosts', () => {
+  const originalFrontendUrl = process.env.FRONTEND_URL;
+
+  afterEach(() => {
+    if (originalFrontendUrl === undefined) delete process.env.FRONTEND_URL;
+    else process.env.FRONTEND_URL = originalFrontendUrl;
+  });
+
+  it('returns empty set when FRONTEND_URL is unset', () => {
+    delete process.env.FRONTEND_URL;
+    expect(getInternalHosts().size).toBe(0);
+  });
+
+  it('parses single FRONTEND_URL into one lower-cased hostname', () => {
+    process.env.FRONTEND_URL = 'https://Kb.Example.COM';
+    expect(Array.from(getInternalHosts())).toEqual(['kb.example.com']);
+  });
+
+  it('parses comma-separated FRONTEND_URL into multiple hostnames', () => {
+    process.env.FRONTEND_URL = 'https://kb.example.com, https://staging.example.com';
+    const hosts = Array.from(getInternalHosts()).sort();
+    expect(hosts).toEqual(['kb.example.com', 'staging.example.com']);
+  });
+
+  it('skips malformed entries silently', () => {
+    process.env.FRONTEND_URL = 'not-a-url, https://kb.example.com';
+    expect(Array.from(getInternalHosts())).toEqual(['kb.example.com']);
   });
 });

--- a/backend/src/domains/knowledge/services/link-extractor.test.ts
+++ b/backend/src/domains/knowledge/services/link-extractor.test.ts
@@ -1,5 +1,24 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { extractInternalLinks, getInternalHosts } from './link-extractor.js';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import type { PoolClient } from 'pg';
+import {
+  extractInternalLinks,
+  getInternalHosts,
+  runExplicitLinkProducer,
+} from './link-extractor.js';
+
+// vi.mock the postgres module so any accidental fall-through to the global
+// `query()` helper would throw — tightens the assertion that the producer
+// only talks to the provided `client` (Finding 2: producer contract).
+vi.mock('../../../core/db/postgres.js', () => ({
+  query: vi.fn(() => {
+    throw new Error(
+      'runExplicitLinkProducer must use the provided PoolClient, not the global pool query()',
+    );
+  }),
+  getPool: vi.fn(() => {
+    throw new Error('runExplicitLinkProducer must not call getPool()');
+  }),
+}));
 
 describe('extractInternalLinks', () => {
   it('returns [] for empty/null html', () => {
@@ -143,5 +162,222 @@ describe('getInternalHosts', () => {
   it('skips malformed entries silently', () => {
     process.env.FRONTEND_URL = 'not-a-url, https://kb.example.com';
     expect(Array.from(getInternalHosts())).toEqual(['kb.example.com']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// runExplicitLinkProducer — incremental rescan + producer-contract tests
+// ─────────────────────────────────────────────────────────────────────────
+//
+// These exercise the symmetric incremental scan (PR #372 review Finding 1)
+// and the "use only the provided client" contract (Finding 2). We mock the
+// `PoolClient` rather than spin up Postgres so the test runs in the unit
+// suite without the integration DB; the SQL strings are inspected directly.
+
+interface MockPoolClient {
+  query: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Build a minimal PoolClient mock that routes:
+ *  - The `loadTitleIndex` SELECT (matched by `FROM pages WHERE deleted_at IS NULL AND title IS NOT NULL`)
+ *    to a configurable list of `{id, title}` rows.
+ *  - The page-fetch SELECT (matched by `FROM pages WHERE deleted_at IS NULL` *with*
+ *    a leading body_html filter or id ANY) to a configurable list.
+ *  - The INSERT into page_relationships to a `{rowCount: 1}` success.
+ */
+function makeClient(opts: {
+  titleRows: { id: number; title: string }[];
+  pageRows: { id: number; body_html: string | null }[];
+  /** Optional: assert the SELECT for pages received specific bind values. */
+  onPageSelect?: (sql: string, params: unknown[] | undefined) => void;
+}): MockPoolClient {
+  const client: MockPoolClient = {
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      const s = String(sql);
+      if (s.includes('SELECT id, title FROM pages')) {
+        return { rows: opts.titleRows, rowCount: opts.titleRows.length };
+      }
+      if (s.includes('SELECT id, body_html FROM pages')) {
+        opts.onPageSelect?.(s, params);
+        return { rows: opts.pageRows, rowCount: opts.pageRows.length };
+      }
+      if (s.includes('INSERT INTO page_relationships')) {
+        return { rows: [], rowCount: 1 };
+      }
+      throw new Error(`Unexpected SQL in mock: ${s}`);
+    }),
+  };
+  return client;
+}
+
+describe('runExplicitLinkProducer — Finding 2 (producer contract)', () => {
+  it('uses ONLY the provided client (does not call the global pool query/getPool)', async () => {
+    // The vi.mock at the top throws on any global query()/getPool() call,
+    // so this test merely needs to complete without those throws to prove
+    // the contract holds. We exercise both the full and incremental paths.
+    const client = makeClient({
+      titleRows: [{ id: 1, title: 'Alpha' }, { id: 2, title: 'Beta' }],
+      pageRows: [{ id: 1, body_html: '<a href="/pages/2">b</a>' }],
+    });
+
+    const fullCount = await runExplicitLinkProducer(client as unknown as PoolClient);
+    expect(fullCount).toBe(1);
+
+    const incCount = await runExplicitLinkProducer(client as unknown as PoolClient, [1]);
+    expect(incCount).toBeGreaterThanOrEqual(0);
+
+    // Every SQL touched the mock client — none escaped to a separate pool.
+    expect(client.query.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it('runs the title-index SELECT on the provided client (not via global query())', async () => {
+    const client = makeClient({
+      titleRows: [{ id: 7, title: 'Gamma' }],
+      pageRows: [],
+    });
+
+    await runExplicitLinkProducer(client as unknown as PoolClient);
+
+    const titleCall = client.query.mock.calls.find((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('SELECT id, title FROM pages'),
+    );
+    expect(titleCall).toBeDefined();
+  });
+});
+
+describe('runExplicitLinkProducer — Finding 1 (symmetric incremental rescan)', () => {
+  it('emits B↔C even when only C is in changedPageIds (B unchanged, B links to C)', async () => {
+    // Scenario from the review: page B (id=10) has `<a href="/pages/20">` to
+    // page C (id=20). C becomes dirty (e.g. label-only re-embed). The
+    // symmetric DELETE in computePageRelationships removes the B↔C row.
+    // The producer MUST re-emit it by re-scanning B (a referrer of C).
+    const titleRows = [
+      { id: 10, title: 'Page B' },
+      { id: 20, title: 'Page C' },
+    ];
+    // Symmetric scan returns BOTH C (changed) and B (referrer of C).
+    const pageRows = [
+      { id: 10, body_html: '<a href="/pages/20">link to C</a>' },
+      { id: 20, body_html: '<p>no outbound links</p>' },
+    ];
+    let capturedSql = '';
+    let capturedParams: unknown[] | undefined;
+    const client = makeClient({
+      titleRows,
+      pageRows,
+      onPageSelect: (sql, params) => {
+        capturedSql = sql;
+        capturedParams = params;
+      },
+    });
+
+    const count = await runExplicitLinkProducer(client as unknown as PoolClient, [20]);
+
+    // SQL contract: the page-select must include both `id = ANY($1)` AND
+    // `body_html LIKE ANY($2)` to catch referrers of changed pages.
+    expect(capturedSql).toContain('id = ANY($1::int[])');
+    expect(capturedSql).toContain('body_html LIKE ANY($2::text[])');
+    // $1 = changed ids, $2 includes the `/pages/20` substring pattern.
+    expect(capturedParams?.[0]).toEqual([20]);
+    const patterns = capturedParams?.[1] as string[];
+    expect(patterns).toContain('%/pages/20%');
+    // And the title-substring pattern for the Confluence shape.
+    expect(patterns).toContain('%#confluence-page:Page C%');
+
+    // One INSERT was issued for the B↔C edge.
+    const insertCalls = client.query.mock.calls.filter((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('INSERT INTO page_relationships'),
+    );
+    expect(insertCalls).toHaveLength(1);
+    // Canonical (lo, hi) ordering: 10 < 20.
+    expect(insertCalls[0][1]).toEqual([10, 20]);
+    expect(count).toBe(1);
+  });
+
+  it('emits B↔C when B references C via #confluence-page:<title> and C is the changed page', async () => {
+    const titleRows = [
+      { id: 100, title: 'Architecture' },
+      { id: 200, title: 'Onboarding' },
+    ];
+    // B (id=100) links to C (id=200) via the Confluence-sync placeholder.
+    const pageRows = [
+      { id: 100, body_html: '<a href="#confluence-page:Onboarding">go</a>' },
+    ];
+    const client = makeClient({ titleRows, pageRows });
+
+    const count = await runExplicitLinkProducer(client as unknown as PoolClient, [200]);
+
+    const insertCalls = client.query.mock.calls.filter((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('INSERT INTO page_relationships'),
+    );
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0][1]).toEqual([100, 200]);
+    expect(count).toBe(1);
+  });
+
+  it('still includes the changed page itself as a source (path (a) of the symmetric scan)', async () => {
+    // C is in changedPageIds; C also has outbound links — those must still
+    // be emitted, in addition to inbound links from referrers.
+    const titleRows = [
+      { id: 1, title: 'A' },
+      { id: 2, title: 'B' },
+      { id: 3, title: 'C' },
+    ];
+    // The symmetric SELECT returns id=3 (changed) AND id=1 (referrer of 3).
+    const pageRows = [
+      { id: 1, body_html: '<a href="/pages/3">to C</a>' },
+      { id: 3, body_html: '<a href="/pages/2">C to B</a>' },
+    ];
+    const client = makeClient({ titleRows, pageRows });
+
+    const count = await runExplicitLinkProducer(client as unknown as PoolClient, [3]);
+
+    const insertCalls = client.query.mock.calls.filter((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('INSERT INTO page_relationships'),
+    );
+    // Two edges: (1,3) from referrer and (2,3) from C's outbound link.
+    expect(insertCalls).toHaveLength(2);
+    const pairs = insertCalls.map((c) => c[1]).sort((a, b) =>
+      (a as number[])[0] - (b as number[])[0],
+    );
+    expect(pairs).toEqual([[1, 3], [2, 3]]);
+    expect(count).toBe(2);
+  });
+
+  it('full-recompute path (no changedPageIds) does not emit the LIKE-ANY pattern filter', async () => {
+    let capturedSql = '';
+    const client = makeClient({
+      titleRows: [{ id: 1, title: 'A' }],
+      pageRows: [{ id: 1, body_html: null }],
+      onPageSelect: (sql) => {
+        capturedSql = sql;
+      },
+    });
+
+    await runExplicitLinkProducer(client as unknown as PoolClient, null);
+
+    // Full recompute = plain `WHERE deleted_at IS NULL`, no LIKE-ANY.
+    expect(capturedSql).toContain('WHERE deleted_at IS NULL');
+    expect(capturedSql).not.toContain('LIKE ANY');
+  });
+
+  it('escapes LIKE meta-chars in titles so a title with `%` does not match unrelated pages', async () => {
+    const titleRows = [{ id: 42, title: 'Weird % Title' }];
+    let capturedParams: unknown[] | undefined;
+    const client = makeClient({
+      titleRows,
+      pageRows: [],
+      onPageSelect: (_sql, params) => {
+        capturedParams = params;
+      },
+    });
+
+    await runExplicitLinkProducer(client as unknown as PoolClient, [42]);
+
+    const patterns = capturedParams?.[1] as string[];
+    // The title's `%` is escaped (`\%`) inside the substring pattern so
+    // PostgreSQL treats it literally; the outer `%…%` wildcards remain.
+    expect(patterns).toContain('%#confluence-page:Weird \\% Title%');
   });
 });

--- a/backend/src/domains/knowledge/services/link-extractor.test.ts
+++ b/backend/src/domains/knowledge/services/link-extractor.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { extractInternalLinks } from './link-extractor.js';
+
+describe('extractInternalLinks', () => {
+  it('returns [] for empty/null html', () => {
+    expect(extractInternalLinks(null, new Map())).toEqual([]);
+    expect(extractInternalLinks(undefined, new Map())).toEqual([]);
+    expect(extractInternalLinks('', new Map())).toEqual([]);
+  });
+
+  it('extracts /pages/:id app-route links', () => {
+    const html = `<p>See <a href="/pages/42">our doc</a> and <a href="/pages/7/section#x">other</a>.</p>`;
+    expect(extractInternalLinks(html, new Map())).toEqual([
+      { targetPageId: 42 },
+      { targetPageId: 7 },
+    ]);
+  });
+
+  it('resolves #confluence-page:<title> to ids via the title map', () => {
+    const html = `<a href="#confluence-page:Architecture">arch</a>`;
+    const map = new Map([['Architecture', 12]]);
+    expect(extractInternalLinks(html, map)).toEqual([{ targetPageId: 12 }]);
+  });
+
+  it('drops #confluence-page:<title> when title is unknown to the map', () => {
+    const html = `<a href="#confluence-page:NoSuchTitle">x</a>`;
+    expect(extractInternalLinks(html, new Map())).toEqual([]);
+  });
+
+  it('dedupes the same target referenced multiple times in one page', () => {
+    const html = `<a href="/pages/5">a</a><a href="/pages/5">b</a>`;
+    expect(extractInternalLinks(html, new Map())).toEqual([{ targetPageId: 5 }]);
+  });
+
+  it('ignores external URLs and non-page anchors', () => {
+    const html = `
+      <a href="https://example.com">external</a>
+      <a href="mailto:x@y.z">mail</a>
+      <a href="#anchor-only">anchor</a>
+      <a href="/spaces/DEV">space</a>
+    `;
+    expect(extractInternalLinks(html, new Map())).toEqual([]);
+  });
+
+  it('ignores anchors without an href', () => {
+    const html = `<a>no href</a>`;
+    expect(extractInternalLinks(html, new Map())).toEqual([]);
+  });
+
+  it('handles malformed/garbled HTML without throwing', () => {
+    const html = `<a href="/pages/3">ok</a><a href=`;
+    expect(extractInternalLinks(html, new Map())).toEqual([{ targetPageId: 3 }]);
+  });
+
+  it('rejects /pages/:id when :id is non-numeric', () => {
+    const html = `<a href="/pages/new">new page form</a>`;
+    expect(extractInternalLinks(html, new Map())).toEqual([]);
+  });
+});

--- a/backend/src/domains/knowledge/services/link-extractor.ts
+++ b/backend/src/domains/knowledge/services/link-extractor.ts
@@ -34,7 +34,6 @@
  */
 import { JSDOM } from 'jsdom';
 import type { PoolClient } from 'pg';
-import { query } from '../../../core/db/postgres.js';
 import { logger } from '../../../core/utils/logger.js';
 
 const APP_PAGE_PATH_RE = /^\/pages\/(\d+)(?:\/|$|\?|#)/;
@@ -143,19 +142,35 @@ export function getInternalHosts(): Set<string> {
 
 /**
  * Build the title→id map used by the `#confluence-page:<title>` resolver.
- * Ambiguous titles are dropped so we never emit an edge to a random page.
- * Returns both the map and an `activeIds` set for filtering deleted targets.
+ * Ambiguous titles are dropped from `titleToId` so we never emit an edge to
+ * a random page. Returns three views over the same underlying rows:
+ *
+ * - `titleToId` — title → id, with ambiguous titles **dropped** (used by
+ *   the parser to resolve `#confluence-page:<title>` to a single id).
+ * - `activeIds` — set of all non-deleted page ids (used to filter out
+ *   edges whose target was deleted between scan and write).
+ * - `idToTitle` — id → title, **including** ids whose title is shared by
+ *   another page. The incremental "find referrers" pass needs the title
+ *   of every changed page so it can search for `#confluence-page:<title>`
+ *   substrings, even when the title is ambiguous.
+ *
+ * MUST run on the caller's transactional `client` — the producer contract
+ * (`embedding-relationship-hooks.ts`) requires producers to read inside
+ * the surrounding BEGIN/COMMIT, not on a separate pool connection.
  */
-async function loadTitleIndex(): Promise<{
+async function loadTitleIndex(client: PoolClient): Promise<{
   titleToId: Map<string, number>;
   activeIds: Set<number>;
+  idToTitle: Map<number, string>;
 }> {
-  const titleRows = await query<{ id: number; title: string }>(
+  const titleRows = await client.query<{ id: number; title: string }>(
     `SELECT id, title FROM pages WHERE deleted_at IS NULL AND title IS NOT NULL`,
   );
   const titleToId = new Map<string, number>();
   const seenTitles = new Set<string>();
+  const idToTitle = new Map<number, string>();
   for (const r of titleRows.rows) {
+    idToTitle.set(r.id, r.title);
     if (seenTitles.has(r.title)) {
       titleToId.delete(r.title);
       continue;
@@ -164,7 +179,20 @@ async function loadTitleIndex(): Promise<{
     titleToId.set(r.title, r.id);
   }
   const activeIds = new Set(titleRows.rows.map((r) => r.id));
-  return { titleToId, activeIds };
+  return { titleToId, activeIds, idToTitle };
+}
+
+/**
+ * Escape a string for use as a LIKE pattern *value*. We're parameterising
+ * the pattern (not concatenating into SQL) so this only neutralises LIKE's
+ * own meta-chars (`%`, `_`, `\`) — there is no SQL-injection vector here.
+ *
+ * Used to build the body_html substring filter for the symmetric
+ * incremental rescan. Without escaping, a page title containing `%` or
+ * `_` would silently match unrelated pages.
+ */
+function escapeLikePattern(raw: string): string {
+  return raw.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
 }
 
 /**
@@ -175,9 +203,18 @@ async function loadTitleIndex(): Promise<{
  * similarity / label_overlap / parent_child edges. Caller is responsible for
  * the surrounding transaction.
  *
- * `changedPageIds`: when provided and non-empty, only those pages are
- * scanned as link sources (matches the existing producer's incremental
- * scoping). Pass `null`/`undefined` for a full recompute.
+ * `changedPageIds`: when provided and non-empty, the scan is scoped
+ * **symmetrically** — both
+ *   (a) the changed pages themselves (as link **sources**), AND
+ *   (b) any other page whose `body_html` could reference one of the changed
+ *       pages as a **target** (via `/pages/<id>` or `#confluence-page:<title>`
+ *       substrings).
+ * This mirrors the symmetric DELETE in `computePageRelationships`
+ * (`page_id_1 = ANY($1) OR page_id_2 = ANY($1)`): without (b), an unchanged
+ * page B that links to a changed page C would have its B↔C edge wiped by
+ * the DELETE and never re-emitted, because B's body was never re-scanned.
+ *
+ * Pass `null`/`undefined` for a full recompute.
  *
  * Returns the number of `(source,target)` edges newly inserted (ON CONFLICT
  * DO NOTHING means re-running yields 0).
@@ -186,19 +223,39 @@ export async function runExplicitLinkProducer(
   client: PoolClient,
   changedPageIds?: readonly number[] | null,
 ): Promise<number> {
-  const { titleToId, activeIds } = await loadTitleIndex();
+  const { titleToId, activeIds, idToTitle } = await loadTitleIndex(client);
   const internalHosts = getInternalHosts();
 
   const useIncremental = changedPageIds && changedPageIds.length > 0;
-  const pagesResult = useIncremental
-    ? await client.query<{ id: number; body_html: string | null }>(
-        `SELECT id, body_html FROM pages
-         WHERE id = ANY($1::int[]) AND deleted_at IS NULL`,
-        [Array.from(changedPageIds!)],
-      )
-    : await client.query<{ id: number; body_html: string | null }>(
-        `SELECT id, body_html FROM pages WHERE deleted_at IS NULL`,
-      );
+
+  let pagesResult: { rows: { id: number; body_html: string | null }[] };
+  if (useIncremental) {
+    // Build the LIKE-pattern list for the "find referrers" pass. Anchor
+    // each pattern with `%/pages/<id>%` (catches both relative `/pages/42`
+    // and absolute `https://host/pages/42`) and `%#confluence-page:<title>%`
+    // for the Confluence-sync placeholder shape. Substring patterns are
+    // intentionally loose — any false-positive page just gets re-parsed by
+    // JSDOM and contributes 0 edges, which is correct (idempotent).
+    const idArr = Array.from(changedPageIds!);
+    const patterns: string[] = [];
+    for (const id of idArr) {
+      patterns.push(`%/pages/${id}%`);
+      const title = idToTitle.get(id);
+      if (title && title.length > 0) {
+        patterns.push(`%#confluence-page:${escapeLikePattern(title)}%`);
+      }
+    }
+    pagesResult = await client.query<{ id: number; body_html: string | null }>(
+      `SELECT id, body_html FROM pages
+       WHERE deleted_at IS NULL
+         AND (id = ANY($1::int[]) OR body_html LIKE ANY($2::text[]))`,
+      [idArr, patterns],
+    );
+  } else {
+    pagesResult = await client.query<{ id: number; body_html: string | null }>(
+      `SELECT id, body_html FROM pages WHERE deleted_at IS NULL`,
+    );
+  }
 
   let edgesWritten = 0;
   for (const page of pagesResult.rows) {

--- a/backend/src/domains/knowledge/services/link-extractor.ts
+++ b/backend/src/domains/knowledge/services/link-extractor.ts
@@ -1,0 +1,155 @@
+/**
+ * Internal-link edge producer for the knowledge graph (#359).
+ *
+ * Scans `pages.body_html` for anchors that point at *internal* pages and
+ * persists each (source → target) edge as a `page_relationships` row with
+ * `relationship_type = 'explicit_link'` and `score = 1.0`. These are
+ * deterministic edges, not similarity-derived; the score is constant.
+ *
+ * Two link shapes the rest of the app generates:
+ *
+ *   1. Direct app-route URLs — what authors paste / what the editor produces:
+ *        `<a href="/pages/42">…</a>`
+ *      The numeric path segment is `pages.id` (integer FK target).
+ *
+ *   2. Confluence sync placeholders — what `confluenceToHtml` emits for
+ *      `<ac:link><ri:page ri:content-title="…"/></ac:link>` (see
+ *      `content-converter.ts:184`):
+ *        `<a href="#confluence-page:My Title">…</a>`
+ *      We resolve the title back to a `pages.id` (matching by exact title
+ *      first; ambiguous titles emit no edge).
+ *
+ * Idempotent: ON CONFLICT on (page_id_1, page_id_2, relationship_type).
+ */
+import { JSDOM } from 'jsdom';
+import { query, getPool } from '../../../core/db/postgres.js';
+import { logger } from '../../../core/utils/logger.js';
+
+const APP_PAGE_PATH_RE = /^\/pages\/(\d+)(?:\/|$|\?|#)/;
+const CONFLUENCE_PAGE_HASH_PREFIX = '#confluence-page:';
+
+export interface ExtractedLink {
+  /** Internal pages.id of the link target. */
+  targetPageId: number;
+}
+
+/**
+ * Pure parser: pull internal-page targets out of an HTML string.
+ * `titleToId` is consulted for the `#confluence-page:<title>` shape.
+ */
+export function extractInternalLinks(
+  html: string | null | undefined,
+  titleToId: Map<string, number>,
+): ExtractedLink[] {
+  if (!html) return [];
+  const dom = new JSDOM(`<body>${html}</body>`, { contentType: 'text/html' });
+  const anchors = dom.window.document.querySelectorAll('a[href]');
+  const seen = new Set<number>();
+  const out: ExtractedLink[] = [];
+
+  for (const a of anchors) {
+    const href = a.getAttribute('href');
+    if (!href) continue;
+
+    // Shape 1: app-route /pages/:id
+    const m = APP_PAGE_PATH_RE.exec(href);
+    if (m) {
+      const id = Number.parseInt(m[1]!, 10);
+      if (Number.isFinite(id) && !seen.has(id)) {
+        seen.add(id);
+        out.push({ targetPageId: id });
+      }
+      continue;
+    }
+
+    // Shape 2: #confluence-page:<title>
+    if (href.startsWith(CONFLUENCE_PAGE_HASH_PREFIX)) {
+      const title = href.slice(CONFLUENCE_PAGE_HASH_PREFIX.length).trim();
+      const id = titleToId.get(title);
+      if (id != null && !seen.has(id)) {
+        seen.add(id);
+        out.push({ targetPageId: id });
+      }
+      continue;
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Walk every page, extract internal links, persist edges. Caller controls
+ * scope via `pageIds` — when omitted, all non-deleted pages are processed.
+ *
+ * Returns the number of *unique* (source,target) edges materialised.
+ * Idempotent: re-running the same input produces the same row count.
+ */
+export async function computeExplicitLinkEdges(
+  pageIds?: readonly number[],
+): Promise<number> {
+  // Title → id table for resolving #confluence-page:<title> hrefs. The map is
+  // built once per run, not per page, so this is O(N) in the corpus.
+  const titleRows = await query<{ id: number; title: string }>(
+    `SELECT id, title FROM pages WHERE deleted_at IS NULL AND title IS NOT NULL`,
+  );
+  const titleToId = new Map<string, number>();
+  // If a title is ambiguous, drop it from the map — emitting an edge to a
+  // random page is worse than emitting no edge.
+  const seenTitles = new Set<string>();
+  for (const r of titleRows.rows) {
+    if (seenTitles.has(r.title)) {
+      titleToId.delete(r.title);
+      continue;
+    }
+    seenTitles.add(r.title);
+    titleToId.set(r.title, r.id);
+  }
+
+  // Active page IDs to filter out targets that point at deleted pages.
+  const activeIds = new Set(titleRows.rows.map((r) => r.id));
+
+  const pagesResult = pageIds && pageIds.length > 0
+    ? await query<{ id: number; body_html: string | null }>(
+        `SELECT id, body_html FROM pages
+         WHERE id = ANY($1::int[]) AND deleted_at IS NULL`,
+        [Array.from(pageIds)],
+      )
+    : await query<{ id: number; body_html: string | null }>(
+        `SELECT id, body_html FROM pages WHERE deleted_at IS NULL`,
+      );
+
+  const pool = getPool();
+  const client = await pool.connect();
+  let edgesWritten = 0;
+  try {
+    await client.query('BEGIN');
+    for (const page of pagesResult.rows) {
+      const links = extractInternalLinks(page.body_html, titleToId);
+      for (const link of links) {
+        if (link.targetPageId === page.id) continue; // self-loops are noise
+        if (!activeIds.has(link.targetPageId)) continue;
+        const [a, b] = page.id < link.targetPageId
+          ? [page.id, link.targetPageId]
+          : [link.targetPageId, page.id];
+        // ON CONFLICT keeps idempotency. score=1.0 since these are
+        // deterministic links, not similarity-derived.
+        const r = await client.query(
+          `INSERT INTO page_relationships (page_id_1, page_id_2, relationship_type, score)
+           VALUES ($1, $2, 'explicit_link', 1.0)
+           ON CONFLICT (page_id_1, page_id_2, relationship_type) DO NOTHING`,
+          [a, b],
+        );
+        edgesWritten += r.rowCount ?? 0;
+      }
+    }
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    logger.error({ err }, 'computeExplicitLinkEdges failed; rolled back');
+    throw err;
+  } finally {
+    client.release();
+  }
+  logger.info({ edgesWritten, pageCount: pagesResult.rows.length }, 'explicit_link edges computed');
+  return edgesWritten;
+}

--- a/backend/src/domains/knowledge/services/link-extractor.ts
+++ b/backend/src/domains/knowledge/services/link-extractor.ts
@@ -6,23 +6,35 @@
  * `relationship_type = 'explicit_link'` and `score = 1.0`. These are
  * deterministic edges, not similarity-derived; the score is constant.
  *
- * Two link shapes the rest of the app generates:
+ * Three link shapes the rest of the app generates:
  *
  *   1. Direct app-route URLs — what authors paste / what the editor produces:
  *        `<a href="/pages/42">…</a>`
  *      The numeric path segment is `pages.id` (integer FK target).
  *
- *   2. Confluence sync placeholders — what `confluenceToHtml` emits for
+ *   2. Absolute deployment-host URLs — what users paste from their browser
+ *      address bar / share via copy-link:
+ *        `<a href="https://kb.example.com/pages/42">…</a>`
+ *      Treated as internal iff the URL host matches a host in `FRONTEND_URL`
+ *      (the canonical app-base-URL env, comma-separated, used elsewhere for
+ *      CORS origin and email login links). Foreign hosts are dropped.
+ *
+ *   3. Confluence sync placeholders — what `confluenceToHtml` emits for
  *      `<ac:link><ri:page ri:content-title="…"/></ac:link>` (see
  *      `content-converter.ts:184`):
  *        `<a href="#confluence-page:My Title">…</a>`
  *      We resolve the title back to a `pages.id` (matching by exact title
  *      first; ambiguous titles emit no edge).
  *
+ * The producer itself runs as part of `computePageRelationships()` (see
+ * embedding-service.ts) so explicit_link edges materialise on every recompute
+ * — both the admin /graph/refresh route and the post-embed incremental path.
+ *
  * Idempotent: ON CONFLICT on (page_id_1, page_id_2, relationship_type).
  */
 import { JSDOM } from 'jsdom';
-import { query, getPool } from '../../../core/db/postgres.js';
+import type { PoolClient } from 'pg';
+import { query } from '../../../core/db/postgres.js';
 import { logger } from '../../../core/utils/logger.js';
 
 const APP_PAGE_PATH_RE = /^\/pages\/(\d+)(?:\/|$|\?|#)/;
@@ -36,10 +48,13 @@ export interface ExtractedLink {
 /**
  * Pure parser: pull internal-page targets out of an HTML string.
  * `titleToId` is consulted for the `#confluence-page:<title>` shape.
+ * `internalHosts` (lower-cased hostnames, no port) gates absolute URLs:
+ * `https://<host>/pages/:id` matches only when host ∈ internalHosts.
  */
 export function extractInternalLinks(
   html: string | null | undefined,
   titleToId: Map<string, number>,
+  internalHosts: ReadonlySet<string> = new Set(),
 ): ExtractedLink[] {
   if (!html) return [];
   const dom = new JSDOM(`<body>${html}</body>`, { contentType: 'text/html' });
@@ -51,7 +66,7 @@ export function extractInternalLinks(
     const href = a.getAttribute('href');
     if (!href) continue;
 
-    // Shape 1: app-route /pages/:id
+    // Shape 1: app-route /pages/:id (relative, same-origin)
     const m = APP_PAGE_PATH_RE.exec(href);
     if (m) {
       const id = Number.parseInt(m[1]!, 10);
@@ -62,7 +77,31 @@ export function extractInternalLinks(
       continue;
     }
 
-    // Shape 2: #confluence-page:<title>
+    // Shape 2: absolute deployment-host URL — only matches when the URL host
+    // is in `internalHosts`. Anything else (foreign hosts, opaque schemes) is
+    // intentionally ignored: edges only count for *our* knowledge base.
+    if (internalHosts.size > 0 && /^https?:\/\//i.test(href)) {
+      let parsed: URL | null = null;
+      try {
+        parsed = new URL(href);
+      } catch {
+        // Malformed absolute URL — skip silently rather than throw.
+      }
+      if (parsed && internalHosts.has(parsed.hostname.toLowerCase())) {
+        const pm = APP_PAGE_PATH_RE.exec(parsed.pathname);
+        if (pm) {
+          const id = Number.parseInt(pm[1]!, 10);
+          if (Number.isFinite(id) && !seen.has(id)) {
+            seen.add(id);
+            out.push({ targetPageId: id });
+          }
+          continue;
+        }
+      }
+      continue;
+    }
+
+    // Shape 3: #confluence-page:<title>
     if (href.startsWith(CONFLUENCE_PAGE_HASH_PREFIX)) {
       const title = href.slice(CONFLUENCE_PAGE_HASH_PREFIX.length).trim();
       const id = titleToId.get(title);
@@ -78,23 +117,43 @@ export function extractInternalLinks(
 }
 
 /**
- * Walk every page, extract internal links, persist edges. Caller controls
- * scope via `pageIds` — when omitted, all non-deleted pages are processed.
- *
- * Returns the number of *unique* (source,target) edges materialised.
- * Idempotent: re-running the same input produces the same row count.
+ * Read FRONTEND_URL (comma-separated, same convention as the CORS origin in
+ * app.ts and the invitation email URL in admin-users.ts) and return the set
+ * of lower-cased hostnames considered "internal" for absolute-URL link
+ * matching. Invalid entries are skipped silently — the env var is allowed to
+ * be empty/missing in dev, and we don't want a malformed entry to break
+ * graph recomputation.
  */
-export async function computeExplicitLinkEdges(
-  pageIds?: readonly number[],
-): Promise<number> {
-  // Title → id table for resolving #confluence-page:<title> hrefs. The map is
-  // built once per run, not per page, so this is O(N) in the corpus.
+export function getInternalHosts(): Set<string> {
+  const raw = process.env.FRONTEND_URL;
+  if (!raw) return new Set();
+  const hosts = new Set<string>();
+  for (const entry of raw.split(',')) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    try {
+      const u = new URL(trimmed);
+      if (u.hostname) hosts.add(u.hostname.toLowerCase());
+    } catch {
+      // ignore malformed entry
+    }
+  }
+  return hosts;
+}
+
+/**
+ * Build the title→id map used by the `#confluence-page:<title>` resolver.
+ * Ambiguous titles are dropped so we never emit an edge to a random page.
+ * Returns both the map and an `activeIds` set for filtering deleted targets.
+ */
+async function loadTitleIndex(): Promise<{
+  titleToId: Map<string, number>;
+  activeIds: Set<number>;
+}> {
   const titleRows = await query<{ id: number; title: string }>(
     `SELECT id, title FROM pages WHERE deleted_at IS NULL AND title IS NOT NULL`,
   );
   const titleToId = new Map<string, number>();
-  // If a title is ambiguous, drop it from the map — emitting an edge to a
-  // random page is worse than emitting no edge.
   const seenTitles = new Set<string>();
   for (const r of titleRows.rows) {
     if (seenTitles.has(r.title)) {
@@ -104,52 +163,66 @@ export async function computeExplicitLinkEdges(
     seenTitles.add(r.title);
     titleToId.set(r.title, r.id);
   }
-
-  // Active page IDs to filter out targets that point at deleted pages.
   const activeIds = new Set(titleRows.rows.map((r) => r.id));
+  return { titleToId, activeIds };
+}
 
-  const pagesResult = pageIds && pageIds.length > 0
-    ? await query<{ id: number; body_html: string | null }>(
+/**
+ * Run the explicit_link producer against an existing transactional client.
+ *
+ * This is the canonical entry point — `computePageRelationships()` calls it
+ * inside its own BEGIN/COMMIT so explicit_link edges land atomically with the
+ * similarity / label_overlap / parent_child edges. Caller is responsible for
+ * the surrounding transaction.
+ *
+ * `changedPageIds`: when provided and non-empty, only those pages are
+ * scanned as link sources (matches the existing producer's incremental
+ * scoping). Pass `null`/`undefined` for a full recompute.
+ *
+ * Returns the number of `(source,target)` edges newly inserted (ON CONFLICT
+ * DO NOTHING means re-running yields 0).
+ */
+export async function runExplicitLinkProducer(
+  client: PoolClient,
+  changedPageIds?: readonly number[] | null,
+): Promise<number> {
+  const { titleToId, activeIds } = await loadTitleIndex();
+  const internalHosts = getInternalHosts();
+
+  const useIncremental = changedPageIds && changedPageIds.length > 0;
+  const pagesResult = useIncremental
+    ? await client.query<{ id: number; body_html: string | null }>(
         `SELECT id, body_html FROM pages
          WHERE id = ANY($1::int[]) AND deleted_at IS NULL`,
-        [Array.from(pageIds)],
+        [Array.from(changedPageIds!)],
       )
-    : await query<{ id: number; body_html: string | null }>(
+    : await client.query<{ id: number; body_html: string | null }>(
         `SELECT id, body_html FROM pages WHERE deleted_at IS NULL`,
       );
 
-  const pool = getPool();
-  const client = await pool.connect();
   let edgesWritten = 0;
-  try {
-    await client.query('BEGIN');
-    for (const page of pagesResult.rows) {
-      const links = extractInternalLinks(page.body_html, titleToId);
-      for (const link of links) {
-        if (link.targetPageId === page.id) continue; // self-loops are noise
-        if (!activeIds.has(link.targetPageId)) continue;
-        const [a, b] = page.id < link.targetPageId
-          ? [page.id, link.targetPageId]
-          : [link.targetPageId, page.id];
-        // ON CONFLICT keeps idempotency. score=1.0 since these are
-        // deterministic links, not similarity-derived.
-        const r = await client.query(
-          `INSERT INTO page_relationships (page_id_1, page_id_2, relationship_type, score)
-           VALUES ($1, $2, 'explicit_link', 1.0)
-           ON CONFLICT (page_id_1, page_id_2, relationship_type) DO NOTHING`,
-          [a, b],
-        );
-        edgesWritten += r.rowCount ?? 0;
-      }
+  for (const page of pagesResult.rows) {
+    const links = extractInternalLinks(page.body_html, titleToId, internalHosts);
+    for (const link of links) {
+      if (link.targetPageId === page.id) continue; // self-loops are noise
+      if (!activeIds.has(link.targetPageId)) continue;
+      const [a, b] = page.id < link.targetPageId
+        ? [page.id, link.targetPageId]
+        : [link.targetPageId, page.id];
+      // Canonical (lo,hi) ordering matches the unique key. ON CONFLICT keeps
+      // idempotency. score=1.0 since these are deterministic, not similarity.
+      const r = await client.query(
+        `INSERT INTO page_relationships (page_id_1, page_id_2, relationship_type, score)
+         VALUES ($1, $2, 'explicit_link', 1.0)
+         ON CONFLICT (page_id_1, page_id_2, relationship_type) DO NOTHING`,
+        [a, b],
+      );
+      edgesWritten += r.rowCount ?? 0;
     }
-    await client.query('COMMIT');
-  } catch (err) {
-    await client.query('ROLLBACK').catch(() => {});
-    logger.error({ err }, 'computeExplicitLinkEdges failed; rolled back');
-    throw err;
-  } finally {
-    client.release();
   }
-  logger.info({ edgesWritten, pageCount: pagesResult.rows.length }, 'explicit_link edges computed');
+  logger.info(
+    { edgesWritten, pageCount: pagesResult.rows.length, mode: useIncremental ? 'incremental' : 'full' },
+    'explicit_link edges produced',
+  );
   return edgesWritten;
 }

--- a/backend/src/domains/knowledge/services/relationship-producers.ts
+++ b/backend/src/domains/knowledge/services/relationship-producers.ts
@@ -1,0 +1,15 @@
+/**
+ * Wire-up helper that registers knowledge-domain edge producers into the
+ * embedding-service registry (#359).
+ *
+ * The `llm` domain owns the `computePageRelationships()` transaction but
+ * cannot import from `knowledge` (ESLint domain boundary). This file lives
+ * in `knowledge` so it CAN import both sides — `app.ts` calls it once at
+ * bootstrap to bridge them.
+ */
+import { registerRelationshipProducer } from '../../llm/services/embedding-relationship-hooks.js';
+import { runExplicitLinkProducer } from './link-extractor.js';
+
+export function registerKnowledgeRelationshipProducers(): void {
+  registerRelationshipProducer('explicitLink', runExplicitLinkProducer);
+}

--- a/backend/src/domains/llm/services/embedding-relationship-hooks.test.ts
+++ b/backend/src/domains/llm/services/embedding-relationship-hooks.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  registerRelationshipProducer,
+  listRelationshipProducers,
+  _resetRelationshipProducersForTests,
+  type RelationshipProducer,
+} from './embedding-relationship-hooks.js';
+
+describe('embedding-relationship-hooks', () => {
+  beforeEach(() => {
+    _resetRelationshipProducersForTests();
+  });
+
+  it('lists producers in registration order', () => {
+    const a: RelationshipProducer = vi.fn().mockResolvedValue(0);
+    const b: RelationshipProducer = vi.fn().mockResolvedValue(0);
+    registerRelationshipProducer('a', a);
+    registerRelationshipProducer('b', b);
+
+    const list = listRelationshipProducers();
+    expect(list.map((p) => p.name)).toEqual(['a', 'b']);
+  });
+
+  it('replaces a producer when re-registered with the same name (idempotent boot)', () => {
+    const v1: RelationshipProducer = vi.fn().mockResolvedValue(0);
+    const v2: RelationshipProducer = vi.fn().mockResolvedValue(0);
+    registerRelationshipProducer('explicitLink', v1);
+    registerRelationshipProducer('explicitLink', v2);
+
+    const list = listRelationshipProducers();
+    expect(list).toHaveLength(1);
+    expect(list[0]!.fn).toBe(v2);
+  });
+
+  it('listRelationshipProducers returns a copy (caller cannot mutate registry)', () => {
+    const fn: RelationshipProducer = vi.fn().mockResolvedValue(0);
+    registerRelationshipProducer('x', fn);
+
+    const list = listRelationshipProducers() as { name: string; fn: RelationshipProducer }[];
+    list.length = 0;
+
+    expect(listRelationshipProducers()).toHaveLength(1);
+  });
+});

--- a/backend/src/domains/llm/services/embedding-relationship-hooks.ts
+++ b/backend/src/domains/llm/services/embedding-relationship-hooks.ts
@@ -1,0 +1,71 @@
+/**
+ * Cross-domain extension point for `computePageRelationships()`.
+ *
+ * The `llm` domain owns the page-relationship producer transaction (so the
+ * graph is never visible as half-deleted, and `processDirtyPages` runs the
+ * full recompute on the post-embed incremental path). But some edge types
+ * are owned by `knowledge` (`explicit_link` parses `body_html` via JSDOM,
+ * which doesn't belong in the embedding service).
+ *
+ * ESLint boundaries forbid `llm → knowledge`. To respect that, knowledge
+ * registers its producer here at startup; `computePageRelationships()`
+ * iterates the registry inside its own BEGIN/COMMIT so cross-domain edges
+ * are still atomic with similarity / label_overlap / parent_child.
+ *
+ * Producers MUST:
+ *   - Use only the provided `client` (no separate pool connection — they're
+ *     inside the caller's transaction).
+ *   - Honour `changedPageIds` for incremental scoping when non-null.
+ *   - Use `ON CONFLICT (page_id_1, page_id_2, relationship_type) DO NOTHING`
+ *     and the canonical `(LEAST, GREATEST)` page-id ordering, since
+ *     `computePageRelationships` already issued the DELETE for the affected
+ *     rows up-front.
+ *   - Return the number of edges they newly inserted.
+ *
+ * Producers MUST NOT throw partial state — any error propagates to
+ * `computePageRelationships`, which ROLLs the whole transaction back.
+ */
+import type { PoolClient } from 'pg';
+
+export type RelationshipProducer = (
+  client: PoolClient,
+  changedPageIds?: readonly number[] | null,
+) => Promise<number>;
+
+interface RegisteredProducer {
+  /** Stable identifier used in logs ("explicit_link", etc.). */
+  name: string;
+  fn: RelationshipProducer;
+}
+
+const _producers: RegisteredProducer[] = [];
+
+/**
+ * Register a producer that runs inside `computePageRelationships()`'s
+ * transaction. Idempotent on `name` — re-registering replaces. Knowledge
+ * calls this at app bootstrap.
+ */
+export function registerRelationshipProducer(name: string, fn: RelationshipProducer): void {
+  const existing = _producers.findIndex((p) => p.name === name);
+  if (existing >= 0) {
+    _producers[existing] = { name, fn };
+  } else {
+    _producers.push({ name, fn });
+  }
+}
+
+/**
+ * Read-only snapshot of registered producers — for the embedding service
+ * to iterate. Returns a fresh array so callers can't mutate the registry.
+ */
+export function listRelationshipProducers(): readonly RegisteredProducer[] {
+  return _producers.slice();
+}
+
+/**
+ * Test-only: clear all registered producers. Not exported from the package
+ * surface, only consumed inside the test files in this folder.
+ */
+export function _resetRelationshipProducersForTests(): void {
+  _producers.length = 0;
+}

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -9,6 +9,7 @@ import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js'
 import { CircuitBreakerOpenError, getProviderBreaker } from '../../../core/services/circuit-breaker.js';
 import { getReembedHistoryRetention } from '../../../core/services/admin-settings-service.js';
 import { enqueueJob } from '../../../core/services/queue-service.js';
+import { listRelationshipProducers } from './embedding-relationship-hooks.js';
 import pgvector from 'pgvector';
 
 const CHUNK_SIZE = 500;          // ~500 tokens target
@@ -931,11 +932,30 @@ export async function computePageRelationships(changedPageIds?: number[]): Promi
       [useIncremental ? changedPageIds : null],
     );
 
+    // #359: cross-domain producers (registered at app bootstrap) run inside
+    // the same transaction. ESLint forbids `llm → knowledge` imports, so the
+    // explicit_link producer registers itself via `registerRelationshipProducer`
+    // — see `embedding-relationship-hooks.ts`. Producers honour the same
+    // `changedPageIds` scoping; failures bubble up and ROLLBACK below.
+    let extraEdges = 0;
+    const extraCounts: Record<string, number> = {};
+    for (const producer of listRelationshipProducers()) {
+      const inserted = await producer.fn(client, useIncremental ? changedPageIds : null);
+      extraCounts[producer.name] = inserted;
+      extraEdges += inserted;
+    }
+
     await client.query('COMMIT');
 
-    const totalEdges = similarityResult.rows.length + labelResult.rows.length;
-    logger.info({ embeddingSimilarity: similarityResult.rows.length, labelOverlap: labelResult.rows.length },
-      'Page relationships computed');
+    const totalEdges = similarityResult.rows.length + labelResult.rows.length + extraEdges;
+    logger.info(
+      {
+        embeddingSimilarity: similarityResult.rows.length,
+        labelOverlap: labelResult.rows.length,
+        ...extraCounts,
+      },
+      'Page relationships computed',
+    );
     return totalEdges;
   } catch (err) {
     await client.query('ROLLBACK');

--- a/backend/src/routes/knowledge/pages-embeddings.ts
+++ b/backend/src/routes/knowledge/pages-embeddings.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { query } from '../../core/db/postgres.js';
 import { RedisCache } from '../../core/services/redis-cache.js';
 import { computePageRelationships } from '../../domains/llm/services/embedding-service.js';
+import { computeExplicitLinkEdges } from '../../domains/knowledge/services/link-extractor.js';
 import { getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
 
 /** Graph cache uses a short TTL (5 min) so relationship changes surface quickly. */
@@ -259,10 +260,19 @@ export async function pagesEmbeddingRoutes(fastify: FastifyInstance) {
   }, async (request) => {
     const userId = request.userId;
 
-    const edgeCount = await computePageRelationships();
+    const similarityCount = await computePageRelationships();
+    // #359: explicit_link edges run after the similarity/label producer
+    // commits — the producer DELETEs all rows up-front, so this re-inserts
+    // explicit links into the freshly-cleared table. Idempotent on its own
+    // unique key.
+    const explicitLinkCount = await computeExplicitLinkEdges();
     await cache.invalidate(userId, 'pages');
 
-    return { message: 'Graph relationships refreshed', edges: edgeCount };
+    return {
+      message: 'Graph relationships refreshed',
+      edges: similarityCount + explicitLinkCount,
+      explicitLinkEdges: explicitLinkCount,
+    };
   });
 }
 

--- a/backend/src/routes/knowledge/pages-embeddings.ts
+++ b/backend/src/routes/knowledge/pages-embeddings.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 import { query } from '../../core/db/postgres.js';
 import { RedisCache } from '../../core/services/redis-cache.js';
 import { computePageRelationships } from '../../domains/llm/services/embedding-service.js';
-import { computeExplicitLinkEdges } from '../../domains/knowledge/services/link-extractor.js';
 import { getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
 
 /** Graph cache uses a short TTL (5 min) so relationship changes surface quickly. */
@@ -260,19 +259,14 @@ export async function pagesEmbeddingRoutes(fastify: FastifyInstance) {
   }, async (request) => {
     const userId = request.userId;
 
-    const similarityCount = await computePageRelationships();
-    // #359: explicit_link edges run after the similarity/label producer
-    // commits — the producer DELETEs all rows up-front, so this re-inserts
-    // explicit links into the freshly-cleared table. Idempotent on its own
-    // unique key.
-    const explicitLinkCount = await computeExplicitLinkEdges();
+    // #359: `computePageRelationships` runs every registered edge producer
+    // inside its transaction — including explicit_link, registered at app
+    // bootstrap via `registerKnowledgeRelationshipProducers()`. Returned
+    // count is the sum across all producers.
+    const edgeCount = await computePageRelationships();
     await cache.invalidate(userId, 'pages');
 
-    return {
-      message: 'Graph relationships refreshed',
-      edges: similarityCount + explicitLinkCount,
-      explicitLinkEdges: explicitLinkCount,
-    };
+    return { message: 'Graph relationships refreshed', edges: edgeCount };
   });
 }
 

--- a/backend/src/routes/knowledge/pages-graph.test.ts
+++ b/backend/src/routes/knowledge/pages-graph.test.ts
@@ -72,6 +72,11 @@ vi.mock('../../domains/llm/services/embedding-service.js', () => ({
   computePageRelationships: (...args: unknown[]) => mockComputePageRelationships(...args),
 }));
 
+const mockComputeExplicitLinkEdges = vi.fn().mockResolvedValue(0);
+vi.mock('../../domains/knowledge/services/link-extractor.js', () => ({
+  computeExplicitLinkEdges: (...args: unknown[]) => mockComputeExplicitLinkEdges(...args),
+}));
+
 vi.mock('../../core/utils/logger.js', () => ({
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }));

--- a/backend/src/routes/knowledge/pages-graph.test.ts
+++ b/backend/src/routes/knowledge/pages-graph.test.ts
@@ -69,12 +69,10 @@ const mockComputePageRelationships = vi.fn().mockResolvedValue(10);
 vi.mock('../../domains/llm/services/embedding-service.js', () => ({
   processDirtyPages: vi.fn().mockResolvedValue({ processed: 0, errors: 0 }),
   isProcessingUser: vi.fn().mockResolvedValue(false),
+  // #359: `computePageRelationships` returns the SUM across all registered
+  // producers (similarity + label_overlap + explicit_link, etc.). The route
+  // no longer calls a separate explicit-link producer.
   computePageRelationships: (...args: unknown[]) => mockComputePageRelationships(...args),
-}));
-
-const mockComputeExplicitLinkEdges = vi.fn().mockResolvedValue(0);
-vi.mock('../../domains/knowledge/services/link-extractor.js', () => ({
-  computeExplicitLinkEdges: (...args: unknown[]) => mockComputeExplicitLinkEdges(...args),
 }));
 
 vi.mock('../../core/utils/logger.js', () => ({


### PR DESCRIPTION
## Summary
The CHECK constraint on page_relationships.relationship_type allowed 'explicit_link' but no code populated these rows. Internal article links — semantically the strongest edge type in a knowledge base — were invisible in the graph.

Added link-extractor service that pulls anchors out of pages.body_html and resolves them to integer page ids:
- /pages/:id app-route URLs (what the editor and authors paste)
- #confluence-page:<title> placeholders emitted by content-converter for ac:link → ri:page references in synced Confluence content; resolved via a one-pass title→id map, ambiguous titles dropped rather than emitting a wrong edge

Pairs are stored canonically (lower id first) and idempotent via ON CONFLICT on the existing (page_id_1, page_id_2, relationship_type) unique constraint. Self-loops dropped, deleted-page targets dropped, malformed HTML doesn't throw.

Wired into POST /api/pages/graph/refresh after computePageRelationships finishes its DELETE+INSERT transaction. Response includes per-type edge counts.

Closes #359 · part of #351 · depends on #358

## Test plan
- [x] 9 parser unit tests: app-route, confluence hash, dedupe, external/non-page rejection, malformed input, non-numeric ids, missing href, empty
- [x] /graph/refresh wiring covered by route-level mock test
- [ ] manual: trigger admin recompute on a synced space, check meta.relationshipsByType.explicit_link > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)