### PR TITLE
feat(#353): bigger editor color pickers + ARIA-grouped Colors section

### DIFF
--- a/frontend/src/shared/components/article/Editor.test.tsx
+++ b/frontend/src/shared/components/article/Editor.test.tsx
@@ -269,4 +269,46 @@ describe('EditorToolbar — header numbering toggle', () => {
 
     expect(screen.queryByTitle('Toggle Header Numbering')).not.toBeInTheDocument();
   });
+
+  // ---------- #353 toolbar grouping + bigger color pickers ----------
+
+  it('renders a labeled Colors group containing both color pickers (#353)', () => {
+    const editor = createMockEditor();
+    render(<EditorToolbar editor={editor} />);
+
+    const group = screen.getByRole('group', { name: 'Colors' });
+    expect(group).toBeInTheDocument();
+    expect(group).toHaveAttribute('data-toolbar-group', 'colors');
+    // Both triggers live inside the group.
+    expect(group.querySelectorAll('[data-testid="color-picker-trigger"]').length).toBe(2);
+  });
+
+  it('color-picker triggers meet the 32x32 minimum target size (#353)', () => {
+    const editor = createMockEditor();
+    render(<EditorToolbar editor={editor} />);
+
+    const triggers = screen.getAllByTestId('color-picker-trigger');
+    expect(triggers.length).toBe(2);
+    for (const trigger of triggers) {
+      // Tailwind h-8 w-8 maps to 32×32 (1rem = 16px).
+      expect(trigger.className).toMatch(/(?:^|\s)h-8(?:\s|$)/);
+      expect(trigger.className).toMatch(/(?:^|\s)w-8(?:\s|$)/);
+    }
+  });
+
+  it('color-picker swatches meet the 24x24 minimum after opening the picker (#353)', () => {
+    const editor = createMockEditor();
+    render(<EditorToolbar editor={editor} />);
+
+    const triggers = screen.getAllByTestId('color-picker-trigger');
+    fireEvent.click(triggers[0]!);
+
+    const swatches = screen.getAllByTestId('color-picker-swatch');
+    expect(swatches.length).toBeGreaterThanOrEqual(8);
+    for (const sw of swatches) {
+      // h-7 w-7 → 28×28 (above the 24 minimum).
+      expect(sw.className).toMatch(/(?:^|\s)h-7(?:\s|$)/);
+      expect(sw.className).toMatch(/(?:^|\s)w-7(?:\s|$)/);
+    }
+  });
 });

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -264,35 +264,49 @@ function ColorPickerDropdown({
       <button
         onClick={() => setOpen(!open)}
         title={title}
+        aria-label={title}
+        // #353: trigger sized 32×32 (h-8 w-8) — was ~24×24 from the
+        // previous `p-1.5` which made the colour pickers a tiny target.
+        // Matches the issue acceptance criteria (>=32×32 trigger).
         className={cn(
-          'rounded p-1.5 transition-colors',
+          'flex h-8 w-8 items-center justify-center rounded-md transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
           activeColor ? 'ring-1 ring-primary/30' : '',
           'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
         )}
+        data-testid="color-picker-trigger"
       >
         <div className="relative">
           {icon}
           {activeColor && (
-            <div className="absolute -bottom-0.5 left-0.5 right-0.5 h-0.5 rounded-full" style={{ backgroundColor: activeColor }} />
+            <div className="absolute -bottom-1 left-0 right-0 h-0.5 rounded-full" style={{ backgroundColor: activeColor }} />
           )}
         </div>
       </button>
       {open && (
-        <div className="absolute top-full left-0 z-50 mt-1 rounded-lg border border-border bg-card p-2 shadow-lg">
-          <div className="grid grid-cols-4 gap-1">
+        <div
+          className="absolute top-full left-0 z-50 mt-1 rounded-lg border border-border bg-card p-2.5 shadow-lg"
+          role="menu"
+          aria-label={`${title} swatches`}
+        >
+          {/* #353: 28×28 swatches (>=24×24 minimum). 4-col grid keeps the
+              popover compact while making each swatch comfortably clickable. */}
+          <div className="grid grid-cols-4 gap-1.5">
             {PRESET_COLORS.map((c) => (
               <button
                 key={c.value}
                 title={c.label}
+                aria-label={c.label}
                 onClick={() => { onSelect(c.value); setOpen(false); }}
-                className="h-6 w-6 rounded-md border border-border/50 transition-transform hover:scale-110"
+                className="h-7 w-7 rounded-md border border-border/50 transition-transform hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
                 style={{ backgroundColor: c.value }}
+                data-testid="color-picker-swatch"
               />
             ))}
           </div>
           <button
             onClick={() => { onReset(); setOpen(false); }}
-            className="mt-1.5 w-full rounded-md px-2 py-0.5 text-xs text-muted-foreground hover:bg-foreground/5"
+            className="mt-2 w-full rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-foreground/5"
           >
             Reset
           </button>
@@ -345,21 +359,23 @@ export function EditorToolbar({ editor, headerNumbering, onToggleHeaderNumbering
 
       <ToolbarSeparator />
 
-      {/* Text color & highlight (#14 #15) */}
-      <ColorPickerDropdown
-        icon={<Palette size={16} />}
-        title="Text Color"
-        activeColor={activeState.textColor}
-        onSelect={(color) => editor.chain().focus().setColor(color).run()}
-        onReset={() => editor.chain().focus().unsetColor().run()}
-      />
-      <ColorPickerDropdown
-        icon={<Highlighter size={16} />}
-        title="Highlight (Ctrl+Shift+H)"
-        activeColor={activeState.highlightColor}
-        onSelect={(color) => editor.chain().focus().toggleHighlight({ color }).run()}
-        onReset={() => editor.chain().focus().unsetHighlight().run()}
-      />
+      {/* #353: Colors group — bigger triggers + ARIA-grouped + testable. */}
+      <div role="group" aria-label="Colors" className="flex items-center gap-0.5" data-toolbar-group="colors">
+        <ColorPickerDropdown
+          icon={<Palette size={16} />}
+          title="Text Color"
+          activeColor={activeState.textColor}
+          onSelect={(color) => editor.chain().focus().setColor(color).run()}
+          onReset={() => editor.chain().focus().unsetColor().run()}
+        />
+        <ColorPickerDropdown
+          icon={<Highlighter size={16} />}
+          title="Highlight (Ctrl+Shift+H)"
+          activeColor={activeState.highlightColor}
+          onSelect={(color) => editor.chain().focus().toggleHighlight({ color }).run()}
+          onReset={() => editor.chain().focus().unsetHighlight().run()}
+        />
+      </div>
 
       <ToolbarSeparator />
 


### PR DESCRIPTION
## Summary
The text-color and highlight-color pickers were hard to hit and read because their triggers came from a generic toolbar button with p-1.5 padding (~24×24 effective target). Issue called for ≥32×32 trigger and ≥24×24 swatches.

- Color trigger: explicit h-8 w-8 (32×32) with focus-visible ring and aria-label so keyboard users get a clear focus target.
- Swatches: h-7 w-7 (28×28, above the 24 minimum), 4×2 grid with comfortable gap-1.5 spacing. role="menu" + per-swatch aria-label.
- Wrapped both color pickers in `<div role="group" aria-label="Colors" data-toolbar-group="colors">` so screen readers announce the cluster as a group and tests can assert grouping survives future edits.

**Out of scope**: the issue's secondary goal (Inline · Block · Lists · Insert · Colors · Align · Utilities order) requires touching every section of the existing well-tested toolbar. This PR ships the high-leverage subset (target size + grouping) and leaves the order debate for a focused redesign.

Refs #353 (this PR addresses the trigger-size + grouping ACs; the toolbar reorder / overflow menu / broader segment grouping ACs are deferred to a follow-up — leave #353 open)

## Test plan
- [x] 3 new tests: Colors group exists with role/data-attr, triggers are h-8 w-8, swatches are h-7 w-7 after open
- [x] Editor + EditorToolbar suite: 18/18 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
