### PR TITLE
feat(#362): parent_child edges from page hierarchy (slice 351e)

### DIFF
--- a/backend/src/core/db/migrations/070_relationship_type_parent_child.sql
+++ b/backend/src/core/db/migrations/070_relationship_type_parent_child.sql
@@ -1,0 +1,25 @@
+-- #362: extend page_relationships.relationship_type to allow 'parent_child'.
+--
+-- Migration 020 declared the original CHECK constraint with three values
+-- (embedding_similarity, label_overlap, explicit_link). #362 adds parent_child
+-- as a new edge type so the page hierarchy is visible in the knowledge graph.
+--
+-- We drop and re-add the constraint rather than ALTER it because Postgres
+-- doesn't support ALTER CONSTRAINT ... CHECK; the drop+add cycle is cheap on
+-- a table this size and atomic inside this single migration transaction.
+--
+-- Note: 'cluster_relationship' is computed in code at request time
+-- (pages-embeddings.ts:409 buildClusteredGraph) and never stored, so it is
+-- intentionally NOT in the CHECK list.
+
+ALTER TABLE page_relationships
+  DROP CONSTRAINT IF EXISTS page_relationships_relationship_type_check;
+
+ALTER TABLE page_relationships
+  ADD CONSTRAINT page_relationships_relationship_type_check
+  CHECK (relationship_type IN (
+    'embedding_similarity',
+    'label_overlap',
+    'explicit_link',
+    'parent_child'
+  ));

--- a/backend/src/domains/llm/services/embedding-service.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.test.ts
@@ -349,23 +349,25 @@ describe('embedding-service', () => {
   });
 
   describe('computePageRelationships', () => {
-    // Transaction call order on mockClient:
-    // [0]=BEGIN, [1]=SET LOCAL statement_timeout, [2]=DELETE, [3]=similarity CTE, [4]=label CTE, [5]=COMMIT
+    // Transaction call order on mockClient (#362 added parent_child INSERT):
+    // [0]=BEGIN, [1]=SET LOCAL statement_timeout, [2]=DELETE,
+    // [3]=similarity CTE, [4]=label CTE, [5]=parent_child INSERT, [6]=COMMIT
 
     it('should delete existing relationships then compute new ones', async () => {
-      // Set up 6 specific client.query responses matching the transaction order
+      // Set up 7 specific client.query responses matching the transaction order
       mockClient.query
         .mockResolvedValueOnce({ rows: [] })                                           // BEGIN
         .mockResolvedValueOnce({ rows: [] })                                           // SET LOCAL statement_timeout
         .mockResolvedValueOnce({ rows: [], rowCount: 0 })                             // DELETE
         .mockResolvedValueOnce({ rows: [{ page_id_1: 'page-1', page_id_2: 'page-2', score: 0.85 }], rowCount: 1 })  // similarity INSERT
         .mockResolvedValueOnce({ rows: [{ page_id_1: 'page-1', page_id_2: 'page-3', score: 0.5 }], rowCount: 1 })   // label INSERT
+        .mockResolvedValueOnce({ rows: [{ page_id_1: 'page-1', page_id_2: 'page-4' }], rowCount: 1 })               // parent_child INSERT (#362)
         .mockResolvedValueOnce({ rows: [] });                                          // COMMIT
 
       const totalEdges = await computePageRelationships();
 
-      expect(totalEdges).toBe(2);
-      expect(mockClient.query).toHaveBeenCalledTimes(6);
+      expect(totalEdges).toBe(3);
+      expect(mockClient.query).toHaveBeenCalledTimes(7);
       expect(mocks.query).not.toHaveBeenCalled();
 
       // calls[0] = BEGIN
@@ -375,8 +377,11 @@ describe('embedding-service', () => {
       // calls[2] = DELETE (global, no params)
       const deleteCall = mockClient.query.mock.calls[2][0] as string;
       expect(deleteCall).toContain('DELETE FROM page_relationships');
-      // calls[5] = COMMIT
-      expect(mockClient.query.mock.calls[5][0]).toBe('COMMIT');
+      // calls[5] = parent_child INSERT (#362)
+      const parentChildCall = mockClient.query.mock.calls[5][0] as string;
+      expect(parentChildCall).toContain("'parent_child'");
+      // calls[6] = COMMIT
+      expect(mockClient.query.mock.calls[6][0]).toBe('COMMIT');
     });
 
     it('should not use userId (global shared tables)', async () => {

--- a/backend/src/domains/llm/services/embedding-service.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.test.ts
@@ -458,17 +458,26 @@ describe('embedding-service', () => {
     });
 
     it('should delete only affected rows when changedPageIds is provided (incremental)', async () => {
+      // 7 query slots: BEGIN, SET LOCAL, DELETE, similarity INSERT, label INSERT,
+      // parent_child INSERT (#362), COMMIT. Each must be explicitly mocked so the
+      // assertions below pin the bind params for the new edge type instead of
+      // relying on the beforeEach catch-all (which would silently absorb a missing
+      // slot and let a regression slip through).
       mockClient.query
-        .mockResolvedValueOnce({ rows: [] })                                     // BEGIN
-        .mockResolvedValueOnce({ rows: [] })                                     // SET LOCAL statement_timeout
-        .mockResolvedValueOnce({ rows: [], rowCount: 2 })                       // DELETE WHERE page_id_1 = ANY($1) OR page_id_2 = ANY($1)
-        .mockResolvedValueOnce({ rows: [{ page_id_1: 1, page_id_2: 2, score: 0.9 }], rowCount: 1 })  // similarity INSERT
-        .mockResolvedValueOnce({ rows: [], rowCount: 0 })                       // label INSERT
-        .mockResolvedValueOnce({ rows: [] });                                    // COMMIT
+        .mockResolvedValueOnce({ rows: [] })                                                          // BEGIN
+        .mockResolvedValueOnce({ rows: [] })                                                          // SET LOCAL statement_timeout
+        .mockResolvedValueOnce({ rows: [], rowCount: 2 })                                             // DELETE WHERE page_id_1 = ANY($1) OR page_id_2 = ANY($1)
+        .mockResolvedValueOnce({ rows: [{ page_id_1: 1, page_id_2: 2, score: 0.9 }], rowCount: 1 })   // similarity INSERT
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })                                             // label INSERT
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })                                             // parent_child INSERT (#362)
+        .mockResolvedValueOnce({ rows: [] });                                                         // COMMIT
 
       const totalEdges = await computePageRelationships([1, 3]);
 
       expect(totalEdges).toBe(1);
+      // Sanity: pin the slot count so a future producer that adds another query
+      // can't quietly shift the assertions below to the wrong call index.
+      expect(mockClient.query).toHaveBeenCalledTimes(7);
 
       // DELETE should contain ANY($1)
       const deleteCall = mockClient.query.mock.calls[2][0] as string;
@@ -482,6 +491,16 @@ describe('embedding-service', () => {
       // label query $1 should be changedPageIds
       const labelCall = mockClient.query.mock.calls[4];
       expect(labelCall[1][0]).toEqual([1, 3]);
+
+      // parent_child query (#362) $1 should be changedPageIds — pins the
+      // incremental contract for the new edge type.
+      const parentChildCall = mockClient.query.mock.calls[5];
+      expect(parentChildCall[0]).toContain("'parent_child'");
+      expect(parentChildCall[1][0]).toEqual([1, 3]);
+
+      // COMMIT must be the final call (would silently fall through to the
+      // beforeEach catch-all if the slot count above were wrong).
+      expect(mockClient.query.mock.calls[6][0]).toBe('COMMIT');
     });
   });
 

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -932,6 +932,36 @@ export async function computePageRelationships(changedPageIds?: number[]): Promi
       [useIncremental ? changedPageIds : null],
     );
 
+    // #362: parent_child edges. pages.parent_id is TEXT (a Confluence id)
+    // while page_relationships.page_id_1/2 is INT FK to pages.id after
+    // migration 030. Join via confluence_id to translate.
+    // Pairs are stored canonically (lower id first) so the unique key
+    // (page_id_1, page_id_2, relationship_type) catches both directions.
+    // Score = 1.0 since these edges are deterministic, not similarity-derived.
+    const parentChildResult = await client.query<{ page_id_1: number; page_id_2: number }>(
+      `WITH parent_links AS (
+         SELECT child.id AS child_id,
+                parent.id AS parent_id
+         FROM pages child
+         JOIN pages parent ON parent.confluence_id = child.parent_id
+         WHERE child.deleted_at IS NULL
+           AND parent.deleted_at IS NULL
+           AND child.parent_id IS NOT NULL
+           AND ($1::int[] IS NULL OR child.id = ANY($1) OR parent.id = ANY($1))
+       )
+       INSERT INTO page_relationships (page_id_1, page_id_2, relationship_type, score)
+       SELECT
+         LEAST(child_id, parent_id),
+         GREATEST(child_id, parent_id),
+         'parent_child',
+         1.0
+       FROM parent_links
+       WHERE child_id <> parent_id
+       ON CONFLICT (page_id_1, page_id_2, relationship_type) DO NOTHING
+       RETURNING page_id_1, page_id_2`,
+      [useIncremental ? changedPageIds : null],
+    );
+
     // #359: cross-domain producers (registered at app bootstrap) run inside
     // the same transaction. ESLint forbids `llm → knowledge` imports, so the
     // explicit_link producer registers itself via `registerRelationshipProducer`
@@ -947,11 +977,16 @@ export async function computePageRelationships(changedPageIds?: number[]): Promi
 
     await client.query('COMMIT');
 
-    const totalEdges = similarityResult.rows.length + labelResult.rows.length + extraEdges;
+    const totalEdges =
+      similarityResult.rows.length +
+      labelResult.rows.length +
+      parentChildResult.rows.length +
+      extraEdges;
     logger.info(
       {
         embeddingSimilarity: similarityResult.rows.length,
         labelOverlap: labelResult.rows.length,
+        parentChild: parentChildResult.rows.length,
         ...extraCounts,
       },
       'Page relationships computed',

--- a/docs/architecture/06-data-model.md
+++ b/docs/architecture/06-data-model.md
@@ -101,10 +101,9 @@ erDiagram
 
     page_relationships {
         bigint id PK
-        uuid user_id FK
         int page_id_1 FK
         int page_id_2 FK
-        text relationship_type
+        text relationship_type "embedding_similarity | label_overlap | explicit_link | parent_child"
         double score
     }
 

--- a/frontend/src/features/graph/GraphPage.tsx
+++ b/frontend/src/features/graph/GraphPage.tsx
@@ -64,6 +64,9 @@ const EDGE_COLORS: Record<string, string> = {
   embedding_similarity: 'rgba(124, 140, 245, 0.35)',
   label_overlap: 'rgba(92, 201, 167, 0.45)',
   explicit_link: 'rgba(245, 158, 66, 0.5)',
+  // #362: parent_child edges get a distinct hue and higher opacity so the
+  // hierarchy is legible against the semantic-similarity haze.
+  parent_child: 'rgba(232, 176, 106, 0.7)',
   cluster_relationship: 'rgba(171, 130, 230, 0.4)',
 };
 


### PR DESCRIPTION
## Summary
For Confluence-synced spaces the **parent → child** page relationship is the most obvious structural edge in a knowledge base, but the graph ignored it: `pages.parent_id` was returned on nodes for context yet never emitted as an edge.

**Migration 070**: extend the `page_relationships.relationship_type` CHECK constraint to allow `'parent_child'` alongside the existing three types. (`'cluster_relationship'` is computed at request time, not stored, so it stays out of the CHECK list — matches existing behaviour.)

**Producer in `computePageRelationships()`**: join `pages.parent_id` (TEXT, Confluence id) → `pages.id` (INT) via the existing `confluence_id` column. Pairs stored canonically (`LEAST`/`GREATEST` so the unique key catches both directions). Score = 1.0 since these are deterministic edges. Idempotent via ON CONFLICT.

**Frontend**: parent_child edges get a distinct hue + higher opacity in `EDGE_COLORS` so the hierarchy is legible against the semantic-similarity haze. The filter sidebar from #360 already exposes parent_child as an edge-type checkbox.

**Docs**: `docs/architecture/06-data-model.md` updated to document the four valid `relationship_type` values (CLAUDE.md rule 6).

Closes #362 · part of #351 · depends on **#358 only** (filter sidebar in #360 picks parent_child up automatically once both land)

## Test plan
- [x] embedding-service suite: 87/87 pass with the new INSERT slot
- [x] migration is forward-only and additive (DROP + ADD CHECK)
- [x] backend + frontend typecheck clean
- [ ] manual: create parent → child page hierarchy, run admin Recompute, confirm parent_child edges appear in /pages/graph meta + render

🤖 Generated with [Claude Code](https://claude.com/claude-code)