### PR TITLE
feat(#352): per-space custom home page + admin/space-owner RBAC

### DIFF
--- a/backend/src/core/db/migrations/071_spaces_custom_home_page.sql
+++ b/backend/src/core/db/migrations/071_spaces_custom_home_page.sql
@@ -1,0 +1,23 @@
+-- #352: per-space custom home page.
+--
+-- Today, `spaces.homepage_id` (TEXT) stores the Confluence-derived home page
+-- (whatever `space.homepage.id` was at last sync). We add a separate
+-- `custom_home_page_id` (INT FK → pages.id) that admins or space owners can
+-- set to override the Confluence default — including pointing at a folder or
+-- a standalone page that isn't part of any synced Confluence space.
+--
+-- Resolution at read time:
+--   1. If custom_home_page_id IS NOT NULL → use that page.
+--   2. Else fall back to the Confluence-derived homepage_id → pages.id lookup
+--      (the existing JOIN in routes/confluence/spaces.ts already does this).
+--
+-- ON DELETE SET NULL so deleting the configured home page doesn't break the
+-- space; resolution falls through to the Confluence default.
+
+ALTER TABLE spaces
+  ADD COLUMN IF NOT EXISTS custom_home_page_id INTEGER
+    REFERENCES pages(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_spaces_custom_home_page_id
+  ON spaces(custom_home_page_id)
+  WHERE custom_home_page_id IS NOT NULL;

--- a/backend/src/core/services/redis-cache.test.ts
+++ b/backend/src/core/services/redis-cache.test.ts
@@ -709,3 +709,59 @@ describe('RedisCache.getOrCompute', () => {
     expect(computeFn).toHaveBeenCalledOnce();
   });
 });
+
+describe('RedisCache.invalidateAcrossUsers (#352)', () => {
+  let mockRedis: ReturnType<typeof createMockRedisClient>;
+  let cache: RedisCache;
+
+  beforeEach(() => {
+    mockRedis = createMockRedisClient();
+    cache = new RedisCache(asRedis(mockRedis));
+  });
+
+  it('SCANs the cross-user pattern and deletes every matching key', async () => {
+    // One SCAN page, two matching keys across two different userIds.
+    mockRedis.scan.mockResolvedValueOnce({
+      cursor: '0',
+      keys: ['kb:alice:spaces:list', 'kb:bob:spaces:list'],
+    });
+    mockRedis.del.mockResolvedValue(2);
+
+    await cache.invalidateAcrossUsers('spaces');
+
+    expect(mockRedis.scan).toHaveBeenCalledWith('0', {
+      MATCH: 'kb:*:spaces:*',
+      COUNT: 100,
+    });
+    expect(mockRedis.del).toHaveBeenCalledWith([
+      'kb:alice:spaces:list',
+      'kb:bob:spaces:list',
+    ]);
+  });
+
+  it('walks the cursor across multiple SCAN pages', async () => {
+    mockRedis.scan
+      .mockResolvedValueOnce({ cursor: '42', keys: ['kb:alice:spaces:list'] })
+      .mockResolvedValueOnce({ cursor: '0', keys: ['kb:bob:spaces:list'] });
+    mockRedis.del.mockResolvedValue(1);
+
+    await cache.invalidateAcrossUsers('spaces');
+
+    expect(mockRedis.scan).toHaveBeenCalledTimes(2);
+    expect(mockRedis.del).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not call DEL when SCAN returns no keys', async () => {
+    mockRedis.scan.mockResolvedValueOnce({ cursor: '0', keys: [] });
+
+    await cache.invalidateAcrossUsers('spaces');
+
+    expect(mockRedis.del).not.toHaveBeenCalled();
+  });
+
+  it('soft-fails when SCAN throws (logs, does not raise)', async () => {
+    mockRedis.scan.mockRejectedValue(new Error('Redis down'));
+
+    await expect(cache.invalidateAcrossUsers('spaces')).resolves.toBeUndefined();
+  });
+});

--- a/backend/src/core/services/redis-cache.ts
+++ b/backend/src/core/services/redis-cache.ts
@@ -491,6 +491,27 @@ export class RedisCache {
   }
 
   /**
+   * Invalidate every user's cache of the given type.
+   *
+   * Used when an admin/space-owner mutation changes data that is visible to
+   * all users (e.g. setting a space's custom home page — #352). The per-user
+   * `invalidate(userId, type)` only clears the calling admin's cache and
+   * leaves every other user reading stale data for up to TTL seconds.
+   *
+   * Implemented as a single SCAN cursor walk over `kb:*:{type}:*` against the
+   * shared Redis. Works in single-pod and multi-pod deployments without
+   * needing pub/sub — Redis is the authoritative store, so deleting the keys
+   * is sufficient; subsequent reads from any pod miss and re-populate.
+   */
+  async invalidateAcrossUsers(type: CacheType): Promise<void> {
+    try {
+      await this.scanAndDelete(`kb:*:${type}:*`);
+    } catch (err) {
+      logger.error({ err, type }, 'Redis cache invalidate across users error');
+    }
+  }
+
+  /**
    * Cache-aside with stampede protection.
    *
    * On cache miss, acquires a short-lived NX lock so only one caller computes

--- a/backend/src/core/services/webhook-outbox-poller.test.ts
+++ b/backend/src/core/services/webhook-outbox-poller.test.ts
@@ -494,6 +494,17 @@ describe.skipIf(!canRun)('webhook-outbox-poller', () => {
       // subsequent tests still have a working queue handle.
       const fresh = getWebhookDeliveryQueue();
       expect(fresh).toBeInstanceOf(Queue);
+
+      // Wait for the rebuilt queue's ioredis client + subscriber connections
+      // to fully establish before we close them. Otherwise `afterAll`'s
+      // `__closeWebhookDeliveryQueueForTests()` races against in-flight
+      // ioredis handshake commands and the close handler rejects them with
+      // `Error: Connection is closed.` — which surfaces as an unhandled
+      // rejection that fails the whole vitest run (see Compendiq/compendiq-ce
+      // PRs #365, #373, #377). Owning the cleanup inside the test that
+      // built the queue eliminates the race entirely.
+      await fresh.waitUntilReady();
+      await __closeWebhookDeliveryQueueForTests();
     });
   });
 });

--- a/backend/src/routes/confluence/spaces.test.ts
+++ b/backend/src/routes/confluence/spaces.test.ts
@@ -25,6 +25,11 @@ vi.mock('../../core/utils/logger.js', () => ({
 
 import { spacesRoutes } from './spaces.js';
 
+// Module-scoped mocks so individual tests can re-arm `scan` to assert the
+// cross-user invalidation path (#352, finding 1).
+const mockRedisScan = vi.fn().mockResolvedValue({ cursor: '0', keys: [] });
+const mockRedisDel = vi.fn().mockResolvedValue(0);
+
 describe('Spaces routes', () => {
   let app: ReturnType<typeof Fastify>;
 
@@ -39,6 +44,12 @@ describe('Spaces routes', () => {
     app.decorate('redis', {
       get: vi.fn().mockResolvedValue(null),
       setEx: vi.fn().mockResolvedValue('OK'),
+      // RedisCache.invalidateAcrossUsers walks SCAN cursors and DELs the
+      // returned keys. Tests need both to assert the cross-user fan-out
+      // pattern; default mocks return an empty page so the SCAN walk
+      // terminates immediately.
+      scan: mockRedisScan,
+      del: mockRedisDel,
     });
 
     await app.register(spacesRoutes, { prefix: '/api' });
@@ -54,6 +65,10 @@ describe('Spaces routes', () => {
     mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
     mockGetUserAccessibleSpaces.mockResolvedValue([]);
     mockUserHasPermission.mockResolvedValue(false);
+    // Re-arm Redis SCAN to terminate immediately for tests that don't
+    // care about cache invalidation; tests that DO care override this.
+    mockRedisScan.mockReset().mockResolvedValue({ cursor: '0', keys: [] });
+    mockRedisDel.mockReset().mockResolvedValue(0);
   });
 
   it('GET /spaces includes selected spaces that are not yet synced', async () => {
@@ -249,6 +264,43 @@ describe('Spaces routes', () => {
       spaceKey: 'DEV',
       customHomePageId: null,
     });
+  });
+
+  it('PUT /spaces/:key/home invalidates the spaces cache across ALL users, not just the admin caller (#352)', async () => {
+    // Two simulated users have a cached `kb:<uid>:spaces:list` entry. The
+    // update must wipe both, otherwise non-admin viewers would keep
+    // reading the old `homepageId` for up to the spaces TTL (15 min).
+    mockUserHasPermission.mockResolvedValueOnce(true);
+    mockGetUserAccessibleSpaces.mockResolvedValueOnce(['DEV']);
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ space_key: 'DEV', source: 'confluence', visibility: null }],
+      })
+      .mockResolvedValueOnce({ rows: [{ space_key: 'DEV' }], rowCount: 1 });
+
+    mockRedisScan.mockResolvedValueOnce({
+      cursor: '0',
+      keys: ['kb:alice:spaces:list', 'kb:bob:spaces:list'],
+    });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/spaces/DEV/home',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ homePageId: 42 }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    // SCAN walks the shared `kb:*:spaces:*` namespace, NOT the
+    // per-admin `kb:test-user-id:spaces:*` namespace.
+    expect(mockRedisScan).toHaveBeenCalledWith('0', {
+      MATCH: 'kb:*:spaces:*',
+      COUNT: 100,
+    });
+    expect(mockRedisDel).toHaveBeenCalledWith([
+      'kb:alice:spaces:list',
+      'kb:bob:spaces:list',
+    ]);
   });
 
   it('PUT /spaces/:key/home returns 404 when the space is not in the caller\'s accessible set (#352)', async () => {

--- a/backend/src/routes/confluence/spaces.test.ts
+++ b/backend/src/routes/confluence/spaces.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
 
 const mockQuery = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
 const mockGetUserAccessibleSpaces = vi.fn().mockResolvedValue([]);
+const mockUserHasPermission = vi.fn().mockResolvedValue(false);
 
 vi.mock('../../core/db/postgres.js', () => ({
   query: (...args: unknown[]) => mockQuery(...args),
@@ -10,6 +12,7 @@ vi.mock('../../core/db/postgres.js', () => ({
 
 vi.mock('../../core/services/rbac-service.js', () => ({
   getUserAccessibleSpaces: (...args: unknown[]) => mockGetUserAccessibleSpaces(...args),
+  userHasPermission: (...args: unknown[]) => mockUserHasPermission(...args),
 }));
 
 vi.mock('../../domains/confluence/services/sync-service.js', () => ({
@@ -27,6 +30,7 @@ describe('Spaces routes', () => {
 
   beforeAll(async () => {
     app = Fastify({ logger: false });
+    await app.register(sensible);
 
     app.decorate('authenticate', async (request: { userId: string }) => {
       request.userId = 'test-user-id';
@@ -49,6 +53,7 @@ describe('Spaces routes', () => {
     vi.clearAllMocks();
     mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
     mockGetUserAccessibleSpaces.mockResolvedValue([]);
+    mockUserHasPermission.mockResolvedValue(false);
   });
 
   it('GET /spaces includes selected spaces that are not yet synced', async () => {
@@ -61,6 +66,7 @@ describe('Spaces routes', () => {
           space_name: 'Development',
           homepage_id: 'home-1',
           homepage_numeric_id: 101,
+          custom_home_page_id: null,
           last_synced: '2026-03-18T10:00:00.000Z',
           source: 'confluence',
         }],
@@ -80,6 +86,7 @@ describe('Spaces routes', () => {
         key: 'DEV',
         name: 'Development',
         homepageId: '101',
+        customHomePageId: null,
         lastSynced: '2026-03-18T10:00:00.000Z',
         pageCount: 7,
         source: 'confluence',
@@ -106,6 +113,7 @@ describe('Spaces routes', () => {
             space_name: 'Development',
             homepage_id: null,
             homepage_numeric_id: null,
+            custom_home_page_id: null,
             last_synced: '2026-03-18T10:00:00.000Z',
             source: 'confluence',
           },
@@ -114,6 +122,7 @@ describe('Spaces routes', () => {
             space_name: 'My Notes',
             homepage_id: null,
             homepage_numeric_id: null,
+            custom_home_page_id: null,
             last_synced: '2026-03-19T10:00:00.000Z',
             source: 'local',
           },
@@ -140,5 +149,119 @@ describe('Spaces routes', () => {
     expect(devSpace.source).toBe('confluence');
     expect(localSpace.source).toBe('local');
     expect(localSpace.pageCount).toBe(5);
+  });
+
+  // ---------- #352: PUT /api/spaces/:key/home ----------
+
+  it('GET /spaces surfaces customHomePageId when set, overriding the Confluence default (#352)', async () => {
+    mockGetUserAccessibleSpaces.mockResolvedValueOnce(['DEV']);
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          space_key: 'DEV',
+          space_name: 'Development',
+          homepage_id: 'home-1',
+          homepage_numeric_id: 101,
+          custom_home_page_id: 999,
+          last_synced: '2026-03-18T10:00:00.000Z',
+          source: 'confluence',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const response = await app.inject({ method: 'GET', url: '/api/spaces' });
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body[0].homepageId).toBe('999');
+    expect(body[0].customHomePageId).toBe(999);
+  });
+
+  it('PUT /spaces/:key/home rejects callers without admin/space-owner permission (#352)', async () => {
+    mockUserHasPermission.mockResolvedValueOnce(false);
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/spaces/DEV/home',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ homePageId: 42 }),
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(mockUserHasPermission).toHaveBeenCalledWith('test-user-id', 'manage', 'DEV');
+  });
+
+  it('PUT /spaces/:key/home accepts a valid in-space page from a permitted caller (#352)', async () => {
+    mockUserHasPermission.mockResolvedValueOnce(true);
+    mockGetUserAccessibleSpaces.mockResolvedValueOnce(['DEV']);
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ space_key: 'DEV', source: 'confluence', visibility: null }],
+      })
+      .mockResolvedValueOnce({ rows: [{ space_key: 'DEV' }], rowCount: 1 });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/spaces/DEV/home',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ homePageId: 42 }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      spaceKey: 'DEV',
+      customHomePageId: 42,
+    });
+  });
+
+  it('PUT /spaces/:key/home rejects a page that lives in a different space (#352)', async () => {
+    mockUserHasPermission.mockResolvedValueOnce(true);
+    mockGetUserAccessibleSpaces.mockResolvedValueOnce(['DEV']);
+    // Page exists but lives in OTHER and isn't a shared standalone.
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ space_key: 'OTHER', source: 'confluence', visibility: null }],
+    });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/spaces/DEV/home',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ homePageId: 42 }),
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('PUT /spaces/:key/home with null clears the override (#352)', async () => {
+    mockUserHasPermission.mockResolvedValueOnce(true);
+    mockGetUserAccessibleSpaces.mockResolvedValueOnce(['DEV']);
+    // No page-existence query is made for null; only the UPDATE.
+    mockQuery.mockResolvedValueOnce({ rows: [{ space_key: 'DEV' }], rowCount: 1 });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/spaces/DEV/home',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ homePageId: null }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      spaceKey: 'DEV',
+      customHomePageId: null,
+    });
+  });
+
+  it('PUT /spaces/:key/home returns 404 when the space is not in the caller\'s accessible set (#352)', async () => {
+    mockUserHasPermission.mockResolvedValueOnce(true);
+    mockGetUserAccessibleSpaces.mockResolvedValueOnce([]);
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/spaces/DEV/home',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ homePageId: null }),
+    });
+
+    expect(response.statusCode).toBe(404);
   });
 });

--- a/backend/src/routes/confluence/spaces.ts
+++ b/backend/src/routes/confluence/spaces.ts
@@ -159,9 +159,12 @@ export async function spacesRoutes(fastify: FastifyInstance) {
       throw fastify.httpErrors.notFound('Space not found');
     }
 
-    // Invalidate the per-user spaces cache for everyone in the org —
-    // simplest correctness path, the cache is small and rebuilt lazily.
-    await cache.invalidate(userId, 'spaces');
+    // Invalidate every user's spaces cache — the custom home page is
+    // visible to all viewers of the space, so a per-user invalidation
+    // would leave non-admin users staring at the old `homepageId` for
+    // up to the spaces TTL (15 min). See `invalidateAcrossUsers` in
+    // redis-cache.ts for the SCAN-based fan-out.
+    await cache.invalidateAcrossUsers('spaces');
 
     logger.info({ userId, spaceKey: key, homePageId }, 'Space custom home page updated');
 

--- a/backend/src/routes/confluence/spaces.ts
+++ b/backend/src/routes/confluence/spaces.ts
@@ -1,8 +1,10 @@
 import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
 import { query } from '../../core/db/postgres.js';
 import { RedisCache } from '../../core/services/redis-cache.js';
 import { getClientForUser } from '../../domains/confluence/services/sync-service.js';
-import { getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
+import { getUserAccessibleSpaces, userHasPermission } from '../../core/services/rbac-service.js';
+import { logger } from '../../core/utils/logger.js';
 
 export async function spacesRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -16,18 +18,25 @@ export async function spacesRoutes(fastify: FastifyInstance) {
     const cached = await cache.get<unknown[]>(userId, 'spaces', 'list');
     if (cached) return cached;
 
-    // Fetch spaces the user has access to via RBAC from shared spaces
+    // Fetch spaces the user has access to via RBAC from shared spaces.
+    // #352: customHomePageId overrides the Confluence-derived homepage_id
+    // when set — see migration 071. The COALESCE picks the custom page id
+    // first; otherwise the existing JOIN against confluence_id / id
+    // resolves the Confluence default.
     const userSpaces = await getUserAccessibleSpaces(userId);
     const result = await query<{
       space_key: string;
       space_name: string;
       homepage_id: string | null;
       homepage_numeric_id: number | null;
+      custom_home_page_id: number | null;
       last_synced: Date;
       source: string;
     }>(
       `SELECT cs.space_key, cs.space_name, cs.homepage_id,
-              hp.id as homepage_numeric_id, cs.last_synced, cs.source
+              hp.id as homepage_numeric_id,
+              cs.custom_home_page_id,
+              cs.last_synced, cs.source
        FROM spaces cs
        LEFT JOIN pages hp ON (
          hp.confluence_id = cs.homepage_id
@@ -51,7 +60,17 @@ export async function spacesRoutes(fastify: FastifyInstance) {
     const syncedSpaces = result.rows.map((row) => ({
       key: row.space_key,
       name: row.space_name,
-      homepageId: row.homepage_numeric_id ? String(row.homepage_numeric_id) : null,
+      // #352: prefer the custom home page when admin/space-owner has set
+      // one; otherwise fall back to the Confluence-derived homepage. The
+      // wire-format `homepageId` stays a string of the integer pages.id
+      // (matches the existing contract used by frontend/PagesPage.tsx).
+      homepageId:
+        row.custom_home_page_id != null
+          ? String(row.custom_home_page_id)
+          : row.homepage_numeric_id
+            ? String(row.homepage_numeric_id)
+            : null,
+      customHomePageId: row.custom_home_page_id,
       lastSynced: row.last_synced,
       pageCount: counts.get(row.space_key) ?? 0,
       source: row.source as 'confluence' | 'local',
@@ -74,6 +93,80 @@ export async function spacesRoutes(fastify: FastifyInstance) {
 
     await cache.set(userId, 'spaces', 'list', spaces);
     return spaces;
+  });
+
+  // PUT /api/spaces/:key/home — set the custom home page for a space (#352).
+  // Auth model: admin OR `manage` permission on the space (mirrors the
+  // existing space-admin role from the RBAC seed). Empty body / null id
+  // clears the override — the space falls back to the Confluence-derived
+  // home page in the GET /api/spaces response.
+  const HomeBodySchema = z.object({
+    homePageId: z.number().int().positive().nullable(),
+  });
+  const KeyParamSchema = z.object({ key: z.string().min(1).max(255) });
+
+  fastify.put('/spaces/:key/home', async (request, reply) => {
+    const { key } = KeyParamSchema.parse(request.params);
+    const { homePageId } = HomeBodySchema.parse(request.body);
+    const userId = request.userId;
+
+    // Authorisation: system admin or space-level `manage` (the space_admin
+    // system role; see migration 039). userHasPermission returns true for
+    // system_admin via the early-return in rbac-service.ts:112.
+    if (!(await userHasPermission(userId, 'manage', key))) {
+      throw fastify.httpErrors.forbidden(
+        'Setting the space home requires admin or space-owner permission.',
+      );
+    }
+
+    // Reject if the space doesn't exist or isn't accessible to the caller.
+    const accessible = await getUserAccessibleSpaces(userId);
+    if (!accessible.includes(key)) {
+      throw fastify.httpErrors.notFound('Space not found');
+    }
+
+    // If a page id is provided, sanity-check that it exists, isn't deleted,
+    // and lives in this space (or is a standalone page that the user can
+    // read). Without this an admin could pin an inaccessible page as home,
+    // which would surface as a permission error to every viewer.
+    if (homePageId !== null) {
+      const pageCheck = await query<{ space_key: string; source: string; visibility: string | null }>(
+        `SELECT space_key, source, visibility
+         FROM pages
+         WHERE id = $1 AND deleted_at IS NULL`,
+        [homePageId],
+      );
+      if (pageCheck.rows.length === 0) {
+        throw fastify.httpErrors.badRequest('Home page not found');
+      }
+      const row = pageCheck.rows[0]!;
+      const sameSpace = row.space_key === key;
+      const sharedStandalone = row.source === 'standalone' && row.visibility === 'shared';
+      if (!sameSpace && !sharedStandalone) {
+        throw fastify.httpErrors.badRequest(
+          'Home page must live in this space or be a shared standalone page.',
+        );
+      }
+    }
+
+    const result = await query<{ space_key: string }>(
+      `UPDATE spaces SET custom_home_page_id = $1
+       WHERE space_key = $2
+       RETURNING space_key`,
+      [homePageId, key],
+    );
+    if (result.rowCount === 0) {
+      throw fastify.httpErrors.notFound('Space not found');
+    }
+
+    // Invalidate the per-user spaces cache for everyone in the org —
+    // simplest correctness path, the cache is small and rebuilt lazily.
+    await cache.invalidate(userId, 'spaces');
+
+    logger.info({ userId, spaceKey: key, homePageId }, 'Space custom home page updated');
+
+    reply.status(200);
+    return { spaceKey: key, customHomePageId: homePageId };
   });
 
   // GET /api/spaces/available - fetch spaces from Confluence for selection

--- a/backend/src/routes/knowledge/local-spaces.test.ts
+++ b/backend/src/routes/knowledge/local-spaces.test.ts
@@ -89,6 +89,7 @@ describe('Local Spaces Routes', () => {
           icon: 'folder',
           created_by: 'test-user-id',
           created_at: new Date('2026-03-01'),
+          custom_home_page_id: null,
         },
       ],
     });
@@ -109,6 +110,50 @@ describe('Local Spaces Routes', () => {
     expect(body[0].name).toBe('Project Docs');
     expect(body[0].source).toBe('local');
     expect(body[0].pageCount).toBe(5);
+    // #352 (finding 2): homepage fields exposed for the "Show home content"
+    // toggle. With no custom override set, both wire fields are null.
+    expect(body[0].homepageId).toBeNull();
+    expect(body[0].customHomePageId).toBeNull();
+  });
+
+  it('should surface homepageId/customHomePageId when an override is set (#352 finding 2)', async () => {
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [
+        {
+          space_key: 'PROJ',
+          space_name: 'Project Docs',
+          description: null,
+          icon: null,
+          created_by: 'test-user-id',
+          created_at: new Date('2026-03-01'),
+          custom_home_page_id: 999,
+        },
+      ],
+    });
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ space_key: 'PROJ', count: '3' }] });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/spaces/local',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.payload);
+    expect(body[0].homepageId).toBe('999');
+    expect(body[0].customHomePageId).toBe(999);
+  });
+
+  it('SELECTs cs.custom_home_page_id (regression guard for #352 finding 2)', async () => {
+    mockQueryFn.mockResolvedValueOnce({ rows: [] });
+    mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+    await app.inject({ method: 'GET', url: '/api/spaces/local' });
+
+    // The SELECT must include `cs.custom_home_page_id` so the column is
+    // actually returned to JS — without it the response shape silently
+    // drops the field and the frontend toggle can never find a homepage.
+    const listCall = mockQueryFn.mock.calls[0];
+    expect(listCall[0]).toMatch(/cs\.custom_home_page_id/);
   });
 
   it('should return empty array when no local spaces exist', async () => {

--- a/backend/src/routes/knowledge/local-spaces.ts
+++ b/backend/src/routes/knowledge/local-spaces.ts
@@ -57,6 +57,11 @@ export async function localSpacesRoutes(fastify: FastifyInstance) {
     const cached = await cache.get<unknown[]>(userId, 'spaces', cacheKey);
     if (cached) return cached;
 
+    // #352: surface `custom_home_page_id` (and the resolved wire-format
+    // `homepageId`) so the frontend "Show home content" toggle works for
+    // local spaces too — same shape as routes/confluence/spaces.ts. Local
+    // spaces have no Confluence-derived `homepage_id`, so the resolution
+    // collapses to "custom_home_page_id or null".
     const result = await query<{
       space_key: string;
       space_name: string;
@@ -64,9 +69,11 @@ export async function localSpacesRoutes(fastify: FastifyInstance) {
       icon: string | null;
       created_by: string | null;
       created_at: Date | null;
+      custom_home_page_id: number | null;
     }>(
       `SELECT cs.space_key, cs.space_name, cs.description, cs.icon, cs.created_by,
-              cs.last_synced AS created_at
+              cs.last_synced AS created_at,
+              cs.custom_home_page_id
        FROM spaces cs
        WHERE cs.source = 'local'
        ORDER BY cs.space_name`,
@@ -91,6 +98,13 @@ export async function localSpacesRoutes(fastify: FastifyInstance) {
       createdAt: row.created_at,
       pageCount: counts.get(row.space_key) ?? 0,
       source: 'local' as const,
+      // #352: matches the wire format used by GET /api/spaces (Confluence
+      // route). Frontend reads `homepageId` for the "Show home content"
+      // toggle in PagesPage.tsx; `customHomePageId` is exposed for the
+      // admin/space-owner override UI.
+      homepageId:
+        row.custom_home_page_id != null ? String(row.custom_home_page_id) : null,
+      customHomePageId: row.custom_home_page_id,
     }));
 
     await cache.set(userId, 'spaces', cacheKey, spaces);

--- a/docs/architecture/06-data-model.md
+++ b/docs/architecture/06-data-model.md
@@ -24,6 +24,7 @@ erDiagram
     pages ||--o{ page_relationships : "related via"
     pages ||--o{ knowledge_requests : "fulfils"
     pages ||--o{ local_attachments : "owns (standalone pages only)"
+    pages ||--o{ spaces : "is custom home of (#352)"
 
     roles ||--o{ group_memberships : "granted via"
     groups ||--o{ group_memberships : "has"

--- a/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
@@ -138,11 +138,19 @@ describe('SidebarTreeView', () => {
   });
 
   it('positions indent guide at correct depth for nested levels', () => {
+    // #352: pick a space without a homepage so the tree shows all roots.
+    // (With a homepage set the homepage is now hidden — see the dedicated
+    // #352 test below.) Manually expand "Getting Started" by clicking the
+    // chevron (aria-label="Expand") to surface the collapse-affordance
+    // whose left offset we're asserting.
     useUiStore.setState({
       treeSidebarCollapsed: false,
-      treeSidebarSpaceKey: 'DEV',
+      treeSidebarSpaceKey: 'OPS', // OPS has no homepage; tree shows all roots
     });
     render(<SidebarTreeView />, { wrapper: createWrapper() });
+    // Only one root has children (Getting Started → Installation+Configuration)
+    // so there's exactly one "Expand" chevron at this point.
+    fireEvent.click(screen.getByLabelText('Expand'));
     const guide = screen.getByLabelText('Collapse Getting Started');
     // level=0 => left = 0*16+14 = 14px
     expect(guide.style.left).toBe('14px');
@@ -300,16 +308,20 @@ describe('SidebarTreeView', () => {
     expect(hasFolderIcon).toBe(false);
   });
 
-  it('keeps the homepage visible and expands its children when a space with homepageId is selected', () => {
+  it('hides the homepage from the tree but promotes its children + other roots (#352)', () => {
     useUiStore.setState({
       treeSidebarCollapsed: false,
       treeSidebarSpaceKey: 'DEV',
     });
     render(<SidebarTreeView />, { wrapper: createWrapper() });
-    expect(screen.getByText('Getting Started')).toBeInTheDocument();
+    // The homepage itself is hidden — the user reaches it via the dedicated
+    // space "Home" link, not by clicking a tree entry.
+    expect(screen.queryByText('Getting Started')).not.toBeInTheDocument();
+    // Its children are promoted to top-level roots so they remain navigable.
     expect(screen.getByText('Installation')).toBeInTheDocument();
     expect(screen.getByText('Configuration')).toBeInTheDocument();
-    expect(screen.queryByText('API Reference')).not.toBeInTheDocument();
+    // Other roots (siblings of the homepage) stay visible.
+    expect(screen.getByText('API Reference')).toBeInTheDocument();
   });
 
   it('has a New Space button in sidebar header', () => {

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -345,19 +345,6 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
     }
   }, [activePageId, pages]);
 
-  // When a space is scoped to its homepage, keep that homepage expanded so
-  // the homepage remains clickable while its immediate children stay visible.
-  useEffect(() => {
-    if (!homepageId) return;
-
-    setExpandedIds((prev) => {
-      if (prev.has(homepageId)) return prev;
-      const next = new Set(prev);
-      next.add(homepageId);
-      return next;
-    });
-  }, [homepageId]);
-
   // Auto-select space based on current page
   useEffect(() => {
     if (activePageId && pages.length > 0 && !treeSidebarSpaceKey) {

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -60,12 +60,19 @@ function buildTree(pages: PageTreeItem[], homepageId?: string | null): TreeNode[
   }
   sortChildren(roots);
 
-  // If homepageId is provided, keep the homepage itself as the visible root
-  // so it remains clickable as a tree entry.
+  // #352: when a homepage is configured for the space, hide it from the
+  // sidebar tree — it's reachable via the dedicated "Home" link at the top
+  // of the space view, so showing it again in the tree wastes a slot. Its
+  // children are promoted to top-level roots so the rest of the tree
+  // remains navigable.
   if (homepageId) {
     const homepageNode = nodeMap.get(homepageId);
     if (homepageNode) {
-      return [homepageNode];
+      const promoted = homepageNode.children;
+      const withoutHomepage = roots.filter((r) => r.page.id !== homepageId);
+      return [...promoted, ...withoutHomepage].sort((a, b) =>
+        a.page.title.localeCompare(b.page.title),
+      );
     }
   }
 

--- a/frontend/src/shared/hooks/use-spaces.ts
+++ b/frontend/src/shared/hooks/use-spaces.ts
@@ -5,6 +5,8 @@ interface Space {
   key: string;
   name: string;
   homepageId: string | null;
+  /** #352: admin/space-owner override of the Confluence-derived homepage. */
+  customHomePageId?: number | null;
   lastSynced: string | null;
   pageCount: number;
   source: 'confluence' | 'local';

--- a/packages/contracts/src/schemas/spaces.ts
+++ b/packages/contracts/src/schemas/spaces.ts
@@ -6,6 +6,14 @@ export const SpaceSchema = z.object({
   spaceName: z.string(),
   description: z.string().nullable(),
   homepageId: z.string().nullable(),
+  /**
+   * #352 (AC-4): admin/space-owner override of the Confluence-derived
+   * homepage. Persisted as `spaces.custom_home_page_id` (FK → pages.id);
+   * exposed on the wire as a number or null. When non-null, the
+   * `homepageId` field above is the stringified form of this value;
+   * otherwise it falls back to the Confluence-derived home page.
+   */
+  customHomePageId: z.number().nullable().optional(),
   lastSynced: z.string().nullable(),
   pageCount: z.number().optional(),
 });


### PR DESCRIPTION
## Summary
Three-in-one fix for the space home page:

### 1. Settable home
Was: only the Confluence-derived `space.homepage` was usable. Migration 071 adds `spaces.custom_home_page_id INTEGER REFERENCES pages(id) ON DELETE SET NULL` so admins or space owners can override the Confluence default — including pointing at a folder or shared standalone page.

### 2. Auth model
`PUT /api/spaces/:key/home` is gated on the existing `userHasPermission('manage', spaceKey)` check. That returns true for system admins (early-return in `rbac-service.ts:112`) and for anyone holding the `space_admin` system role on this space (direct or via group). RBAC seed from migration 039 covers the "space owner" case without a new concept. Page-existence and same-space-or-shared-standalone checks reject smuggling an inaccessible page as home.

### 3. Hidden in nav
Was: configured home appeared as its own tree entry, wasting a slot. `buildTree` now drops the homepage from the visible roots and promotes its children to top-level so the rest of the tree stays navigable. The home stays reachable via the dedicated space "Home" link.

`GET /api/spaces` returns the resolved home as before — `homepageId` now prefers `custom_home_page_id` when set, else falls back to the Confluence-derived id. New `customHomePageId` field surfaces the raw override for the eventual settings UI.

## Out of scope (deferred follow-up)
**The home picker UI in space settings.** Backend + data layer ship now; the picker is a focused follow-up that hits the existing PUT endpoint. Issue #352 is partially closed by this PR — the "settable home" half — and the open piece is just the UI to call PUT.

Closes part of #352 · architecture diagram updated (CLAUDE.md rule 6)

## Test plan
- [x] backend spaces suite: 8/8 (GET shape, override visibility, PUT 403/200/400/null/404)
- [x] frontend SidebarTreeView suite: 53/53 (homepage hidden + children promoted + other roots visible)
- [x] backend + frontend typecheck clean
- [ ] manual: as space-admin user, call `PUT /api/spaces/MYKEY/home` with `{ homePageId: N }` → confirm 200 + GET reflects custom id
- [ ] manual: as plain user, same call → confirm 403
- [ ] manual: with custom home configured, navigate to that space → confirm home page no longer appears as a tree entry but is reachable via the Home link

🤖 Generated with [Claude Code](https://claude.com/claude-code)