### PR TITLE
feat(#361): graph perf Phase 3 — per-hop cap + tiered threshold

### DIFF
--- a/backend/src/routes/knowledge/pages-embeddings.ts
+++ b/backend/src/routes/knowledge/pages-embeddings.ts
@@ -15,9 +15,25 @@ const GraphQuerySchema = z.object({
 
 const LocalGraphQuerySchema = z.object({
   hops: z.coerce.number().int().min(1).max(3).default(2),
+  // #361 Phase 3: per-hop neighbor cap on the recursive BFS so a 3-hop
+  // expansion can't pull most of a 2000-page corpus. Defaults to 50 which
+  // is comfortable for a 1-2-hop ego graph; admins/power users can raise it
+  // when targeted exploration is needed.
+  perHopLimit: z.coerce.number().int().min(1).max(500).default(50),
 });
 
 const IdParamSchema = z.object({ id: z.string().min(1) });
+
+// #361 Phase 3: read-time similarity-score floor tiered by corpus size.
+// The producer-side threshold stays low (0.4) so we don't lose data; the
+// read filter trims the rendered set to keep the graph readable on big
+// corpora. Source-of-truth comment in `embedding-service.ts:842`.
+function tieredMinScoreForCorpus(pagesTotal: number): number {
+  if (pagesTotal < 500) return 0.4;
+  if (pagesTotal < 2000) return 0.6;
+  return 0.7;
+}
+export const __testHelpers = { tieredMinScoreForCorpus };
 
 export async function pagesEmbeddingRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -98,7 +114,13 @@ export async function pagesEmbeddingRoutes(fastify: FastifyInstance) {
     // Build a set of accessible node IDs to filter edges
     const nodeIdSet = new Set(nodesResult.rows.map((r) => r.id));
 
-    // Fetch pre-computed relationships as edges, filtered to accessible nodes
+    // Fetch pre-computed relationships as edges, filtered to accessible nodes.
+    // #361 Phase 3: tier the read-time similarity-score floor by corpus size
+    // so large knowledge bases stay readable. Producer-side threshold stays
+    // low (0.4) so the underlying data is not lossy. Non-similarity edge
+    // types (label_overlap, explicit_link, parent_child) bypass the score
+    // floor since their score=1.0 is meaningful, not similarity-derived.
+    const minScoreFloor = tieredMinScoreForCorpus(nodesResult.rows.length);
     const edgesResult = await query<{
       page_id_1: number;
       page_id_2: number;
@@ -108,8 +130,9 @@ export async function pagesEmbeddingRoutes(fastify: FastifyInstance) {
       `SELECT pr.page_id_1, pr.page_id_2, pr.relationship_type, pr.score
        FROM page_relationships pr
        WHERE pr.page_id_1 = ANY($1::int[]) AND pr.page_id_2 = ANY($1::int[])
+         AND (pr.relationship_type <> 'embedding_similarity' OR pr.score >= $2)
        ORDER BY pr.score DESC`,
-      [Array.from(nodeIdSet)],
+      [Array.from(nodeIdSet), minScoreFloor],
     );
 
     const nodes = nodesResult.rows.map((row) => ({
@@ -162,7 +185,7 @@ export async function pagesEmbeddingRoutes(fastify: FastifyInstance) {
   fastify.get('/pages/:id/graph/local', async (request) => {
     const userId = request.userId;
     const { id } = IdParamSchema.parse(request.params);
-    const { hops } = LocalGraphQuerySchema.parse(request.query);
+    const { hops, perHopLimit } = LocalGraphQuerySchema.parse(request.query);
 
     // Resolve to integer page ID
     const isNumericId = /^\d+$/.test(id);
@@ -185,25 +208,29 @@ export async function pagesEmbeddingRoutes(fastify: FastifyInstance) {
       return { nodes: [], edges: [], centerId: String(centerPageId) };
     }
 
-    // Find connected page IDs within N hops via recursive CTE on page_relationships
+    // Find connected page IDs within N hops via recursive CTE on
+    // page_relationships. #361 Phase 3: cap each hop at $3 neighbours so a
+    // 3-hop expansion can't pull most of a 2000-page corpus. Higher-score
+    // edges are preferred via ORDER BY pr.score DESC inside LATERAL.
     const neighborResult = await query<{ page_id: number; hop: number }>(
       `WITH RECURSIVE neighbors AS (
          SELECT $1::int AS page_id, 0 AS hop
          UNION
-         SELECT CASE
-           WHEN pr.page_id_1 = n.page_id THEN pr.page_id_2
-           ELSE pr.page_id_1
-         END AS page_id,
-         n.hop + 1 AS hop
+         SELECT next.page_id, n.hop + 1 AS hop
          FROM neighbors n
-         JOIN page_relationships pr
-           ON pr.page_id_1 = n.page_id OR pr.page_id_2 = n.page_id
+         CROSS JOIN LATERAL (
+           SELECT CASE WHEN pr.page_id_1 = n.page_id THEN pr.page_id_2 ELSE pr.page_id_1 END AS page_id
+           FROM page_relationships pr
+           WHERE (pr.page_id_1 = n.page_id OR pr.page_id_2 = n.page_id)
+           ORDER BY pr.score DESC
+           LIMIT $3
+         ) next
          WHERE n.hop < $2
        )
        SELECT DISTINCT page_id, MIN(hop) AS hop
        FROM neighbors
        GROUP BY page_id`,
-      [centerPageId, hops],
+      [centerPageId, hops, perHopLimit],
     );
 
     const neighborIds = neighborResult.rows.map((r) => r.page_id);

--- a/backend/src/routes/knowledge/pages-graph.test.ts
+++ b/backend/src/routes/knowledge/pages-graph.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vites
 import Fastify from 'fastify';
 import sensible from '@fastify/sensible';
 import { ZodError } from 'zod';
-import { pagesEmbeddingRoutes } from './pages-embeddings.js';
+import { pagesEmbeddingRoutes, __testHelpers } from './pages-embeddings.js';
 import { getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
 
 // Track cache set calls to verify TTL
@@ -624,6 +624,27 @@ describe('Knowledge Graph API', () => {
       expect(edgesCall![1]![1]).toBe(0.4);
     });
 
+    it('applies a 0.6 floor in the 500–1999 medium-corpus tier', async () => {
+      // Use 750 (mid-range medium tier) to assert the 0.6 floor binding.
+      const mediumNodes = Array.from({ length: 750 }, (_, i) => ({
+        id: i + 1,
+        confluence_id: `p-${i + 1}`,
+        space_key: 'DEV',
+        title: `Page ${i + 1}`,
+        labels: [],
+        embedding_status: 'embedded',
+        last_modified_at: new Date(),
+        parent_id: null,
+      }));
+      mockQueryFn.mockResolvedValueOnce({ rows: mediumNodes });
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      await app.inject({ method: 'GET', url: '/api/pages/graph' });
+      const edgesCall = mockQueryFn.mock.calls[2];
+      expect(edgesCall![1]![1]).toBe(0.6);
+    });
+
     it('applies a 0.7 floor at >= 2000 pages (large-corpus tier)', async () => {
       const bigNodes = Array.from({ length: 2000 }, (_, i) => ({
         id: i + 1,
@@ -642,6 +663,30 @@ describe('Knowledge Graph API', () => {
       await app.inject({ method: 'GET', url: '/api/pages/graph' });
       const edgesCall = mockQueryFn.mock.calls[2];
       expect(edgesCall![1]![1]).toBe(0.7);
+    });
+  });
+
+  // Direct unit tests for the tier function. These exercise the boundary
+  // conditions in isolation (no Fastify, no mocks, no DB) and are the
+  // reason `__testHelpers` is exported from `pages-embeddings.ts`.
+  describe('tieredMinScoreForCorpus — boundary unit tests (#361)', () => {
+    const { tieredMinScoreForCorpus } = __testHelpers;
+
+    it('returns 0.4 for empty / very small corpora', () => {
+      expect(tieredMinScoreForCorpus(0)).toBe(0.4);
+      expect(tieredMinScoreForCorpus(1)).toBe(0.4);
+      expect(tieredMinScoreForCorpus(499)).toBe(0.4);
+    });
+
+    it('returns 0.6 across the 500–1999 medium tier (boundary inclusive)', () => {
+      expect(tieredMinScoreForCorpus(500)).toBe(0.6); // lower boundary
+      expect(tieredMinScoreForCorpus(1000)).toBe(0.6);
+      expect(tieredMinScoreForCorpus(1999)).toBe(0.6); // upper boundary
+    });
+
+    it('returns 0.7 at the 2000 large-tier boundary and above', () => {
+      expect(tieredMinScoreForCorpus(2000)).toBe(0.7); // boundary
+      expect(tieredMinScoreForCorpus(50_000)).toBe(0.7);
     });
   });
 });

--- a/backend/src/routes/knowledge/pages-graph.test.ts
+++ b/backend/src/routes/knowledge/pages-graph.test.ts
@@ -550,4 +550,98 @@ describe('Knowledge Graph API', () => {
       expect(mockComputePageRelationships).toHaveBeenCalledWith();
     });
   });
+
+  // ---------- #361 Phase 3: per-hop cap + tiered threshold ----------
+
+  describe('GET /api/pages/:id/graph/local — perHopLimit (#361)', () => {
+    it('forwards the perHopLimit query param into the recursive CTE', async () => {
+      // page lookup
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ id: 1, space_key: 'DEV' }] });
+      // neighbours BFS
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ page_id: 1, hop: 0 }] });
+      // node fetch
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+      // embedding count
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+      // edges
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/pages/1/graph/local?hops=2&perHopLimit=20',
+      });
+      expect(response.statusCode).toBe(200);
+
+      // The 2nd query is the BFS — its $3 binding should be the requested cap.
+      const bfsCall = mockQueryFn.mock.calls[1];
+      expect(bfsCall![1]).toEqual([1, 2, 20]);
+      // The CTE should use a CROSS JOIN LATERAL with LIMIT $3 to actually cap.
+      const sql = bfsCall![0] as string;
+      expect(sql).toContain('CROSS JOIN LATERAL');
+      expect(sql).toContain('LIMIT $3');
+    });
+
+    it('defaults perHopLimit to 50 when omitted', async () => {
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ id: 1, space_key: 'DEV' }] });
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      await app.inject({ method: 'GET', url: '/api/pages/1/graph/local' });
+      expect(mockQueryFn.mock.calls[1]![1]).toEqual([1, 2, 50]);
+    });
+
+    it('rejects perHopLimit > 500', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/pages/1/graph/local?perHopLimit=10000',
+      });
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe('GET /api/pages/graph — tiered similarity threshold (#361)', () => {
+    it('applies a 0.4 floor at < 500 pages (small-corpus tier)', async () => {
+      const smallNodes = Array.from({ length: 10 }, (_, i) => ({
+        id: i + 1,
+        confluence_id: `p-${i + 1}`,
+        space_key: 'DEV',
+        title: `Page ${i + 1}`,
+        labels: [],
+        embedding_status: 'embedded',
+        last_modified_at: new Date(),
+        parent_id: null,
+      }));
+      mockQueryFn.mockResolvedValueOnce({ rows: smallNodes }); // nodes
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });          // embeddings
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });          // edges
+
+      const response = await app.inject({ method: 'GET', url: '/api/pages/graph' });
+      expect(response.statusCode).toBe(200);
+      // 3rd call is the edges query; $2 is the score floor.
+      const edgesCall = mockQueryFn.mock.calls[2];
+      expect(edgesCall![1]![1]).toBe(0.4);
+    });
+
+    it('applies a 0.7 floor at >= 2000 pages (large-corpus tier)', async () => {
+      const bigNodes = Array.from({ length: 2000 }, (_, i) => ({
+        id: i + 1,
+        confluence_id: `p-${i + 1}`,
+        space_key: 'DEV',
+        title: `Page ${i + 1}`,
+        labels: [],
+        embedding_status: 'embedded',
+        last_modified_at: new Date(),
+        parent_id: null,
+      }));
+      mockQueryFn.mockResolvedValueOnce({ rows: bigNodes });
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      await app.inject({ method: 'GET', url: '/api/pages/graph' });
+      const edgesCall = mockQueryFn.mock.calls[2];
+      expect(edgesCall![1]![1]).toBe(0.7);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Phase 3 (low-risk, no new deps, no renderer decision required) of the performance work. Phases 1 (synthetic benchmark) and 2 (server-side ForceAtlas2 in `worker_threads` / BullMQ) are deferred — they need real-corpus measurements to drive the decision and benefit from shipping these caps first.

### Per-hop neighbor cap on `/graph/local`
Replaces the unbounded JOIN inside the recursive CTE with a `CROSS JOIN LATERAL ... LIMIT $3` on each BFS step, ordered by `score DESC`. Without this cap, a 3-hop expansion at a popular node in a 2000-page corpus could pull most of the corpus through the recursion. New `perHopLimit` query param (default 50, max 500) lets power users widen the search when they want targeted exploration.

### Tiered read-time similarity threshold
Producer-side threshold stays at 0.4 (data integrity — don't lose edges we may want later). At read time, `/pages/graph` applies a corpus-size-tiered floor:

| Pages | Floor |
|---|---|
| `<500` | 0.4 (small-corpus tier; no thinning) |
| `500–1999` | 0.6 (medium tier) |
| `>=2000` | 0.7 (large tier — research-recommended, prevents hairball) |

Non-similarity edges (label_overlap, explicit_link, parent_child) bypass the floor since their `score=1.0` is meaningful, not similarity-derived.

## Out of scope (next up)
- Synthetic benchmark script (`scripts/perf-graph-bench.ts`) at 500 / 1000 / 2000 / 5000 nodes — needs Playwright + FPS sampling.
- Server-side `graphology` + `graphology-layout-forceatlas2` in `worker_threads` or BullMQ so the layout cost moves off the request path; new `page_graph_layout (page_id, x, y)` table.
- Renderer decision (sigma.js v3 vs stay on react-force-graph-2d) — measurement-driven, not assumed.

Closes part of #361 · Phases 1 + 2 tracked separately

## Test plan
- [x] backend graph-route suite: 18/18 (5 new for #361)
- [x] perHopLimit forwarded into BFS as $3 binding; default 50; rejects values >500
- [x] tiered floor: 0.4 at 10-page corpus, 0.7 at 2000-page corpus
- [x] backend typecheck clean
- [ ] manual: open `/graph?focus=:id` and confirm /graph/local response shape unchanged at default `perHopLimit=50`

🤖 Generated with [Claude Code](https://claude.com/claude-code)