### PR TITLE
fix(test): eliminate webhook-outbox-poller ioredis flake

### DIFF
--- a/backend/src/core/services/webhook-outbox-poller.test.ts
+++ b/backend/src/core/services/webhook-outbox-poller.test.ts
@@ -494,6 +494,17 @@ describe.skipIf(!canRun)('webhook-outbox-poller', () => {
       // subsequent tests still have a working queue handle.
       const fresh = getWebhookDeliveryQueue();
       expect(fresh).toBeInstanceOf(Queue);
+
+      // Wait for the rebuilt queue's ioredis client + subscriber connections
+      // to fully establish before we close them. Otherwise `afterAll`'s
+      // `__closeWebhookDeliveryQueueForTests()` races against in-flight
+      // ioredis handshake commands and the close handler rejects them with
+      // `Error: Connection is closed.` — which surfaces as an unhandled
+      // rejection that fails the whole vitest run (see Compendiq/compendiq-ce
+      // PRs #365, #373, #377). Owning the cleanup inside the test that
+      // built the queue eliminates the race entirely.
+      await fresh.waitUntilReady();
+      await __closeWebhookDeliveryQueueForTests();
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes a vitest×BullMQ×ioredis lifecycle race in `webhook-outbox-poller.test.ts` that was emitting an unhandled `Error: Connection is closed.` after the test file completed, failing CI on PRs #365, #373, and #377.

## Root cause

The `runs recovery sweep at init and returns an idempotent teardown` test (around L467–L497) verifies that the module-level webhook delivery queue can be **rebuilt** after teardown:

```ts
await teardown();              // closes original deliveryQueue
await teardown();              // idempotent
const fresh = getWebhookDeliveryQueue();   // rebuilds — opens 2 ioredis connections
expect(fresh).toBeInstanceOf(Queue);
// test ends here — fresh is left mid-handshake
```

The rebuilt queue is then closed by `afterAll()` via `__closeWebhookDeliveryQueueForTests()` (L182–L195). But by that point ioredis has just opened its **client + subscriber** connections internally and they are still mid-handshake — `Queue#close()` races the in-flight commands, the close handler rejects them with `Error: Connection is closed.` (stack: `node_modules/ioredis/built/redis/event_handler.js:214:25`), and the rejection escapes as unhandled.

The race only became consistently observable once the total test-file count crossed ~170 — added test parallelism tightens the timing window enough that the rebuilt queue's two ioredis sockets aren't both connected before `afterAll()` fires.

## Fix

Own the cleanup of the rebuilt queue **inside the test that built it**:

1. `await fresh.waitUntilReady()` — wait for both ioredis connections (client + subscriber) to finish handshaking. `waitUntilReady()` is inherited from BullMQ's `QueueBase` (verified against `bullmq@5.74.1` `dist/esm/classes/queue-base.d.ts:58`).
2. `await __closeWebhookDeliveryQueueForTests()` — close the rebuilt queue while we still own the timing.

By the time `afterAll()` runs, `deliveryQueue === null` and there is no rebuilt queue to close, so the race is gone.

The change is localised — 11 added lines, all inside the one offending test — and does not alter the assertions the test makes (`expect(fresh).toBeInstanceOf(Queue)` still runs).

## Why this is the right fix (not a workaround)

The assertion exists to verify the singleton can be re-instantiated after teardown. After we've verified that, the half-constructed queue has no remaining purpose in the test — leaving it alive for `afterAll()` to close racily is the bug. Owning cleanup at the same scope as construction is the standard fix for this class of vitest+BullMQ lifecycle race.

## Verification

- TypeScript: `npm run typecheck -w backend` — clean.
- ESLint: `npx eslint src/core/services/webhook-outbox-poller.test.ts` — clean.
- Scoped vitest: `npm test -w backend src/core/services/webhook-outbox-poller.test.ts` — file imports cleanly; tests skip locally because Redis isn't reachable on this dev box (the suite has its own `describe.skipIf(!canRun)` guard for environments without Postgres+Redis). Real validation will land via CI on this PR, where Redis is available.
- No other tests in the suite import `getWebhookDeliveryQueue` or `__closeWebhookDeliveryQueueForTests`, so blast radius is limited to this file (`grep -r 'getWebhookDeliveryQueue\|__closeWebhookDeliveryQueueForTests' backend/src --include='*.test.ts'`).

## Unblocks

- Compendiq/compendiq-ce#365
- Compendiq/compendiq-ce#373
- Compendiq/compendiq-ce#377

## Test plan

- [ ] CI green on this PR (proves the unhandled rejection is gone with Redis present)
- [ ] Re-run CI on #365, #373, #377 after merge — flake should not recur