### PR TITLE
fix(llm-providers): allowlist private-network base URLs before SSRF check

### DIFF
--- a/backend/src/routes/llm/llm-providers.test.ts
+++ b/backend/src/routes/llm/llm-providers.test.ts
@@ -268,6 +268,74 @@ describe.skipIf(!dbAvailable)('SSRF guard — private-network base URLs accepted
     // The shared origin is still owned by Shared-A — must remain allowlisted.
     expect(() => validateUrl('http://10.0.0.70/v1')).not.toThrow();
   });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // INFO #5: PATCH revoke-on-failure paths now have explicit coverage.
+  // The route does `await revokeAllowlistIfUnused(patch.baseUrl)` in three
+  // branches (catch-on-validate, catch-on-updateProvider, 404-not-found);
+  // only the validate branch was implicitly covered by inspection of POST.
+  // The two tests below pin the remaining branches so a regression that
+  // dropped the revoke from either branch would be caught here.
+  // ──────────────────────────────────────────────────────────────────────
+
+  it('PATCH against a non-existent provider id returns 404 and revokes the speculative allowlist entry', async () => {
+    const { validateUrl, SsrfError } = await import('../../core/utils/ssrf-guard.js');
+
+    // No DB row exists at this UUID — `updateProvider` returns undefined,
+    // taking the `if (!updated) … 404` branch.
+    const r = await app.inject({
+      method: 'PATCH',
+      url: '/api/admin/llm-providers/00000000-0000-4000-8000-000000000000',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({ baseUrl: 'http://10.0.0.99/v1' }),
+    });
+    expect(r.statusCode).toBe(404);
+
+    // The 404 branch must call `revokeAllowlistIfUnused(patch.baseUrl)`.
+    // Nothing else references this origin, so the allowlist entry should
+    // be revoked and `validateUrl` should fall back to the SSRF block.
+    expect(() => validateUrl('http://10.0.0.99/v1')).toThrow(SsrfError);
+  });
+
+  it('PATCH name collision (updateProvider throws) revokes the speculative allowlist entry', async () => {
+    const { validateUrl, SsrfError } = await import('../../core/utils/ssrf-guard.js');
+
+    // Seed two distinct providers with distinct names + non-overlapping origins.
+    const a = await app.inject({
+      method: 'POST', url: '/api/admin/llm-providers',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({ name: 'Throw-A', baseUrl: 'http://10.0.0.80/v1', authType: 'none', verifySsl: true }),
+    });
+    expect(a.statusCode).toBe(201);
+    const b = await app.inject({
+      method: 'POST', url: '/api/admin/llm-providers',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({ name: 'Throw-B', baseUrl: 'http://10.0.0.81/v1', authType: 'none', verifySsl: true }),
+    });
+    expect(b.statusCode).toBe(201);
+
+    // PATCH B's name to collide with A's, and at the same time bring in a
+    // brand-new baseUrl (origin http://10.0.0.82) so the speculative
+    // allowlist entry is observable. `updateProvider` will throw on the
+    // unique-name constraint — taking the catch-on-updateProvider branch.
+    const fail = await app.inject({
+      method: 'PATCH',
+      url: `/api/admin/llm-providers/${b.json().id}`,
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({ name: 'Throw-A', baseUrl: 'http://10.0.0.82/v1' }),
+    });
+    expect(fail.statusCode).toBeGreaterThanOrEqual(400);
+
+    // The catch branch must revoke the speculative allowlist entry —
+    // nothing references the new origin, so it should be revoked.
+    expect(() => validateUrl('http://10.0.0.82/v1')).toThrow(SsrfError);
+    // Provider A's original origin must be untouched.
+    expect(() => validateUrl('http://10.0.0.80/v1')).not.toThrow();
+    // Provider B's original origin must also be untouched (the throw
+    // happens AFTER `previous` is captured but BEFORE the GC-on-success
+    // path runs, so the previous origin stays allowlisted).
+    expect(() => validateUrl('http://10.0.0.81/v1')).not.toThrow();
+  });
 });
 
 describe.skipIf(!dbAvailable)('DELETE race conditions return 409 (not 500)', () => {

--- a/backend/src/routes/llm/llm-providers.test.ts
+++ b/backend/src/routes/llm/llm-providers.test.ts
@@ -149,7 +149,9 @@ describe.skipIf(!dbAvailable)('SSRF guard — private-network base URLs accepted
     expect(r.json().baseUrl).toBe('http://10.0.0.5:1234/v1');
   });
 
-  it('POST with duplicate name revokes the speculative allowlist entry', async () => {
+  it('POST with duplicate name revokes the speculative allowlist entry (verified directly)', async () => {
+    const { validateUrl, SsrfError } = await import('../../core/utils/ssrf-guard.js');
+
     // Seed the row that will collide.
     await app.inject({
       method: 'POST', url: '/api/admin/llm-providers',
@@ -157,20 +159,114 @@ describe.skipIf(!dbAvailable)('SSRF guard — private-network base URLs accepted
       payload: JSON.stringify({ name: 'Dup', baseUrl: 'http://10.0.0.10/v1', authType: 'none', verifySsl: true }),
     });
     // Second POST: same unique name, different (private) baseUrl. The DB
-    // unique-constraint should fail and the route should propagate that.
+    // unique-constraint will fail; the route revokes the speculative
+    // allowlist entry IFF no other provider references it.
     const r = await app.inject({
       method: 'POST', url: '/api/admin/llm-providers',
       headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
       payload: JSON.stringify({ name: 'Dup', baseUrl: 'http://10.0.0.99/v1', authType: 'none', verifySsl: true }),
     });
-    // Either a 4xx or 500 — what we ASSERT here is that no row was created,
-    // so the speculative allowlist entry was revoked (otherwise it'd be a
-    // dangling allowlist over a non-existent provider).
     expect(r.statusCode).toBeGreaterThanOrEqual(400);
-    const list = await query<{ count: string }>(
-      "SELECT count(*)::text AS count FROM llm_providers WHERE base_url = 'http://10.0.0.99/v1'",
-    );
-    expect(list.rows[0]!.count).toBe('0');
+
+    // Direct allowlist assertion: validateUrl on the failed origin must now
+    // throw (allowlist was revoked). Without this, a row-count check could
+    // pass even if revoke logic broke.
+    expect(() => validateUrl('http://10.0.0.99/v1')).toThrow(SsrfError);
+  });
+
+  it('failed POST does NOT revoke the allowlist of a concurrent successful sibling for the same origin', async () => {
+    const { validateUrl } = await import('../../core/utils/ssrf-guard.js');
+
+    // First POST succeeds with origin http://10.0.0.50:1234.
+    const ok = await app.inject({
+      method: 'POST', url: '/api/admin/llm-providers',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({
+        name: 'Sibling-A',
+        baseUrl: 'http://10.0.0.50:1234/v1',
+        authType: 'none', verifySsl: true,
+      }),
+    });
+    expect(ok.statusCode).toBe(201);
+
+    // Second POST: SAME baseUrl, different name that we'll force to fail
+    // by re-using a unique name from the first row. Repurpose: collide on
+    // 'Sibling-A' to trigger the unique-name failure path.
+    const fail = await app.inject({
+      method: 'POST', url: '/api/admin/llm-providers',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({
+        name: 'Sibling-A', // duplicate → fails
+        baseUrl: 'http://10.0.0.50:1234/v2', // same origin, different path
+        authType: 'none', verifySsl: true,
+      }),
+    });
+    expect(fail.statusCode).toBeGreaterThanOrEqual(400);
+
+    // Critical assertion: the allowlist for the SHARED origin must STILL
+    // be present (Sibling-A still owns it). The naïve revoke would have
+    // stripped it.
+    expect(() => validateUrl('http://10.0.0.50:1234/v1')).not.toThrow();
+  });
+
+  it('PATCH that changes baseUrl revokes the old origin when nothing else references it', async () => {
+    const { validateUrl, SsrfError } = await import('../../core/utils/ssrf-guard.js');
+
+    const create = await app.inject({
+      method: 'POST', url: '/api/admin/llm-providers',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({
+        name: 'Migrate',
+        baseUrl: 'http://10.0.0.60/v1',
+        authType: 'none', verifySsl: true,
+      }),
+    });
+    expect(create.statusCode).toBe(201);
+    const { id } = create.json();
+
+    // Pre-condition: old origin is allowlisted.
+    expect(() => validateUrl('http://10.0.0.60/v1')).not.toThrow();
+
+    const patch = await app.inject({
+      method: 'PATCH', url: `/api/admin/llm-providers/${id}`,
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({ baseUrl: 'http://10.0.0.61/v1' }),
+    });
+    expect(patch.statusCode).toBe(200);
+
+    // New origin allowlisted, OLD origin garbage-collected because no
+    // surviving row references it.
+    expect(() => validateUrl('http://10.0.0.61/v1')).not.toThrow();
+    expect(() => validateUrl('http://10.0.0.60/v1')).toThrow(SsrfError);
+  });
+
+  it('PATCH baseUrl change does NOT revoke the old origin when another provider still uses it', async () => {
+    const { validateUrl } = await import('../../core/utils/ssrf-guard.js');
+
+    // Two providers share origin http://10.0.0.70.
+    const a = await app.inject({
+      method: 'POST', url: '/api/admin/llm-providers',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({ name: 'Shared-A', baseUrl: 'http://10.0.0.70/v1', authType: 'none', verifySsl: true }),
+    });
+    expect(a.statusCode).toBe(201);
+    const b = await app.inject({
+      method: 'POST', url: '/api/admin/llm-providers',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({ name: 'Shared-B', baseUrl: 'http://10.0.0.70/v2', authType: 'none', verifySsl: true }),
+    });
+    expect(b.statusCode).toBe(201);
+
+    // Migrate B away from the shared origin. A should still keep it allowlisted.
+    const patch = await app.inject({
+      method: 'PATCH', url: `/api/admin/llm-providers/${b.json().id}`,
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({ baseUrl: 'http://10.0.0.71/v1' }),
+    });
+    expect(patch.statusCode).toBe(200);
+
+    // The shared origin is still owned by Shared-A — must remain allowlisted.
+    expect(() => validateUrl('http://10.0.0.70/v1')).not.toThrow();
   });
 });
 

--- a/backend/src/routes/llm/llm-providers.test.ts
+++ b/backend/src/routes/llm/llm-providers.test.ts
@@ -90,13 +90,19 @@ describe.skipIf(!dbAvailable)('GET /api/admin/llm-providers', () => {
   });
 });
 
-describe.skipIf(!dbAvailable)('SSRF guard returns 400 (not 500)', () => {
+describe.skipIf(!dbAvailable)('SSRF guard — private-network base URLs accepted (LM Studio / Ollama / on-prem vLLM)', () => {
+  // The original SSRF block-list rejected loopback / RFC-1918 base URLs at
+  // POST/PATCH time, which made on-prem and LAN LLM endpoints unreachable
+  // from the admin UI (the Confluence settings flow already handled this
+  // correctly by allowlisting BEFORE validating). These tests pin the new
+  // ordering: allowlist → validate → write. Protocol restrictions remain
+  // (Zod accepts only http/https; non-HTTP protocols never reach the route).
   beforeEach(async () => {
     await truncateAllTables();
     ({ token: adminToken } = await createAdminAndLogin());
   });
 
-  it('POST with loopback baseUrl returns 400 with SSRF error message', async () => {
+  it('POST with loopback baseUrl is now accepted and allowlisted', async () => {
     const r = await app.inject({
       method: 'POST', url: '/api/admin/llm-providers',
       headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
@@ -107,13 +113,26 @@ describe.skipIf(!dbAvailable)('SSRF guard returns 400 (not 500)', () => {
         verifySsl: true,
       }),
     });
-    expect(r.statusCode).toBe(400);
-    expect(r.json().error).toMatch(/ssrf/i);
-    // Stack trace must not leak in the response body
-    expect(JSON.stringify(r.json())).not.toMatch(/at .+\.ts:\d+/);
+    expect(r.statusCode).toBe(201);
+    expect(r.json()).toMatchObject({ name: 'Loopback', baseUrl: 'http://127.0.0.1/v1' });
   });
 
-  it('PATCH with loopback baseUrl returns 400 with SSRF error message', async () => {
+  it('POST with RFC-1918 baseUrl is accepted and allowlisted', async () => {
+    const r = await app.inject({
+      method: 'POST', url: '/api/admin/llm-providers',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({
+        name: 'LM Studio (LAN)',
+        baseUrl: 'http://192.168.178.185:1234/v1',
+        authType: 'none',
+        verifySsl: true,
+      }),
+    });
+    expect(r.statusCode).toBe(201);
+    expect(r.json()).toMatchObject({ baseUrl: 'http://192.168.178.185:1234/v1' });
+  });
+
+  it('PATCH from public to RFC-1918 baseUrl is accepted', async () => {
     const create = await app.inject({
       method: 'POST', url: '/api/admin/llm-providers',
       headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
@@ -124,10 +143,34 @@ describe.skipIf(!dbAvailable)('SSRF guard returns 400 (not 500)', () => {
     const r = await app.inject({
       method: 'PATCH', url: `/api/admin/llm-providers/${id}`,
       headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
-      payload: JSON.stringify({ baseUrl: 'http://127.0.0.1/v1' }),
+      payload: JSON.stringify({ baseUrl: 'http://10.0.0.5:1234/v1' }),
     });
-    expect(r.statusCode).toBe(400);
-    expect(r.json().error).toMatch(/ssrf/i);
+    expect(r.statusCode).toBe(200);
+    expect(r.json().baseUrl).toBe('http://10.0.0.5:1234/v1');
+  });
+
+  it('POST with duplicate name revokes the speculative allowlist entry', async () => {
+    // Seed the row that will collide.
+    await app.inject({
+      method: 'POST', url: '/api/admin/llm-providers',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({ name: 'Dup', baseUrl: 'http://10.0.0.10/v1', authType: 'none', verifySsl: true }),
+    });
+    // Second POST: same unique name, different (private) baseUrl. The DB
+    // unique-constraint should fail and the route should propagate that.
+    const r = await app.inject({
+      method: 'POST', url: '/api/admin/llm-providers',
+      headers: { authorization: `Bearer ${adminToken}`, 'content-type': 'application/json' },
+      payload: JSON.stringify({ name: 'Dup', baseUrl: 'http://10.0.0.99/v1', authType: 'none', verifySsl: true }),
+    });
+    // Either a 4xx or 500 — what we ASSERT here is that no row was created,
+    // so the speculative allowlist entry was revoked (otherwise it'd be a
+    // dangling allowlist over a non-existent provider).
+    expect(r.statusCode).toBeGreaterThanOrEqual(400);
+    const list = await query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM llm_providers WHERE base_url = 'http://10.0.0.99/v1'",
+    );
+    expect(list.rows[0]!.count).toBe('0');
   });
 });
 

--- a/backend/src/routes/llm/llm-providers.ts
+++ b/backend/src/routes/llm/llm-providers.ts
@@ -17,7 +17,12 @@ import {
   listModels as clientListModels,
 } from '../../domains/llm/services/openai-compatible-client.js';
 import { emitLlmAudit } from '../../domains/llm/services/llm-audit-hook.js';
-import { assertNonSsrfUrl, addAllowedBaseUrl, SsrfError } from '../../core/utils/ssrf-guard.js';
+import {
+  validateUrl,
+  addAllowedBaseUrl,
+  removeAllowedBaseUrl,
+  SsrfError,
+} from '../../core/utils/ssrf-guard.js';
 import { getRateLimits } from '../../core/services/rate-limit-service.js';
 
 const ADMIN_RATE_LIMIT = {
@@ -44,18 +49,31 @@ export async function llmProviderRoutes(fastify: FastifyInstance) {
     { preHandler: fastify.requireAdmin, ...ADMIN_RATE_LIMIT },
     async (request, reply) => {
       const input = LlmProviderInputSchema.parse(request.body);
+      // Allowlist BEFORE validating so private-network LLM endpoints
+      // (LM Studio / Ollama on the LAN, on-prem vLLM, etc.) aren't rejected
+      // by the SSRF guard. Mirrors the Confluence test-connection flow.
+      // Protocol restrictions (HTTP/HTTPS only) still apply post-allowlist
+      // because validateUrl() runs the protocol check before short-circuiting
+      // on the allowlist.
+      addAllowedBaseUrl(input.baseUrl);
       try {
-        await assertNonSsrfUrl(input.baseUrl);
+        validateUrl(input.baseUrl);
       } catch (err) {
+        removeAllowedBaseUrl(input.baseUrl);
         if (err instanceof SsrfError) {
           return reply.code(400).send({ error: err.message });
         }
         throw err;
       }
-      const provider = await createProvider(input);
-      // Every configured provider URL must be allowlisted for the ssrf-guard
-      // so that subsequent outbound calls from the service layer aren't rejected.
-      addAllowedBaseUrl(provider.baseUrl);
+      let provider;
+      try {
+        provider = await createProvider(input);
+      } catch (err) {
+        // DB write failed (e.g. unique-name violation) — revoke the
+        // speculative allowlist entry so it doesn't outlive the failed row.
+        removeAllowedBaseUrl(input.baseUrl);
+        throw err;
+      }
       emitLlmAudit({
         event: 'llm_provider_created',
         userId: request.userId,
@@ -74,18 +92,30 @@ export async function llmProviderRoutes(fastify: FastifyInstance) {
       const { id } = IdParamsSchema.parse(request.params);
       const patch = LlmProviderUpdateSchema.parse(request.body);
       if (patch.baseUrl) {
+        // Same allowlist-before-validate ordering as POST so private-network
+        // base URLs can be patched in. Revoke on any downstream failure.
+        addAllowedBaseUrl(patch.baseUrl);
         try {
-          await assertNonSsrfUrl(patch.baseUrl);
+          validateUrl(patch.baseUrl);
         } catch (err) {
+          removeAllowedBaseUrl(patch.baseUrl);
           if (err instanceof SsrfError) {
             return reply.code(400).send({ error: err.message });
           }
           throw err;
         }
       }
-      const updated = await updateProvider(id, patch);
-      if (!updated) return reply.code(404).send({ error: 'Provider not found' });
-      if (patch.baseUrl) addAllowedBaseUrl(updated.baseUrl);
+      let updated;
+      try {
+        updated = await updateProvider(id, patch);
+      } catch (err) {
+        if (patch.baseUrl) removeAllowedBaseUrl(patch.baseUrl);
+        throw err;
+      }
+      if (!updated) {
+        if (patch.baseUrl) removeAllowedBaseUrl(patch.baseUrl);
+        return reply.code(404).send({ error: 'Provider not found' });
+      }
       emitLlmAudit({
         event: 'llm_provider_updated',
         userId: request.userId,

--- a/backend/src/routes/llm/llm-providers.ts
+++ b/backend/src/routes/llm/llm-providers.ts
@@ -91,9 +91,25 @@ export async function llmProviderRoutes(fastify: FastifyInstance) {
       // Allowlist BEFORE validating so private-network LLM endpoints
       // (LM Studio / Ollama on the LAN, on-prem vLLM, etc.) aren't rejected
       // by the SSRF guard. Mirrors the Confluence test-connection flow.
-      // Protocol restrictions (HTTP/HTTPS only) still apply post-allowlist
-      // because validateUrl() runs the protocol check before short-circuiting
-      // on the allowlist.
+      //
+      // Protocol restrictions (HTTP/HTTPS only) still apply post-allowlist:
+      // `validateUrl` runs the protocol check (`ssrf-guard.ts` —
+      // PROTOCOL_BLOCK) BEFORE the allowlist short-circuit (ALLOWLIST_HIT),
+      // so a swap of those two checks in the future would silently break
+      // this caller's defence-in-depth. That ordering is load-bearing.
+      //
+      // Note on DNS rebinding: `assertNonSsrfUrl` (which performs DNS
+      // resolution + private-IP validation via `resolveAndValidateIp`) is
+      // intentionally NOT called here. We use the sync `validateUrl`
+      // because the allowlist short-circuits before any DNS work would
+      // happen anyway, and once a URL is allowlisted the runtime call
+      // path is exempt from DNS validation by design. The trust model is
+      // "authenticated admin pastes a URL and we trust it" — same as the
+      // Confluence flow. A DNS-rebinding attacker would need admin
+      // credentials to even reach this route. If the threat model ever
+      // requires create-time DNS validation, swap to `assertNonSsrfUrl`
+      // and accept that admins can no longer add `*.local` / private-DNS
+      // hostnames whose A-record currently resolves to a private IP.
       addAllowedBaseUrl(input.baseUrl);
       try {
         validateUrl(input.baseUrl);

--- a/backend/src/routes/llm/llm-providers.ts
+++ b/backend/src/routes/llm/llm-providers.ts
@@ -24,6 +24,45 @@ import {
   SsrfError,
 } from '../../core/utils/ssrf-guard.js';
 import { getRateLimits } from '../../core/services/rate-limit-service.js';
+import { query } from '../../core/db/postgres.js';
+
+/**
+ * Revoke a per-pod allowlist entry only when no surviving `llm_providers`
+ * row references that origin. Two routes need this:
+ *   - POST: a concurrent successful sibling request may have committed the
+ *     same `base_url` (different `name`); revoking would strip its
+ *     allowlist out from under it.
+ *   - PATCH (baseUrl change): the previous origin may still be configured
+ *     on a different provider.
+ *
+ * The check is by full normalised origin (the same key the SSRF allowlist
+ * uses). Provider rows store the full base URL incl. path; we extract the
+ * origin and compare via `LOWER` on either side so case differences in the
+ * scheme/host don't cause a false negative.
+ */
+async function revokeAllowlistIfUnused(baseUrl: string): Promise<void> {
+  let origin: string;
+  try {
+    origin = new URL(baseUrl).origin;
+  } catch {
+    // If we can't parse it, we can't safely match other rows — bail out
+    // and just remove. A later bootstrap will rebuild from the DB anyway.
+    removeAllowedBaseUrl(baseUrl);
+    return;
+  }
+  // Match on origin so URLs with different paths (`http://h:1234/v1` vs
+  // `http://h:1234/api`) — but the same SSRF-relevant origin — count.
+  const result = await query<{ count: string }>(
+    `SELECT count(*)::text AS count
+       FROM llm_providers
+      WHERE LOWER(SUBSTRING(base_url FROM '^[a-zA-Z][a-zA-Z0-9+.-]*://[^/]*')) = LOWER($1)`,
+    [origin],
+  );
+  const stillUsed = parseInt(result.rows[0]!.count, 10) > 0;
+  if (!stillUsed) {
+    removeAllowedBaseUrl(baseUrl);
+  }
+}
 
 const ADMIN_RATE_LIMIT = {
   config: { rateLimit: { max: async () => (await getRateLimits()).admin.max, timeWindow: '1 minute' } },
@@ -59,7 +98,10 @@ export async function llmProviderRoutes(fastify: FastifyInstance) {
       try {
         validateUrl(input.baseUrl);
       } catch (err) {
-        removeAllowedBaseUrl(input.baseUrl);
+        // No DB row to check yet — but if a CONCURRENT sibling request
+        // for the same baseUrl has already committed, we must NOT strip
+        // its allowlist out from under it. Use the unused-origin guard.
+        await revokeAllowlistIfUnused(input.baseUrl);
         if (err instanceof SsrfError) {
           return reply.code(400).send({ error: err.message });
         }
@@ -70,8 +112,10 @@ export async function llmProviderRoutes(fastify: FastifyInstance) {
         provider = await createProvider(input);
       } catch (err) {
         // DB write failed (e.g. unique-name violation) — revoke the
-        // speculative allowlist entry so it doesn't outlive the failed row.
-        removeAllowedBaseUrl(input.baseUrl);
+        // speculative allowlist entry only if no other provider already
+        // owns this origin. Prevents a concurrent successful sibling from
+        // losing its allowlist.
+        await revokeAllowlistIfUnused(input.baseUrl);
         throw err;
       }
       emitLlmAudit({
@@ -91,6 +135,10 @@ export async function llmProviderRoutes(fastify: FastifyInstance) {
     async (request, reply) => {
       const { id } = IdParamsSchema.parse(request.params);
       const patch = LlmProviderUpdateSchema.parse(request.body);
+      // Capture the previous baseUrl BEFORE we mutate state so a baseUrl
+      // change can revoke the OLD origin's allowlist entry once it's no
+      // longer referenced (mirrors the Confluence flow on URL replace).
+      const previous = patch.baseUrl ? await getProviderById(id) : null;
       if (patch.baseUrl) {
         // Same allowlist-before-validate ordering as POST so private-network
         // base URLs can be patched in. Revoke on any downstream failure.
@@ -98,7 +146,7 @@ export async function llmProviderRoutes(fastify: FastifyInstance) {
         try {
           validateUrl(patch.baseUrl);
         } catch (err) {
-          removeAllowedBaseUrl(patch.baseUrl);
+          await revokeAllowlistIfUnused(patch.baseUrl);
           if (err instanceof SsrfError) {
             return reply.code(400).send({ error: err.message });
           }
@@ -109,12 +157,22 @@ export async function llmProviderRoutes(fastify: FastifyInstance) {
       try {
         updated = await updateProvider(id, patch);
       } catch (err) {
-        if (patch.baseUrl) removeAllowedBaseUrl(patch.baseUrl);
+        if (patch.baseUrl) await revokeAllowlistIfUnused(patch.baseUrl);
         throw err;
       }
       if (!updated) {
-        if (patch.baseUrl) removeAllowedBaseUrl(patch.baseUrl);
+        if (patch.baseUrl) await revokeAllowlistIfUnused(patch.baseUrl);
         return reply.code(404).send({ error: 'Provider not found' });
+      }
+      // baseUrl actually changed → garbage-collect the previous origin if
+      // no other provider still references it. Without this, repeated
+      // PATCHes leave a growing pile of stale per-pod allowlist entries.
+      if (
+        patch.baseUrl &&
+        previous &&
+        previous.baseUrl !== patch.baseUrl
+      ) {
+        await revokeAllowlistIfUnused(previous.baseUrl);
       }
       emitLlmAudit({
         event: 'llm_provider_updated',


### PR DESCRIPTION
## Why

The Compendiq EE stack lets admins point Compendiq at any OpenAI-compatible LLM endpoint via Settings → LLM. But trying to add an LM Studio at `http://192.168.178.185:1234/v1` (or an on-prem Ollama at `http://10.0.0.5:11434/v1`, etc.) returned a generic "Request failed" — actually a `400` from the SSRF guard rejecting the RFC-1918 IP **before** the URL had a chance to enter the allowlist.

The Confluence test-connection flow already had the right ordering (`addAllowedBaseUrl` → `validateUrl` → on failure `removeAllowedBaseUrl`) for exactly this reason — see `backend/src/routes/foundation/settings.ts:236-251`. This PR mirrors that pattern in `llm-providers.ts`.

## What changes

`backend/src/routes/llm/llm-providers.ts`:
- POST: `addAllowedBaseUrl(input.baseUrl)` → `validateUrl(input.baseUrl)` (sync; protocol check still runs first) → `createProvider(...)`. On any failure the speculative allowlist entry is revoked with `removeAllowedBaseUrl` so we never leave a dangling allowlist over a non-existent provider.
- PATCH: same pattern, only when `patch.baseUrl` is being changed; the entry is revoked on validate failure, on `updateProvider` throw, and on 404.

The runtime path is unchanged: `llm-provider-bootstrap.ts:73` already calls `addAllowedBaseUrlSilent` for every existing row at startup, so private-network providers worked once a row existed (the issue was *only* the create/update path).

## Defence-in-depth notes

- `LlmProviderInputSchema` enforces `http(s)` at Zod time (`packages/contracts/src/llm.ts:13`), so `file:/javascript:/data:` URLs never reach the SSRF guard.
- `validateUrl` runs the protocol check **before** the allowlist short-circuit (`ssrf-guard.ts:238` runs before line 243), so even an allowlisted non-HTTP origin would be rejected.
- The user submitting the URL is an authenticated admin; the same trust model as the existing Confluence private-network allowance.

## Tests

The 2 original "loopback returns 400" tests are renamed and inverted to assert the new "loopback / RFC-1918 / public-to-RFC-1918 transition is accepted" behaviour — the correctness bar this PR pins. A new test for duplicate-name collision proves the allowlist is revoked when the DB row never lands.

```
SSRF guard — private-network base URLs accepted ...
  ✓ POST with loopback baseUrl is now accepted and allowlisted
  ✓ POST with RFC-1918 baseUrl is accepted and allowlisted
  ✓ PATCH from public to RFC-1918 baseUrl is accepted
  ✓ POST with duplicate name revokes the speculative allowlist entry
```

## Repro

Pre-fix: in Settings → LLM, "Add provider" with base URL `http://192.168.178.185:1234/v1`, auth `none` → toast "Request failed". Backend logs: `400 SSRF blocked: cannot connect to internal/private network`.

Post-fix: same flow → 201, provider listed, allowlist hit on first chat completion.

## Risks

- Loopback URLs (`http://127.0.0.1/...`) are now also accepted at create-time. This matches Confluence settings behavior. The user is an authenticated admin; the trust gate is the admin role plus the deliberate URL submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)