### PR TITLE
feat(#379): per-space home page picker UI

### DIFF
--- a/frontend/src/features/settings/SpaceHomePicker.test.tsx
+++ b/frontend/src/features/settings/SpaceHomePicker.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SpaceHomePicker } from './SpaceHomePicker';
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+interface FetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+// Tracks every fetch the component makes so individual tests can assert
+// the body of the PUT /spaces/:key/home request.
+function mockFetch(handler: (call: FetchCall) => unknown) {
+  const calls: FetchCall[] = [];
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+    const call: FetchCall = { url: String(url), init };
+    calls.push(call);
+    const body = handler(call);
+    return new Response(JSON.stringify(body ?? {}), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+  return calls;
+}
+
+describe('SpaceHomePicker (#379)', () => {
+  beforeEach(() => {
+    // The default permission response is "allowed" — individual tests
+    // override this when they need to exercise the disabled path.
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders a disabled trigger when the user lacks manage permission', async () => {
+    mockFetch((call) => {
+      if (call.url.includes('/permissions/check')) return { allowed: false };
+      return {};
+    });
+
+    render(
+      <SpaceHomePicker spaceKey="DEV" resolvedHomePageId={null} customHomePageId={null} />,
+      { wrapper: createWrapper() },
+    );
+
+    const trigger = await screen.findByTestId('space-home-picker-trigger-DEV');
+    await waitFor(() => expect(trigger).toBeDisabled());
+    expect(trigger).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('renders an enabled trigger when the user can manage the space', async () => {
+    mockFetch((call) => {
+      if (call.url.includes('/permissions/check')) return { allowed: true };
+      return {};
+    });
+
+    render(
+      <SpaceHomePicker spaceKey="DEV" resolvedHomePageId={null} customHomePageId={null} />,
+      { wrapper: createWrapper() },
+    );
+
+    const trigger = await screen.findByTestId('space-home-picker-trigger-DEV');
+    await waitFor(() => expect(trigger).not.toBeDisabled());
+  });
+
+  it('reflects the "custom override set" state on the trigger', async () => {
+    mockFetch((call) => {
+      if (call.url.includes('/permissions/check')) return { allowed: true };
+      return {};
+    });
+
+    render(
+      <SpaceHomePicker spaceKey="DEV" resolvedHomePageId="42" customHomePageId={42} />,
+      { wrapper: createWrapper() },
+    );
+
+    const trigger = await screen.findByTestId('space-home-picker-trigger-DEV');
+    await waitFor(() => expect(trigger).toHaveTextContent(/custom home set/i));
+  });
+
+  it('PUTs the chosen page id when a search result is clicked', async () => {
+    const calls = mockFetch((call) => {
+      if (call.url.includes('/permissions/check')) return { allowed: true };
+      if (call.url.includes('/search')) {
+        return {
+          items: [
+            {
+              id: 999,
+              title: 'Welcome page',
+              excerpt: '',
+              source: 'confluence',
+              spaceKey: 'DEV',
+              score: 1,
+            },
+          ],
+          total: 1,
+        };
+      }
+      if (call.url.includes('/spaces/DEV/home')) {
+        return { spaceKey: 'DEV', customHomePageId: 999 };
+      }
+      return {};
+    });
+
+    render(
+      <SpaceHomePicker spaceKey="DEV" resolvedHomePageId={null} customHomePageId={null} />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(await screen.findByTestId('space-home-picker-trigger-DEV'));
+
+    const search = await screen.findByTestId('space-home-picker-search-DEV');
+    fireEvent.change(search, { target: { value: 'wel' } });
+
+    const result = await screen.findByTestId('space-home-picker-result-999');
+    fireEvent.click(result);
+
+    await waitFor(() => {
+      const put = calls.find((c) => c.init?.method === 'PUT');
+      expect(put).toBeTruthy();
+      expect(put!.url).toContain('/spaces/DEV/home');
+      expect(JSON.parse(put!.init!.body as string)).toEqual({ homePageId: 999 });
+    });
+  });
+
+  it('PUTs homePageId: null when "Use Confluence default" is clicked', async () => {
+    const calls = mockFetch((call) => {
+      if (call.url.includes('/permissions/check')) return { allowed: true };
+      if (call.url.includes('/spaces/DEV/home')) {
+        return { spaceKey: 'DEV', customHomePageId: null };
+      }
+      return {};
+    });
+
+    render(
+      <SpaceHomePicker
+        spaceKey="DEV"
+        resolvedHomePageId="42"
+        customHomePageId={42}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(await screen.findByTestId('space-home-picker-trigger-DEV'));
+    fireEvent.click(await screen.findByTestId('space-home-picker-reset-DEV'));
+
+    await waitFor(() => {
+      const put = calls.find((c) => c.init?.method === 'PUT');
+      expect(put).toBeTruthy();
+      expect(put!.url).toContain('/spaces/DEV/home');
+      expect(JSON.parse(put!.init!.body as string)).toEqual({ homePageId: null });
+    });
+  });
+
+  it('disables "Use Confluence default" when no override is set', async () => {
+    mockFetch((call) => {
+      if (call.url.includes('/permissions/check')) return { allowed: true };
+      return {};
+    });
+
+    render(
+      <SpaceHomePicker spaceKey="DEV" resolvedHomePageId={null} customHomePageId={null} />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(await screen.findByTestId('space-home-picker-trigger-DEV'));
+    const reset = await screen.findByTestId('space-home-picker-reset-DEV');
+    expect(reset).toBeDisabled();
+  });
+
+  it('scopes the search to the current space (forwards spaceKey to /search)', async () => {
+    const calls = mockFetch((call) => {
+      if (call.url.includes('/permissions/check')) return { allowed: true };
+      if (call.url.includes('/search')) return { items: [], total: 0 };
+      return {};
+    });
+
+    render(
+      <SpaceHomePicker spaceKey="OPS" resolvedHomePageId={null} customHomePageId={null} />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(await screen.findByTestId('space-home-picker-trigger-OPS'));
+    const search = await screen.findByTestId('space-home-picker-search-OPS');
+    fireEvent.change(search, { target: { value: 'foo' } });
+
+    await waitFor(() => {
+      const searchCall = calls.find((c) => c.url.includes('/search'));
+      expect(searchCall?.url).toContain('spaceKey=OPS');
+      expect(searchCall?.url).toMatch(/q=foo/);
+    });
+  });
+});

--- a/frontend/src/features/settings/SpaceHomePicker.tsx
+++ b/frontend/src/features/settings/SpaceHomePicker.tsx
@@ -1,0 +1,228 @@
+import { useState } from 'react';
+import * as Popover from '@radix-ui/react-popover';
+import { Home, RotateCcw, Search, Loader2, Check } from 'lucide-react';
+import { toast } from 'sonner';
+import { useSetSpaceHome } from '../../shared/hooks/use-spaces';
+import { useSearch } from '../../shared/hooks/use-standalone';
+import { usePage } from '../../shared/hooks/use-pages';
+import { usePermission } from '../../shared/hooks/use-permission';
+import { cn } from '../../shared/lib/cn';
+
+interface SpaceHomePickerProps {
+  spaceKey: string;
+  /** Resolved homepage id from `useSpaces()` — custom override OR Confluence default. */
+  resolvedHomePageId: string | null;
+  /** Raw custom override (null when the space falls back to the Confluence default). */
+  customHomePageId: number | null | undefined;
+}
+
+/**
+ * #379: Per-space home page picker. Renders a small "Set home" affordance
+ * inside Settings → Spaces; opens a Radix Popover with a search-style
+ * page selector scoped to the current space. The "Use Confluence default"
+ * button clears the override (PUT homePageId: null).
+ *
+ * RBAC: gated on `usePermission('manage', 'space', spaceKey)`. The same
+ * permission the backend enforces in PUT /api/spaces/:key/home — so a
+ * non-permitted user just sees a disabled trigger with a tooltip, and
+ * even if they bypass the gate the backend returns 403 which surfaces
+ * as a sonner toast through the mutation's error path.
+ */
+export function SpaceHomePicker({
+  spaceKey,
+  resolvedHomePageId,
+  customHomePageId,
+}: SpaceHomePickerProps) {
+  const { allowed: canManage, loading: permLoading } = usePermission(
+    'manage',
+    'space',
+    spaceKey,
+  );
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+
+  const setHome = useSetSpaceHome();
+
+  // Show the resolved current home (page title + breadcrumb-ish hint).
+  // The search hook is enabled at q.length >= 2 so the page lookup here
+  // is independent and only fires when we have an id to look up.
+  const currentHome = usePage(resolvedHomePageId ?? undefined);
+
+  // Page search results scoped to this space (acceptance bullet:
+  // "search-style page selector scoped to the current space").
+  const search = useSearch({ q: query.trim(), spaceKey });
+
+  const setOverride = (homePageId: number | null) => {
+    setHome.mutate(
+      { spaceKey, homePageId },
+      {
+        onSuccess: () => {
+          toast.success(
+            homePageId === null
+              ? 'Reverted to the Confluence default home page.'
+              : 'Space home page updated.',
+          );
+          setOpen(false);
+          setQuery('');
+        },
+        onError: (err) => {
+          toast.error(err.message || 'Could not update the space home page.');
+        },
+      },
+    );
+  };
+
+  // Hide while the permission check is loading to avoid flicker; show a
+  // disabled trigger when the user can't manage the space (acceptance:
+  // "non-permitted user shows a disabled state or hides the control").
+  if (permLoading) return null;
+
+  const triggerLabel = customHomePageId != null ? 'Custom home set' : 'Use default home';
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          disabled={!canManage}
+          aria-disabled={!canManage}
+          aria-label={`Set home page for ${spaceKey}`}
+          title={
+            canManage
+              ? `Pick a custom home page for ${spaceKey}`
+              : 'You need admin or manage permission to set the home page'
+          }
+          data-testid={`space-home-picker-trigger-${spaceKey}`}
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            'flex shrink-0 items-center gap-1.5 rounded-md border border-border/50 px-2.5 py-1 text-xs',
+            'transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+            canManage
+              ? 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground'
+              : 'cursor-not-allowed opacity-50',
+            customHomePageId != null && 'border-primary/40 text-primary',
+          )}
+        >
+          <Home size={12} />
+          {triggerLabel}
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="end"
+          sideOffset={6}
+          onClick={(e) => e.stopPropagation()}
+          className="z-50 w-80 rounded-lg border border-border bg-card p-3 shadow-lg outline-none"
+          data-testid={`space-home-picker-content-${spaceKey}`}
+        >
+          <div className="mb-2 flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="text-xs font-semibold text-foreground">Space home page</p>
+              <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                {customHomePageId != null
+                  ? 'Currently using a custom override.'
+                  : 'Currently using the Confluence default.'}
+              </p>
+            </div>
+          </div>
+
+          {/* Resolved current home display. The space may resolve to no
+              homepage at all (Confluence space without one + no override),
+              in which case this block stays hidden. */}
+          {resolvedHomePageId && (
+            <div
+              className="mb-2 flex items-center gap-2 rounded-md bg-foreground/5 px-2 py-1.5"
+              data-testid="space-home-picker-current"
+            >
+              <Check size={12} className="text-primary" />
+              <p className="min-w-0 truncate text-xs">
+                <span className="text-muted-foreground">Current: </span>
+                <span className="font-medium">
+                  {currentHome.data?.title ?? `Page #${resolvedHomePageId}`}
+                </span>
+              </p>
+            </div>
+          )}
+
+          {/* Search input. spaceKey is forwarded so results stay scoped to
+              this space — backend `PUT /spaces/:key/home` rejects pages
+              from other spaces (except shared standalone), so cross-space
+              picking would just be a wasted round-trip. */}
+          <div className="relative mb-2">
+            <Search
+              size={12}
+              className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={`Search pages in ${spaceKey}…`}
+              className="w-full rounded-md border border-border/50 bg-background py-1.5 pl-7 pr-2 text-xs focus:border-primary/50 focus:outline-none focus:ring-1 focus:ring-primary/30"
+              data-testid={`space-home-picker-search-${spaceKey}`}
+              autoFocus
+            />
+          </div>
+
+          {/* Search results — empty state only when we've issued a query
+              (useSearch is enabled at q.length >= 2). */}
+          <div className="max-h-56 overflow-y-auto" role="listbox" aria-label="Page results">
+            {query.trim().length < 2 ? (
+              <p className="px-1 py-2 text-[11px] text-muted-foreground">
+                Type at least 2 characters to search.
+              </p>
+            ) : search.isLoading ? (
+              <div className="flex items-center justify-center py-3 text-muted-foreground">
+                <Loader2 size={14} className="animate-spin" />
+              </div>
+            ) : (search.data?.items ?? []).length === 0 ? (
+              <p className="px-1 py-2 text-[11px] text-muted-foreground">No matching pages.</p>
+            ) : (
+              <ul className="space-y-0.5">
+                {(search.data?.items ?? []).map((p) => {
+                  const isCurrent =
+                    resolvedHomePageId != null && String(p.id) === String(resolvedHomePageId);
+                  return (
+                    <li key={p.id}>
+                      <button
+                        type="button"
+                        role="option"
+                        aria-selected={isCurrent}
+                        disabled={setHome.isPending}
+                        onClick={() => setOverride(p.id)}
+                        className={cn(
+                          'flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors',
+                          'hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                          isCurrent && 'bg-primary/10 text-primary',
+                        )}
+                        data-testid={`space-home-picker-result-${p.id}`}
+                      >
+                        <span className="flex-1 truncate">{p.title}</span>
+                        {isCurrent && <Check size={12} className="shrink-0 text-primary" />}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          {/* "Use Confluence default" — clears the override. Disabled when
+              there isn't one to clear, so the action is unambiguous. */}
+          <div className="mt-2 flex items-center justify-end border-t border-border/40 pt-2">
+            <button
+              type="button"
+              onClick={() => setOverride(null)}
+              disabled={setHome.isPending || customHomePageId == null}
+              className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-foreground/5 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              data-testid={`space-home-picker-reset-${spaceKey}`}
+            >
+              <RotateCcw size={12} />
+              Use Confluence default
+            </button>
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/frontend/src/features/settings/SpacesTab.tsx
+++ b/frontend/src/features/settings/SpacesTab.tsx
@@ -4,6 +4,7 @@ import { RefreshCw, CheckSquare, Square, Loader2 } from 'lucide-react';
 import { apiFetch } from '../../shared/lib/api';
 import { cn } from '../../shared/lib/cn';
 import { toast } from 'sonner';
+import { SpaceHomePicker } from './SpaceHomePicker';
 
 interface AvailableSpace {
   key: string;
@@ -16,6 +17,10 @@ interface SyncedSpace {
   name: string;
   lastSynced: string | null;
   pageCount: number;
+  /** #352: resolved home (custom override OR Confluence default). */
+  homepageId?: string | null;
+  /** #352: raw custom override (null when falling back to Confluence default). */
+  customHomePageId?: number | null;
 }
 
 interface SpacesTabProps {
@@ -133,15 +138,18 @@ export function SpacesTab({ selectedSpaces: initialSelected = EMPTY_SPACES, show
         </button>
       </div>
 
-      {/* Space list */}
+      {/* Space list. Each row mixes a selection toggle (the whole row) with
+          a per-space home picker (#379). Nested <button> inside <button>
+          would be invalid HTML, so the row is a div with role=listitem
+          plus an inner <button> for the toggle, and the home picker is a
+          sibling that calls stopPropagation in its own click handler. */}
       {allSpaces.length > 0 ? (
         <div className="space-y-1.5" role="list" aria-label="Spaces list">
           {allSpaces.map((space) => {
             const isSelected = selected.has(space.key);
             return (
-              <button
+              <div
                 key={space.key}
-                onClick={() => toggleSpace(space.key)}
                 className={cn(
                   'flex w-full items-center gap-3 rounded-lg border px-4 py-3 text-left transition-colors',
                   isSelected
@@ -150,22 +158,39 @@ export function SpacesTab({ selectedSpaces: initialSelected = EMPTY_SPACES, show
                 )}
                 role="listitem"
               >
-                {isSelected ? (
-                  <CheckSquare size={18} className="shrink-0 text-primary" />
-                ) : (
-                  <Square size={18} className="shrink-0 text-muted-foreground" />
-                )}
-                <div className="min-w-0 flex-1">
-                  <p className="text-sm font-medium">{space.name}</p>
-                  <p className="text-xs text-muted-foreground">{space.key}</p>
-                </div>
-                {space.lastSynced && (
-                  <div className="text-right text-xs text-muted-foreground">
-                    <p>{space.pageCount} pages</p>
-                    <p>Synced: {new Date(space.lastSynced).toLocaleDateString()}</p>
+                <button
+                  type="button"
+                  onClick={() => toggleSpace(space.key)}
+                  className="flex min-w-0 flex-1 items-center gap-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 rounded-md"
+                  aria-pressed={isSelected}
+                  aria-label={`${isSelected ? 'Deselect' : 'Select'} ${space.name}`}
+                >
+                  {isSelected ? (
+                    <CheckSquare size={18} className="shrink-0 text-primary" />
+                  ) : (
+                    <Square size={18} className="shrink-0 text-muted-foreground" />
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium">{space.name}</p>
+                    <p className="text-xs text-muted-foreground">{space.key}</p>
                   </div>
+                  {space.lastSynced && (
+                    <div className="text-right text-xs text-muted-foreground">
+                      <p>{space.pageCount} pages</p>
+                      <p>Synced: {new Date(space.lastSynced).toLocaleDateString()}</p>
+                    </div>
+                  )}
+                </button>
+                {/* #379: home picker only renders for synced spaces — an
+                    unsynced space has no pages locally to choose from. */}
+                {space.lastSynced && (
+                  <SpaceHomePicker
+                    spaceKey={space.key}
+                    resolvedHomePageId={space.homepageId ?? null}
+                    customHomePageId={space.customHomePageId ?? null}
+                  />
                 )}
-              </button>
+              </div>
             );
           })}
         </div>
@@ -208,6 +233,8 @@ function mergeSpaces(available: AvailableSpace[], synced: SyncedSpace[], selecte
     name: string;
     lastSynced?: string | null;
     pageCount?: number;
+    homepageId?: string | null;
+    customHomePageId?: number | null;
   }> = [];
   const seen = new Set<string>();
 
@@ -219,6 +246,8 @@ function mergeSpaces(available: AvailableSpace[], synced: SyncedSpace[], selecte
       name: space.name,
       lastSynced: syncInfo?.lastSynced,
       pageCount: syncInfo?.pageCount,
+      homepageId: syncInfo?.homepageId ?? null,
+      customHomePageId: syncInfo?.customHomePageId ?? null,
     });
     seen.add(space.key);
   }
@@ -231,6 +260,8 @@ function mergeSpaces(available: AvailableSpace[], synced: SyncedSpace[], selecte
         name: space.name,
         lastSynced: space.lastSynced,
         pageCount: space.pageCount,
+        homepageId: space.homepageId ?? null,
+        customHomePageId: space.customHomePageId ?? null,
       });
       seen.add(space.key);
     }

--- a/frontend/src/shared/hooks/use-spaces.ts
+++ b/frontend/src/shared/hooks/use-spaces.ts
@@ -45,6 +45,36 @@ export function useSync() {
   });
 }
 
+/**
+ * #379: PUT /api/spaces/:key/home — set the custom home page for a space.
+ * Pass `homePageId: null` to clear the override and fall back to the
+ * Confluence default. Backend gates on admin-or-manage; the UI also gates
+ * via `usePermission('manage', 'space', key)` so the trigger only renders
+ * for permitted users, but a 403 surfaces here as a normal mutation error
+ * for the caller to toast.
+ */
+export function useSetSpaceHome() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    { spaceKey: string; customHomePageId: number | null },
+    Error,
+    { spaceKey: string; homePageId: number | null }
+  >({
+    mutationFn: ({ spaceKey, homePageId }) =>
+      apiFetch(`/spaces/${encodeURIComponent(spaceKey)}/home`, {
+        method: 'PUT',
+        body: JSON.stringify({ homePageId }),
+      }),
+    onSuccess: () => {
+      // Backend already invalidates every user's spaces cache via cache-bus
+      // (see spaces.ts:167). Frontend just needs to refetch so the sidebar
+      // tree picks up the new homepageId immediately.
+      queryClient.invalidateQueries({ queryKey: ['spaces'] });
+      queryClient.invalidateQueries({ queryKey: ['pages'] });
+    },
+  });
+}
+
 export function useSyncStatus() {
   return useQuery<{
     userId: string;


### PR DESCRIPTION
Closes #379. Follow-up to #352 / #377 — the backend, migration, RBAC guard, and nav-tree filter shipped in #377; this PR wires the missing CE-side UI.

## Summary
- New `SpaceHomePicker` component dropped into Settings → Spaces rows. Trigger labels itself \"Use default home\" or \"Custom home set\" depending on whether `customHomePageId` is present.
- Built on Radix `Popover`. The popover hosts a search-style page selector scoped to the current space (uses the existing `useSearch({ q, spaceKey })` hook from `use-standalone.ts`, exactly as the issue called out), shows the resolved current home, and offers a \"Use Confluence default\" button that sends `PUT /api/spaces/:key/home` with `{ homePageId: null }` to clear the override.
- New `useSetSpaceHome` mutation hook in `use-spaces.ts` calls the new endpoint and invalidates `['spaces']` + `['pages']` on success — the backend already broadcasts a per-user-fanout cache invalidation (spaces.ts:167), so the frontend just needs to refetch and the sidebar tree picks up the new resolved `homepageId` immediately.
- RBAC gating: `usePermission('manage', 'space', spaceKey)` — the same permission the backend enforces. Non-permitted users see a disabled trigger with an explanatory tooltip; the mutation also surfaces a 403 as a `sonner` toast for the optimistic-UI fallback path the issue calls out.
- `SpacesTab.tsx` row refactor: the row was a `<button>` for the toggle, which made the picker (also a button) invalid HTML when nested. Refactored to a `<div role=\"listitem\">` with an inner `<button>` for the toggle plus the picker as a sibling that calls `stopPropagation` so its events don't bubble.

## Acceptance checklist (from #379)
- [x] Picker only appears for users who pass the same RBAC check the backend enforces — disabled trigger when `usePermission('manage','space',key)` returns `allowed:false`.
- [x] Successful save invalidates `useSpaces()` so the sidebar tree updates immediately.
- [x] Setting null restores the Confluence default; UI clearly shows the fallback (\"Currently using the Confluence default.\" copy).
- [x] Test: rendering the picker for a non-permitted user shows a disabled state.
- [x] Test: save triggers PUT with the chosen page id; clear triggers PUT with null.

## Test plan
- [x] `npx vitest run src/features/settings/SpaceHomePicker.test.tsx` — 7 new tests pass (RBAC gating, PUT payload for set + clear, search scoping by spaceKey, reset-button-disabled-when-no-override)
- [x] `npx vitest run src/features/settings/SpacesTab.test.tsx` — 15 existing tests still pass after the row refactor
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on the new + modified files
- [x] Production frontend bundle verified to contain all `space-home-picker-*` test ids
- [ ] Manual: pick a custom home for a Confluence space → sidebar tree re-roots immediately; reset → falls back to Confluence default
- [ ] Manual: log in as a non-admin without manage permission → trigger is disabled with the explanatory tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)