### PR TITLE
feat(#380 Phase 1): synthetic graph perf benchmark

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -202,3 +202,108 @@ docker exec compendiq-ee-postgres-1 psql -U kb_user -d kb_creator -c \
   "DELETE FROM admin_settings WHERE setting_key='rate_limit_global_max';"
 docker restart compendiq-ee-backend-1
 ```
+
+---
+
+## Graph performance benchmark (#380 Phase 1)
+
+`scripts/perf-graph-bench.ts` measures the graph page (`/graph?focus=...&full=1`)
+under synthetic loads of 500 / 1000 / 2000 / 5000 nodes with realistic edge
+density (top-K=5 per node, similarity ≥ 0.6 to match the corpus-tiered
+floor from #378). It seeds Postgres directly, drives a Playwright session,
+and writes `perf/graph-bench-results.json`.
+
+### What it records (per size)
+
+- **time-to-first-paint** — navigation → canvas mounted in DOM
+- **layout convergence** — until `requestAnimationFrame` activity stalls
+  (force simulation has finished its `cooldownTicks=100` budget)
+- **fps during pan + drag** of 3 random nodes (2 s sample window)
+- **`performance.memory.usedJSHeapSize`** (Chrome only)
+
+### Decision rule (from the issue, applied to the 2000-node sample)
+
+- < 30 fps drag **OR** > 5 s convergence → Phase 2 (server-side ForceAtlas2)
+  is justified
+- otherwise the per-hop cap + tiered threshold from #378 are sufficient
+  and Phase 2 stays deferred
+
+The verdict is printed at the end of the run and stored in the JSON output.
+
+### Running it
+
+Postgres must be reachable from the host and the dev frontend / backend
+must be up. The fastest path on the local dev stack:
+
+```bash
+# 1. Bring up the dev stack (backend on :3052, frontend on :8081)
+docker compose -f docker/docker-compose.yml up -d --build
+
+# 2. Register a benchmark user once. The script does not touch bcrypt
+#    directly — it logs in through /api/auth/login like a real client.
+curl -X POST http://localhost:3052/api/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"benchuser","password":"benchpass123"}'
+
+# 3. Postgres on the dev compose is bound to host port 5432 by default.
+#    If yours is on the internal-only data-net (EE stack), open a one-off
+#    port-forward via `docker run --network compendiq-ee_data-net ...`
+#    or temporarily expose 5432 in the compose override.
+
+# 4. Run the bench (subset)
+npx tsx scripts/perf-graph-bench.ts --sizes=500,1000,2000
+
+# 5. Full sweep
+npx tsx scripts/perf-graph-bench.ts
+
+# 6. Drop the synthetic fixtures (the script also runs cleanup on exit
+#    unless you pass --keep-fixtures)
+npx tsx scripts/perf-graph-bench.ts --cleanup
+```
+
+### Flags / env
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--sizes=500,1000,2000,5000` | full sweep | Comma-separated node counts |
+| `--web-url=URL` | `http://localhost:8081` | Frontend origin Playwright navigates to |
+| `--backend-url=URL` | `http://localhost:3051` | Backend used for `/api/auth/login` |
+| `--username=NAME` | `benchuser` | Must already exist (register once) |
+| `--password=PASS` | `benchpass123` | |
+| `--headless=true|false` | `true` | `false` to watch the browser drive |
+| `--keep-fixtures` | off | Skip cleanup at the end of the run |
+| `--cleanup` | — | Drop fixtures and exit (no measurement) |
+| `POSTGRES_URL` env | `postgresql://kb_user:changeme-postgres@localhost:5432/kb_creator` | |
+
+### Unit tests for the helpers
+
+The pure helpers (`neighbours`, `decide`) carry their own test suite:
+
+```bash
+npx vitest run --config scripts/vitest.config.ts
+```
+
+So the threshold logic and the edge-density invariants can be regressed
+without booting Postgres or a browser.
+
+### Result format
+
+```json
+{
+  "schemaVersion": 1,
+  "issue": "#380",
+  "runAt": "2026-04-28T13:00:00.000Z",
+  "config": { "sizes": [...], "edgesPerNode": 5, "minScore": 0.6, "maxScore": 0.95 },
+  "samples": [
+    { "size": 500, "pageCount": 500, "edgeCount": 1234,
+      "timeToFirstPaintMs": 380, "layoutConvergenceMs": 720,
+      "fpsDuringInteraction": 60, "jsHeapUsedMb": 92.4 },
+    ...
+  ],
+  "verdict": { "phase2Justified": false, "reasons": [] }
+}
+```
+
+Paste the four samples + verdict into the PR comment — that's the
+artefact the issue asks for ("paste numbers in the PR comment, not just
+the verdict").

--- a/perf/README.md
+++ b/perf/README.md
@@ -274,6 +274,7 @@ npx tsx scripts/perf-graph-bench.ts --cleanup
 | `--keep-fixtures` | off | Skip cleanup at the end of the run |
 | `--cleanup` | — | Drop fixtures and exit (no measurement) |
 | `POSTGRES_URL` env | `postgresql://kb_user:changeme-postgres@localhost:5432/kb_creator` | |
+| `REDIS_URL` env | unset | Optional. When set, the script flushes the bench user's RBAC space-list cache after seeding so consecutive runs with different `--sizes` don't read a stale 60 s-cached value. |
 
 ### Unit tests for the helpers
 
@@ -285,6 +286,25 @@ npx vitest run --config scripts/vitest.config.ts
 
 So the threshold logic and the edge-density invariants can be regressed
 without booting Postgres or a browser.
+
+### Caveats / known gotchas
+
+- **RBAC cache TTL**: `getUserAccessibleSpaces` caches results in Redis for
+  60 s (per `rbac-service.ts`). If the bench user has been seeded with a
+  *different* set of spaces in the previous 60 s (e.g. you ran the bench
+  with `--sizes=500,1000` and immediately re-ran with `--sizes=2000,5000`),
+  the cached space list may be stale and the global graph endpoint will
+  return rows from spaces that aren't in this run's seed. Either wait
+  60 s between runs that mutate the bench user's space access, or flush
+  the Redis key (`compendiq:cache:<userId>:spaces:list`) between runs.
+- **Reduced motion**: the script pins `reducedMotion: 'no-preference'`
+  on the Playwright context. Without that, the GraphPage's
+  `cooldownTicks={prefersReducedMotion ? 0 : 100}` short-circuits and
+  the convergence sample bottoms out at 0 ms regardless of size.
+- **Postgres reachability**: dev compose binds Postgres on the
+  `data-net` (internal-only on the EE stack, exposed on the CE stack).
+  If your Postgres is internal-only, run the bench inside a sidecar
+  container that joins the data network, or temporarily expose 5432.
 
 ### Result format
 

--- a/perf/README.md
+++ b/perf/README.md
@@ -267,7 +267,7 @@ npx tsx scripts/perf-graph-bench.ts --cleanup
 |------|---------|-------|
 | `--sizes=500,1000,2000,5000` | full sweep | Comma-separated node counts |
 | `--web-url=URL` | `http://localhost:8081` | Frontend origin Playwright navigates to |
-| `--backend-url=URL` | `http://localhost:3051` | Backend used for `/api/auth/login` |
+| `--backend-url=URL` | `http://localhost:3052` | Backend used for `/api/auth/login` (matches dev compose's `BACKEND_HOST_PORT` default) |
 | `--username=NAME` | `benchuser` | Must already exist (register once) |
 | `--password=PASS` | `benchpass123` | |
 | `--headless=true|false` | `true` | `false` to watch the browser drive |

--- a/scripts/perf-graph-bench.test.ts
+++ b/scripts/perf-graph-bench.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { neighbours, decide, EDGES_PER_NODE, type BenchSample } from './perf-graph-bench';
+
+describe('perf-graph-bench helpers (#380 Phase 1)', () => {
+  describe('neighbours', () => {
+    it('returns at most EDGES_PER_NODE neighbours for any node', () => {
+      for (const n of [10, 100, 500, 2000]) {
+        for (const i of [0, Math.floor(n / 2), n - 1]) {
+          expect(neighbours(i, n).length).toBeLessThanOrEqual(EDGES_PER_NODE);
+        }
+      }
+    });
+
+    it('never returns the source node as its own neighbour', () => {
+      for (const n of [10, 100, 1000]) {
+        for (let i = 0; i < n; i++) {
+          expect(neighbours(i, n)).not.toContain(i);
+        }
+      }
+    });
+
+    it('produces unique neighbours per call', () => {
+      const result = neighbours(50, 1000);
+      expect(new Set(result).size).toBe(result.length);
+    });
+
+    it('wraps around so first/last nodes still get neighbours', () => {
+      // Node 0 should still produce neighbours via the modular wrap
+      // (offset -1 wraps to n-1) — otherwise the head of the graph would
+      // be a sink.
+      expect(neighbours(0, 100).length).toBeGreaterThan(0);
+      expect(neighbours(99, 100).length).toBeGreaterThan(0);
+    });
+
+    it('includes a long-range hop (~sqrt(n)) so the graph is not just a ring', () => {
+      // For n=2000, sqrt is ~44 — neighbours(0, 2000) should include
+      // either 44 or, where collisions happen, a sibling. We just assert
+      // that one of the neighbours is far away from i.
+      const out = neighbours(0, 2000);
+      const hasLongRange = out.some((j) => Math.min(j, 2000 - j) >= 10);
+      expect(hasLongRange).toBe(true);
+    });
+  });
+
+  describe('decide', () => {
+    function sample(overrides: Partial<BenchSample>): BenchSample {
+      return {
+        size: 2000,
+        pageCount: 2000,
+        edgeCount: 5000,
+        centerPageId: 1,
+        timeToFirstPaintMs: 500,
+        layoutConvergenceMs: 2000,
+        fpsDuringInteraction: 60,
+        jsHeapUsedMb: 100,
+        ...overrides,
+      };
+    }
+
+    it('says Phase 2 is NOT justified when 2000-node sample is healthy', () => {
+      const verdict = decide([sample({ size: 2000 })]);
+      expect(verdict.phase2Justified).toBe(false);
+      expect(verdict.reasons).toEqual([]);
+    });
+
+    it('flags fps < 30 at 2000 nodes', () => {
+      const verdict = decide([sample({ size: 2000, fpsDuringInteraction: 22 })]);
+      expect(verdict.phase2Justified).toBe(true);
+      expect(verdict.reasons.some((r) => r.includes('fps'))).toBe(true);
+    });
+
+    it('flags convergence > 5000 ms at 2000 nodes', () => {
+      const verdict = decide([sample({ size: 2000, layoutConvergenceMs: 6500 })]);
+      expect(verdict.phase2Justified).toBe(true);
+      expect(verdict.reasons.some((r) => r.includes('convergence'))).toBe(true);
+    });
+
+    it('reports both reasons when both thresholds breach', () => {
+      const verdict = decide([
+        sample({ size: 2000, layoutConvergenceMs: 7000, fpsDuringInteraction: 18 }),
+      ]);
+      expect(verdict.phase2Justified).toBe(true);
+      expect(verdict.reasons.length).toBe(2);
+    });
+
+    it('returns phase2Justified=false with an explanation when no 2000-node sample exists', () => {
+      const verdict = decide([sample({ size: 1000 })]);
+      expect(verdict.phase2Justified).toBe(false);
+      expect(verdict.reasons[0]).toMatch(/2000-node/);
+    });
+
+    it('uses the 2000-node sample even when other sizes also breach', () => {
+      // 5000 with bad fps must NOT trigger Phase 2 on its own — the
+      // decision rule is anchored on the 2000 sample (issue #380).
+      const verdict = decide([
+        sample({ size: 1000, fpsDuringInteraction: 55 }),
+        sample({ size: 2000, fpsDuringInteraction: 55, layoutConvergenceMs: 2500 }),
+        sample({ size: 5000, fpsDuringInteraction: 12 }),
+      ]);
+      expect(verdict.phase2Justified).toBe(false);
+    });
+  });
+});

--- a/scripts/perf-graph-bench.test.ts
+++ b/scripts/perf-graph-bench.test.ts
@@ -48,7 +48,7 @@ describe('perf-graph-bench helpers (#380 Phase 1)', () => {
         size: 2000,
         pageCount: 2000,
         edgeCount: 5000,
-        centerPageId: 1,
+        samplePageId: 1,
         timeToFirstPaintMs: 500,
         layoutConvergenceMs: 2000,
         fpsDuringInteraction: 60,

--- a/scripts/perf-graph-bench.test.ts
+++ b/scripts/perf-graph-bench.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { neighbours, decide, EDGES_PER_NODE, type BenchSample } from './perf-graph-bench';
+import {
+  neighbours,
+  decide,
+  benchInitScriptBody,
+  EDGES_PER_NODE,
+  type BenchSample,
+} from './perf-graph-bench';
 
 describe('perf-graph-bench helpers (#380 Phase 1)', () => {
   describe('neighbours', () => {
@@ -98,6 +104,95 @@ describe('perf-graph-bench helpers (#380 Phase 1)', () => {
         sample({ size: 5000, fpsDuringInteraction: 12 }),
       ]);
       expect(verdict.phase2Justified).toBe(false);
+    });
+  });
+
+  // ---- benchInitScriptBody single-shot guarantee ----
+  // Playwright's addInitScript replays the script on every navigation,
+  // and the prior bug shipped a fresh rAF wrapper layer on each replay.
+  // The fix relies on a window-level `__benchInstalled` flag. These
+  // tests pin that contract in a fake-DOM so a regression can't slip
+  // through without the full Playwright lane catching it.
+  describe('benchInitScriptBody single-shot guarantee', () => {
+    function buildFakeWindow(): {
+      rafCalls: Array<(t: number) => void>;
+      windowProxy: Record<string, unknown>;
+    } {
+      const rafCalls: Array<(t: number) => void> = [];
+      const baseRaf = (cb: (t: number) => void) => {
+        rafCalls.push(cb);
+        return rafCalls.length;
+      };
+      const ls = new Map<string, string>();
+      const windowProxy: Record<string, unknown> = {
+        requestAnimationFrame: baseRaf,
+        localStorage: {
+          setItem: (k: string, v: string) => ls.set(k, v),
+          getItem: (k: string) => ls.get(k) ?? null,
+        },
+        performance: { now: () => 0 },
+      };
+      return { rafCalls, windowProxy };
+    }
+
+    function runScript(windowProxy: Record<string, unknown>) {
+      // Simulate Playwright's evaluation: the script body sees the page
+      // window as `window`. Bind a tiny shim so the function body's
+      // `window` references resolve to our fake.
+      const fn = new Function(
+        'window',
+        'localStorage',
+        'performance',
+        `(${benchInitScriptBody.toString()})({ token: 'tok' });`,
+      );
+      fn(windowProxy, windowProxy.localStorage, windowProxy.performance);
+    }
+
+    it('wraps requestAnimationFrame exactly once across multiple replays', () => {
+      const { windowProxy } = buildFakeWindow();
+      const original = windowProxy.requestAnimationFrame;
+
+      // First replay (initial page load).
+      runScript(windowProxy);
+      const afterFirst = windowProxy.requestAnimationFrame;
+      expect(afterFirst).not.toBe(original);
+      expect(windowProxy.__benchInstalled).toBe(true);
+
+      // Second replay (a goto in the same page lifetime).
+      runScript(windowProxy);
+      expect(windowProxy.requestAnimationFrame).toBe(afterFirst);
+
+      // Third replay (next iteration of the size sweep).
+      runScript(windowProxy);
+      expect(windowProxy.requestAnimationFrame).toBe(afterFirst);
+    });
+
+    it('resets the rAF counter on every replay', () => {
+      const { windowProxy } = buildFakeWindow();
+
+      runScript(windowProxy);
+      const bench1 = windowProxy.__bench as Record<string, number>;
+      bench1.rafCount = 42;
+      bench1.lastRaf = 9999;
+
+      runScript(windowProxy);
+      const bench2 = windowProxy.__bench as Record<string, number>;
+      expect(bench2.rafCount).toBe(0);
+      expect(bench2.lastRaf).toBe(0);
+      expect(bench2.startedAt).toBe(0);
+    });
+
+    it('seeds the auth token into localStorage so the SPA boots authenticated', () => {
+      const { windowProxy } = buildFakeWindow();
+      runScript(windowProxy);
+
+      const stored = (windowProxy.localStorage as { getItem: (k: string) => string | null }).getItem(
+        'compendiq-auth',
+      );
+      expect(stored).toBeTruthy();
+      const parsed = JSON.parse(stored!);
+      expect(parsed.state.accessToken).toBe('tok');
+      expect(parsed.state.isAuthenticated).toBe(true);
     });
   });
 });

--- a/scripts/perf-graph-bench.ts
+++ b/scripts/perf-graph-bench.ts
@@ -1,0 +1,621 @@
+#!/usr/bin/env npx tsx
+/**
+ * Graph performance benchmark — issue #380 Phase 1.
+ *
+ * Generates synthetic graphs at the four target sizes (default
+ * 500/1000/2000/5000) with realistic edge density (top-K=5 per node, score
+ * >= 0.6 to match the corpus-tiered floor that landed in #378), drives a
+ * Playwright session against `/graph?focus=<id>&full=1`, and records:
+ *
+ *   - layout convergence time (rAF activity stalls)
+ *   - fps during a programmatic pan + drag of 3 random nodes
+ *   - time-to-first-paint (canvas mounted in DOM)
+ *   - JS heap usage from `performance.memory`
+ *
+ * Output: `perf/graph-bench-results.json`. The script applies the issue's
+ * decision rule and prints whether Phase 2 is justified.
+ *
+ * Usage:
+ *   docker compose -f docker/docker-compose.yml up -d --build   # bring up the dev stack
+ *   npx tsx scripts/perf-graph-bench.ts                         # full sweep
+ *   npx tsx scripts/perf-graph-bench.ts --sizes=500,1000        # subset
+ *   npx tsx scripts/perf-graph-bench.ts --cleanup               # remove fixtures
+ *
+ * Env / flags:
+ *   POSTGRES_URL          (default postgresql://kb_user:changeme-postgres@localhost:5432/kb_creator)
+ *   --web-url=URL         (default http://localhost:8081)
+ *   --backend-url=URL     (default http://localhost:3051)
+ *   --username=...        (default benchuser)
+ *   --password=...        (default benchpass123)
+ *   --headless=true|false (default true; set false to watch the browser)
+ *   --keep-fixtures       (skip cleanup at the end so re-runs are faster)
+ *
+ * The synthetic fixtures live in spaces named `PERF-BENCH-<size>` and pages
+ * with `confluence_id` prefix `perf-bench-<size>-`, so cleanup never
+ * touches real corpora. The benchmark user is granted access via the
+ * existing RBAC seed (`user_space_selections` + `space_admin` role), so
+ * the same fixtures show up in the `/api/pages/graph` endpoint without
+ * any RBAC monkey-patching.
+ */
+
+import pg from 'pg';
+import { chromium } from 'playwright';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const { Pool } = pg;
+
+// ── Configuration ───────────────────────────────────────────────────────────
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '..');
+const RESULTS_PATH = resolve(REPO_ROOT, 'perf/graph-bench-results.json');
+
+const POSTGRES_URL =
+  process.env.POSTGRES_URL ??
+  'postgresql://kb_user:changeme-postgres@localhost:5432/kb_creator';
+
+interface Args {
+  sizes: number[];
+  webUrl: string;
+  backendUrl: string;
+  username: string;
+  password: string;
+  cleanup: boolean;
+  keepFixtures: boolean;
+  headless: boolean;
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const get = (name: string, fallback: string) => {
+    const arg = argv.find((a) => a.startsWith(`--${name}=`));
+    return arg ? arg.slice(name.length + 3) : fallback;
+  };
+  const flag = (name: string) => argv.includes(`--${name}`);
+  const sizes = get('sizes', '500,1000,2000,5000')
+    .split(',')
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  return {
+    sizes,
+    webUrl: get('web-url', 'http://localhost:8081').replace(/\/$/, ''),
+    backendUrl: get('backend-url', 'http://localhost:3051').replace(/\/$/, ''),
+    username: get('username', 'benchuser'),
+    password: get('password', 'benchpass123'),
+    cleanup: flag('cleanup'),
+    keepFixtures: flag('keep-fixtures'),
+    headless: get('headless', 'true') !== 'false',
+  };
+}
+
+// ── Edge density: top-K=5 per node, score floor 0.6 ─────────────────────────
+
+export const EDGES_PER_NODE = 5;
+export const MIN_SCORE = 0.6;
+export const MAX_SCORE = 0.95;
+
+function randomScore(): number {
+  return MIN_SCORE + Math.random() * (MAX_SCORE - MIN_SCORE);
+}
+
+/**
+ * Deterministic neighbour generator — exported for unit tests so the
+ * synthetic graph density can be verified without touching Postgres.
+ *
+ * A node connects to its ±1, ±2 ring plus a `sqrt(n)` long-range hop.
+ * That mimics the cluster-with-bridges shape of a real Confluence corpus
+ * and keeps the centre node reachable from most others, which is what a
+ * focused (`?focus=`) view actually exercises.
+ */
+export function neighbours(i: number, n: number): number[] {
+  const offsets = [1, -1, 2, -2, Math.floor(Math.sqrt(n))];
+  const seen = new Set<number>();
+  const out: number[] = [];
+  for (const off of offsets) {
+    const j = (i + off + n) % n;
+    if (j === i || seen.has(j)) continue;
+    seen.add(j);
+    out.push(j);
+    if (out.length >= EDGES_PER_NODE) break;
+  }
+  return out;
+}
+
+// ── DB helpers ──────────────────────────────────────────────────────────────
+
+interface SeedResult {
+  spaceKey: string;
+  centerPageId: number;
+  pageCount: number;
+  edgeCount: number;
+}
+
+const SPACE_PREFIX = 'PERF-BENCH-';
+const PAGE_PREFIX = 'perf-bench-';
+
+async function ensureSpace(client: pg.PoolClient, spaceKey: string): Promise<void> {
+  await client.query(
+    `INSERT INTO spaces (space_key, space_name, source, last_synced)
+     VALUES ($1, $2, 'confluence', NOW())
+     ON CONFLICT (space_key) DO NOTHING`,
+    [spaceKey, `Bench ${spaceKey}`],
+  );
+}
+
+async function ensureUser(
+  client: pg.PoolClient,
+  username: string,
+  password: string,
+): Promise<string> {
+  const existing = await client.query<{ id: string }>(
+    'SELECT id FROM users WHERE username = $1',
+    [username],
+  );
+  if (existing.rows.length > 0) return existing.rows[0]!.id;
+
+  // Use bcrypt via the existing column. The benchmark only ever logs in
+  // through the real /auth/login flow, so the hash needs to verify against
+  // bcrypt — defer to the running backend's /auth/register instead.
+  throw new Error(
+    `User '${username}' not found. Register them via:\n` +
+      `  curl -X POST ${'<backend-url>'}/api/auth/register \\\n` +
+      `       -H 'Content-Type: application/json' \\\n` +
+      `       -d '{"username":"${username}","password":"${password}"}'`,
+  );
+}
+
+async function grantSpaceAccess(
+  client: pg.PoolClient,
+  userId: string,
+  spaceKey: string,
+): Promise<void> {
+  await client.query(
+    `INSERT INTO user_space_selections (user_id, space_key)
+     VALUES ($1, $2)
+     ON CONFLICT DO NOTHING`,
+    [userId, spaceKey],
+  );
+}
+
+async function cleanupSize(client: pg.PoolClient, size: number): Promise<void> {
+  const spaceKey = `${SPACE_PREFIX}${size}`;
+  await client.query(
+    `DELETE FROM pages WHERE confluence_id LIKE $1`,
+    [`${PAGE_PREFIX}${size}-%`],
+  );
+  await client.query(`DELETE FROM spaces WHERE space_key = $1`, [spaceKey]);
+}
+
+async function seedSize(
+  pool: pg.Pool,
+  size: number,
+  userId: string,
+): Promise<SeedResult> {
+  const spaceKey = `${SPACE_PREFIX}${size}`;
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await cleanupSize(client, size);
+    await ensureSpace(client, spaceKey);
+    await grantSpaceAccess(client, userId, spaceKey);
+
+    // Bulk-insert pages. parent_id stays NULL so there's no parent_child
+    // edges to confuse the embedding-similarity layout numbers — Phase 1
+    // is measuring the renderer + force layout under a known edge type.
+    const ids: number[] = [];
+    for (let batchStart = 0; batchStart < size; batchStart += 500) {
+      const batchEnd = Math.min(batchStart + 500, size);
+      const values: string[] = [];
+      const params: unknown[] = [];
+      let p = 1;
+      for (let i = batchStart; i < batchEnd; i++) {
+        const cid = `${PAGE_PREFIX}${size}-${i.toString().padStart(6, '0')}`;
+        values.push(
+          `($${p++}, $${p++}, $${p++}, '', '', 1, ARRAY[]::text[], 'bench', NOW(), NOW(), false, 'embedded', NOW(), 'confluence', 'shared', 'page')`,
+        );
+        params.push(cid, spaceKey, `Bench page ${i}`);
+      }
+      const res = await client.query<{ id: number }>(
+        `INSERT INTO pages (
+            confluence_id, space_key, title, body_text, body_html,
+            version, labels, author, last_modified_at, last_synced,
+            embedding_dirty, embedding_status, embedded_at,
+            source, visibility, page_type
+          ) VALUES ${values.join(',')} RETURNING id`,
+        params,
+      );
+      ids.push(...res.rows.map((r) => r.id));
+    }
+
+    // Build the edge list — top-K=5 neighbours per node, all
+    // `embedding_similarity` with score >= 0.6.
+    const edgeRows: Array<{ a: number; b: number; score: number }> = [];
+    const seenPair = new Set<string>();
+    for (let i = 0; i < ids.length; i++) {
+      for (const j of neighbours(i, ids.length)) {
+        const a = ids[i]!;
+        const b = ids[j]!;
+        const lo = Math.min(a, b);
+        const hi = Math.max(a, b);
+        if (lo === hi) continue;
+        const key = `${lo}-${hi}`;
+        if (seenPair.has(key)) continue;
+        seenPair.add(key);
+        edgeRows.push({ a: lo, b: hi, score: randomScore() });
+      }
+    }
+
+    // Bulk insert edges. The unique constraint is
+    // (page_id_1, page_id_2, relationship_type) — pairs are normalised to
+    // (lo, hi) so each undirected edge appears once.
+    for (let batchStart = 0; batchStart < edgeRows.length; batchStart += 1000) {
+      const batchEnd = Math.min(batchStart + 1000, edgeRows.length);
+      const values: string[] = [];
+      const params: unknown[] = [];
+      let p = 1;
+      for (let i = batchStart; i < batchEnd; i++) {
+        const e = edgeRows[i]!;
+        values.push(
+          `($${p++}, $${p++}, 'embedding_similarity', $${p++}, NOW())`,
+        );
+        params.push(e.a, e.b, e.score);
+      }
+      await client.query(
+        `INSERT INTO page_relationships
+            (page_id_1, page_id_2, relationship_type, score, created_at)
+          VALUES ${values.join(',')}
+          ON CONFLICT DO NOTHING`,
+        params,
+      );
+    }
+
+    await client.query('COMMIT');
+
+    return {
+      spaceKey,
+      centerPageId: ids[Math.floor(ids.length / 2)]!,
+      pageCount: ids.length,
+      edgeCount: edgeRows.length,
+    };
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+// ── Browser instrumentation ─────────────────────────────────────────────────
+
+export interface BenchSample {
+  size: number;
+  pageCount: number;
+  edgeCount: number;
+  /** Centre page id (the `?focus=` target). */
+  centerPageId: number;
+  /** Time from navigation to the canvas being mounted, in ms. */
+  timeToFirstPaintMs: number;
+  /** Time from canvas mount until rAF activity stalls (force layout settles), in ms. */
+  layoutConvergenceMs: number;
+  /** FPS sampled during the programmatic pan + drag of 3 random nodes. */
+  fpsDuringInteraction: number;
+  /** `performance.memory.usedJSHeapSize` at the end of the run, in MB. */
+  jsHeapUsedMb: number | null;
+}
+
+async function login(
+  page: import('playwright').Page,
+  backendUrl: string,
+  username: string,
+  password: string,
+): Promise<string> {
+  const res = await page.request.post(`${backendUrl}/api/auth/login`, {
+    data: { username, password },
+  });
+  if (!res.ok()) {
+    throw new Error(`Login failed: ${res.status()} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { accessToken: string };
+  return body.accessToken;
+}
+
+const FIRST_PAINT_TIMEOUT_MS = 30_000;
+// The simulation uses cooldownTicks=100 with d3AlphaDecay=0.03 — convergence
+// settles in ~1–3 s on small graphs, ~5–10 s once the node count climbs.
+// 30 s is a generous upper bound for the 5000-node case.
+const CONVERGENCE_TIMEOUT_MS = 30_000;
+const CONVERGENCE_QUIET_MS = 350;
+const FPS_WINDOW_MS = 2_000;
+
+async function runOne(
+  page: import('playwright').Page,
+  webUrl: string,
+  size: number,
+  seed: SeedResult,
+  accessToken: string,
+): Promise<BenchSample> {
+  // Inject the auth token + a tiny rAF instrumentation BEFORE the SPA
+  // starts up. The instrumentation timestamps every requestAnimationFrame
+  // tick — convergence is detected by polling for "no rAF in the last N ms".
+  await page.addInitScript(
+    ({ token }) => {
+      try {
+        // The auth store hydrates from localStorage on mount.
+        localStorage.setItem(
+          'compendiq-auth',
+          JSON.stringify({
+            state: { accessToken: token, isAuthenticated: true, user: null },
+            version: 0,
+          }),
+        );
+      } catch {
+        /* localStorage may be unavailable in some contexts */
+      }
+      const w = window as unknown as Record<string, unknown>;
+      w.__bench = {
+        rafCount: 0,
+        lastRaf: 0,
+        startedAt: 0,
+      };
+      const orig = window.requestAnimationFrame.bind(window);
+      window.requestAnimationFrame = (cb) =>
+        orig((t) => {
+          const data = w.__bench as Record<string, number>;
+          data.rafCount++;
+          data.lastRaf = performance.now();
+          if (data.startedAt === 0) data.startedAt = data.lastRaf;
+          return cb(t);
+        });
+    },
+    { token: accessToken },
+  );
+
+  const url = `${webUrl}/graph?focus=${seed.centerPageId}&full=1`;
+  const navStart = Date.now();
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+
+  // ─ TTFP: wait for the canvas to be in the DOM. react-force-graph-2d
+  //   renders a single <canvas> inside [data-testid="graph-container"].
+  await page.waitForSelector('[data-testid="graph-container"] canvas', {
+    timeout: FIRST_PAINT_TIMEOUT_MS,
+  });
+  const timeToFirstPaintMs = Date.now() - navStart;
+
+  // ─ Convergence: poll until rAF has been idle for CONVERGENCE_QUIET_MS.
+  //   The first paint isn't the start of the simulation — the engine
+  //   warms up after the data fetch resolves — so we use the rAF start
+  //   timestamp captured inside the page.
+  const layoutConvergenceMs = await page.evaluate(
+    async ({ quietMs, timeoutMs }) => {
+      const w = window as unknown as Record<string, unknown>;
+      const data = w.__bench as Record<string, number>;
+      const startedAt = data.startedAt || performance.now();
+      const deadline = performance.now() + timeoutMs;
+      while (performance.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 50));
+        if (performance.now() - data.lastRaf >= quietMs) {
+          return Math.max(0, data.lastRaf - startedAt);
+        }
+      }
+      // If we never see a quiet window, report the elapsed time so
+      // the verdict still flags this size as a Phase-2 candidate.
+      return performance.now() - startedAt;
+    },
+    { quietMs: CONVERGENCE_QUIET_MS, timeoutMs: CONVERGENCE_TIMEOUT_MS },
+  );
+
+  // ─ Pan + drag interaction. We sample fps over a short window while
+  //   driving programmatic mouse moves on the canvas. The canvas centre
+  //   is used as the pan anchor; the drag is a small wiggle on three
+  //   random nodes — we don't have node screen positions so the wiggle
+  //   is approximated by moves around the canvas centre, which is
+  //   representative of "user interacting with the graph".
+  const box = await page
+    .locator('[data-testid="graph-container"] canvas')
+    .boundingBox();
+  if (!box) throw new Error('Could not measure canvas bounding box');
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+
+  // Reset the rAF counter to measure fps during the interaction window.
+  await page.evaluate(() => {
+    const w = window as unknown as Record<string, unknown>;
+    const data = w.__bench as Record<string, number>;
+    data.rafCount = 0;
+  });
+  const fpsStart = performance.now();
+  // 1) Pan: mouse-down + drag from centre.
+  await page.mouse.move(cx, cy);
+  await page.mouse.down();
+  for (let s = 0; s < 10; s++) {
+    await page.mouse.move(cx + s * 12, cy + s * 7, { steps: 4 });
+    await page.waitForTimeout(20);
+  }
+  await page.mouse.up();
+  // 2) Drag 3 "random" nodes. We don't know exact node screen positions
+  //    so we issue drag gestures at offsets around the canvas centre.
+  for (let n = 0; n < 3; n++) {
+    const dx = (Math.random() - 0.5) * box.width * 0.6;
+    const dy = (Math.random() - 0.5) * box.height * 0.6;
+    await page.mouse.move(cx + dx, cy + dy);
+    await page.mouse.down();
+    for (let s = 0; s < 6; s++) {
+      await page.mouse.move(cx + dx + s * 10, cy + dy + s * 5, { steps: 4 });
+      await page.waitForTimeout(25);
+    }
+    await page.mouse.up();
+  }
+  // Pad out to FPS_WINDOW_MS so the sample is over a stable window.
+  const elapsed = performance.now() - fpsStart;
+  if (elapsed < FPS_WINDOW_MS) {
+    await page.waitForTimeout(FPS_WINDOW_MS - elapsed);
+  }
+
+  const fpsDuringInteraction = await page.evaluate((windowMs) => {
+    const w = window as unknown as Record<string, unknown>;
+    const data = w.__bench as Record<string, number>;
+    return (data.rafCount * 1000) / windowMs;
+  }, FPS_WINDOW_MS);
+
+  // ─ Memory (Chrome only). Wrapped in a try/catch because a strict
+  //   Content-Security-Policy can disable `performance.memory`.
+  const jsHeapUsedMb = await page.evaluate(() => {
+    type ChromePerformance = Performance & { memory?: { usedJSHeapSize: number } };
+    const mem = (performance as ChromePerformance).memory;
+    return mem ? Math.round((mem.usedJSHeapSize / (1024 * 1024)) * 10) / 10 : null;
+  });
+
+  return {
+    size,
+    pageCount: seed.pageCount,
+    edgeCount: seed.edgeCount,
+    centerPageId: seed.centerPageId,
+    timeToFirstPaintMs,
+    layoutConvergenceMs: Math.round(layoutConvergenceMs),
+    fpsDuringInteraction: Math.round(fpsDuringInteraction * 10) / 10,
+    jsHeapUsedMb,
+  };
+}
+
+// ── Decision rule (issue #380) ──────────────────────────────────────────────
+
+export interface Verdict {
+  phase2Justified: boolean;
+  reasons: string[];
+}
+
+/**
+ * Apply the issue-#380 decision rule to a set of samples. Exported for
+ * unit tests so the threshold logic can be exercised without booting a
+ * browser.
+ */
+export function decide(samples: BenchSample[]): Verdict {
+  const reasons: string[] = [];
+  const target = samples.find((s) => s.size === 2000);
+  if (!target) {
+    return {
+      phase2Justified: false,
+      reasons: ['No 2000-node sample collected — verdict cannot be applied.'],
+    };
+  }
+  if (target.fpsDuringInteraction < 30) {
+    reasons.push(
+      `2000-node drag fps = ${target.fpsDuringInteraction} (< 30 fps threshold).`,
+    );
+  }
+  if (target.layoutConvergenceMs > 5000) {
+    reasons.push(
+      `2000-node layout convergence = ${target.layoutConvergenceMs} ms (> 5000 ms threshold).`,
+    );
+  }
+  return { phase2Justified: reasons.length > 0, reasons };
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  const pool = new Pool({ connectionString: POSTGRES_URL });
+
+  if (args.cleanup) {
+    const client = await pool.connect();
+    try {
+      for (const size of args.sizes) await cleanupSize(client, size);
+      console.log(`Cleaned up sizes ${args.sizes.join(', ')}.`);
+    } finally {
+      client.release();
+      await pool.end();
+    }
+    return;
+  }
+
+  const userClient = await pool.connect();
+  let userId: string;
+  try {
+    userId = await ensureUser(userClient, args.username, args.password);
+  } finally {
+    userClient.release();
+  }
+
+  console.log(`Bench user: ${args.username} (${userId})`);
+  console.log(`Sizes: ${args.sizes.join(', ')}`);
+
+  const seeds = new Map<number, SeedResult>();
+  for (const size of args.sizes) {
+    process.stdout.write(`Seeding ${size} pages... `);
+    const seed = await seedSize(pool, size, userId);
+    seeds.set(size, seed);
+    console.log(`OK (${seed.pageCount} pages, ${seed.edgeCount} edges, focus=${seed.centerPageId})`);
+  }
+
+  const browser = await chromium.launch({ headless: args.headless });
+  const samples: BenchSample[] = [];
+  try {
+    const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    const page = await context.newPage();
+    const accessToken = await login(page, args.backendUrl, args.username, args.password);
+
+    for (const size of args.sizes) {
+      const seed = seeds.get(size)!;
+      console.log(`\nMeasuring ${size} nodes...`);
+      const sample = await runOne(page, args.webUrl, size, seed, accessToken);
+      samples.push(sample);
+      console.log(
+        `  ttfp=${sample.timeToFirstPaintMs}ms  conv=${sample.layoutConvergenceMs}ms` +
+          `  fps=${sample.fpsDuringInteraction}  heap=${sample.jsHeapUsedMb ?? 'n/a'}MB`,
+      );
+    }
+  } finally {
+    await browser.close();
+    if (!args.keepFixtures) {
+      const client = await pool.connect();
+      try {
+        for (const size of args.sizes) await cleanupSize(client, size);
+      } finally {
+        client.release();
+      }
+    }
+    await pool.end();
+  }
+
+  const verdict = decide(samples);
+  const report = {
+    schemaVersion: 1,
+    issue: '#380',
+    runAt: new Date().toISOString(),
+    config: {
+      sizes: args.sizes,
+      edgesPerNode: EDGES_PER_NODE,
+      minScore: MIN_SCORE,
+      maxScore: MAX_SCORE,
+    },
+    samples,
+    verdict,
+  };
+
+  await mkdir(dirname(RESULTS_PATH), { recursive: true });
+  await writeFile(RESULTS_PATH, JSON.stringify(report, null, 2) + '\n', 'utf8');
+  console.log(`\nWrote ${RESULTS_PATH}`);
+
+  console.log('\n── Verdict ────────────────────────────────────────────');
+  if (verdict.phase2Justified) {
+    console.log('Phase 2 is JUSTIFIED:');
+    for (const r of verdict.reasons) console.log(`  - ${r}`);
+  } else {
+    console.log('Phase 2 is NOT justified — per-hop cap + tiered threshold');
+    console.log('from #378 are sufficient at the measured corpus shape.');
+  }
+}
+
+// Only auto-run when invoked directly (`npx tsx scripts/perf-graph-bench.ts`).
+// Importing this module from a test (perf-graph-bench.test.ts) won't trip
+// the bench, since vitest passes a different entry URL for test runners.
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('perf-graph-bench.ts')) {
+  main().catch((err) => {
+    console.error('perf-graph-bench failed:', err);
+    process.exit(1);
+  });
+}

--- a/scripts/perf-graph-bench.ts
+++ b/scripts/perf-graph-bench.ts
@@ -82,7 +82,10 @@ function parseArgs(): Args {
   return {
     sizes,
     webUrl: get('web-url', 'http://localhost:8081').replace(/\/$/, ''),
-    backendUrl: get('backend-url', 'http://localhost:3051').replace(/\/$/, ''),
+    // Default to :3052 — the dev compose maps backend → host port 3052
+    // (BACKEND_HOST_PORT in docker-compose.yml). 3051 is the in-container
+    // port, which isn't reachable from a host-side Playwright run.
+    backendUrl: get('backend-url', 'http://localhost:3052').replace(/\/$/, ''),
     username: get('username', 'benchuser'),
     password: get('password', 'benchpass123'),
     cleanup: flag('cleanup'),
@@ -107,8 +110,8 @@ function randomScore(): number {
  *
  * A node connects to its ±1, ±2 ring plus a `sqrt(n)` long-range hop.
  * That mimics the cluster-with-bridges shape of a real Confluence corpus
- * and keeps the centre node reachable from most others, which is what a
- * focused (`?focus=`) view actually exercises.
+ * and keeps the global graph well-connected, which is what the bench
+ * actually renders (`?full=1`, no `focus=`).
  */
 export function neighbours(i: number, n: number): number[] {
   const offsets = [1, -1, 2, -2, Math.floor(Math.sqrt(n))];
@@ -128,7 +131,10 @@ export function neighbours(i: number, n: number): number[] {
 
 interface SeedResult {
   spaceKey: string;
-  centerPageId: number;
+  /** A representative page id from the seed — used as a stable handle in
+   *  the JSON output. The bench renders the GLOBAL graph (`?full=1`,
+   *  no `focus=`), so this id is not used to route the page. */
+  samplePageId: number;
   pageCount: number;
   edgeCount: number;
 }
@@ -172,16 +178,28 @@ async function grantSpaceAccess(
   userId: string,
   spaceKey: string,
 ): Promise<void> {
+  // RBAC space access is determined solely by `space_role_assignments`
+  // (see rbac-service.ts:`getUserAccessibleSpaces`, which explicitly
+  // states it does NOT consult `user_space_selections`). The earlier
+  // version of this script wrote to `user_space_selections` and the
+  // bench user got back `[]` accessible spaces → the graph endpoint
+  // returned no nodes regardless of how many we seeded. Assign the
+  // bench user the `editor` role for read access to the space.
   await client.query(
-    `INSERT INTO user_space_selections (user_id, space_key)
-     VALUES ($1, $2)
-     ON CONFLICT DO NOTHING`,
-    [userId, spaceKey],
+    `INSERT INTO space_role_assignments (space_key, principal_type, principal_id, role_id)
+     SELECT $1, 'user', $2::text, r.id
+     FROM roles r
+     WHERE r.name = 'editor'
+     ON CONFLICT (space_key, principal_type, principal_id) DO NOTHING`,
+    [spaceKey, userId],
   );
 }
 
 async function cleanupSize(client: pg.PoolClient, size: number): Promise<void> {
   const spaceKey = `${SPACE_PREFIX}${size}`;
+  // page_relationships cascades on pages.id; pages don't cascade-delete
+  // role assignments (different lifecycle), so drop those explicitly.
+  await client.query(`DELETE FROM space_role_assignments WHERE space_key = $1`, [spaceKey]);
   await client.query(
     `DELETE FROM pages WHERE confluence_id LIKE $1`,
     [`${PAGE_PREFIX}${size}-%`],
@@ -276,7 +294,7 @@ async function seedSize(
 
     return {
       spaceKey,
-      centerPageId: ids[Math.floor(ids.length / 2)]!,
+      samplePageId: ids[Math.floor(ids.length / 2)]!,
       pageCount: ids.length,
       edgeCount: edgeRows.length,
     };
@@ -294,13 +312,18 @@ export interface BenchSample {
   size: number;
   pageCount: number;
   edgeCount: number;
-  /** Centre page id (the `?focus=` target). */
-  centerPageId: number;
+  /** A representative seeded page id, retained as a stable handle in
+   *  the JSON output. The bench renders the GLOBAL graph; this id is
+   *  not used to route the page. */
+  samplePageId: number;
   /** Time from navigation to the canvas being mounted, in ms. */
   timeToFirstPaintMs: number;
   /** Time from canvas mount until rAF activity stalls (force layout settles), in ms. */
   layoutConvergenceMs: number;
-  /** FPS sampled during the programmatic pan + drag of 3 random nodes. */
+  /** FPS sampled during programmatic pan + drag interaction across the
+   *  canvas. Drives simulation + render workload regardless of where
+   *  individual nodes happen to land in screen space (the renderer's
+   *  internal node positions aren't exposed to the page). */
   fpsDuringInteraction: number;
   /** `performance.memory.usedJSHeapSize` at the end of the run, in MB. */
   jsHeapUsedMb: number | null;
@@ -330,18 +353,23 @@ const CONVERGENCE_TIMEOUT_MS = 30_000;
 const CONVERGENCE_QUIET_MS = 350;
 const FPS_WINDOW_MS = 2_000;
 
-async function runOne(
+/**
+ * Install the auth token + rAF instrumentation ONCE for the lifetime of
+ * the page. Playwright's `addInitScript` is replayed on every navigation
+ * and registrations stack up — calling it inside the per-size loop
+ * meant the rAF wrapper was double/triple/quadruple-installed and the
+ * fps reading was inflated by the same factor (3× at the 2000-node
+ * decision sample, hiding any Phase-2-justifying regression). The
+ * inner `__benchInstalled` guard belt-and-braces against a re-add if
+ * this function is ever called twice by mistake.
+ */
+async function installBenchInit(
   page: import('playwright').Page,
-  webUrl: string,
-  size: number,
-  seed: SeedResult,
   accessToken: string,
-): Promise<BenchSample> {
-  // Inject the auth token + a tiny rAF instrumentation BEFORE the SPA
-  // starts up. The instrumentation timestamps every requestAnimationFrame
-  // tick — convergence is detected by polling for "no rAF in the last N ms".
+): Promise<void> {
   await page.addInitScript(
     ({ token }) => {
+      const w = window as unknown as Record<string, unknown>;
       try {
         // The auth store hydrates from localStorage on mount.
         localStorage.setItem(
@@ -354,12 +382,11 @@ async function runOne(
       } catch {
         /* localStorage may be unavailable in some contexts */
       }
-      const w = window as unknown as Record<string, unknown>;
-      w.__bench = {
-        rafCount: 0,
-        lastRaf: 0,
-        startedAt: 0,
-      };
+      // Reset the counters on every navigation; only wrap rAF on the
+      // first install so iterations N>1 don't accumulate wrappers.
+      w.__bench = { rafCount: 0, lastRaf: 0, startedAt: 0 };
+      if (w.__benchInstalled) return;
+      w.__benchInstalled = true;
       const orig = window.requestAnimationFrame.bind(window);
       window.requestAnimationFrame = (cb) =>
         orig((t) => {
@@ -372,8 +399,31 @@ async function runOne(
     },
     { token: accessToken },
   );
+}
 
-  const url = `${webUrl}/graph?focus=${seed.centerPageId}&full=1`;
+async function runOne(
+  page: import('playwright').Page,
+  webUrl: string,
+  size: number,
+  seed: SeedResult,
+): Promise<BenchSample> {
+  // Reset counters fresh for this iteration. The init script also resets
+  // them on navigation, but we do it here so the values are clean even
+  // if `goto` is fast enough to start the SPA before the init runs.
+  await page.evaluate(() => {
+    const w = window as unknown as Record<string, unknown>;
+    w.__bench = { rafCount: 0, lastRaf: 0, startedAt: 0 };
+  });
+
+  // The bench renders the GLOBAL graph (`?full=1`, no `focus=`). On
+  // origin/dev (#360 / #375), the GraphPage routes
+  //   wantsGlobal = !focusPageId && showFullGraph
+  // so combining `focus=…&full=1` would silently downgrade to the
+  // ego-graph endpoint (`/pages/{id}/graph/local?hops=2`), which caps
+  // at ~30 nodes regardless of seeded corpus size — every sample would
+  // measure the same ~30-node graph. Dropping the `focus=` param is
+  // what makes the seeded sizes actually matter.
+  const url = `${webUrl}/graph?full=1`;
   const navStart = Date.now();
   await page.goto(url, { waitUntil: 'domcontentloaded' });
 
@@ -407,12 +457,16 @@ async function runOne(
     { quietMs: CONVERGENCE_QUIET_MS, timeoutMs: CONVERGENCE_TIMEOUT_MS },
   );
 
-  // ─ Pan + drag interaction. We sample fps over a short window while
-  //   driving programmatic mouse moves on the canvas. The canvas centre
-  //   is used as the pan anchor; the drag is a small wiggle on three
-  //   random nodes — we don't have node screen positions so the wiggle
-  //   is approximated by moves around the canvas centre, which is
-  //   representative of "user interacting with the graph".
+  // ─ Pan + drag interaction. Drives the renderer + simulation under
+  //   load while we sample fps over a short window. We don't reach
+  //   inside react-force-graph-2d for actual node screen positions —
+  //   the gestures land on whatever the canvas is showing at the time.
+  //   That's deliberate: the metric is "rAF rate while the user is
+  //   interacting with the graph", which is what determines whether
+  //   the page feels smooth. The renderer redraws on every tick of the
+  //   force simulation regardless of which pixel the cursor is over,
+  //   so the fps reading is dominated by simulation cost, not by
+  //   whether we happened to grab a node.
   const box = await page
     .locator('[data-testid="graph-container"] canvas')
     .boundingBox();
@@ -435,8 +489,8 @@ async function runOne(
     await page.waitForTimeout(20);
   }
   await page.mouse.up();
-  // 2) Drag 3 "random" nodes. We don't know exact node screen positions
-  //    so we issue drag gestures at offsets around the canvas centre.
+  // 2) Three drag gestures at random canvas offsets — see the comment
+  //    above; these intentionally don't target specific nodes.
   for (let n = 0; n < 3; n++) {
     const dx = (Math.random() - 0.5) * box.width * 0.6;
     const dy = (Math.random() - 0.5) * box.height * 0.6;
@@ -472,7 +526,7 @@ async function runOne(
     size,
     pageCount: seed.pageCount,
     edgeCount: seed.edgeCount,
-    centerPageId: seed.centerPageId,
+    samplePageId: seed.samplePageId,
     timeToFirstPaintMs,
     layoutConvergenceMs: Math.round(layoutConvergenceMs),
     fpsDuringInteraction: Math.round(fpsDuringInteraction * 10) / 10,
@@ -548,7 +602,7 @@ async function main(): Promise<void> {
     process.stdout.write(`Seeding ${size} pages... `);
     const seed = await seedSize(pool, size, userId);
     seeds.set(size, seed);
-    console.log(`OK (${seed.pageCount} pages, ${seed.edgeCount} edges, focus=${seed.centerPageId})`);
+    console.log(`OK (${seed.pageCount} pages, ${seed.edgeCount} edges, sample=${seed.samplePageId})`);
   }
 
   const browser = await chromium.launch({ headless: args.headless });
@@ -557,11 +611,15 @@ async function main(): Promise<void> {
     const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
     const page = await context.newPage();
     const accessToken = await login(page, args.backendUrl, args.username, args.password);
+    // Install the auth-token + rAF instrumentation ONCE for the lifetime
+    // of the page. Calling it inside the iteration loop accumulates
+    // wrappers; see installBenchInit.
+    await installBenchInit(page, accessToken);
 
     for (const size of args.sizes) {
       const seed = seeds.get(size)!;
       console.log(`\nMeasuring ${size} nodes...`);
-      const sample = await runOne(page, args.webUrl, size, seed, accessToken);
+      const sample = await runOne(page, args.webUrl, size, seed);
       samples.push(sample);
       console.log(
         `  ttfp=${sample.timeToFirstPaintMs}ms  conv=${sample.layoutConvergenceMs}ms` +

--- a/scripts/perf-graph-bench.ts
+++ b/scripts/perf-graph-bench.ts
@@ -386,7 +386,15 @@ const FIRST_PAINT_TIMEOUT_MS = 30_000;
 // settles in ~1–3 s on small graphs, ~5–10 s once the node count climbs.
 // 30 s is a generous upper bound for the 5000-node case.
 const CONVERGENCE_TIMEOUT_MS = 30_000;
-const CONVERGENCE_QUIET_MS = 350;
+// Convergence is detected when the rAF rate drops below `IDLE_RATE_HZ` for
+// `CONVERGENCE_QUIET_MS` consecutive sampling. The page has continuous
+// background rAF activity (Framer Motion, Radix transitions, layout
+// reflows) at ~5–15 Hz, so "rAF goes fully quiet" never trips. The force
+// simulation drives rAF at the screen rate (~60 Hz) while running, so a
+// drop below 25 Hz reliably signals "force layout has stopped".
+const CONVERGENCE_SAMPLE_MS = 100;
+const CONVERGENCE_QUIET_MS = 500;
+const IDLE_RATE_HZ = 25;
 const FPS_WINDOW_MS = 2_000;
 
 /**
@@ -472,27 +480,53 @@ async function runOne(
   });
   const timeToFirstPaintMs = Date.now() - navStart;
 
-  // ─ Convergence: poll until rAF has been idle for CONVERGENCE_QUIET_MS.
-  //   The first paint isn't the start of the simulation — the engine
-  //   warms up after the data fetch resolves — so we use the rAF start
-  //   timestamp captured inside the page.
+  // ─ Convergence: sample the rAF rate over short windows and declare
+  //   the force layout settled when the rate falls below `IDLE_RATE_HZ`
+  //   for `CONVERGENCE_QUIET_MS` of consecutive low samples.
+  //
+  //   The earlier "rAF goes fully quiet" approach didn't work on the
+  //   real page — Framer Motion + Radix transitions + occasional
+  //   reflows keep rAF firing at ~5–15 Hz indefinitely, so the quiet
+  //   window never opens and convergence pegs at the timeout. The
+  //   force simulation drives rAF at the screen rate while running,
+  //   so a drop below 25 Hz reliably distinguishes "simulation
+  //   stopped" from "page is otherwise idle but never silent".
   const layoutConvergenceMs = await page.evaluate(
-    async ({ quietMs, timeoutMs }) => {
+    async ({ quietMs, timeoutMs, sampleMs, idleRateHz }) => {
       const w = window as unknown as Record<string, unknown>;
       const data = w.__bench as Record<string, number>;
       const startedAt = data.startedAt || performance.now();
       const deadline = performance.now() + timeoutMs;
+
+      let prevCount = data.rafCount;
+      let prevAt = performance.now();
+      let quietSince: number | null = null;
+
       while (performance.now() < deadline) {
-        await new Promise((r) => setTimeout(r, 50));
-        if (performance.now() - data.lastRaf >= quietMs) {
-          return Math.max(0, data.lastRaf - startedAt);
+        await new Promise((r) => setTimeout(r, sampleMs));
+        const now = performance.now();
+        const elapsed = now - prevAt;
+        const rate = elapsed > 0 ? ((data.rafCount - prevCount) * 1000) / elapsed : 0;
+        prevCount = data.rafCount;
+        prevAt = now;
+
+        if (rate < idleRateHz) {
+          if (quietSince === null) quietSince = now - elapsed;
+          if (now - quietSince >= quietMs) {
+            return Math.max(0, quietSince - startedAt);
+          }
+        } else {
+          quietSince = null;
         }
       }
-      // If we never see a quiet window, report the elapsed time so
-      // the verdict still flags this size as a Phase-2 candidate.
       return performance.now() - startedAt;
     },
-    { quietMs: CONVERGENCE_QUIET_MS, timeoutMs: CONVERGENCE_TIMEOUT_MS },
+    {
+      quietMs: CONVERGENCE_QUIET_MS,
+      timeoutMs: CONVERGENCE_TIMEOUT_MS,
+      sampleMs: CONVERGENCE_SAMPLE_MS,
+      idleRateHz: IDLE_RATE_HZ,
+    },
   );
 
   // ─ Pan + drag interaction. Drives the renderer + simulation under

--- a/scripts/perf-graph-bench.ts
+++ b/scripts/perf-graph-bench.ts
@@ -40,6 +40,7 @@
 
 import pg from 'pg';
 import { chromium } from 'playwright';
+import { createClient } from 'redis';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -329,6 +330,41 @@ export interface BenchSample {
   jsHeapUsedMb: number | null;
 }
 
+/**
+ * Best-effort flush of the bench user's RBAC space-list cache.
+ * `getUserAccessibleSpaces` caches under `rbac:spaces:<userId>` for 60 s
+ * (rbac-service.ts:14). If the previous run granted access to a different
+ * set of `PERF-BENCH-<size>` spaces, the cached list can be stale and the
+ * global graph endpoint will surface rows from spaces not in this run's
+ * seed. Falls back to a no-op when REDIS_URL is unset / unreachable —
+ * the bench README documents the manual workaround in that case.
+ */
+async function flushRbacCache(userId: string): Promise<void> {
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    console.log('  (REDIS_URL unset — skipped RBAC cache flush; wait 60 s if re-running with different sizes)');
+    return;
+  }
+  const client = createClient({ url });
+  client.on('error', () => { /* swallow — handled below */ });
+  try {
+    await client.connect();
+    await client.del(`rbac:spaces:${userId}`);
+    await client.del(`rbac:admin:${userId}`);
+    await client.del(`rbac:global:${userId}`);
+    console.log(`  Flushed RBAC cache for user ${userId}.`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.log(`  (RBAC cache flush skipped: ${msg})`);
+  } finally {
+    try {
+      await client.quit();
+    } catch {
+      /* ignore quit errors */
+    }
+  }
+}
+
 async function login(
   page: import('playwright').Page,
   backendUrl: string,
@@ -362,43 +398,46 @@ const FPS_WINDOW_MS = 2_000;
  * decision sample, hiding any Phase-2-justifying regression). The
  * inner `__benchInstalled` guard belt-and-braces against a re-add if
  * this function is ever called twice by mistake.
+ *
+ * The body is exported as `benchInitScriptBody` so a unit test can
+ * exercise the single-shot guarantee against a JSDOM-style fake `window`
+ * — Playwright's `addInitScript` runs this code as-is on every nav.
  */
+export function benchInitScriptBody(this: unknown, { token }: { token: string }): void {
+  const w = window as unknown as Record<string, unknown>;
+  try {
+    // The auth store hydrates from localStorage on mount.
+    localStorage.setItem(
+      'compendiq-auth',
+      JSON.stringify({
+        state: { accessToken: token, isAuthenticated: true, user: null },
+        version: 0,
+      }),
+    );
+  } catch {
+    /* localStorage may be unavailable in some contexts */
+  }
+  // Reset the counters on every navigation; only wrap rAF on the
+  // first install so iterations N>1 don't accumulate wrappers.
+  w.__bench = { rafCount: 0, lastRaf: 0, startedAt: 0 };
+  if (w.__benchInstalled) return;
+  w.__benchInstalled = true;
+  const orig = window.requestAnimationFrame.bind(window);
+  window.requestAnimationFrame = (cb) =>
+    orig((t) => {
+      const data = w.__bench as Record<string, number>;
+      data.rafCount++;
+      data.lastRaf = performance.now();
+      if (data.startedAt === 0) data.startedAt = data.lastRaf;
+      return cb(t);
+    });
+}
+
 async function installBenchInit(
   page: import('playwright').Page,
   accessToken: string,
 ): Promise<void> {
-  await page.addInitScript(
-    ({ token }) => {
-      const w = window as unknown as Record<string, unknown>;
-      try {
-        // The auth store hydrates from localStorage on mount.
-        localStorage.setItem(
-          'compendiq-auth',
-          JSON.stringify({
-            state: { accessToken: token, isAuthenticated: true, user: null },
-            version: 0,
-          }),
-        );
-      } catch {
-        /* localStorage may be unavailable in some contexts */
-      }
-      // Reset the counters on every navigation; only wrap rAF on the
-      // first install so iterations N>1 don't accumulate wrappers.
-      w.__bench = { rafCount: 0, lastRaf: 0, startedAt: 0 };
-      if (w.__benchInstalled) return;
-      w.__benchInstalled = true;
-      const orig = window.requestAnimationFrame.bind(window);
-      window.requestAnimationFrame = (cb) =>
-        orig((t) => {
-          const data = w.__bench as Record<string, number>;
-          data.rafCount++;
-          data.lastRaf = performance.now();
-          if (data.startedAt === 0) data.startedAt = data.lastRaf;
-          return cb(t);
-        });
-    },
-    { token: accessToken },
-  );
+  await page.addInitScript(benchInitScriptBody, { token: accessToken });
 }
 
 async function runOne(
@@ -407,23 +446,22 @@ async function runOne(
   size: number,
   seed: SeedResult,
 ): Promise<BenchSample> {
-  // Reset counters fresh for this iteration. The init script also resets
-  // them on navigation, but we do it here so the values are clean even
-  // if `goto` is fast enough to start the SPA before the init runs.
-  await page.evaluate(() => {
-    const w = window as unknown as Record<string, unknown>;
-    w.__bench = { rafCount: 0, lastRaf: 0, startedAt: 0 };
-  });
-
-  // The bench renders the GLOBAL graph (`?full=1`, no `focus=`). On
+  // The bench renders the GLOBAL graph (`?full=1`, no `focus=`) and
+  // restricts it to THIS iteration's seeded space via `&space=`. On
   // origin/dev (#360 / #375), the GraphPage routes
   //   wantsGlobal = !focusPageId && showFullGraph
   // so combining `focus=…&full=1` would silently downgrade to the
   // ego-graph endpoint (`/pages/{id}/graph/local?hops=2`), which caps
-  // at ~30 nodes regardless of seeded corpus size — every sample would
-  // measure the same ~30-node graph. Dropping the `focus=` param is
-  // what makes the seeded sizes actually matter.
-  const url = `${webUrl}/graph?full=1`;
+  // at ~30 nodes regardless of seeded corpus size.
+  //
+  // The `&space=` filter is load-bearing for the size sweep: `main()`
+  // seeds all four sizes upfront and grants the bench user editor
+  // access to every `PERF-BENCH-<size>` space, so without the filter
+  // the global endpoint would return the union (~8500 nodes) on every
+  // iteration and the four "size buckets" would all measure the same
+  // graph. With `space=` set, the GraphPage forwards `spaceKey=…` to
+  // `/api/pages/graph` and the seeded-size invariant is preserved.
+  const url = `${webUrl}/graph?full=1&space=${encodeURIComponent(seed.spaceKey)}`;
   const navStart = Date.now();
   await page.goto(url, { waitUntil: 'domcontentloaded' });
 
@@ -605,10 +643,26 @@ async function main(): Promise<void> {
     console.log(`OK (${seed.pageCount} pages, ${seed.edgeCount} edges, sample=${seed.samplePageId})`);
   }
 
+  // Best-effort RBAC cache flush so consecutive runs that change the
+  // bench user's space access don't read a stale 60 s-cached space list
+  // from `getUserAccessibleSpaces`. If REDIS_URL is unset or the broker
+  // is unreachable, the script just logs and proceeds — not an error.
+  await flushRbacCache(userId);
+
   const browser = await chromium.launch({ headless: args.headless });
   const samples: BenchSample[] = [];
   try {
-    const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    // `reducedMotion: 'no-preference'` — important. The GraphPage uses
+    // `cooldownTicks={prefersReducedMotion ? 0 : 100}` (and similarly
+    // bumps warmupTicks). If the host's `prefers-reduced-motion: reduce`
+    // setting leaks through, the force simulation runs zero ticks → the
+    // convergence sample bottoms out at 0 ms regardless of corpus size.
+    // Pin the value so the bench measures the rendering path users with
+    // motion enabled actually see.
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 900 },
+      reducedMotion: 'no-preference',
+    });
     const page = await context.newPage();
     const accessToken = await login(page, args.backendUrl, args.username, args.password);
     // Install the auth-token + rAF instrumentation ONCE for the lifetime

--- a/scripts/vitest.config.ts
+++ b/scripts/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+// Local config so `npx vitest run --config scripts/vitest.config.ts` can
+// exercise the pure helpers in scripts/perf-graph-bench.ts (issue #380).
+// The bench script lives outside the backend/frontend workspaces so the
+// existing `src/**/*.test.ts` includes never pick it up.
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['scripts/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Phase 1 of #380 / #361's measurement-driven plan. Phase 2 (server-side ForceAtlas2 + page_graph_layout cache) and the sigma.js renderer migration are intentionally deferred — they only land if the numbers from this Phase 1 run say they're justified.

## Summary
- New `scripts/perf-graph-bench.ts` — generates synthetic graphs at 500/1000/2000/5000 nodes with realistic edge density (top-K=5 per node, similarity score in [0.6, 0.95] to match the corpus-tiered floor that landed in #378), drives a Playwright session against `/graph?focus=<id>&full=1`, and records the four metrics the issue asks for to `perf/graph-bench-results.json`:
  - **time-to-first-paint** — navigation → canvas mounted in DOM
  - **layout convergence** — until `requestAnimationFrame` activity stalls (force simulation has finished its `cooldownTicks=100` budget)
  - **fps during pan + drag** of 3 random nodes (2 s sample window)
  - **`performance.memory.usedJSHeapSize`** (Chrome only)
- Edge topology: ±1 / ±2 ring + a `sqrt(n)` long-range hop, so the graph has the cluster-with-bridges shape of a real Confluence corpus rather than a disconnected forest.
- Runner uses the real `/api/auth/login` flow, then injects a tiny `requestAnimationFrame` instrumentation via `addInitScript` so convergence can be detected by polling for \"no rAF in the last 350 ms\". This avoids modifying production code or the GraphPage component.
- Decision rule (issue #380, applied to the 2000-node sample): `< 30 fps drag` OR `> 5 s convergence` → Phase 2 is justified. The verdict + reasons are printed at the end of the run and stored in the JSON output.
- Pure helpers (`neighbours`, `decide`) are exported and covered by 11 vitest cases in `scripts/perf-graph-bench.test.ts`, runnable via `npx vitest run --config scripts/vitest.config.ts` — pin the edge-density invariants and the threshold logic so they regress without booting Postgres or a browser.
- Fixtures live in spaces named `PERF-BENCH-<size>` and pages with `confluence_id` prefix `perf-bench-<size>-`, so cleanup never touches real corpora.
- `perf/README.md` documents end-to-end usage (dev-stack prerequisites, CLI flags, JSON schema of the output).

## Acceptance checklist (from #380)
- [x] Phase 1 benchmark lands.
- [ ] **Numbers from a real run pasted in this PR comment** — coming once the bench has been driven against the dev stack on a mid-tier machine. (Postgres on the dev compose is on an internal-only network; see `perf/README.md` for the sidecar / port-forward options.)

## What did NOT land
- Phase 2 (server-side ForceAtlas2, `page_graph_layout` table, `worker_threads` / BullMQ off-thread compute)
- sigma.js v3 + graphology renderer migration
- Both are gated on Phase 1 numbers, per the issue.

## Test plan
- [x] `npx vitest run --config scripts/vitest.config.ts` — 11 tests pass (edge-density invariants, decision-rule thresholds, both-breach + neither-breach paths)
- [x] `npx tsc --noEmit` clean on the script + test
- [x] Seed/cleanup SQL exercised end-to-end against the running Postgres container (no schema mismatches)
- [ ] Driven against the dev stack with real numbers — to be added in a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)