### PR TITLE
feat(ui): pane styling polish, settings click bug, AI page sticky chrome

### DIFF
--- a/backend/src/core/utils/version.ts
+++ b/backend/src/core/utils/version.ts
@@ -30,6 +30,7 @@ function loadVersion(): string {
 export interface AppBuildInfo {
   edition: string;
   commit: string;
+  ceCommit?: string;
   builtAt: string;
 }
 
@@ -50,6 +51,7 @@ function loadBuildInfo(): AppBuildInfo {
       return {
         edition: parsed.edition ?? DEFAULT_BUILD_INFO.edition,
         commit: parsed.commit ?? DEFAULT_BUILD_INFO.commit,
+        ceCommit: parsed.ceCommit,
         builtAt: parsed.builtAt ?? DEFAULT_BUILD_INFO.builtAt,
       };
     } catch {

--- a/backend/src/routes/foundation/health.ts
+++ b/backend/src/routes/foundation/health.ts
@@ -95,6 +95,7 @@ export async function healthRoutes(fastify: FastifyInstance) {
       version: APP_VERSION,
       edition: APP_BUILD_INFO.edition,
       commit: APP_BUILD_INFO.commit,
+      ceCommit: APP_BUILD_INFO.ceCommit,
       builtAt: APP_BUILD_INFO.builtAt,
       uptime: process.uptime(),
     });
@@ -123,6 +124,7 @@ export async function healthRoutes(fastify: FastifyInstance) {
       version: APP_VERSION,
       edition: APP_BUILD_INFO.edition,
       commit: APP_BUILD_INFO.commit,
+      ceCommit: APP_BUILD_INFO.ceCommit,
       builtAt: APP_BUILD_INFO.builtAt,
     });
   });
@@ -176,6 +178,7 @@ export async function healthRoutes(fastify: FastifyInstance) {
         version: APP_VERSION,
         edition: APP_BUILD_INFO.edition,
         commit: APP_BUILD_INFO.commit,
+        ceCommit: APP_BUILD_INFO.ceCommit,
         builtAt: APP_BUILD_INFO.builtAt,
         uptime: process.uptime(),
       });
@@ -192,6 +195,7 @@ export async function healthRoutes(fastify: FastifyInstance) {
         version: APP_VERSION,
         edition: APP_BUILD_INFO.edition,
         commit: APP_BUILD_INFO.commit,
+        ceCommit: APP_BUILD_INFO.ceCommit,
         builtAt: APP_BUILD_INFO.builtAt,
         uptime: process.uptime(),
       });

--- a/frontend/src/features/ai/AiAssistantPage.test.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.test.tsx
@@ -116,12 +116,17 @@ describe('AiAssistantPage', () => {
     expect(screen.getByText('Diagram')).toBeInTheDocument();
   });
 
-  it('uses space-y-4 natural scroll layout without fixed height', () => {
+  it('uses flex-1 column layout so the input bar anchors to the bottom of the viewport', () => {
+    // The AI page opts into the flex column propagated by AppLayout +
+    // PageTransition (both ship `flex flex-1 flex-col` on their wrappers).
+    // That lets this page reach `flex-1` without a `calc(100vh - chrome)`
+    // magic number that would drift with header / service-status height.
     const { container } = render(<AiAssistantPage />, { wrapper: createWrapper() });
     const rootDiv = container.firstElementChild as HTMLElement;
-    expect(rootDiv.className).toContain('space-y-3');
-    expect(rootDiv.className).not.toContain('h-full');
+    expect(rootDiv.className).toContain('flex-1');
+    expect(rootDiv.className).toContain('flex-col');
     expect(rootDiv.className).not.toContain('calc');
+    expect(rootDiv.className).not.toContain('100vh');
   });
 
   it('does not render a conversations sidebar', () => {

--- a/frontend/src/features/ai/AiAssistantPage.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.tsx
@@ -201,7 +201,12 @@ function AiAssistantInner() {
       initial={{ opacity: 0, y: 6 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.18 }}
-      className="flex min-h-[calc(100vh-104px)] flex-col gap-3"
+      // flex-1 walks up through the wrapper chain (AppLayout +
+      // PageTransition both opt into a flex column) so this page fills the
+      // available scroll height without depending on a `calc(100vh - chrome)`
+      // magic number that would drift if the header / service-status banner
+      // height changes.
+      className="flex flex-1 flex-col gap-3"
     >
       {/* Sticky sub-header: mode selector + optional type selector.
           Sits at top-0 of the scroll container so it stays visible as

--- a/frontend/src/features/ai/AiAssistantPage.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.tsx
@@ -201,9 +201,13 @@ function AiAssistantInner() {
       initial={{ opacity: 0, y: 6 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.18 }}
-      className="space-y-3"
+      className="flex min-h-[calc(100vh-104px)] flex-col gap-3"
     >
-      {/* Mode selector — Obsidian-like: minimal, no heavy glass */}
+      {/* Sticky sub-header: mode selector + optional type selector.
+          Sits at top-0 of the scroll container so it stays visible as
+          messages grow. backdrop-blur on the inner card keeps the surface
+          legible against the live content scrolling under it. */}
+      <div className="sticky top-0 z-20 -mx-1 space-y-3 bg-background/85 px-1 py-1 backdrop-blur">
       <div className="flex flex-wrap items-center gap-1 rounded-xl border border-border/40 bg-card/50 px-3 py-2 backdrop-blur-sm">
         <div
           role="tablist"
@@ -307,12 +311,16 @@ function AiAssistantInner() {
         </label>
       </div>
 
-      {/* Mode-specific type selectors */}
+      {/* Mode-specific type selectors — included in the sticky header so
+          they stay alongside the tabs while scrolling. */}
       {mode === 'improve' && <ImproveTypeSelector />}
       {mode === 'diagram' && <DiagramTypeSelector />}
+      </div>
 
-      {/* Messages — clean document-like surface, no heavy glass */}
-      <div className="overflow-hidden rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm">
+      {/* Messages — clean document-like surface, no heavy glass.
+          flex-1 so the messages area grows to fill the column, pushing
+          the sticky input bar to the bottom of the page. */}
+      <div className="flex-1 overflow-hidden rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm">
         <div className="min-h-[360px] space-y-4 p-5">
           {messages.length === 0 && (
             <div className="flex min-h-[300px] flex-col items-center justify-center text-center">
@@ -344,13 +352,17 @@ function AiAssistantInner() {
         </div>
       </div>
 
-      {/* Mode-specific input bar */}
-      {mode === 'ask' && <AskModeInput />}
-      {mode === 'improve' && <ImproveModeInput />}
-      {mode === 'generate' && <GenerateModeInput />}
-      {mode === 'summarize' && <SummarizeModeInput />}
-      {mode === 'diagram' && <DiagramModeInput />}
-      {mode === 'quality' && <QualityModeInput />}
+      {/* Mode-specific input bar — sticky at the bottom of the scroll
+          container, with a translucent backdrop so chat content scrolls
+          legibly behind it. */}
+      <div className="sticky bottom-0 z-20 -mx-1 bg-background/85 px-1 py-1 backdrop-blur">
+        {mode === 'ask' && <AskModeInput />}
+        {mode === 'improve' && <ImproveModeInput />}
+        {mode === 'generate' && <GenerateModeInput />}
+        {mode === 'summarize' && <SummarizeModeInput />}
+        {mode === 'diagram' && <DiagramModeInput />}
+        {mode === 'quality' && <QualityModeInput />}
+      </div>
     </m.div>
   );
 }

--- a/frontend/src/features/settings/LoginPage.tsx
+++ b/frontend/src/features/settings/LoginPage.tsx
@@ -35,7 +35,7 @@ export function LoginPage() {
 
   return (
     <div className="bg-background flex min-h-screen items-center justify-center p-4">
-      <div className="nm-card w-full max-w-md p-8">
+      <div className="w-full max-w-md rounded-xl border border-border/40 bg-card/50 p-8 backdrop-blur-sm">
         <div className="mb-2 flex flex-col items-center gap-3">
           <CompendiqLogo size={56} className="text-primary" animated />
           <h1 className="text-center text-2xl font-bold">

--- a/frontend/src/features/settings/SettingsLayout.tsx
+++ b/frontend/src/features/settings/SettingsLayout.tsx
@@ -69,7 +69,7 @@ export function SettingsLayout() {
     >
       <h1 className="mb-6 text-2xl font-bold tracking-[-0.01em]">Settings</h1>
 
-      <div className="nm-card grid grid-cols-1 md:grid-cols-[240px_1fr]">
+      <div className="grid grid-cols-1 rounded-xl border border-border/40 bg-card/50 backdrop-blur-sm md:grid-cols-[240px_1fr]">
         <nav
           aria-label="Settings"
           className="border-b border-white/10 p-3 md:border-b-0 md:border-r"

--- a/frontend/src/features/settings/panels/SystemTab.tsx
+++ b/frontend/src/features/settings/panels/SystemTab.tsx
@@ -6,6 +6,7 @@ interface HealthResponse {
   version?: string;
   edition?: string;
   commit?: string;
+  ceCommit?: string;
   builtAt?: string;
 }
 
@@ -71,6 +72,14 @@ export function SystemTab() {
               {backendBuild?.commit ?? '…'}
             </span>
           </div>
+          {backendBuild?.ceCommit && (
+            <div className="flex items-center justify-between">
+              <span>Backend CE commit</span>
+              <span className="font-mono" data-testid="backend-ce-commit">
+                {backendBuild.ceCommit}
+              </span>
+            </div>
+          )}
           <div className="flex items-center justify-between">
             <span>Frontend commit</span>
             <span className="font-mono" data-testid="frontend-commit">{__APP_COMMIT__}</span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -93,11 +93,11 @@ h1, h2, h3, h4, h5, h6,
 @theme {
   /* Default theme: Graphite Honey — graphite surfaces with honey accent (neumorphic dark).
      Hex values mirror compendiq-landing/src/styles/tokens.css [data-theme='graphite-honey']. */
-  --color-background: #121211;          /* graphite */
-  --color-foreground: #f5efe0;          /* warm cream, not pure white */
-  --color-card: #22211e;
-  --color-card-foreground: #f5efe0;
-  --color-card-elevated: #2a2925;
+  --color-background: #121212;          /* neutral graphite (was #121211 — warm tint removed) */
+  --color-foreground: #ece9e2;          /* near-neutral cream (was #f5efe0 — warmth dialled back) */
+  --color-card: #1f1f1f;                /* neutral dark gray pane (was #22211e — warm tint removed) */
+  --color-card-foreground: #ece9e2;
+  --color-card-elevated: #262626;       /* neutral elevated pane (was #2a2925) */
   --color-primary: #f9c74f;             /* honey — identical across themes */
   --color-primary-foreground: #0a0a0a;  /* black on honey for AA contrast */
   --color-primary-gradient-start: #fdd56d;
@@ -231,7 +231,7 @@ h1, h2, h3, h4, h5, h6,
 /* ---- Theme: Honey Linen — linen cream with honey accent (neumorphic light) ----
    Hex values mirror compendiq-landing/src/styles/tokens.css [data-theme='honey-linen']. */
 [data-theme="honey-linen"] {
-  --color-background: #f7f7f4;          /* near-neutral white with a whisper of warmth */
+  --color-background: #f7f7f7;          /* neutral near-white (was #f7f7f4 — warmth removed) */
   --color-foreground: #0a0a0a;          /* near-black brand text */
   --color-card: #ffffff;                /* pure white card */
   --color-card-foreground: #0a0a0a;

--- a/frontend/src/neumorphic-themes.test.ts
+++ b/frontend/src/neumorphic-themes.test.ts
@@ -108,12 +108,12 @@ describe('Theme store ships exactly Graphite Honey + Honey Linen', () => {
   it('preview hex colors carry the brand anchors', () => {
     const dark = THEMES.find((t) => t.id === 'graphite-honey')!;
     const light = THEMES.find((t) => t.id === 'honey-linen')!;
-    expect(dark.preview.bg.toLowerCase()).toBe('#121211');
+    expect(dark.preview.bg.toLowerCase()).toBe('#121212');
     expect(dark.preview.primary.toLowerCase()).toBe('#f9c74f');
     // Honey Linen background must match the actual rendered surface
     // (`--color-background` in [data-theme="honey-linen"]), not a brand-y
     // approximation — the picker chip is the only preview users see.
-    expect(light.preview.bg.toLowerCase()).toBe('#f7f7f4');
+    expect(light.preview.bg.toLowerCase()).toBe('#f7f7f7');
     expect(light.preview.primary.toLowerCase()).toBe('#f9c74f');
   });
 
@@ -138,12 +138,17 @@ describe('Default @theme block carries Graphite Honey anchors', () => {
     expect(themeBlock).not.toBe('');
   });
 
-  it('background is graphite #121211', () => {
-    expect(themeBlock).toMatch(/--color-background:\s*#121211/i);
+  it('background is neutral graphite #121212', () => {
+    // Neutralised from #121211 in the v0.4 follow-up to remove the warm tint
+    // that bled into translucent panes (`bg-card/50`) and made the surface
+    // read as yellow instead of dark gray. Brand honey accent unchanged.
+    expect(themeBlock).toMatch(/--color-background:\s*#121212/i);
   });
 
-  it('foreground is warm cream #f5efe0', () => {
-    expect(themeBlock).toMatch(/--color-foreground:\s*#f5efe0/i);
+  it('foreground is near-neutral cream #ece9e2', () => {
+    // Dialled back from #f5efe0 in the v0.4 follow-up — same legibility
+    // (still ≥ AA on graphite) without the warm yellow cast.
+    expect(themeBlock).toMatch(/--color-foreground:\s*#ece9e2/i);
   });
 
   it('primary is brand honey #f9c74f', () => {
@@ -194,10 +199,11 @@ describe('[data-theme="honey-linen"] block', () => {
     expect(honeyLinenBlock).not.toBe('');
   });
 
-  it('background is near-white with a hint of warmth', () => {
-    // Was #fbf7ef (warmer linen); shifted to #f7f7f4 — near-neutral white
-    // per the v0.4 refinement to reduce yellow cast in the light theme.
-    expect(honeyLinenBlock).toMatch(/--color-background:\s*#f7f7f4/i);
+  it('background is neutral near-white #f7f7f7', () => {
+    // Was #fbf7ef (warmer linen) → #f7f7f4 (whisper of warmth) → #f7f7f7
+    // (fully neutral) in the v0.4 follow-up. Removes the yellow cast that
+    // bled through translucent `bg-card/50` panes in light mode.
+    expect(honeyLinenBlock).toMatch(/--color-background:\s*#f7f7f7/i);
   });
 
   it('foreground is brand near-black #0a0a0a', () => {

--- a/frontend/src/shared/components/layout/AppLayout.tsx
+++ b/frontend/src/shared/components/layout/AppLayout.tsx
@@ -284,9 +284,13 @@ export function AppLayout({ children }: { children: ReactNode }) {
         {/* Main content area + optional right sidebar */}
         <div className="flex flex-1 overflow-hidden">
           <main className="flex flex-1 flex-col overflow-hidden">
-            <div ref={scrollContainerRef} data-scroll-container className="min-h-0 flex-1 overflow-y-auto px-4 pt-4 pb-4 [scrollbar-gutter:stable_both-edges]">
+            <div ref={scrollContainerRef} data-scroll-container className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 pt-4 pb-4 [scrollbar-gutter:stable_both-edges]">
               <PageTransition>
-                <div className={cn('mx-auto w-full', isArticleRoute ? 'max-w-[1400px]' : 'max-w-7xl')}>
+                {/* flex flex-1 flex-col so pages that opt in (e.g. /ai) can use
+                    flex-1 on a child to fill the available scroll height
+                    without resorting to a `calc(100vh - chrome)` magic number.
+                    Pages that don't opt in render with natural flow as before. */}
+                <div className={cn('mx-auto flex w-full flex-1 flex-col', isArticleRoute ? 'max-w-[1400px]' : 'max-w-7xl')}>
                   {children}
                 </div>
               </PageTransition>

--- a/frontend/src/shared/components/layout/PageTransition.test.tsx
+++ b/frontend/src/shared/components/layout/PageTransition.test.tsx
@@ -116,4 +116,22 @@ describe('PageTransition', () => {
     );
     expect(screen.getByText('Page view')).toBeInTheDocument();
   });
+
+  it('exit motion variant disables pointer-events so transition overlay does not swallow real clicks', async () => {
+    // Regression test for the Settings/AI panel click-loss bug. AnimatePresence
+    // mode="sync" keeps the exiting page mounted with `position: absolute;
+    // inset: 0` for ~220 ms while opacity fades out. Because <Outlet> reads
+    // from the *current* router context, both layers render the same panel —
+    // a real user click during the transition window lands on the
+    // soon-to-unmount overlay and is dropped when React unmounts the node.
+    // The fix is to set `pointerEvents: 'none'` on the exit variant so the
+    // overlay is invisible to hit-testing. Read the source directly so the
+    // test fails loudly if the property is removed by future refactors.
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const src = await fs.readFile(path.join(here, 'PageTransition.tsx'), 'utf-8');
+    expect(src).toMatch(/exit=\{[^}]*pointerEvents:\s*['"]none['"]/);
+  });
 });

--- a/frontend/src/shared/components/layout/PageTransition.tsx
+++ b/frontend/src/shared/components/layout/PageTransition.tsx
@@ -76,7 +76,7 @@ export function PageTransition({ children }: PageTransitionProps) {
         : 0;
 
   return (
-    <div style={{ position: 'relative' }}>
+    <div className="flex flex-1 flex-col" style={{ position: 'relative' }}>
       <AnimatePresence mode="sync" initial={false}>
         <m.div
           key={location.pathname}
@@ -94,7 +94,7 @@ export function PageTransition({ children }: PageTransitionProps) {
             duration: reducedMotion ? 0.1 : DURATION,
             ease: [0.25, 0.1, 0.25, 1], // cubic-bezier for smooth deceleration
           }}
-          className="w-full"
+          className="flex w-full flex-1 flex-col"
           style={animating ? { willChange: 'opacity, transform' } : undefined}
           onAnimationStart={() => setAnimating(true)}
           onAnimationComplete={() => setAnimating(false)}

--- a/frontend/src/shared/components/layout/PageTransition.tsx
+++ b/frontend/src/shared/components/layout/PageTransition.tsx
@@ -82,7 +82,14 @@ export function PageTransition({ children }: PageTransitionProps) {
           key={location.pathname}
           initial={{ opacity: 0, x: slideX }}
           animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: -slideX, position: 'absolute', top: 0, left: 0, right: 0 }}
+          // pointerEvents:'none' on exit: AnimatePresence keeps the exiting
+          // element absolutely positioned over the new one for ~220ms. Because
+          // <Outlet> always reads the current router context, both layers
+          // render the same panel — and a real user click during the
+          // transition window lands on the soon-to-unmount overlay, so focus
+          // never sticks. Disabling pointer events on the exit lets clicks
+          // pass through to the live page underneath.
+          exit={{ opacity: 0, x: -slideX, position: 'absolute', top: 0, left: 0, right: 0, pointerEvents: 'none' }}
           transition={{
             duration: reducedMotion ? 0.1 : DURATION,
             ease: [0.25, 0.1, 0.25, 1], // cubic-bezier for smooth deceleration

--- a/frontend/src/shared/hooks/use-keyboard-shortcuts.ts
+++ b/frontend/src/shared/hooks/use-keyboard-shortcuts.ts
@@ -106,8 +106,11 @@ export function useKeyboardShortcuts(
     // ESC inside a plain input/textarea/select blurs it so the user can
     // immediately use single-key shortcuts. Limited to native form fields —
     // contentEditable / TipTap have their own ESC semantics (close menu,
-    // exit cell, etc.) and we leave those alone.
-    if (event.key === 'Escape' && !hasModifier) {
+    // exit cell, etc.) and we leave those alone. We also bail when another
+    // listener already called preventDefault() (e.g. a Radix Dialog that
+    // wants to close on ESC and keep focus management intact) — checking
+    // defaultPrevented is what lets dialog ESC handlers win cleanly.
+    if (event.key === 'Escape' && !hasModifier && !event.defaultPrevented) {
       const target = event.target as HTMLElement | null;
       const tag = target?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {

--- a/frontend/src/shared/hooks/use-keyboard-shortcuts.ts
+++ b/frontend/src/shared/hooks/use-keyboard-shortcuts.ts
@@ -103,6 +103,19 @@ export function useKeyboardShortcuts(
     const hasModifier = event.metaKey || event.ctrlKey || event.altKey;
     const editable = isEditableTarget(event);
 
+    // ESC inside a plain input/textarea/select blurs it so the user can
+    // immediately use single-key shortcuts. Limited to native form fields —
+    // contentEditable / TipTap have their own ESC semantics (close menu,
+    // exit cell, etc.) and we leave those alone.
+    if (event.key === 'Escape' && !hasModifier) {
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+        target!.blur();
+        return;
+      }
+    }
+
     if (!hasModifier && !editable) {
       const key = event.key;
 

--- a/frontend/src/stores/theme-store.ts
+++ b/frontend/src/stores/theme-store.ts
@@ -42,7 +42,7 @@ export const THEMES: ThemeMeta[] = [
     label: 'Graphite Honey',
     description: 'Graphite surfaces with honey accent — neumorphic dark',
     category: 'dark',
-    preview: { bg: '#121211', card: '#22211e', primary: '#f9c74f', accent: '#f5efe0' },
+    preview: { bg: '#121212', card: '#1f1f1f', primary: '#f9c74f', accent: '#ece9e2' },
   },
   {
     id: 'honey-linen',
@@ -52,7 +52,7 @@ export const THEMES: ThemeMeta[] = [
     // Hex values must match the actual rendered surfaces in
     // index.css [data-theme="honey-linen"] — the picker chip is the only
     // way users see the surface color before applying the theme.
-    preview: { bg: '#f7f7f4', card: '#ffffff', primary: '#f9c74f', accent: '#0a0a0a' },
+    preview: { bg: '#f7f7f7', card: '#ffffff', primary: '#f9c74f', accent: '#0a0a0a' },
   },
 ];
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,7 @@ const rootPkg = JSON.parse(readFileSync(path.resolve(__dirname, '../package.json
 interface BuildInfo {
   edition: string;
   commit: string;
+  ceCommit?: string;
   builtAt: string;
 }
 let buildInfo: BuildInfo = { edition: 'community', commit: 'unknown', builtAt: '' };
@@ -28,7 +29,11 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   define: {
     __APP_VERSION__: JSON.stringify(rootPkg.version),
-    __APP_COMMIT__: JSON.stringify(buildInfo.commit),
+    // The frontend bundle is built entirely from CE source, even in EE
+    // builds (the EE overlay only patches the backend). Surface the CE
+    // commit as the frontend commit so it accurately reflects what was
+    // compiled. In CE-only builds ceCommit is absent; fall back to commit.
+    __APP_COMMIT__: JSON.stringify(buildInfo.ceCommit ?? buildInfo.commit),
     __APP_EDITION__: JSON.stringify(buildInfo.edition),
     __APP_BUILT_AT__: JSON.stringify(buildInfo.builtAt),
   },


### PR DESCRIPTION
## Summary

Cluster of UI polish + bugfixes uncovered while wiring up the EE build:

### Pane styling
- Settings, login, and AI panes now use a flat `bg-card/50 backdrop-blur` surface (same as the article view) instead of the neumorphic `nm-card` glow.
- Card / background tokens neutralised in both themes — Graphite Honey `--color-card` `#22211e → #1f1f1f`, `--color-background` `#121211 → #121212`, foreground `#f5efe0 → #ece9e2`; Honey Linen `--color-background` `#f7f7f4 → #f7f7f7`. Honey accent (`--color-primary`) preserved.

### Settings click-loss bug
After navigating into Settings and switching panels, real user clicks on the freshly-rendered inputs were being dropped (only the first reload worked). Root cause: `PageTransition` uses `<AnimatePresence mode="sync">` keyed on `pathname` and gives the exiting layer `position:absolute; inset:0`. Because `<Outlet>` always reads the *current* router context, both layers render the *same* panel — leaving an absolutely-positioned duplicate on top of the live one for ~220 ms. Real clicks during that window land on the soon-to-unmount overlay. Fix: add `pointerEvents:'none'` to the `exit` motion variant so the overlay no longer intercepts hit-testing.

### AI page sticky chrome
The AI assistant (`/ai`) sub-header (Q&A · Improve · Generate · Summarize · Diagram · Quality) and the mode-specific input bar are now sticky top / sticky bottom; the messages container is `flex-1` so the input anchors to the bottom of the viewport even when the conversation is empty.

### ESC blurs inputs
Single-key shortcuts are intentionally suppressed while focus is in an input/textarea (WCAG 2.1.4 carve-out in `useKeyboardShortcuts`). To make it easy to escape a focused field, ESC inside a plain `INPUT` / `TEXTAREA` / `SELECT` now blurs it. TipTap and other contentEditable surfaces are intentionally left alone because they have their own ESC semantics.

### Build info on `/api/health` + Settings → System
The frontend bundle is built from CE source even in EE builds (only the backend is overlaid), so showing the EE commit as the "Frontend commit" was misleading. Now:
- `build-info.json` carries both `commit` (active build) and `ceCommit` (underlying CE source).
- `APP_BUILD_INFO.ceCommit` exposed on `/api/health` so the System tab can render it as a second row.
- `vite.config.ts` falls back to `ceCommit ?? commit` for `__APP_COMMIT__` so the frontend always reports the commit it was actually compiled from.

## Test plan

- [ ] Login page, Settings page, AI page panes look flat (no neumorphic glow), neutral gray background in dark mode and clean white in light mode.
- [ ] Settings → AI Prompts → click in any prompt textarea immediately on first navigation: textarea focuses, no reload required.
- [ ] AI assistant `/ai`: scroll the conversation, mode tabs and input bar stay pinned to top/bottom respectively.
- [ ] Focus a search input, press ESC → cursor leaves the field. Focus a TipTap editor, press ESC → editor's own ESC handling continues to work.
- [ ] `/api/health` response includes both `commit` and `ceCommit`. Settings → System renders a "Backend CE commit" row in EE builds; "Frontend commit" matches the CE source commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)