### PR TITLE
fix(audit): emit auth_method on LOGIN_FAILED

### DIFF
--- a/backend/src/routes/foundation/auth.ts
+++ b/backend/src/routes/foundation/auth.ts
@@ -105,14 +105,14 @@ export async function authRoutes(fastify: FastifyInstance) {
     );
 
     if (result.rows.length === 0) {
-      await logAuditEvent(null, 'LOGIN_FAILED', 'user', undefined, { username: body.username, reason: 'user_not_found' }, request);
+      await logAuditEvent(null, 'LOGIN_FAILED', 'user', undefined, { auth_method: 'local', username: body.username, reason: 'user_not_found' }, request);
       throw fastify.httpErrors.unauthorized('Invalid username or password');
     }
 
     const user = result.rows[0]!;
     const valid = await bcrypt.compare(body.password, user.password_hash);
     if (!valid) {
-      await logAuditEvent(user.id, 'LOGIN_FAILED', 'user', user.id, { reason: 'invalid_password' }, request);
+      await logAuditEvent(user.id, 'LOGIN_FAILED', 'user', user.id, { auth_method: 'local', reason: 'invalid_password' }, request);
       throw fastify.httpErrors.unauthorized('Invalid username or password');
     }
 
@@ -124,7 +124,7 @@ export async function authRoutes(fastify: FastifyInstance) {
         'LOGIN_FAILED',
         'user',
         user.id,
-        { reason: 'deactivated' },
+        { auth_method: 'local', reason: 'deactivated' },
         request,
       );
       throw fastify.httpErrors.unauthorized('Account is deactivated — contact an administrator');


### PR DESCRIPTION
## Summary

LOGIN success and SESSION_CREATED already carry \`auth_method: 'local'\` in metadata (#307 P0b). The three LOGIN_FAILED emit sites do not, which breaks the Authentication & Session compliance report's per-source failed-login split (Compendiq/compendiq-ee#115 Report 4): in production all LOGIN_FAILED rows lack the field, so \`login_failed_local\` / \`login_failed_oidc\` on the cover sheet always read 0 even when local logins were failing.

Adds \`auth_method: 'local'\` to all three local-auth-route LOGIN_FAILED emissions: \`user_not_found\`, \`invalid_password\`, \`deactivated\`. OIDC-failed logins are still logged via the EE OIDC route and would need a separate LOGIN_FAILED emission there if/when an OIDC pipeline failure ever surfaces as a LOGIN_FAILED audit row (currently OIDC failures throw before audit emission — out of scope).

No behavioural change for any consumer that reads \`reason\`; the new key is additive.

## Caller flagged this

EE PR Compendiq/compendiq-ee#134 (Sprint 3 slice 1 of #115). The Authentication & Session compliance report cover-sheet histogram surfaced this as a 0 in audits where it should not have been. EE PR documents the gap as a temporary cover-sheet caveat; this CE PR fixes the root cause.

## Test plan

- [x] No existing test asserts on LOGIN_FAILED metadata shape (\`audit-service.test.ts\` exercises \`logAuditEvent\` directly with hand-rolled metadata; \`auth-routes.test.ts\` does not pivot on the metadata blob).
- [ ] After merge: bump EE submodule pointer (auto-sync handles this) and verify \`login_failed_local\` cover-sheet count is non-zero in EE compliance report integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)