### PR TITLE
fix(Compendiq/compendiq-ee#115): wire Compliance Reports tab into live settings IA

### DIFF
--- a/frontend/src/features/settings/SettingsLayout.test.tsx
+++ b/frontend/src/features/settings/SettingsLayout.test.tsx
@@ -123,7 +123,7 @@ describe('SettingsLayout — rail visibility', () => {
     authState.user = { role: 'admin' };
     enterpriseState.isEnterprise = true;
     enterpriseState.hasFeature = (feature) =>
-      ['org_llm_policy', 'llm_audit_trail', 'data_retention_policies', 'scim_provisioning'].includes(feature);
+      ['org_llm_policy', 'llm_audit_trail', 'data_retention_policies', 'scim_provisioning', 'compliance_reports'].includes(feature);
 
     renderLayoutAt('/settings/personal/confluence');
 
@@ -134,6 +134,27 @@ describe('SettingsLayout — rail visibility', () => {
     expect(screen.getByTestId('nav-settings-llm-policy')).toBeInTheDocument();
     expect(screen.getByTestId('nav-settings-llm-audit')).toBeInTheDocument();
     expect(screen.getByTestId('nav-settings-retention')).toBeInTheDocument();
+    // Regression: compliance reports tab was added in #115 Sprint 4 against
+    // the legacy SettingsPage, which is no longer mounted by App.tsx. This
+    // assertion fails if the entry is dropped from settings-nav.ts again.
+    expect(screen.getByTestId('nav-settings-compliance-reports')).toBeInTheDocument();
+  });
+
+  it('hides compliance-reports for an EE admin without the compliance_reports feature', async () => {
+    authState.user = { role: 'admin' };
+    enterpriseState.isEnterprise = true;
+    // Enterprise + SSO + retention but explicitly NOT compliance_reports.
+    // Mirrors a customer on a tier whose feature set excludes the report
+    // generator (e.g. business tier in the EE plugin's TIER_FEATURES map).
+    enterpriseState.hasFeature = (feature) =>
+      ['data_retention_policies'].includes(feature);
+
+    renderLayoutAt('/settings/personal/confluence');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nav-settings-retention')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('nav-settings-compliance-reports')).not.toBeInTheDocument();
   });
 });
 
@@ -276,6 +297,26 @@ describe('SettingsPanelRoute — EE deep-link loading race (PR #218 review findi
 
     await waitFor(() => {
       expect(screen.getByTestId('nav-settings-confluence')).toHaveAttribute('aria-current', 'page');
+    });
+  });
+
+  it('renders the compliance-reports panel for an EE admin with the feature', async () => {
+    // Pins the routing wiring added for Compendiq/compendiq-ee#115 Sprint 4:
+    // settings-nav.ts must declare the entry AND SettingsPanelRoute.tsx must
+    // map `security/compliance-reports` to ComplianceReportsTab. Either side
+    // missing => bounce to /settings/personal/confluence.
+    authState.user = { role: 'admin' };
+    enterpriseState.isLoading = false;
+    enterpriseState.isEnterprise = true;
+    enterpriseState.hasFeature = (feature) => feature === 'compliance_reports';
+
+    renderLayoutAt('/settings/security/compliance-reports');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nav-settings-compliance-reports')).toHaveAttribute(
+        'aria-current',
+        'page',
+      );
     });
   });
 });

--- a/frontend/src/features/settings/SettingsPanelRoute.tsx
+++ b/frontend/src/features/settings/SettingsPanelRoute.tsx
@@ -40,6 +40,7 @@ const LlmPolicyTab = lazy(() => import('../admin/LlmPolicyTab').then((m) => ({ d
 const DataRetentionTab = lazy(() => import('../admin/DataRetentionTab').then((m) => ({ default: m.DataRetentionTab })));
 const LlmAuditPage = lazy(() => import('../admin/LlmAuditPage').then((m) => ({ default: m.LlmAuditPage })));
 const ScimSettingsPage = lazy(() => import('../admin/ScimSettingsPage').then((m) => ({ default: m.ScimSettingsPage })));
+const ComplianceReportsTab = lazy(() => import('../admin/ComplianceReportsTab').then((m) => ({ default: m.ComplianceReportsTab })));
 const UsersAdminPage = lazy(() => import('../admin/UsersAdminPage').then((m) => ({ default: m.UsersAdminPage })));
 const SyncConflictPolicyTab = lazy(() => import('../admin/SyncConflictPolicyTab').then((m) => ({ default: m.SyncConflictPolicyTab })));
 const SyncConflictsPage = lazy(() => import('../admin/SyncConflictsPage').then((m) => ({ default: m.SyncConflictsPage })));
@@ -112,6 +113,7 @@ const PANELS: Readonly<Record<string, PanelRenderer>> = {
   'security/webhooks': () => <WebhooksTab />,
   'security/scim': () => <ScimSettingsPage />,
   'security/retention': () => <DataRetentionTab />,
+  'security/compliance-reports': () => <ComplianceReportsTab />,
 
   'system/license': () => <LicenseStatusCard />,
   'system/errors': () => <ErrorDashboard />,

--- a/frontend/src/features/settings/settings-nav.ts
+++ b/frontend/src/features/settings/settings-nav.ts
@@ -185,6 +185,17 @@ export const SETTINGS_NAV: readonly SettingsNavGroup[] = [
         enterpriseOnly: true,
         requiresFeature: 'data_retention_policies',
       }),
+      // Compliance Reports (Compendiq/compendiq-ee#115). Self-serve PDF +
+      // CSV evidence packets for SOC 2 / ISO 27001 audits — sits next to
+      // Data Retention because both surface auditor-facing evidence.
+      // Backend routes live under /api/admin/compliance-reports/* and are
+      // gated by the `compliance_reports` enterprise feature flag.
+      navItem('compliance-reports', 'Compliance Reports', {
+        adminOnly: true,
+        enterpriseOnly: true,
+        requiresFeature: 'compliance_reports',
+        legacyTabId: null,
+      }),
     ],
   },
   {


### PR DESCRIPTION
## Summary

Sprint 4 of [compendiq-ee#115](https://github.com/Compendiq/compendiq-ee/issues/115) (CE PR #391) added the Compliance Reports admin tab to the **legacy** `SettingsPage.tsx`. That file is no longer mounted by `App.tsx` — the live route has been `SettingsLayout` + `SettingsPanelRoute` (driven by `settings-nav.ts`) since PR #218's IA reorg. As a result, the new tab never appeared in the rail and `/settings/security/compliance-reports` redirected to the default panel for every user, including EE admins on enterprise-tier licenses.

This PR wires the tab into the live routing surface.

## Changes

- **`settings-nav.ts`** — add a `compliance-reports` entry under the **Security & Access** group, right after Data Retention. Gated on `adminOnly + enterpriseOnly + requiresFeature: 'compliance_reports'`. `legacyTabId: null` because there's no `?tab=` URL to back-compat (the legacy entry never shipped to a user before this fix).
- **`SettingsPanelRoute.tsx`** — lazy-import `ComplianceReportsTab` and map `security/compliance-reports` → component. The tab itself is unchanged; it already self-renders the gated empty state on 402/403/404.
- **`SettingsLayout.test.tsx`** — three new regressions:
  - Rail link appears for an EE admin with `compliance_reports`.
  - Rail link stays hidden when the feature is absent (e.g. business-tier license).
  - Panel route renders the tab when the URL is hit directly (pins both halves of the wiring).

The legacy `SettingsPage.tsx` entry is left untouched — the file is dead code already and a wider cleanup is out of scope here.

## Verification

- `npm run typecheck` ✅
- `npm run lint -w frontend` ✅
- `npm run test -w frontend -- src/features/settings/SettingsLayout.test.tsx src/features/settings/settings-nav.test.ts` → 27 passing (2 new).
- End-to-end against an enterprise-tier license in the local Compose stack: rail now shows "Compliance Reports" under Security & Access; panel renders the catalogue grid; production bundle ships a dedicated `ComplianceReportsTab-*.js` chunk via the lazy import.

## Test plan

- [ ] CI passes (typecheck + lint + frontend tests).
- [ ] After merge + EE submodule sync, the EE Compose stack rebuild surfaces the tab without further changes.
- [ ] Manual: log in as an admin on an enterprise license → Settings → Security & Access → Compliance Reports → catalogue grid renders the seven reports.
- [ ] Manual: log in as a business-tier admin → no Compliance Reports entry; direct navigation to `/settings/security/compliance-reports` bounces to the default panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)