### PR TITLE
fix: wire RBAC admin page into live settings IA

### DIFF
--- a/frontend/src/features/settings/SettingsLayout.test.tsx
+++ b/frontend/src/features/settings/SettingsLayout.test.tsx
@@ -123,7 +123,7 @@ describe('SettingsLayout — rail visibility', () => {
     authState.user = { role: 'admin' };
     enterpriseState.isEnterprise = true;
     enterpriseState.hasFeature = (feature) =>
-      ['org_llm_policy', 'llm_audit_trail', 'data_retention_policies', 'scim_provisioning', 'compliance_reports'].includes(feature);
+      ['org_llm_policy', 'llm_audit_trail', 'data_retention_policies', 'scim_provisioning', 'compliance_reports', 'advanced_rbac'].includes(feature);
 
     renderLayoutAt('/settings/personal/confluence');
 
@@ -138,6 +138,11 @@ describe('SettingsLayout — rail visibility', () => {
     // the legacy SettingsPage, which is no longer mounted by App.tsx. This
     // assertion fails if the entry is dropped from settings-nav.ts again.
     expect(screen.getByTestId('nav-settings-compliance-reports')).toBeInTheDocument();
+    // Regression: RbacPage + CustomRoleEditor are a complete admin UI
+    // for the `advanced_rbac` enterprise feature, but were never mounted
+    // in the live IA. This assertion fails if the entry is dropped from
+    // settings-nav.ts again.
+    expect(screen.getByTestId('nav-settings-rbac')).toBeInTheDocument();
   });
 
   it('hides compliance-reports for an EE admin without the compliance_reports feature', async () => {
@@ -155,6 +160,22 @@ describe('SettingsLayout — rail visibility', () => {
       expect(screen.getByTestId('nav-settings-retention')).toBeInTheDocument();
     });
     expect(screen.queryByTestId('nav-settings-compliance-reports')).not.toBeInTheDocument();
+  });
+
+  it('hides rbac for an EE admin without the advanced_rbac feature', async () => {
+    authState.user = { role: 'admin' };
+    enterpriseState.isEnterprise = true;
+    // Enterprise admin on a tier whose feature set excludes advanced_rbac
+    // (e.g. team tier in the EE plugin's TIER_FEATURES map). SSO is
+    // ungated EE so it still appears, pinning the test.
+    enterpriseState.hasFeature = (_feature) => false;
+
+    renderLayoutAt('/settings/personal/confluence');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nav-settings-sso')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('nav-settings-rbac')).not.toBeInTheDocument();
   });
 });
 
@@ -314,6 +335,26 @@ describe('SettingsPanelRoute — EE deep-link loading race (PR #218 review findi
 
     await waitFor(() => {
       expect(screen.getByTestId('nav-settings-compliance-reports')).toHaveAttribute(
+        'aria-current',
+        'page',
+      );
+    });
+  });
+
+  it('renders the rbac panel for an EE admin with the advanced_rbac feature', async () => {
+    // Pins the routing wiring for the orphaned RbacPage: settings-nav.ts
+    // must declare the entry AND SettingsPanelRoute.tsx must map
+    // `security/rbac` to RbacPage. Either side missing => bounce to
+    // /settings/personal/confluence.
+    authState.user = { role: 'admin' };
+    enterpriseState.isLoading = false;
+    enterpriseState.isEnterprise = true;
+    enterpriseState.hasFeature = (feature) => feature === 'advanced_rbac';
+
+    renderLayoutAt('/settings/security/rbac');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nav-settings-rbac')).toHaveAttribute(
         'aria-current',
         'page',
       );

--- a/frontend/src/features/settings/SettingsPanelRoute.tsx
+++ b/frontend/src/features/settings/SettingsPanelRoute.tsx
@@ -41,6 +41,7 @@ const DataRetentionTab = lazy(() => import('../admin/DataRetentionTab').then((m)
 const LlmAuditPage = lazy(() => import('../admin/LlmAuditPage').then((m) => ({ default: m.LlmAuditPage })));
 const ScimSettingsPage = lazy(() => import('../admin/ScimSettingsPage').then((m) => ({ default: m.ScimSettingsPage })));
 const ComplianceReportsTab = lazy(() => import('../admin/ComplianceReportsTab').then((m) => ({ default: m.ComplianceReportsTab })));
+const RbacPage = lazy(() => import('../admin/RbacPage').then((m) => ({ default: m.RbacPage })));
 const UsersAdminPage = lazy(() => import('../admin/UsersAdminPage').then((m) => ({ default: m.UsersAdminPage })));
 const SyncConflictPolicyTab = lazy(() => import('../admin/SyncConflictPolicyTab').then((m) => ({ default: m.SyncConflictPolicyTab })));
 const SyncConflictsPage = lazy(() => import('../admin/SyncConflictsPage').then((m) => ({ default: m.SyncConflictsPage })));
@@ -107,6 +108,7 @@ const PANELS: Readonly<Record<string, PanelRenderer>> = {
   'integrations/mcp-docs': () => <McpDocsTab />,
 
   'security/users': () => <UsersAdminPage />,
+  'security/rbac': () => <RbacPage />,
   'security/rate-limits': () => <RateLimitsTab />,
   'security/sso': () => <OidcSettingsPage />,
   'security/ip-allowlist': () => <IpAllowlistTab />,

--- a/frontend/src/features/settings/settings-nav.ts
+++ b/frontend/src/features/settings/settings-nav.ts
@@ -158,6 +158,18 @@ export const SETTINGS_NAV: readonly SettingsNavGroup[] = [
       // Per-user admin CRUD (#304). Lives under Security & Access because it
       // governs who can authenticate, not what settings they see.
       navItem('users', 'Users', { adminOnly: true, legacyTabId: null }),
+      // Roles & Permissions (advanced_rbac). RbacPage + CustomRoleEditor
+      // are a fully implemented admin UI for system roles, custom roles,
+      // and per-user assignments — backed by /api/admin/roles*,
+      // /api/admin/permissions, and /api/admin/role-assignments — but
+      // were never mounted in the live IA. Sits next to Users because
+      // both manage who-can-do-what.
+      navItem('rbac', 'Roles & Permissions', {
+        adminOnly: true,
+        enterpriseOnly: true,
+        requiresFeature: 'advanced_rbac',
+        legacyTabId: null,
+      }),
       navItem('rate-limits', 'Rate Limits', { adminOnly: true }),
       navItem('sso', 'SSO / OIDC', {
         adminOnly: true,


### PR DESCRIPTION
## Summary

`RbacPage.tsx` (777 lines) and `CustomRoleEditor.tsx` (501 lines) are a fully implemented admin UI for the `advanced_rbac` enterprise feature — system-role browser, custom-role CRUD, and per-user assignments — but they have never been mounted anywhere reachable in the SPA. `App.tsx` has no route, `settings-nav.ts` has no entry, and `SettingsPanelRoute.tsx` has no panel mapping. The backend has been exposing `/api/admin/roles*`, `/api/admin/permissions`, and `/api/admin/role-assignments` under the same feature flag, so the surface has been advertised in license features but never reachable from the UI.

Same dead-wiring class as PR #395 (Compliance Reports). This PR wires RBAC into the live IA using the same pattern.

## Changes

- **`frontend/src/features/settings/settings-nav.ts`** — add an `rbac` entry under the **Security & Access** group, right after `users`. RBAC sits naturally next to Users because both manage who-can-do-what. Gated on `adminOnly + enterpriseOnly + requiresFeature: 'advanced_rbac'`. `legacyTabId: null` because there is no `?tab=` URL to back-compat (the page was never reachable before this fix).
- **`frontend/src/features/settings/SettingsPanelRoute.tsx`** — lazy-import `RbacPage` and map `security/rbac` → component. The page itself is unchanged; it already self-renders an empty state when the user lacks permissions or the feature is off.
- **`frontend/src/features/settings/SettingsLayout.test.tsx`** — three new regressions:
  - Rail link appears for an EE admin with the `advanced_rbac` feature (extends the existing EE-only-items test).
  - Rail link stays hidden for an EE admin without the feature (e.g. team-tier license).
  - Panel route renders the page when `/settings/security/rbac` is hit directly (pins both halves of the wiring).

Backend routes referenced (already shipped on `dev` and gated by `advanced_rbac`):
- `GET/POST/PUT/DELETE /api/admin/roles*`
- `GET /api/admin/permissions`
- `GET/POST/DELETE /api/admin/role-assignments`

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅ (backend + frontend)
- `npm run test -w frontend -- src/features/settings/SettingsLayout.test.tsx` → 17 passing (3 new) ✅
- All run inside the merged EE build tree (`./scripts/build-enterprise.sh --skip-obfuscate` then `cd build && …`) so the wiring is exercised against the same module graph that ships in the EE image.

## Test plan

- [ ] CI passes (typecheck + lint + frontend tests).
- [ ] After merge + EE submodule sync, the EE Compose stack rebuild surfaces the tab without further changes.
- [ ] Manual: log in as an admin on an enterprise license with `advanced_rbac` → Settings → Security & Access → Roles & Permissions → role list renders with system + custom roles, and the "Create Custom Role" affordance is reachable.
- [ ] Manual: log in as an EE admin without `advanced_rbac` (e.g. team-tier) → no Roles & Permissions entry in the rail; direct navigation to `/settings/security/rbac` bounces to the default panel.

Precedent: PR #395 (Compliance Reports wiring) — same three-file glue, same gating shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)