### PR TITLE
feat: surface /admin/analytics for admins via user menu

### DIFF
--- a/frontend/src/shared/components/layout/UserMenu.test.tsx
+++ b/frontend/src/shared/components/layout/UserMenu.test.tsx
@@ -14,10 +14,14 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
+// Mutable across tests so we can flip role between non-admin and admin.
+let mockUser: { username: string; role?: 'user' | 'admin' } | null = {
+  username: 'testuser',
+};
 vi.mock('../../../stores/auth-store', () => ({
   useAuthStore: (selector: (s: Record<string, unknown>) => unknown) =>
     selector({
-      user: { username: 'testuser' },
+      user: mockUser,
     }),
 }));
 
@@ -58,6 +62,8 @@ describe('UserMenu', () => {
     mockOpenShortcuts.mockClear();
     mockSetSingleKeyShortcutsEnabled.mockClear();
     mockSingleKeyShortcutsEnabled = true;
+    // Default to a non-admin signed-in user; admin tests opt in.
+    mockUser = { username: 'testuser' };
   });
 
   afterEach(() => {
@@ -169,6 +175,51 @@ describe('UserMenu', () => {
 
     await vi.waitFor(() => {
       expect(mockLogoutApi).toHaveBeenCalled();
+    });
+  });
+
+  // /admin/analytics is mounted at App.tsx:165 but no UI links to it.
+  // The admin-only Analytics item in this menu is the discoverability fix —
+  // these tests pin the gating so a future refactor doesn't regress it back
+  // to URL-only access.
+  it('does NOT show the Analytics item for a non-admin user', async () => {
+    mockUser = { username: 'testuser', role: 'user' };
+    renderUserMenu();
+    const trigger = screen.getByRole('button');
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' });
+
+    await vi.waitFor(() => {
+      expect(trigger).toHaveAttribute('data-state', 'open');
+    });
+    // Settings is always visible — pin that the menu is fully open.
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.queryByText('Analytics')).not.toBeInTheDocument();
+  });
+
+  it('shows the Analytics item for an admin user', async () => {
+    mockUser = { username: 'adminuser', role: 'admin' };
+    renderUserMenu();
+    const trigger = screen.getByRole('button');
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Analytics')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to /admin/analytics when Analytics is selected by an admin', async () => {
+    mockUser = { username: 'adminuser', role: 'admin' };
+    renderUserMenu();
+    const trigger = screen.getByRole('button');
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' });
+
+    await vi.waitFor(() => {
+      expect(trigger).toHaveAttribute('data-state', 'open');
+    });
+
+    fireEvent.click(screen.getByText('Analytics'));
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/admin/analytics');
     });
   });
 });

--- a/frontend/src/shared/components/layout/UserMenu.tsx
+++ b/frontend/src/shared/components/layout/UserMenu.tsx
@@ -1,6 +1,6 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import * as Switch from '@radix-ui/react-switch';
-import { Keyboard, LogOut, Settings, User } from 'lucide-react';
+import { BarChart3, Keyboard, LogOut, Settings, User } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../../stores/auth-store';
 import { useKeyboardShortcutsStore } from '../../../stores/keyboard-shortcuts-store';
@@ -44,6 +44,20 @@ export function UserMenu() {
             <Settings size={14} />
             Settings
           </DropdownMenu.Item>
+          {user?.role === 'admin' && (
+            // /admin/analytics is mounted in App.tsx but no UI links to it.
+            // Surface it here so admins can reach the search-effectiveness,
+            // content-gap, AI-usage, and knowledge-health dashboards without
+            // having to know the URL. Enterprise gating still happens
+            // server-side on each /admin/analytics/* endpoint.
+            <DropdownMenu.Item
+              onSelect={() => navigate('/admin/analytics')}
+              className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-sm text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground transition-colors"
+            >
+              <BarChart3 size={14} />
+              Analytics
+            </DropdownMenu.Item>
+          )}
           <DropdownMenu.Item
             onSelect={openShortcuts}
             className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-sm text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground transition-colors"


### PR DESCRIPTION
## Summary

`AnalyticsPage` is mounted at `/admin/analytics` in `App.tsx` (line 165) but no UI element links to it — admins have to know the URL. The page hosts the `advanced_analytics` and `ai_usage_analytics` enterprise dashboards (search effectiveness, content gaps, AI usage, knowledge health). The page itself already exists and works; this PR is purely a discoverability fix.

Add an admin-only **Analytics** item to the user-menu dropdown, sitting between **Settings** and **Keyboard Shortcuts**. Non-admins see no change. Enterprise feature gating still happens server-side on each `/admin/analytics/*` endpoint, so a CE admin clicking through gets the existing empty-state response from the dashboards.

## Changes

- **`frontend/src/shared/components/layout/UserMenu.tsx`**
  - Import `BarChart3` from `lucide-react` to match the dashboard's visual identity.
  - Render a new `DropdownMenu.Item` labelled *Analytics* between *Settings* and *Keyboard Shortcuts*, gated on `user?.role === 'admin'` (read from the existing `useAuthStore` selector).
  - On select, call `navigate('/admin/analytics')`.
  - Styling/className mirror the adjacent items exactly.
- **`frontend/src/shared/components/layout/UserMenu.test.tsx`**
  - Promote the previously-fixed `useAuthStore` mock user to a per-test mutable `mockUser`, defaulting to a non-admin so existing assertions are unchanged.
  - Three new regressions:
    - Non-admin: Analytics item is **absent** when the menu is open (Settings present pins that the menu is fully expanded).
    - Admin: Analytics item is **present** when the menu is open.
    - Admin: clicking Analytics calls `navigate('/admin/analytics')`.

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅ (backend + frontend)
- `npm run test -w frontend -- src/shared/components/layout/UserMenu.test.tsx` → 14 passing (3 new) ✅
- All run inside the merged EE build tree (`./scripts/build-enterprise.sh --skip-obfuscate` then `cd build && …`).

## Test plan

- [ ] CI passes (typecheck + lint + frontend tests).
- [ ] After merge + EE submodule sync, the EE Compose stack rebuild surfaces the menu item without further changes.
- [ ] Manual: log in as a non-admin user → user menu has no Analytics entry.
- [ ] Manual: log in as an admin → user menu shows Analytics between Settings and Keyboard Shortcuts; clicking it navigates to `/admin/analytics` and the existing dashboard tabs render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)