### PR TITLE
fix(#398): declare @tiptap/core frontend dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-switch": "^1.1.3",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-virtual": "^3.13.21",
+    "@tiptap/core": "^3.0.0",
     "@tiptap/extension-code-block-lowlight": "^3.0.0",
     "@tiptap/extension-color": "^3.21.0",
     "@tiptap/extension-drag-handle-react": "^3.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,7 @@
         "@radix-ui/react-switch": "^1.1.3",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-virtual": "^3.13.21",
+        "@tiptap/core": "^3.0.0",
         "@tiptap/extension-code-block-lowlight": "^3.0.0",
         "@tiptap/extension-color": "^3.21.0",
         "@tiptap/extension-drag-handle-react": "^3.21.0",


### PR DESCRIPTION
## Summary
- add @tiptap/core as an explicit frontend dependency
- update the workspace lock metadata without changing the resolved Tiptap package graph

## Validation
- node JSON parse check for package-lock.json and frontend/package.json
- git diff --check

Closes #398