### PR TITLE
fix(#402): ignore stale command palette search responses

### DIFF
--- a/frontend/src/shared/components/layout/CommandPalette.test.tsx
+++ b/frontend/src/shared/components/layout/CommandPalette.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -31,6 +31,22 @@ vi.mock('react-router-dom', async () => {
     useNavigate: () => mockNavigate,
   };
 });
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
 
 describe('CommandPalette', () => {
   beforeEach(() => {
@@ -104,14 +120,11 @@ describe('CommandPalette', () => {
 
   it('searches pages on input with debounce', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          items: [
-            { id: '1', title: 'Test Page', spaceKey: 'TST' },
-          ],
-        }),
-        { headers: { 'Content-Type': 'application/json' } },
-      ),
+      jsonResponse({
+        items: [
+          { id: '1', title: 'Test Page', spaceKey: 'TST' },
+        ],
+      }),
     );
 
     useCommandPaletteStore.getState().open();
@@ -127,6 +140,62 @@ describe('CommandPalette', () => {
       },
       { timeout: 2000 },
     );
+    unmount();
+  });
+
+  it('ignores stale search responses that resolve after the latest query', async () => {
+    const oldSearch = deferred<Response>();
+    const newSearch = deferred<Response>();
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = String(input);
+      if (url.includes('search=old')) return oldSearch.promise;
+      if (url.includes('search=new')) return newSearch.promise;
+      return Promise.resolve(jsonResponse({ items: [] }));
+    });
+
+    useCommandPaletteStore.getState().open();
+    const { unmount } = render(<CommandPalette />, { wrapper: createWrapper() });
+
+    const input = screen.getByLabelText('Search');
+    fireEvent.change(input, { target: { value: 'old' } });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/api/pages?search=old&limit=8'),
+        expect.any(Object),
+      );
+    });
+
+    fireEvent.change(input, { target: { value: 'new' } });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/api/pages?search=new&limit=8'),
+        expect.any(Object),
+      );
+    });
+
+    await act(async () => {
+      newSearch.resolve(jsonResponse({
+        items: [{ id: 'new-page', title: 'Latest Result', spaceKey: 'NEW' }],
+      }));
+      await newSearch.promise;
+    });
+
+    expect(await screen.findByText('Latest Result')).toBeInTheDocument();
+
+    await act(async () => {
+      oldSearch.resolve(jsonResponse({
+        items: [{ id: 'old-page', title: 'Stale Result', spaceKey: 'OLD' }],
+      }));
+      await oldSearch.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Latest Result')).toBeInTheDocument();
+      expect(screen.queryByText('Stale Result')).not.toBeInTheDocument();
+    });
+
     unmount();
   });
 

--- a/frontend/src/shared/components/layout/CommandPalette.tsx
+++ b/frontend/src/shared/components/layout/CommandPalette.tsx
@@ -58,7 +58,7 @@ export function CommandPalette() {
   const [isSearching, setIsSearching] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchSequenceRef = useRef(0);
 
   // AI mode: activated when query starts with "/ai"
   const isAiMode = query.trimStart().toLowerCase().startsWith('/ai');
@@ -80,29 +80,41 @@ export function CommandPalette() {
 
   // Search pages with debounce (skip in AI mode)
   useEffect(() => {
+    const searchSequence = searchSequenceRef.current + 1;
+    searchSequenceRef.current = searchSequence;
+
     if (!query.trim() || isAiMode) {
       setResults([]);
       setSelectedIndex(0);
+      setIsSearching(false);
       return;
     }
 
-    if (debounceRef.current) clearTimeout(debounceRef.current);
+    const controller = new AbortController();
 
-    debounceRef.current = setTimeout(async () => {
+    const timeoutId = setTimeout(async () => {
       setIsSearching(true);
       try {
-        const data = await apiFetch<{ items: SearchResult[] }>(`/pages?search=${encodeURIComponent(query)}&limit=8`);
+        const data = await apiFetch<{ items: SearchResult[] }>(
+          `/pages?search=${encodeURIComponent(query)}&limit=8`,
+          { signal: controller.signal },
+        );
+        if (searchSequenceRef.current !== searchSequence) return;
         setResults(data.items);
         setSelectedIndex(0);
       } catch {
+        if (controller.signal.aborted || searchSequenceRef.current !== searchSequence) return;
         setResults([]);
       } finally {
-        setIsSearching(false);
+        if (searchSequenceRef.current === searchSequence) {
+          setIsSearching(false);
+        }
       }
     }, 250);
 
     return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
+      clearTimeout(timeoutId);
+      controller.abort();
     };
   }, [query, isAiMode]);
 


### PR DESCRIPTION
## Summary
- replace the shared debounce ref with per-query timeout cleanup
- abort obsolete command-palette searches
- ignore late responses unless they match the latest search sequence
- add a regression for out-of-order search responses

## Validation
- npm test -w frontend -- CommandPalette.test.tsx
- npm run typecheck -w frontend

Closes #402