### PR TITLE
chore(knip): mark EE extension-point exports as @public

### DIFF
--- a/backend/src/core/services/ai-review-hook.ts
+++ b/backend/src/core/services/ai-review-hook.ts
@@ -21,6 +21,12 @@ export type AiReviewAction =
   | 'auto_tag'
   | 'apply_improvement';
 
+/**
+ * @public Used by the EE overlay
+ * (`overlay/backend/src/enterprise/ai-review-service.ts`) as the return
+ * type of `submitForReview`, which the EE plugin registers into the CE
+ * hook via `setAiReviewHook(...)`. Knip's CE-scoped scan cannot see it.
+ */
 export type AiReviewDecision =
   | { mode: 'auto-publish' }
   | { mode: 'pending'; reviewId: string };

--- a/backend/src/core/services/pii-scan-hook.ts
+++ b/backend/src/core/services/pii-scan-hook.ts
@@ -17,6 +17,11 @@
 /**
  * The action type under which the scan is being performed. Matches the
  * llm-audit-hook action taxonomy + 'auto_tag' for the pages-tags path.
+ *
+ * @public Typed contract consumed dynamically via
+ * `await import('@compendiq/enterprise')` and referenced by
+ * `packages/contracts/src/schemas/pii-policy.ts`. Knip cannot see those
+ * consumers from the CE-scoped scan.
  */
 export type PiiScanAction =
   | 'chat'

--- a/backend/src/core/services/sync-conflict-policy-service.ts
+++ b/backend/src/core/services/sync-conflict-policy-service.ts
@@ -30,6 +30,11 @@
 
 import { makeCachedSetting } from './cached-setting.js';
 
+/**
+ * @public Re-exported and consumed by the EE overlay
+ * (`overlay/backend/src/enterprise/sync-conflict-service.ts`). Knip's
+ * CE-scoped scan cannot see that consumer.
+ */
 export type SyncConflictPolicy =
   | 'confluence-wins'
   | 'compendiq-wins'
@@ -41,6 +46,9 @@ const VALID_POLICIES: ReadonlySet<SyncConflictPolicy> = new Set([
   'manual-review',
 ]);
 
+/**
+ * @public Consumed by the EE overlay alongside `SyncConflictPolicy`.
+ */
 export const DEFAULT_SYNC_CONFLICT_POLICY: SyncConflictPolicy = 'confluence-wins';
 
 let getPolicy: (() => SyncConflictPolicy) | null = null;

--- a/backend/src/domains/llm/services/llm-audit-hook.ts
+++ b/backend/src/domains/llm/services/llm-audit-hook.ts
@@ -38,6 +38,10 @@ export interface LlmAuditEntry {
  * (provider CRUD, use-case assignment updates, etc.) where there is no
  * inference happening. Metadata is a free-form bag of ids / field names /
  * etc. Kept as a separate shape so the inference hook stays strict.
+ *
+ * @public Forward-compat extension-point payload (PR #259). Five CE
+ * route call sites already emit admin entries through `emitLlmAudit`;
+ * the EE writer will be wired via `setLlmAdminAuditHook`.
  */
 export interface LlmAdminAuditEntry {
   event:
@@ -66,6 +70,9 @@ export function setLlmAuditHook(hook: LlmAuditHook): void {
 /**
  * Register an admin-event audit hook (called by EE plugin at startup).
  * In CE mode this stays null — admin events are a no-op.
+ *
+ * @public Registration surface for the EE plugin; pairs with
+ * `LlmAdminAuditEntry`. Symmetric to `setLlmAuditHook`.
  */
 export function setLlmAdminAuditHook(hook: LlmAdminAuditHook): void {
   _adminHook = hook;


### PR DESCRIPTION
## Summary
- Closes #455, #478, #487, #489 — four \`[knip]\` issues that were flagged as unused exports but are actually consumed by the EE overlay or by dynamic \`await import('@compendiq/enterprise')\` paths that knip's CE-scoped scan can't see.
- Adds \`@public\` JSDoc tags (knip's standard "deliberate-public" marker) on the affected symbols, with a comment naming the EE consumer at each site so the rationale lives next to the code.
- No behaviour change. JSDoc only — \`+26\` lines, no logic touched.

## Affected symbols
| File | Symbol | EE consumer |
|---|---|---|
| \`backend/src/core/services/sync-conflict-policy-service.ts\` | \`SyncConflictPolicy\`, \`DEFAULT_SYNC_CONFLICT_POLICY\` | \`overlay/backend/src/enterprise/sync-conflict-service.ts\` |
| \`backend/src/core/services/pii-scan-hook.ts\` | \`PiiScanAction\` | \`await import('@compendiq/enterprise')\` + \`packages/contracts/src/schemas/pii-policy.ts\` |
| \`backend/src/core/services/ai-review-hook.ts\` | \`AiReviewDecision\` | \`overlay/backend/src/enterprise/ai-review-service.ts\` (registered via \`setAiReviewHook\`) |
| \`backend/src/domains/llm/services/llm-audit-hook.ts\` | \`LlmAdminAuditEntry\`, \`setLlmAdminAuditHook\` | Forward-compat extension point from PR #259; 5 CE call sites already emit through it |

## Test plan
- [x] \`npm run knip\` — six target symbols no longer appear in the unused-exports report
- [x] \`npx tsc --noEmit\` (backend) — clean
- [ ] CI green on this PR

## Why \`@public\` instead of deletion or symbol removal
Each symbol is part of a deliberate CE↔EE extension-point contract. Deleting them (as the original \`[knip]\` issues suggested) would break the EE build at typecheck time. \`@public\` is the narrowest fix: knip stops complaining, no other tool's behaviour changes, and the next reviewer sees the rationale at the declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)