### PR TITLE
ci(#401): validate mcp-docs sidecar

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -89,3 +89,28 @@ jobs:
 
       - name: Contracts tests
         run: npm test -w @compendiq/contracts
+
+  mcp-docs:
+    name: MCP Docs Sidecar
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mcp-docs
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+          cache-dependency-path: mcp-docs/package-lock.json
+
+      - name: Install MCP docs dependencies
+        run: npm ci
+
+      - name: Typecheck MCP docs
+        run: npm run typecheck
+
+      - name: Test MCP docs
+        run: npm test

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -18,9 +18,7 @@ const config: KnipConfig = {
       project: ['src/**/*.ts'],
     },
     'mcp-docs': {
-      entry: ['src/index.ts'],
       project: ['src/**/*.ts'],
-      ignore: ['src/**/*.test.ts'],
       ignoreDependencies: ['pino-pretty'],
     },
   },

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -17,6 +17,12 @@ const config: KnipConfig = {
       entry: ['src/index.ts'],
       project: ['src/**/*.ts'],
     },
+    'mcp-docs': {
+      entry: ['src/index.ts'],
+      project: ['src/**/*.ts'],
+      ignore: ['src/**/*.test.ts'],
+      ignoreDependencies: ['pino-pretty'],
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- add an MCP Docs Sidecar job to PR Check with npm ci, typecheck, and tests
- add mcp-docs to Knip workspace config so the sidecar source is classified as live code

## Validation
- npm run typecheck (inside mcp-docs)
- npm test (inside mcp-docs)
- npx knip --reporter json (verified no mcp-docs/src unused-file findings)

Closes #401