### PR TITLE
chore(#492): remove unused SanitizeResult export from sanitize-llm-input.ts

### DIFF
--- a/backend/src/core/utils/sanitize-llm-input.ts
+++ b/backend/src/core/utils/sanitize-llm-input.ts
@@ -41,7 +41,7 @@ const INJECTION_PATTERNS: Array<{ pattern: RegExp; description: string }> = [
   { pattern: /---+\s*\n\s*(system|new\s+instructions)/i, description: 'delimiter injection' },
 ];
 
-export interface SanitizeResult {
+interface SanitizeResult {
   sanitized: string;
   wasModified: boolean;
   warnings: string[];


### PR DESCRIPTION
Closes #492

## Change

Drop the `export` keyword from the `SanitizeResult` interface in `backend/src/core/utils/sanitize-llm-input.ts`. The type is still needed as the return-type annotation for the (exported) `sanitizeLlmInput` function, but it does not need to be exported itself.

```diff
-export interface SanitizeResult {
+interface SanitizeResult {
   sanitized: string;
   wasModified: boolean;
   warnings: string[];
 }
```

## Evidence

**Consumer scan (CE):**
```
$ grep -rn "SanitizeResult" --include='*.ts' --include='*.tsx' backend/ frontend/ packages/ e2e/ scripts/
backend/src/core/utils/sanitize-llm-output.ts:5:export interface OutputSanitizeResult {
backend/src/core/utils/sanitize-llm-output.ts:78:export function sanitizeLlmOutput(output: string, rules: OutputRules): OutputSanitizeResult {
backend/src/core/utils/sanitize-llm-input.ts:44:export interface SanitizeResult {
backend/src/core/utils/sanitize-llm-input.ts:56:export function sanitizeLlmInput(input: string): SanitizeResult {
backend/src/routes/llm/_helpers.ts:12:import { sanitizeLlmOutput, type OutputSanitizeResult } from '../../core/utils/sanitize-llm-output.js';
backend/src/routes/llm/_helpers.ts:159:    postProcess?: (content: string) => OutputSanitizeResult;
backend/src/routes/llm/_helpers.ts:244:): Promise<((content: string) => OutputSanitizeResult) | undefined> {
```

The only `SanitizeResult` (input) references are inside `sanitize-llm-input.ts` itself. The hits in `sanitize-llm-output.ts` / `_helpers.ts` are the unrelated `OutputSanitizeResult` type, which remains exported and consumed.

**EE cross-scan:** Performed prior to this PR — no EE consumer.

**Knip:**
```
$ npx knip 2>&1 | grep -A2 SanitizeResult
(no output)
```

## Verification

- `cd backend && npx vitest run src/core/utils/sanitize-llm-input.test.ts` — 29/29 passing
- `npx vitest run src/core/utils/sanitize-llm-input.test.ts src/core/utils/sanitize-llm-output.test.ts` — 50/50 passing
- `npm run typecheck -w backend` — clean
- `npm run lint -w backend` — clean
- `npm test -w backend` — exit code 0
- `npx knip` — `SanitizeResult` no longer flagged

## Risk

Type-only refactor. No runtime behavior change. No public API change (the export had no consumers, in CE or EE).