### PR TITLE
chore(#502): remove unused AppBuildInfo type export

### DIFF
--- a/backend/src/core/utils/version.ts
+++ b/backend/src/core/utils/version.ts
@@ -27,7 +27,7 @@ function loadVersion(): string {
 // to <repo root>/build-info.json. EE builds overwrite the committed CE
 // placeholder with real git commit hashes via scripts/build-enterprise.sh.
 // The runtime image copies this file so we can read it here.
-export interface AppBuildInfo {
+interface AppBuildInfo {
   edition: string;
   commit: string;
   ceCommit?: string;


### PR DESCRIPTION
## Summary

- Drops the `export` keyword from the `AppBuildInfo` interface in `backend/src/core/utils/version.ts`. The type is only used internally (annotating `DEFAULT_BUILD_INFO`, the `loadBuildInfo()` return, and the `APP_BUILD_INFO` runtime const) — no source file outside `version.ts` imports it.
- `APP_VERSION` is **untouched**. Still exported and still read at startup by `backend/src/app.ts` (lines 72 and 156).
- `APP_BUILD_INFO` is **untouched**. Still exported and still consumed by `backend/src/routes/foundation/health.ts` and `health-api.ts`.

## EE consumer check

`grep -rn "AppBuildInfo"` across `backend/src`, `frontend/src`, `packages/`, `e2e/`, and `scripts/` returns hits only inside `version.ts` itself. The Enterprise repo (`compendiq-enterprise`) doesn't import the type either — EE extends via the `core/enterprise/` extension points, not via internal version utilities. The runtime contract `APP_BUILD_INFO` remains exported for any future EE consumer that wants the build metadata shape.

## Validation

- `npm run typecheck -w backend` — clean
- `npm run lint -w backend` — clean (max-warnings=0)
- No `version.test.ts` exists, so no targeted vitest run applicable.

Closes #502

🤖 Generated with Claude Code