### PR TITLE
chore(#443): remove unused createChildLogger export from logger.ts

### DIFF
--- a/backend/src/core/utils/logger.ts
+++ b/backend/src/core/utils/logger.ts
@@ -10,12 +10,3 @@ export const logger: Logger = pino({
     },
   }),
 });
-
-/**
- * Create a child logger with additional context (e.g., correlation ID).
- * Use this when you need to attach request-scoped metadata to logs
- * outside of Fastify's request lifecycle.
- */
-export function createChildLogger(bindings: Record<string, unknown>): Logger {
-  return logger.child(bindings);
-}


### PR DESCRIPTION
Closes #443

## Summary

`createChildLogger` in `backend/src/core/utils/logger.ts` had no callers anywhere in CE. Verified via:

```
grep -rn "createChildLogger" --include='*.ts' --include='*.tsx' backend/ frontend/ packages/ e2e/ scripts/
backend/src/core/utils/logger.ts:19:export function createChildLogger(bindings: Record<string, unknown>): Logger {
```

Only the function's own definition matched — no consumers. Removing the export (and the function body) keeps the logger surface minimal. `pino`'s `logger.child()` remains available directly if request-scoped logging is needed later.

## EE consumer note

EE (`compendiq-enterprise`) does **not** import this helper either — extension points use `core/enterprise/loader.ts` and the Fastify request logger, not `createChildLogger`. Safe to drop.

## Validation

- `npm run typecheck -w backend` — clean
- `npm run lint -w backend` — clean
- No `logger.test.ts` exists (skipped per plan); pre-commit hooks passed

Full backend suite intentionally not run — change is a pure dead-code deletion with no behavioral surface area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)