### PR TITLE
chore(#449): remove unused getEncryptionKeyByVersion export from crypto.ts

### DIFF
--- a/backend/src/core/utils/crypto.ts
+++ b/backend/src/core/utils/crypto.ts
@@ -80,7 +80,7 @@ export function getLatestEncryptionKey(): VersionedKey {
  * Returns the encryption key for a specific version.
  * @throws if the requested version is not configured
  */
-export function getEncryptionKeyByVersion(version: number): VersionedKey {
+function getEncryptionKeyByVersion(version: number): VersionedKey {
   const keys = getEncryptionKeys();
   const found = keys.find((k) => k.version === version);
   if (!found) {


### PR DESCRIPTION
Closes #449.

## What

Drop the `export` keyword from `getEncryptionKeyByVersion()` in `backend/src/core/utils/crypto.ts`. The function stays — it is the internal key-resolver used by `decryptPat()` to support versioned-key rotation — it just becomes module-private.

## Why

`grep -rn "getEncryptionKeyByVersion" backend/ frontend/ packages/ e2e/ scripts/` returned exactly two hits, both inside `crypto.ts` itself: the declaration (line 83) and the internal call site in `decryptPat()` (line 142). No external consumer in CE.

Confirmed no EE consumer either: this is a pure module-internal helper for AES-256-GCM key versioning; EE does not duplicate the crypto helper.

## Security note

Encryption helpers (`encryptPat`, `decryptPat`, `reEncryptPat`, `getLatestEncryptionKey`, `getEncryptionKeys`), AES-256-GCM constants, IV/auth-tag handling, and key-rotation logic are **untouched**. Only the `export` modifier on a single helper changed. PAT round-trip tests still pass:

- `npx vitest run src/core/utils/crypto.test.ts` → **16/16 passing**
- `npm run typecheck -w backend` → clean
- `npm run lint -w backend` → clean (`--max-warnings=0`)

## Diff

```diff
- * @throws if the requested version is not configured
- */
-export function getEncryptionKeyByVersion(version: number): VersionedKey {
+ * @throws if the requested version is not configured
+ */
+function getEncryptionKeyByVersion(version: number): VersionedKey {
```

One-line change, one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)