### PR TITLE
chore(#445): remove unused resolveClientIp export from ip-allowlist-hook.ts

### DIFF
--- a/backend/src/core/plugins/ip-allowlist-hook.ts
+++ b/backend/src/core/plugins/ip-allowlist-hook.ts
@@ -85,10 +85,11 @@ function resolveClientIpFromXff(
 }
 
 /**
- * Resolve the effective client IP for allowlist matching. Exported for unit
- * testing — the hook itself uses this helper internally.
+ * Resolve the effective client IP for allowlist matching. Used internally by
+ * the hook below; behaviour is exercised end-to-end via the plugin tests
+ * rather than directly.
  */
-export function resolveClientIp(req: FastifyRequest): {
+function resolveClientIp(req: FastifyRequest): {
   clientIp: string;
   socketIp: string;
 } {


### PR DESCRIPTION
Closes #445

## Summary

knip flagged `resolveClientIp` in `backend/src/core/plugins/ip-allowlist-hook.ts` as an unused export. The helper is used only internally by the plugin factory in the same file (line 120), and the plugin's test suite (`ip-allowlist-hook.test.ts`) imports the default-exported plugin, not this helper.

Drop the `export` keyword (function stays in place, behaviour unchanged) and refresh the JSDoc that previously claimed it was exported for unit testing.

## EE cross-scan

No consumer of `resolveClientIp` exists in the `compendiq-enterprise` repo. Safe to unexport — no public-API impact.

## Validation

- [x] `npm run build -w packages/contracts` — green
- [x] `npm run lint -w backend` — green (`--max-warnings=0`)
- [x] `npx vitest run src/core/plugins/ip-allowlist-hook.test.ts` — 12/12 pass
- [x] `npm run typecheck -w backend` — pre-existing errors on `origin/dev` (p-limit / ipaddr.js / bullmq type issues in unrelated files); this change introduces zero new typecheck errors

## Test plan

- [x] Existing `ip-allowlist-hook.test.ts` suite (12 cases) still passes — covers exempt paths, untrusted-peer XFF rejection, trusted-proxy XFF walking, IPv4/IPv6 allowlist matching, audit fire-and-forget, and 403 reply shape.