### PR TITLE
chore(#447): remove unused getCurrentScope export from rbac-request-scope.ts

### DIFF
--- a/backend/src/core/services/rbac-request-scope.ts
+++ b/backend/src/core/services/rbac-request-scope.ts
@@ -40,10 +40,6 @@ export function enterRbacScope(userId: string): void {
   storage.enterWith({ userId });
 }
 
-export function getCurrentScope(): RbacScope | undefined {
-  return storage.getStore();
-}
-
 export function setScopedSpaces(spaces: string[]): void {
   const scope = storage.getStore();
   if (scope) scope.spaces = spaces;


### PR DESCRIPTION
## Summary

Knip flagged `getCurrentScope` in `backend/src/core/services/rbac-request-scope.ts` as an unused export.

- **EE cross-scan**: no consumer in `compendiq-enterprise`.
- **Internal scan**: no callers in `backend/`, `frontend/`, `packages/`, `e2e/`, `scripts/` — `setScopedSpaces` and `getScopedSpaces` call `storage.getStore()` directly, so `getCurrentScope` was never used as a helper either.
- **Action**: delete the function entirely (no `export` to drop, no internal use to preserve).

Closes #447

## Test plan

- [x] `npm run build -w packages/contracts` — clean
- [x] `npm run typecheck -w backend` — clean
- [x] `npm run lint -w backend` — clean
- [x] `npx vitest run src/core/services/rbac-request-scope.test.ts` — 4/4 passed
- [x] Pre-commit hook ran (no `--no-verify`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)