### PR TITLE
chore(#444): remove unused exports from llm-queue.ts

### DIFF
--- a/backend/src/domains/llm/services/llm-queue.ts
+++ b/backend/src/domains/llm/services/llm-queue.ts
@@ -42,7 +42,7 @@ import {
 // (see the subscriber comment in that init function) for deterministic
 // ordering vs. the cached-setting's async re-read.
 
-export interface LlmQueueMetrics {
+interface LlmQueueMetrics {
   concurrency: number;
   activeCount: number;
   pendingCount: number;
@@ -92,7 +92,7 @@ export function setMaxQueueDepth(n: number): void {
   _maxQueueDepth = Math.max(1, n);
 }
 
-export function setTimeoutMs(ms: number): void {
+function setTimeoutMs(ms: number): void {
   _timeoutMs = Math.max(1000, ms);
 }
 
@@ -115,7 +115,7 @@ export class QueueFullError extends Error {
   }
 }
 
-export class LlmTimeoutError extends Error {
+class LlmTimeoutError extends Error {
   constructor(timeoutMs: number) {
     super(`LLM request timed out after ${timeoutMs}ms`);
     this.name = 'LlmTimeoutError';


### PR DESCRIPTION
## Summary

Closes #444 — knip flagged three unused exports in
`backend/src/domains/llm/services/llm-queue.ts`. All three are
still load-bearing **inside** the module, so only the `export`
keyword is dropped (declarations preserved).

| Name | Why kept | Why un-exported |
|---|---|---|
| `LlmQueueMetrics` (interface) | Return type of `getMetrics()` | No external import; consumers (e.g. `routes/foundation/health.ts`) only call the function and embed the result structurally. |
| `setTimeoutMs` (function) | Called by `initLlmQueue()` (line 169) | No external caller. |
| `LlmTimeoutError` (class) | Thrown + `instanceof`-checked inside `enqueue()` (lines 136, 145) | No external `instanceof` check or import. |

### EE cross-scan
Per the issue note, EE has **no consumer** of `setTimeoutMs`,
`LlmTimeoutError`, or `LlmQueueMetrics`. Safe to un-export in CE
without an EE-side companion change.

### #404 collision
This PR is purely deletions of `export` keywords — no touch to
the limiter, queue, or backpressure logic. #404's planned drain
work in this same file is unaffected.

## Validation

- [x] `npm run build -w packages/contracts` ✅
- [x] `npm run typecheck -w backend` ✅
- [x] `npm run lint -w backend` ✅ (max-warnings=0)
- [x] `npx vitest run src/domains/llm/services/llm-queue.test.ts` ✅ (18/18)

## Test plan

- [ ] CI green on `chore/444-unused-llm-queue-exports`
- [ ] knip no longer flags `LlmQueueMetrics` / `setTimeoutMs` / `LlmTimeoutError`
- [ ] `/api/health` still returns `llmQueue` metrics block (no behavioural change — only an `export` keyword was removed from the type, not the function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)