### PR TITLE
chore(#448): remove unused exports from redis-cache.ts

### DIFF
--- a/backend/src/core/services/redis-cache.ts
+++ b/backend/src/core/services/redis-cache.ts
@@ -46,7 +46,7 @@ export async function invalidateGraphCache(userId: string): Promise<void> {
  * compute "held for" without hardcoding the value. 1 hour default —
  * prevents permanent locks on crash.
  */
-export const EMBEDDING_LOCK_TTL = Math.floor(EMBEDDING_LOCK_TTL_MS / 1000);
+const EMBEDDING_LOCK_TTL = Math.floor(EMBEDDING_LOCK_TTL_MS / 1000);
 
 /**
  * Redis Set that mirrors the active set of per-user embedding lock keys.
@@ -152,7 +152,7 @@ export async function isEmbeddingLocked(userId: string): Promise<boolean> {
 // ── Embedding lock visibility + admin escape hatch (plan §2.1) ───────────
 
 /** Snapshot of a single active per-user embedding lock (issue #257). */
-export interface EmbeddingLockSnapshot {
+interface EmbeddingLockSnapshot {
   userId: string;
   /** Lock identity token (random UUID written by `acquireEmbeddingLock`).
    *  Exposed so the worker can verify, before each write, that the lock it


### PR DESCRIPTION
## Summary

knip flagged two exports in `backend/src/core/services/redis-cache.ts` as unused:

- `EMBEDDING_LOCK_TTL` — the seconds-scaled lock TTL constant. Used internally at line 94 (`String(EMBEDDING_LOCK_TTL)` inside `acquireEmbeddingLock`), but no module imports it.
- `EmbeddingLockSnapshot` — return-type interface for `listActiveEmbeddingLocks`. Used internally for the function signature and intermediate `out` array, but no module imports it.

Every external consumer (frontend `ActiveEmbeddingLocksBanner`, backend route handlers, EE) imports `EMBEDDING_LOCK_TTL_MS` and `EmbeddingLockSnapshot` from `@compendiq/contracts`, not from this module — so dropping the `export` keyword is safe. The symbols themselves remain so the internal helpers still compile.

## EE cross-scan

`compendiq-enterprise` imports only `getRedisClient` from `redis-cache.ts`. It does **not** import `EMBEDDING_LOCK_TTL` or `EmbeddingLockSnapshot`. No EE consumer impact.

## Test plan

- [x] `npm run build -w packages/contracts` — passes
- [x] `npm run typecheck -w backend` — passes
- [x] `npm run lint -w backend` — passes (`--max-warnings=0`)
- [x] `npx vitest run src/core/services/redis-cache.test.ts` — 61/61 passing
- [ ] CI green

Closes #448