### PR TITLE
chore(#446): remove unused exports from presence-service.ts

### DIFF
--- a/backend/src/core/services/presence-service.ts
+++ b/backend/src/core/services/presence-service.ts
@@ -30,7 +30,7 @@ export const ACTIVE_WINDOW_SEC = 20;
 export const VIEWERS_TTL_SEC = 30;
 
 /** TTL on the per-user meta HASH — refreshed on every heartbeat. */
-export const META_TTL_SEC = 90;
+const META_TTL_SEC = 90;
 
 function viewersKey(pageId: string): string {
   return `presence:viewers:${pageId}`;
@@ -50,7 +50,7 @@ function channelFor(pageId: string): string {
 
 const CHANNEL_PATTERN = 'presence:page:*';
 
-export interface PresenceMeta {
+interface PresenceMeta {
   name: string;
   role: string;
 }


### PR DESCRIPTION
Closes #446

## Summary

Knip flagged `META_TTL_SEC` and `PresenceMeta` as unused exports in `backend/src/core/services/presence-service.ts`. Both are still referenced **internally**:

- `META_TTL_SEC` is the Redis `EXPIRE` TTL applied to the per-user meta hash (`presence:meta:{userId}`) inside `recordHeartbeat`.
- `PresenceMeta` is the parameter type of `recordHeartbeat`.

So we drop the `export` keyword only — keep the symbols. No behavior change.

## EE cross-scan

Searched the EE repo for `META_TTL_SEC` and `PresenceMeta` — no consumers. Safe to de-export.

## Test plan

- [x] `npm run build -w packages/contracts` — clean
- [x] `npm run typecheck -w backend` — clean
- [x] `npm run lint -w backend` — clean
- [x] `npx vitest run src/core/services/presence-service.test.ts` — 12/12 pass (against live Redis)