### PR TITLE
chore(#453): remove unused exports from subpage-context.ts

### DIFF
--- a/backend/src/domains/confluence/services/subpage-context.ts
+++ b/backend/src/domains/confluence/services/subpage-context.ts
@@ -12,7 +12,7 @@ import { htmlToMarkdown } from '../../../core/services/content-converter.js';
 import { logger } from '../../../core/utils/logger.js';
 
 /** Maximum combined context size in characters (approx 60K tokens for most LLMs). */
-export const MAX_COMBINED_CONTEXT_CHARS = 200_000;
+const MAX_COMBINED_CONTEXT_CHARS = 200_000;
 
 /** Maximum depth for recursive sub-page fetching (prevent runaway recursion). */
 const MAX_DEPTH = 5;
@@ -20,14 +20,14 @@ const MAX_DEPTH = 5;
 /** Maximum number of sub-pages to include (prevent huge page trees). */
 const MAX_SUB_PAGES = 50;
 
-export interface PageContent {
+interface PageContent {
   confluenceId: string;
   title: string;
   bodyHtml: string;
   depth: number;
 }
 
-export interface AssembledContext {
+interface AssembledContext {
   /** The combined markdown text with page boundary markers. */
   markdown: string;
   /** Total number of pages included (parent + sub-pages). */


### PR DESCRIPTION
## Summary

Knip flagged three unused exports in `backend/src/domains/confluence/services/subpage-context.ts`. All three are referenced only inside the module itself, so this PR narrows their visibility to module scope by dropping the `export` keyword. No symbols are deleted — `fetchSubPages` and `assembleSubPageContext` still use them internally.

Names addressed:

- `MAX_COMBINED_CONTEXT_CHARS` (const)
- `PageContent` (interface)
- `AssembledContext` (interface)

## Cross-repo scan

- Backend, frontend, `packages/`, `e2e/`, `scripts/`: only the source file and its compiled artefacts in `backend/dist/` reference these names. Test file (`subpage-context.test.ts`) does not import any of them.
- EE (`compendiq-enterprise`): no consumer of `MAX_COMBINED_CONTEXT_CHARS`, `PageContent`, or `AssembledContext`. Safe to drop the export.

## Validation

- `npm run build -w packages/contracts` — pass
- `npm run typecheck -w backend` — pass
- `npm run lint -w backend` — pass
- `npx vitest run backend/src/domains/confluence/services/subpage-context.test.ts` — 12/12 pass

Closes #453