### PR TITLE
chore(#452): remove unused exports from notification-service.ts

### DIFF
--- a/backend/src/core/services/notification-service.ts
+++ b/backend/src/core/services/notification-service.ts
@@ -1,7 +1,7 @@
 import { query } from '../../core/db/postgres.js';
 import { logger } from '../../core/utils/logger.js';
 
-export interface CreateNotificationParams {
+interface CreateNotificationParams {
   userId: string;
   type: string;
   title: string;
@@ -11,7 +11,7 @@ export interface CreateNotificationParams {
   sourcePageId?: number;
 }
 
-export interface Notification {
+interface Notification {
   id: number;
   userId: string;
   type: string;
@@ -24,7 +24,7 @@ export interface Notification {
   createdAt: Date;
 }
 
-export interface NotificationPreference {
+interface NotificationPreference {
   type: string;
   inApp: boolean;
   email: boolean;
@@ -65,7 +65,7 @@ export async function createNotification(params: CreateNotificationParams): Prom
   }
 }
 
-export interface ListNotificationsFilter {
+interface ListNotificationsFilter {
   userId: string;
   unreadOnly?: boolean;
   type?: string;
@@ -254,15 +254,4 @@ export async function isWatching(pageId: number, userId: string): Promise<boolea
   const row = result.rows[0];
   if (!row) throw new Error('Expected a row from EXISTS query');
   return row.exists;
-}
-
-/**
- * Returns all user IDs watching a given article.
- */
-export async function getArticleWatchers(pageId: number): Promise<string[]> {
-  const result = await query<{ user_id: string }>(
-    'SELECT user_id FROM article_watchers WHERE page_id = $1',
-    [pageId],
-  );
-  return result.rows.map((r) => r.user_id);
 }


### PR DESCRIPTION
## Summary

Cleans up unused exports flagged by knip in `backend/src/core/services/notification-service.ts`:

- Drop `export` on internal-only types: `CreateNotificationParams`, `Notification`, `NotificationPreference`, `ListNotificationsFilter` (still used inside this module as parameter/return types).
- Delete `getArticleWatchers` function entirely (no internal or external usage).

## EE cross-scan

No EE consumer of `getArticleWatchers`, `CreateNotificationParams`, `Notification`, `NotificationPreference`, or `ListNotificationsFilter`. The only external consumer of this module is `backend/src/routes/foundation/notifications.ts`, which imports functions only — none of the affected names.

Frontend `Notification` matches are local types in `frontend/src/shared/components/layout/NotificationDropdown.tsx` and `frontend/src/shared/hooks/use-standalone.ts`, not imports from this backend service.

## Test plan

- [x] `npm run build -w packages/contracts` — clean
- [x] `npm run lint -w backend` — clean
- [x] `npm run typecheck -w backend` — no errors related to this change (pre-existing `p-limit` errors on dev are unrelated)
- [x] `npx vitest run src/routes/foundation/notifications.test.ts` — 25/25 pass

Closes #452