### PR TITLE
chore(#450): clean up unused exports in webhook-delivery; mark EE-consumed @public

### DIFF
--- a/backend/src/core/services/webhook-delivery.ts
+++ b/backend/src/core/services/webhook-delivery.ts
@@ -97,9 +97,9 @@ const BACKOFF_SECONDS: readonly number[] = [
   5 * 60 * 60,
 ];
 
-// ─── Public option + data types ──────────────────────────────────────────
+// ─── Option + data types ─────────────────────────────────────────────────
 
-export interface WebhookDeliveryOptions {
+interface WebhookDeliveryOptions {
   /** Worker concurrency. Default 16. */
   concurrency?: number;
   /** Per-job overall HTTP deadline (headers + body). Default 10_000 ms. */
@@ -118,7 +118,7 @@ export interface WebhookDeliveryOptions {
  * documented in the delivery spec — tests drive the service with the
  * snake_case form directly.
  */
-export interface OutboxJobData {
+interface OutboxJobData {
   /** `webhook_outbox.id` — UUID. */
   id: string;
   /** `webhook_subscriptions.id` — UUID. */
@@ -130,6 +130,13 @@ export interface OutboxJobData {
   payload: unknown;
 }
 
+/**
+ * @public
+ * Consumed by EE webhook-service via `type` import at:
+ *   overlay/backend/src/enterprise/webhook-service.ts:62-65,810
+ *
+ * Do not remove this `export` without coordinating with the EE repo.
+ */
 export interface DeliveryOutcome {
   outcome: 'success' | 'failure' | 'timeout' | 'ssrf_blocked';
   httpStatus?: number;
@@ -218,6 +225,12 @@ function getWebhookAgent(perJobTimeoutMs: number): Agent {
  * Start the delivery worker. Called from `app.ts` after
  * `initWebhookOutboxPoller`. Idempotent — a second call returns the
  * original teardown without starting a second worker.
+ *
+ * @public
+ * Consumed by the EE plugin via dynamic import at:
+ *   overlay/backend/src/enterprise/plugin.ts:458,477
+ *
+ * Do not remove this `export` without coordinating with the EE repo.
  */
 export async function initWebhookDeliveryWorker(
   opts: WebhookDeliveryOptions = {},


### PR DESCRIPTION
## Summary

Partial close for CE issue #450 (Knip-flagged unused exports in `backend/src/core/services/webhook-delivery.ts`). EE cross-scan split the four flags into two outcomes:

| Export | EE consumer? | Action |
|---|---|---|
| `WebhookDeliveryOptions` | No | Dropped `export` keyword (still used internally as parameter type in `initWebhookDeliveryWorker` and `__deliverOnce`). |
| `OutboxJobData` | No | Dropped `export` keyword (still used internally by `__deliverOnce`, `normaliseJobData`, `deliverOne`, `finishRetryable`, `emitAudit`). |
| `initWebhookDeliveryWorker` | **Yes** — `overlay/backend/src/enterprise/plugin.ts:458,477` (dynamic import) | **Kept exported**, annotated `@public` with EE consumer reference. |
| `DeliveryOutcome` | **Yes** — `overlay/backend/src/enterprise/webhook-service.ts:62-65,810` (`type` import) | **Kept exported**, annotated `@public` with EE consumer reference. |

The two `@public` JSDoc tags document the EE consumer paths so future Knip sweeps don't re-flag them and reviewers don't accidentally drop the `export` keyword.

No behavior change — purely a visibility cleanup. Section header rename `Public option + data types` → `Option + data types` reflects that two of the three types in that block are no longer exported.

## Verification

- `npm run build -w packages/contracts` — pass
- `npm run typecheck -w backend` — pass
- `npm run lint -w backend` — pass (`--max-warnings=0`)
- `npx vitest run src/core/services/webhook-delivery.test.ts` — 1 pass / 11 skipped (skips are `it.skip` flagged in test source, unrelated to this change)

## Test plan

- [x] Backend typecheck passes
- [x] Backend lint passes (zero warnings allowed)
- [x] webhook-delivery test file passes
- [ ] CI confirms no other workspace regresses
- [ ] EE repo Knip sweep against this branch confirms `initWebhookDeliveryWorker` and `DeliveryOutcome` resolve cleanly

Closes #450