### PR TITLE
chore(#476): remove unused SmtpConfig export from email-service.ts

### DIFF
--- a/backend/src/core/services/email-service.ts
+++ b/backend/src/core/services/email-service.ts
@@ -15,7 +15,7 @@ import { logger } from '../utils/logger.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 
-export interface SmtpConfig {
+interface SmtpConfig {
   host: string;
   port: number;
   secure: boolean;


### PR DESCRIPTION
Closes #476

## Summary

Knip flagged `SmtpConfig` as an unused export in `backend/src/core/services/email-service.ts`. The interface is referenced five times inside the file itself (`DEFAULT_CONFIG`, `_config`, `createTransport`, `updateSmtpConfig`, `getSmtpConfig`) but no other module imports it, so dropping the `export` keyword keeps the type available internally without leaking it to the public surface.

## Cross-scan

Verified with:

```
grep -rn "SmtpConfig" --include='*.ts' --include='*.tsx' backend/ frontend/ packages/ e2e/ scripts/
```

- Only `email-service.ts` references it in backend/contracts/e2e/scripts.
- `frontend/src/features/settings/SmtpSettingsTab.tsx` defines its own local `SmtpConfig` interface — it does not import the backend type.
- `routes/foundation/admin.ts` imports `getSmtpConfig`/`updateSmtpConfig`/`sendTestEmail` (functions), not the type.

**EE cross-scan:** no EE consumer of `SmtpConfig`. Safe to drop `export`.

## Validation

- `npm run build -w packages/contracts` — clean
- `npm run typecheck -w backend` — pre-existing `p-limit` / `ipaddr.js` errors unrelated to this change; no new errors
- `npm run lint -w backend` — clean
- `npx vitest run src/core/services/email-service.test.ts` — 4/4 passing

## Test plan

- [x] Unit tests for `email-service` still pass
- [x] No external consumers of `SmtpConfig` exist
- [x] Frontend `SmtpSettingsTab` is unaffected (uses its own local type)