### PR TITLE
chore(#456): remove unused exports from llm-provider-service.ts

### DIFF
--- a/backend/src/domains/llm/services/llm-provider-service.ts
+++ b/backend/src/domains/llm/services/llm-provider-service.ts
@@ -18,7 +18,7 @@ interface ProviderRow {
 }
 
 /** Server-side config — decrypted. NEVER returned from HTTP routes. */
-export interface ProviderConfigRow {
+interface ProviderConfigRow {
   id: string;
   name: string;
   baseUrl: string;
@@ -70,11 +70,6 @@ export async function listProviders(): Promise<LlmProvider[]> {
 
 export async function getProviderById(id: string): Promise<ProviderConfigRow | null> {
   const r = await query<ProviderRow>(`SELECT * FROM llm_providers WHERE id=$1`, [id]);
-  return r.rows[0] ? rowToConfig(r.rows[0]) : null;
-}
-
-export async function getDefaultProvider(): Promise<ProviderConfigRow | null> {
-  const r = await query<ProviderRow>(`SELECT * FROM llm_providers WHERE is_default=TRUE LIMIT 1`);
   return r.rows[0] ? rowToConfig(r.rows[0]) : null;
 }
 


### PR DESCRIPTION
## Summary

Knip cleanup for `backend/src/domains/llm/services/llm-provider-service.ts`:

- Removed unused `export async function getDefaultProvider()` — no consumers in CE or EE.
- Demoted `ProviderConfigRow` from `export interface` to `interface` — only used internally by `getProviderById` and `rowToConfig`.

The grep hit on `getDefaultProviderConfig` in `routes/llm/llm-models.ts` is a different symbol (locally-defined helper) and is unrelated.

## EE cross-scan

No EE consumer of `getDefaultProvider` or `ProviderConfigRow`. Safe to delete / unexport.

## Test plan

- [x] `npm run build -w packages/contracts` — pass
- [x] `npm run lint -w backend` — pass
- [x] `npx vitest run src/domains/llm/services/llm-provider-service.test.ts` — 10 tests skipped (DB-dependent, Postgres not running in worktree); 0 failures
- [x] Backend typecheck reports only pre-existing errors unrelated to this file (missing `bullmq`, `p-limit` call signatures, `ip-cidr` type union) — `llm-provider-service.ts` itself is clean

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)