### PR TITLE
chore(#459): remove unused exports from ai-safety-service.ts

### DIFF
--- a/backend/src/core/services/ai-safety-service.ts
+++ b/backend/src/core/services/ai-safety-service.ts
@@ -3,14 +3,14 @@ import { logAuditEvent } from './audit-service.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export interface AiGuardrails {
+interface AiGuardrails {
   noFabricationInstruction: string;
   noFabricationEnabled: boolean;
 }
 
 export type ReferenceAction = 'flag' | 'strip' | 'off';
 
-export interface AiOutputRules {
+interface AiOutputRules {
   stripReferences: boolean;
   referenceAction: ReferenceAction;
 }
@@ -197,8 +197,3 @@ export async function upsertAiOutputRules(
   }
 }
 
-/** Exposed for testing — reset both caches */
-export function _resetCache(): void {
-  guardrailCache = null;
-  outputRuleCache = null;
-}


### PR DESCRIPTION
Closes #459

## Summary

Knip flagged three unused exports in `backend/src/core/services/ai-safety-service.ts`:

- `_resetCache` — orphan test helper; no test file, no runtime consumer (the `_resetCache` reference in `sse-stream-limit-gate.test.ts` belongs to the `rate-limit-service` mock, not this module). **Deleted.**
- `AiGuardrails`, `AiOutputRules` — only used internally as parameter/return types within `ai-safety-service.ts` itself. **`export` keyword dropped, types kept.**

`ReferenceAction` remains exported — it is consumed by `core/utils/sanitize-llm-output.ts`.

## EE cross-scan

No EE consumer of `_resetCache`, `AiGuardrails`, or `AiOutputRules`. Safe to remove from CE without coordinating an EE change.

## Validation

- `npm run build -w packages/contracts` — pass
- `npm run typecheck -w backend` — no new errors in `ai-safety-service.ts` or its consumers (`admin.ts`, `_helpers.ts`, `settings.ts`, `sanitize-llm-output.ts`); pre-existing unrelated errors in `bullmq` / `p-limit` / `ipaddr.js`-using files exist on `dev` already
- `npm run lint -w backend` — pass
- `npx vitest run src/routes/llm/sse-stream-limit-gate.test.ts` — 30/30 pass (consumer test)
- No `ai-safety-service.test.ts` exists; nothing to run for the file itself

## Test plan

- [x] Lint clean
- [x] Consumer route test passes
- [x] No external consumer of the removed symbols (verified by repo-wide grep)