### PR TITLE
chore(#477): remove unused exports from admin-user-service.ts

### DIFF
--- a/backend/src/core/services/admin-user-service.ts
+++ b/backend/src/core/services/admin-user-service.ts
@@ -93,7 +93,7 @@ export async function getUser(id: string): Promise<AdminUser | null> {
   return res.rows[0] ? rowToAdminUser(res.rows[0]) : null;
 }
 
-export interface CreateUserOptions {
+interface CreateUserOptions {
   username: string;
   email?: string | null;
   displayName?: string | null;
@@ -108,7 +108,7 @@ export interface CreateUserOptions {
   generateRandomPassword?: boolean;
 }
 
-export interface CreateUserResult {
+interface CreateUserResult {
   user: AdminUser;
   /** Populated when `generateRandomPassword: true` — otherwise undefined. */
   temporaryPassword?: string;
@@ -152,7 +152,7 @@ export async function createUser(opts: CreateUserOptions): Promise<CreateUserRes
   }
 }
 
-export interface UpdateUserOptions {
+interface UpdateUserOptions {
   email?: string | null;
   displayName?: string | null;
   role?: AdminUserRole;
@@ -228,7 +228,7 @@ export async function updateUser(id: string, patch: UpdateUserOptions): Promise<
   }
 }
 
-export interface DeactivateOptions {
+interface DeactivateOptions {
   actorUserId: string;
   reason?: string;
 }
@@ -307,7 +307,7 @@ export async function reactivateUser(targetUserId: string): Promise<AdminUser> {
   return rowToAdminUser(res.rows[0]!);
 }
 
-export interface DeleteUserOptions {
+interface DeleteUserOptions {
   actorUserId: string;
 }
 


### PR DESCRIPTION
Closes #477

## Summary

Knip flagged five interfaces in `backend/src/core/services/admin-user-service.ts` as unused exports:

- `CreateUserOptions` (line 96)
- `CreateUserResult` (line 111)
- `UpdateUserOptions` (line 155)
- `DeactivateOptions` (line 231)
- `DeleteUserOptions` (line 310)

All five are still consumed internally as parameter / return types of the publicly exported functions (`createUser`, `updateUser`, `deactivateUser`, `deleteUser`). The fix is surgical: drop the `export` keyword and keep the interfaces in place — no logic changes, no deletions.

## EE cross-scan

Verified against the EE consumer list. EE imports the **function** exports — `createUser`, `updateUser`, `deactivateUser`, `reactivateUser`, `AdminUserServiceError` — and **none** of these are touched here. The five interfaces being de-exported are not consumed by EE. Function exports are explicitly retained.

## Validation

- `npm run build -w packages/contracts` — passes
- `npm run lint -w backend` — passes (zero warnings)
- `npm run typecheck -w backend` — same 19 pre-existing errors as `origin/dev` (all in unrelated files: `p-limit`, `ip-allowlist`); zero new errors introduced
- `npx vitest run src/core/services/admin-user-service.test.ts` — 23 tests skip cleanly (DB-required, postgres not running locally); test file references no removed symbols

## Test plan

- [ ] CI typecheck / lint / knip pass
- [ ] CI test job runs `admin-user-service.test.ts` against postgres
- [ ] `npm run knip` no longer reports the five symbols