### PR TITLE
chore(#481): remove unused CachedSettingOptions export from cached-setting.ts

### DIFF
--- a/backend/src/core/services/cached-setting.ts
+++ b/backend/src/core/services/cached-setting.ts
@@ -36,7 +36,7 @@ import { query } from '../db/postgres.js';
 import { logger } from '../utils/logger.js';
 import { subscribe, onReconnect, type CacheBusChannel } from './redis-cache-bus.js';
 
-export interface CachedSettingOptions<T> {
+interface CachedSettingOptions<T> {
   key: string;
   cacheBusChannel: CacheBusChannel;
   parse: (raw: string | null) => T;


### PR DESCRIPTION
Closes #481

## Summary

`CachedSettingOptions` in `backend/src/core/services/cached-setting.ts` was exported but only used internally as the parameter type for `makeCachedSetting` in the same file. Drop the `export` keyword so it remains a file-local type.

## Verification

- `grep -rn "CachedSettingOptions"` across `backend/`, `frontend/`, `packages/`, `e2e/`, `scripts/` returns only the two in-file references (declaration + parameter use).
- Contracts build: pass
- Backend lint: pass
- Targeted vitest (`cached-setting.test.ts`): 10/10 pass
- Backend typecheck: pre-existing errors on dev in `pages-crud.ts` (`p-limit`) and `admin-ip-allowlist.ts`; this change introduces no new typecheck errors.

## EE consumer note

No EE consumer. Verified the symbol is not referenced by the dynamic `@compendiq/enterprise` loader surface or any EE extension point — `CachedSettingOptions` is an internal helper type for an in-process cached settings factory and is not part of any documented EE contract.