### PR TITLE
chore(#479): remove unused exports from audit-service.ts

### DIFF
--- a/backend/src/core/services/audit-service.ts
+++ b/backend/src/core/services/audit-service.ts
@@ -133,7 +133,7 @@ export type AuditAction =
   | 'BULK_PAGE_TAGS_REPLACED'
   | 'BULK_PAGE_PERMISSION_CHANGED';
 
-export interface AuditLogEntry {
+interface AuditLogEntry {
   id: string;
   userId: string | null;
   action: string;
@@ -180,7 +180,7 @@ export async function logAuditEvent(
   }
 }
 
-export interface AuditLogFilter {
+interface AuditLogFilter {
   userId?: string;
   action?: string;
   resourceType?: string;


### PR DESCRIPTION
Closes #479

## Summary

Removes the `export` keyword from `AuditLogEntry` and `AuditLogFilter` in `backend/src/core/services/audit-service.ts`. Both interfaces remain — they're used internally as type annotations on `getAuditLog`'s parameter and return type — but they no longer leak across the module boundary.

## EE no-consumer note

Verified via `grep -rn "AuditLogEntry\|AuditLogFilter" --include='*.ts' --include='*.tsx' backend/ frontend/ packages/ e2e/ scripts/`: the only references are inside `audit-service.ts` itself. EE imports `logAuditEvent` from this module — neither flagged type has any CE or EE consumer.

## Validation

- `npm run build -w packages/contracts` — pass
- `npm run typecheck -w backend` — no new errors (the 19 pre-existing errors on `dev` are unchanged: missing `bullmq` types, `p-limit` callable signature, `ip-allowlist` overload — none touch `audit-service.ts`)
- `npm run lint -w backend` — pass
- `cd backend && npx vitest run src/core/services/audit-service.test.ts` — 2 passed, 32 skipped

🤖 Generated with Claude Code