### PR TITLE
chore(#482): remove unused exports from circuit-breaker.ts

### DIFF
--- a/backend/src/core/services/circuit-breaker.ts
+++ b/backend/src/core/services/circuit-breaker.ts
@@ -1,14 +1,14 @@
 import { logger } from '../utils/logger.js';
 
-export type CircuitBreakerState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+type CircuitBreakerState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
 
-export interface CircuitBreakerConfig {
+interface CircuitBreakerConfig {
   failureThreshold: number;
   successThreshold: number;
   timeout: number; // ms
 }
 
-export interface CircuitBreakerStatus {
+interface CircuitBreakerStatus {
   state: CircuitBreakerState;
   failureCount: number;
   successCount: number;
@@ -184,7 +184,7 @@ export function invalidateProviderBreaker(providerId: string): void {
  * Snapshot of a single live per-provider breaker used for health reporting.
  * `state` is lowercased to match the legacy health payload shape.
  */
-export interface ProviderBreakerSnapshot {
+interface ProviderBreakerSnapshot {
   providerId: string;
   state: string;
   failureCount: number;


### PR DESCRIPTION
Closes #482

## Summary

Drop `export` from four type/interface declarations in `backend/src/core/services/circuit-breaker.ts` that are only referenced internally within the same file:

- `CircuitBreakerState` — used as field/parameter type at lines 12, 26, 129
- `CircuitBreakerConfig` — used at lines 19, 30, 33 (default config + class field + ctor param)
- `CircuitBreakerStatus` — only the return type of `getStatus()`
- `ProviderBreakerSnapshot` — used as the return type / accumulator type of `listProviderBreakers()`

The actual public surface (`CircuitBreaker` class, `CircuitBreakerOpenError`, `getProviderBreaker`, `invalidateProviderBreaker`, `listProviderBreakers`) is untouched.

## EE consumer check

None. Grep across `backend/`, `frontend/`, `packages/`, `e2e/`, `scripts/` confirms only `circuit-breaker.ts` itself references these names. No EE consumer per issue tracker.

## Verification

- `npm run build -w @compendiq/contracts` — pass
- `npm run lint -w backend` — pass (0 warnings, max-warnings=0)
- `npx vitest run src/core/services/circuit-breaker` — 17/17 pass
- Backend typecheck: file produces zero errors; pre-existing unrelated errors in `webhook-delivery.ts`, `llm-queue.ts`, `pages-crud.ts`, `trusted-proxy.ts` are baseline-dev state and not introduced by this change

## Test plan

- [x] Targeted vitest passes
- [x] Lint clean
- [x] Contracts build clean
- [x] No new typecheck regressions
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)