### PR TITLE
chore(#480): remove unused exports from bulk-page-selection.ts

### DIFF
--- a/backend/src/core/services/bulk-page-selection.ts
+++ b/backend/src/core/services/bulk-page-selection.ts
@@ -45,7 +45,7 @@ export const BulkPageFilterSchema = z
   })
   .strict();
 
-export type BulkPageFilter = z.infer<typeof BulkPageFilterSchema>;
+type BulkPageFilter = z.infer<typeof BulkPageFilterSchema>;
 
 /**
  * Wire shape for any bulk route's `selection` body. Routes use this in
@@ -77,7 +77,7 @@ export const BulkSelectionSchema = z
 
 export type BulkSelection = z.infer<typeof BulkSelectionSchema>;
 
-export interface ResolvedBulkRow {
+interface ResolvedBulkRow {
   id: number;
   confluenceId: string | null;
   spaceKey: string | null;
@@ -90,7 +90,7 @@ export interface ResolvedBulkRow {
   labels: string[];
 }
 
-export interface BulkSelectionResolutionError {
+interface BulkSelectionResolutionError {
   /**
    * Discriminator. `count_drift` maps to HTTP 409 in the route layer; the
    * shape is stable so the frontend can render a "the selection changed
@@ -103,7 +103,7 @@ export interface BulkSelectionResolutionError {
   actual?: number;
 }
 
-export interface ResolveBulkSelectionResult {
+interface ResolveBulkSelectionResult {
   rows: ResolvedBulkRow[];
   /** IDs supplied by the caller that did not resolve to any page (only for ids-mode). */
   notFoundIds: string[];


### PR DESCRIPTION
Closes #480

## Summary

Drop `export` from four types in `backend/src/core/services/bulk-page-selection.ts`:

- `BulkPageFilter`
- `ResolvedBulkRow`
- `BulkSelectionResolutionError`
- `ResolveBulkSelectionResult`

All four are referenced only inside `bulk-page-selection.ts` itself (parameter, return, and internal types). No CE consumer imports them — `pages-crud.ts` and the test only import `BulkPageFilterSchema`, `BulkSelectionSchema`, `BulkSelection`, `resolveBulkSelection`, `BulkSelectionError`, `buildFilterClauses`. **EE has no consumer either** (per issue triage).

Types remain in scope for internal use without leaking across the module boundary.

## Validation

- [x] `npm run build -w @compendiq/contracts` — passes
- [x] `npm run lint -w backend` — passes
- [x] `npx vitest run backend/src/core/services/bulk-page-selection.test.ts` — 16/16 pass
- [x] `npm run typecheck -w backend` — no new errors (pre-existing bullmq / p-limit worktree-resolution noise unrelated to this change)

## Test plan

- [ ] CI green on `dev`