### PR TITLE
chore(#483): remove unused exports from email-templates.ts

### DIFF
--- a/backend/src/core/services/email-templates.ts
+++ b/backend/src/core/services/email-templates.ts
@@ -63,7 +63,7 @@ function wrap(title: string, body: string): string {
 </html>`;
 }
 
-export interface SyncCompletedData {
+interface SyncCompletedData {
   userName: string;
   spacesCount: number;
   pagesCount: number;
@@ -85,7 +85,7 @@ export function syncCompleted(data: SyncCompletedData): { subject: string; html:
   };
 }
 
-export interface SyncFailedData {
+interface SyncFailedData {
   userName: string;
   errorMessage: string;
   spaceKey?: string;
@@ -106,7 +106,7 @@ export function syncFailed(data: SyncFailedData): { subject: string; html: strin
   };
 }
 
-export interface KnowledgeRequestData {
+interface KnowledgeRequestData {
   assigneeName: string;
   requesterName: string;
   title: string;
@@ -129,7 +129,7 @@ export function knowledgeRequestCreated(data: KnowledgeRequestData): { subject: 
   };
 }
 
-export interface CommentData {
+interface CommentData {
   authorName: string;
   recipientName: string;
   articleTitle: string;
@@ -151,7 +151,7 @@ export function articleComment(data: CommentData): { subject: string; html: stri
   };
 }
 
-export interface LicenseExpiryData {
+interface LicenseExpiryData {
   adminName: string;
   daysRemaining: number;
   expiryDate: string;
@@ -173,7 +173,7 @@ export function licenseExpiry(data: LicenseExpiryData): { subject: string; html:
   };
 }
 
-export interface AccountInvitationData {
+interface AccountInvitationData {
   /** Recipient's display name (falls back to username). */
   recipientName: string;
   /** Username to log in with. */


### PR DESCRIPTION
## Summary

Drop the `export` keyword from six template-data interfaces in `backend/src/core/services/email-templates.ts`:

- `SyncCompletedData`
- `SyncFailedData`
- `KnowledgeRequestData`
- `CommentData`
- `LicenseExpiryData`
- `AccountInvitationData`

They remain used internally as parameter types for the exported render functions (`syncCompleted`, `syncFailed`, `knowledgeRequestCreated`, `articleComment`, `licenseExpiry`, `accountInvitation`), but are no longer part of the module's public surface.

## EE no-consumer note

Verified via repo-wide grep (`backend/`, `frontend/`, `packages/`, `e2e/`, `scripts/`): no external consumer imports any of these names. There is no EE consumer either — these are CE-internal email template data shapes.

## Validation

- `npm run build -w @compendiq/contracts` — passes
- `backend` typecheck — no new errors in `email-templates.ts` (only pre-existing unrelated errors)
- `eslint src/core/services/email-templates.ts` — clean
- `vitest run src/core/services/email-templates.test.ts` — 6/6 pass

Closes #483