### PR TITLE
chore(#488): remove unused StreamSlot export from sse-stream-limiter.ts

### DIFF
--- a/backend/src/core/services/sse-stream-limiter.ts
+++ b/backend/src/core/services/sse-stream-limiter.ts
@@ -120,7 +120,7 @@ redis.call("expire", KEYS[1], ARGV[2])
 return 1
 `;
 
-export interface StreamSlot {
+interface StreamSlot {
   acquired: boolean;
   /**
    * Release the slot. Idempotent — calling twice DECRs once. Safe to call


### PR DESCRIPTION
Closes #488

## Summary

Drops the `export` keyword from the `StreamSlot` interface in `backend/src/core/services/sse-stream-limiter.ts`. The type is only referenced internally — by `failOpenSlot()`'s return type and `acquireStreamSlot()`'s return type. External consumers (`llm-ask`, `llm-generate`, `llm-summarize`, `llm-improve`, `llm-diagram`, `llm-quality`, and the tests) import the `acquireStreamSlot` function only and let TypeScript infer the slot type — they never reference `StreamSlot` by name.

## EE consumer note

No EE consumer. Verified via `grep -rn "StreamSlot" --include='*.ts' --include='*.tsx' backend/ frontend/ packages/ e2e/ scripts/` — every hit is inside this CE file or its tests. Safe to drop the export without coordinating with `compendiq-enterprise`.

## Verification

- `npx eslint backend/src/core/services/sse-stream-limiter.ts` — clean
- `npx vitest run sse-stream-limiter.test.ts sse-stream-limit-gate.test.ts` — 30 passed, 14 skipped (env-gated), 0 failed