### PR TITLE
chore(#486): remove unused McpDocsSettings export from mcp-docs-settings.ts

### DIFF
--- a/backend/src/core/services/mcp-docs-settings.ts
+++ b/backend/src/core/services/mcp-docs-settings.ts
@@ -6,7 +6,7 @@
 import { query, getPool } from '../db/postgres.js';
 import { logger } from '../utils/logger.js';
 
-export interface McpDocsSettings {
+interface McpDocsSettings {
   enabled: boolean;
   url: string;
   domainMode: 'allowlist' | 'blocklist';


### PR DESCRIPTION
Closes #486

## Summary

The `McpDocsSettings` interface in `backend/src/core/services/mcp-docs-settings.ts` was exported but is consumed only within the same module (used by `DEFAULTS`, the return type of `getMcpDocsSettings`, and the `updates` parameter of `upsertMcpDocsSettings`).

This PR drops the `export` keyword to keep the symbol module-private. The runtime functions `getMcpDocsSettings` and `upsertMcpDocsSettings` remain exported (they have legitimate external consumers in `mcp-docs-client.ts`, `llm-admin.ts`, and the test file).

## Consumer audit

```
grep -rn "McpDocsSettings" --include='*.ts' --include='*.tsx' backend/ frontend/ packages/ e2e/ scripts/
```

- Backend: only the file itself references the interface name (DEFAULTS / getMcpDocsSettings / upsertMcpDocsSettings).
- Frontend: `AskMode.tsx` and `McpDocsTab.tsx` declare their **own local** `McpDocsSettings` interfaces (no cross-package import).
- `packages/`, `e2e/`, `scripts/`: no references.

## EE no-consumer note

The private `compendiq-enterprise` repo does not import `McpDocsSettings` from CE — confirmed no EE consumer. Removing the export is safe across the open-core boundary.

## Verification

- `npx vitest run src/core/services/mcp-docs-settings.test.ts` — 3/3 pass
- `eslint src/core/services/mcp-docs-settings.ts src/core/services/mcp-docs-client.ts src/routes/llm/llm-admin.ts` — clean
- Diff is a single-character change (`export interface` → `interface`)

## Test plan

- [x] Existing `mcp-docs-settings.test.ts` still passes
- [x] No new lint errors on touched files
- [x] No external consumer broken (full-repo grep)

Co-Authored-By: Claude <noreply@anthropic.com>