### PR TITLE
chore(#490): remove unused OutboxPollerOptions export from webhook-outbox-poller.ts

### DIFF
--- a/backend/src/core/services/webhook-outbox-poller.ts
+++ b/backend/src/core/services/webhook-outbox-poller.ts
@@ -120,7 +120,7 @@ export function getWebhookDeliveryQueue(): Queue {
 
 // ─── Options & teardown types ────────────────────────────────────────────
 
-export interface OutboxPollerOptions {
+interface OutboxPollerOptions {
   /** ms between polls. Defaults to 5000. */
   pollIntervalMs?: number;
   /** Max rows claimed per cycle. Defaults to 50. */


### PR DESCRIPTION
Closes #490

## Summary

`OutboxPollerOptions` is flagged as an unused export by knip. Verified there is no external consumer in CE: `grep -rn 'OutboxPollerOptions'` finds only the declaration and a single internal use as the parameter type for `initWebhookOutboxPoller`.

The fix drops the `export` keyword while preserving the interface for internal documentation/typing.

## EE consumer check

EE imports `initWebhookOutboxPoller` (the function) but not `OutboxPollerOptions` (the type). `initWebhookOutboxPoller` is **explicitly retained** as an export — only the unused type-level export is removed. EE callers pass plain object literals which are structurally typed against the now-private interface; their call sites continue to compile unchanged.

## Test plan

- [x] `grep` confirms no external consumer of `OutboxPollerOptions`
- [x] `eslint` clean on modified file
- [x] `tsc --noEmit` shows no new errors (pre-existing `bullmq`/implicit-any errors are unchanged from `dev`)
- [x] Pre-commit hooks pass (no `--no-verify`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)