### PR TITLE
chore(#484): remove unused exports from error-tracker.ts

### DIFF
--- a/backend/src/core/services/error-tracker.ts
+++ b/backend/src/core/services/error-tracker.ts
@@ -1,14 +1,14 @@
 import { query } from '../db/postgres.js';
 import { logger } from '../utils/logger.js';
 
-export interface ErrorContext {
+interface ErrorContext {
   userId?: string;
   requestPath?: string;
   correlationId?: string;
   [key: string]: unknown;
 }
 
-export interface ErrorLogEntry {
+interface ErrorLogEntry {
   id: string;
   errorType: string;
   message: string;
@@ -21,13 +21,13 @@ export interface ErrorLogEntry {
   createdAt: string;
 }
 
-export interface ErrorSummary {
+interface ErrorSummary {
   errorType: string;
   count: number;
   lastOccurrence: string;
 }
 
-export interface ErrorSummaryResponse {
+interface ErrorSummaryResponse {
   last24h: ErrorSummary[];
   last7d: ErrorSummary[];
   last30d: ErrorSummary[];


### PR DESCRIPTION
## Summary

Drop `export` from four interfaces in `backend/src/core/services/error-tracker.ts` that are only consumed inside the same file:

- `ErrorContext` — only used as the `trackError(context)` parameter type
- `ErrorLogEntry` — only used in the `listErrors` return type
- `ErrorSummary` — only used inside `ErrorSummaryResponse`
- `ErrorSummaryResponse` — only used as the `getErrorSummary` return type

The frontend's `ErrorDashboard.tsx` declares its own local `ErrorLogEntry` / `ErrorSummaryResponse` interfaces and does not import from this module.

## EE consumer note

No `@compendiq/enterprise` (EE) consumer references any of these names. Verified by grep across `backend/`, `frontend/`, `packages/`, `e2e/`, `scripts/`. Safe to narrow visibility in CE without breaking EE.

## Test plan

- [x] `npm run build -w packages/contracts`
- [x] Backend typecheck: no new errors in `error-tracker.ts` (pre-existing `p-limit` / `admin-ip-allowlist` errors unrelated)
- [x] `npm run lint -w backend` — clean
- [x] Adjacent test file imports only the functions, not the types — unaffected

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)