### PR TITLE
chore(#485): remove unused LocalAttachmentRecord export from local-attachment-service.ts

### DIFF
--- a/backend/src/core/services/local-attachment-service.ts
+++ b/backend/src/core/services/local-attachment-service.ts
@@ -43,7 +43,7 @@ export class LocalAttachmentError extends Error {
   }
 }
 
-export interface LocalAttachmentRecord {
+interface LocalAttachmentRecord {
   id: number;
   pageId: number;
   filename: string;


### PR DESCRIPTION
Closes #485

## Summary

`LocalAttachmentRecord` was exported from `backend/src/core/services/local-attachment-service.ts` but only consumed internally by `mapRow()` and the `putLocalAttachment` / `getLocalAttachment` / `listLocalAttachments` functions in the same file. Dropping the `export` keyword keeps it as an internal row-mapping type.

## EE consumer

Verified no EE consumer. Search across `backend/`, `frontend/`, `packages/`, `e2e/`, and `scripts/` for `LocalAttachmentRecord` returned only same-file references. The EE `compendiq-enterprise` repo does not consume this symbol either (local attachments are CE-only standalone-page storage; EE adds OIDC/license, not attachment plumbing).

## Test plan

- [x] `grep -rn LocalAttachmentRecord` confirms only internal references remain
- [x] `npm run lint -w backend` passes (max-warnings=0)
- [x] Pre-commit hooks ran on the commit
- [ ] CI typecheck/test on PR