### PR TITLE
chore(#496): remove unused WebSearchFormat export from _web-search-helper.ts

### DIFF
--- a/backend/src/routes/llm/_web-search-helper.ts
+++ b/backend/src/routes/llm/_web-search-helper.ts
@@ -16,7 +16,7 @@ export interface WebSource {
   snippet: string;
 }
 
-export interface WebSearchFormat {
+interface WebSearchFormat {
   /** Label prefix for each source, e.g. 'Reference' or 'Web Source' */
   sourceLabel: string;
   /** Header text for the web context section, e.g. 'Verified reference material from web search' */


### PR DESCRIPTION
Closes #496

## Summary

`WebSearchFormat` interface in `backend/src/routes/llm/_web-search-helper.ts` was exported but only consumed internally (as a parameter type for `formatWebContext` within the same file). Drop the `export` keyword to reduce the public surface.

## Verification

- `grep -rn "WebSearchFormat" --include='*.ts' --include='*.tsx' backend/ frontend/ packages/ e2e/ scripts/` — only references are inside `_web-search-helper.ts` itself (declaration + internal usage + doc comment).
- No EE consumer (private `compendiq-enterprise` repo does not import this symbol; CE-side helper underscore-prefix `_web-search-helper.ts` signals route-private helper).
- ESLint passes on the modified file. The interface remains in the file for internal typing — only the `export` modifier is dropped, so no behavior change.

## EE no-consumer note

Confirmed no Enterprise consumer: `WebSearchFormat` is a CE-internal LLM route helper config type with no contract surface. Safe to de-export.