### PR TITLE
chore(#494): remove unused exports from rate-limit-service.ts

### DIFF
--- a/backend/src/core/services/rate-limit-service.ts
+++ b/backend/src/core/services/rate-limit-service.ts
@@ -3,12 +3,12 @@ import { logAuditEvent } from './audit-service.js';
 
 // ─── Rate limit categories ────────────────────────────────────────────────────
 
-export interface RateLimitConfig {
+interface RateLimitConfig {
   max: number;
   timeWindow: string;
 }
 
-export interface RateLimits {
+interface RateLimits {
   global: RateLimitConfig;
   auth: RateLimitConfig;
   admin: RateLimitConfig;
@@ -75,7 +75,7 @@ export async function getRateLimits(): Promise<RateLimits> {
 
 // ─── Setter ───────────────────────────────────────────────────────────────────
 
-export type RateLimitUpdate = Partial<Record<keyof RateLimits, number>>;
+type RateLimitUpdate = Partial<Record<keyof RateLimits, number>>;
 
 const KEY_MAP: Record<keyof RateLimits, string> = {
   global: 'rate_limit_global_max',


### PR DESCRIPTION
Closes #494

## Summary

Drop the `export` keyword from three internal-only types in `backend/src/core/services/rate-limit-service.ts`:

- `RateLimitConfig`
- `RateLimits`
- `RateLimitUpdate`

All three are only referenced within `rate-limit-service.ts` itself. The exported functions `getRateLimits` and `upsertRateLimits` are unchanged.

## EE consumer check

The Enterprise Edition (`compendiq-enterprise`) imports `getRateLimits` only — never the flagged types. `getRateLimits` is retained as an export. No EE-side changes required.

## Verification

- `grep -rn "RateLimitConfig\|RateLimits\b\|RateLimitUpdate"` across `backend/`, `frontend/`, `packages/`, `e2e/`, `scripts/` shows usages limited to `rate-limit-service.ts`.
- `npx eslint src/core/services/rate-limit-service.ts` clean.
- Backend `npm run typecheck` produces no rate-limit-related errors (pre-existing unrelated errors in `bullmq`/`p-limit`/`trusted-proxy` files exist on `dev` independently of this change).

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>