### PR TITLE
chore(#495): remove unused PageVersion export from version-tracker.ts

### DIFF
--- a/backend/src/domains/knowledge/services/version-tracker.ts
+++ b/backend/src/domains/knowledge/services/version-tracker.ts
@@ -8,7 +8,7 @@ import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js'
 // Re-export from core so existing consumers keep working
 export { saveVersionSnapshot } from '../../../core/services/version-snapshot.js';
 
-export interface PageVersion {
+interface PageVersion {
   id: string;
   pageId: number;
   confluenceId: string | null;


### PR DESCRIPTION
## Summary

Removes the unused `export` from the `PageVersion` interface in `backend/src/domains/knowledge/services/version-tracker.ts`. The interface is only referenced internally as a return-type annotation (`getVersionHistory`, `getVersion`); no other CE module imports it, and no EE consumer references it either.

## Verification

- `grep -rn "\bPageVersion\b" --include='*.ts' --include='*.tsx' backend/ frontend/ packages/ e2e/ scripts/` -> only the three internal references in `version-tracker.ts` itself.
- EE consumer check: no consumer.
- Backend `tsc --noEmit` clean against the modified file.
- `eslint` clean against the modified file.

Closes #495

## Test plan

- [x] Grep for `PageVersion` token across `backend/`, `frontend/`, `packages/`, `e2e/`, `scripts/` — only internal hits remain
- [x] `npx tsc --noEmit` in `backend/` passes
- [x] `npx eslint` on the changed file passes