### PR TITLE
chore(#491): remove unused exports from webhook-signer.ts

### DIFF
--- a/backend/src/core/services/webhook-signer.ts
+++ b/backend/src/core/services/webhook-signer.ts
@@ -47,7 +47,7 @@ import { timingSafeEqual } from 'node:crypto';
 /** Default skew tolerance matches the Standard Webhooks spec (§5). */
 const DEFAULT_TOLERANCE_SECONDS = 300;
 
-export interface SignWebhookOptions {
+interface SignWebhookOptions {
   /** Decrypted plaintext subscription secret. NOT the encrypted BYTEA. */
   secret: string;
   /** `webhook_outbox.webhook_id` — stable across retries, receiver dedup key. */
@@ -58,13 +58,13 @@ export interface SignWebhookOptions {
   payload: string;
 }
 
-export interface SignedWebhookHeaders {
+interface SignedWebhookHeaders {
   'webhook-id': string;
   'webhook-timestamp': string;
   'webhook-signature': string;
 }
 
-export interface VerifyWebhookOptions {
+interface VerifyWebhookOptions {
   /**
    * Single secret or an array. Arrays let verifiers accept a signature
    * produced under *either* the primary or the secondary secret during


### PR DESCRIPTION
## Summary

Drops `export` keyword on three internal-only type interfaces in `backend/src/core/services/webhook-signer.ts`:

- `SignWebhookOptions`
- `SignedWebhookHeaders`
- `VerifyWebhookOptions`

All three are only referenced as parameter/return types of the exported `signWebhook` and `verifyWebhook` functions inside the same file. No external consumer in `backend`, `frontend`, `packages/`, `e2e/`, or `scripts/`.

**EE no-consumer note**: verified no consumer in the EE repo — these were never imported outside this module.

The interfaces are kept in place (now unexported) so the public function signatures still type-check.

## Test plan

- [x] `npm run build -w @compendiq/contracts` — passes
- [x] `npm run typecheck -w backend` — no new errors (pre-existing p-limit / ipaddr.js issues unrelated)
- [x] `npm run lint -w backend` — clean
- [x] `npx vitest run src/core/services/webhook-signer.test.ts` — 14/14 passing

Closes #491