### PR TITLE
chore(#493): remove unused exports from confluence-client.ts

### DIFF
--- a/backend/src/domains/confluence/services/confluence-client.ts
+++ b/backend/src/domains/confluence/services/confluence-client.ts
@@ -62,14 +62,14 @@ interface PaginatedResponse<T> {
   _links?: { next?: string };
 }
 
-export interface RetryOptions {
+interface RetryOptions {
   /** Maximum number of attempts (including the first). Default: 3 */
   maxAttempts?: number;
   /** Base delay in milliseconds before the first retry. Default: 1000 */
   baseDelay?: number;
 }
 
-export interface ConfluenceClientOptions {
+interface ConfluenceClientOptions {
   /** Retry configuration for transient errors. */
   retry?: RetryOptions;
 }
@@ -983,4 +983,4 @@ export async function withRetry<T>(
   throw new Error('withRetry: unreachable');
 }
 
-export type { ConfluenceSpace, ConfluencePage, ConfluenceAttachment, PaginatedResponse };
+export type { ConfluenceSpace, ConfluencePage, ConfluenceAttachment };


### PR DESCRIPTION
## Summary

Removes three unused exports from `backend/src/domains/confluence/services/confluence-client.ts`:

- `RetryOptions` — used only internally as a type within the same file (drop `export`).
- `ConfluenceClientOptions` — used only internally as the constructor options type (drop `export`).
- `PaginatedResponse` — already declared without `export` on its `interface`; was being re-exported at the bottom of the file. No external consumer imports it; removed from the re-export list. The interface remains internal-only.

## EE no-consumer note

Greps across `backend/`, `frontend/`, `packages/`, `e2e/`, and `scripts/` confirmed no external CE consumer of any of the three names. Per the issue, there is no EE consumer either.

## Validation

- `npm run build -w @compendiq/contracts` — clean
- `npm run typecheck -w backend` — no new errors (pre-existing `p-limit` errors in `pages-crud.ts` are unrelated)
- `npm run lint -w backend` — clean
- `npx vitest run src/domains/confluence/services/confluence-client.test.ts` — 100 tests passed

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)