### PR TITLE
chore(#501): remove unused SummaryStatus export from summary-worker.ts

### DIFF
--- a/backend/src/domains/knowledge/services/summary-worker.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.ts
@@ -68,7 +68,7 @@ let lastRunAt: Date | null = null;
 // Public status
 // ---------------------------------------------------------------------------
 
-export interface SummaryStatus {
+interface SummaryStatus {
   totalPages: number;
   summarizedPages: number;
   summarizingPages: number;


### PR DESCRIPTION
Closes #501

## Summary
Drop the `export` keyword from the `SummaryStatus` interface in `backend/src/domains/knowledge/services/summary-worker.ts`. The type is only used internally as the return type of `getSummaryStatus()`; no external module imports it as a named type.

## EE no-consumer note
Verified via grep across `backend/`, `frontend/`, `packages/`, `e2e/`, `scripts/`. The only references to a `SummaryStatus` identifier in the backend are this declaration and its internal use as a return-type annotation. Frontend has its own unrelated `SummaryStatus` string-union type alias in `frontend/src/shared/hooks/use-pages.ts` (different shape, different purpose). The companion contracts type is `PageSummaryStatus` in `packages/contracts/src/schemas/pages.ts`. No EE consumer in the private `compendiq-enterprise` repo can reference this internal worker type — workers are CE-internal infrastructure not part of any cross-edition contract.

## Test plan
- [x] `grep -rn "SummaryStatus"` confirms no external named-import consumer
- [x] `npx vitest run src/domains/knowledge/services/summary-worker.test.ts` — clean (17 skipped, no import/compile errors)
- [x] Pre-commit hooks passed