### PR TITLE
chore(#500): remove unused QualityScores export from quality-worker.ts

### DIFF
--- a/backend/src/domains/knowledge/services/quality-worker.ts
+++ b/backend/src/domains/knowledge/services/quality-worker.ts
@@ -71,7 +71,7 @@ let lastRunAt: Date | null = null;
 
 // ─── Score parsing ────────────────────────────────────────────────────────────
 
-export interface QualityScores {
+interface QualityScores {
   overall: number;
   completeness: number;
   clarity: number;


### PR DESCRIPTION
Closes #500

## Summary

Removes the `export` keyword from the `QualityScores` interface in `backend/src/domains/knowledge/services/quality-worker.ts`. The interface is only used internally as the return type of `parseQualityScores` and has no external consumers.

## Verification

`grep -rn "QualityScores" --include='*.ts' --include='*.tsx' backend/ frontend/ packages/ e2e/ scripts/` confirmed:
- `QualityScores` (the interface) is referenced only inside `quality-worker.ts` itself.
- The test file imports `parseQualityScores` (the function), not the `QualityScores` interface.
- No EE consumer — the symbol is not part of any cross-edition contract (LLM audit hook, enterprise loader/types, license, OIDC).

## Validation

- `npx vitest run src/domains/knowledge/services/quality-worker.test.ts` — 9 passed (skipped tests are unrelated, integration-only).
- `npx eslint src/domains/knowledge/services/quality-worker.ts` — clean.
- Pre-existing unrelated typecheck errors (p-limit, turndown-plugin-gfm, ipaddr.js) are not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)