### PR TITLE
chore(#499): remove unused ExtractedLink export from link-extractor.ts

### DIFF
--- a/backend/src/domains/knowledge/services/link-extractor.ts
+++ b/backend/src/domains/knowledge/services/link-extractor.ts
@@ -39,7 +39,7 @@ import { logger } from '../../../core/utils/logger.js';
 const APP_PAGE_PATH_RE = /^\/pages\/(\d+)(?:\/|$|\?|#)/;
 const CONFLUENCE_PAGE_HASH_PREFIX = '#confluence-page:';
 
-export interface ExtractedLink {
+interface ExtractedLink {
   /** Internal pages.id of the link target. */
   targetPageId: number;
 }


### PR DESCRIPTION
Closes #499

## Summary

`ExtractedLink` in `backend/src/domains/knowledge/services/link-extractor.ts` is consumed only by `extractInternalLinks` within the same file. No other module imports it.

A repo-wide grep (`backend/`, `frontend/`, `packages/`, `e2e/`, `scripts/`) returns three hits, all internal to `link-extractor.ts`:

- L42: `interface ExtractedLink` (declaration)
- L57: `extractInternalLinks` return type
- L62: local `out` variable type

Dropping the `export` keyword keeps the surface area minimal.

## EE no-consumer note

Confirmed no EE consumer: `ExtractedLink` is a producer-internal shape used only inside the explicit_link edge producer. `@compendiq/enterprise` has no need for it — the only externally-relevant export from this module is `runExplicitLinkProducer`, which is invoked by `relationship-producers.ts` (CE) and is unaffected by this change.

## Validation

- `npx vitest run backend/src/domains/knowledge/services/link-extractor.test.ts` — 27/27 pass
- `npx eslint backend/src/domains/knowledge/services/link-extractor.ts` — clean
- `tsc --noEmit` shows no new errors related to `ExtractedLink` or `link-extractor.ts` (pre-existing errors unchanged)