### PR TITLE
chore(#497): remove unused exports from openai-compatible-client.ts

### DIFF
--- a/backend/src/domains/llm/services/openai-compatible-client.ts
+++ b/backend/src/domains/llm/services/openai-compatible-client.ts
@@ -13,10 +13,10 @@ export interface ProviderConfig {
   verifySsl: boolean;
 }
 
-export interface LlmModel { name: string; }
-export interface HealthResult { connected: boolean; error?: string; }
+interface LlmModel { name: string; }
+interface HealthResult { connected: boolean; error?: string; }
 export interface ChatMessage { role: 'system' | 'user' | 'assistant'; content: string; }
-export interface StreamChunk { content: string; done: boolean; }
+interface StreamChunk { content: string; done: boolean; }
 
 const dispatchers = new Map<string, Agent>();
 function dispatcherFor(cfg: ProviderConfig): Agent | undefined {


### PR DESCRIPTION
Closes #497.

Drops the `export` keyword from `LlmModel`, `HealthResult`, and `StreamChunk` in `backend/src/domains/llm/services/openai-compatible-client.ts`. All three are used only as internal return/yield types within the same file:

- `LlmModel` — return type of internal `listModels()`
- `HealthResult` — return type of internal `checkHealth()`
- `StreamChunk` — yield type of internal `streamChat()` async generator

## Verification

Grepped all three names across `backend/`, `frontend/`, `packages/`, `e2e/`, `scripts/`:

- `LlmModel`: only referenced inside `openai-compatible-client.ts`. The frontend's `LlmModel` in `frontend/src/features/setup/steps/LlmStep.tsx` is a separate locally-defined interface, not imported from this file.
- `HealthResult`: only referenced inside `openai-compatible-client.ts`.
- `StreamChunk`: only referenced inside `openai-compatible-client.ts`. (`backend/src/domains/knowledge/services/summary-worker.ts` mentions the name in a comment string only.)

## EE consumer

No EE consumer — the enterprise repo does not import these types.

## Validation

- `npm run build -w @compendiq/contracts`: PASS
- `npm run lint -w backend`: PASS (max-warnings=0)
- `npx vitest run src/domains/llm/services/openai-compatible-client.test.ts`: 13/13 PASS
- `npx tsc --noEmit` in `backend/`: error count unchanged from `origin/dev` baseline (19 pre-existing errors in `llm-queue.ts`, `pages-crud.ts`, `admin-ip-allowlist.ts` — all unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)