### PR TITLE
chore(#498): remove unused DuplicateCandidate export from duplicate-detector.ts

### DIFF
--- a/backend/src/domains/knowledge/services/duplicate-detector.ts
+++ b/backend/src/domains/knowledge/services/duplicate-detector.ts
@@ -4,7 +4,7 @@ import { logger } from '../../../core/utils/logger.js';
 
 const RAG_EF_SEARCH = parseInt(process.env.RAG_EF_SEARCH ?? '100', 10);
 
-export interface DuplicateCandidate {
+interface DuplicateCandidate {
   confluenceId: string;
   title: string;
   spaceKey: string;


### PR DESCRIPTION
Closes #498

Drops the unused `export` keyword from the `DuplicateCandidate` interface in `backend/src/domains/knowledge/services/duplicate-detector.ts`. The type is consumed only within the same file.

## Verification
- `grep -rn "DuplicateCandidate" backend/ frontend/ packages/ e2e/ scripts/` confirmed no external consumers (the frontend `DuplicateDetector.tsx` declares its own local interface; `dist/` matches are build artifacts).
- `npx eslint backend/src/domains/knowledge/services/duplicate-detector.ts` clean.
- `tsc --noEmit` clean for this file (only pre-existing unrelated `p-limit` error in `pages-crud.ts`).

## EE consumer note
No EE consumer. The `compendiq-enterprise` repo does not import `DuplicateCandidate` — duplicate detection is a CE-internal feature.