### PR TITLE
chore(#434): remove unused getSearchState export from search-extension.ts

### DIFF
--- a/frontend/src/shared/components/article/search-extension.ts
+++ b/frontend/src/shared/components/article/search-extension.ts
@@ -2,7 +2,6 @@ import { Extension } from '@tiptap/core';
 import {
   search as searchPlugin,
   SearchQuery,
-  getSearchState,
   setSearchState,
   findNext,
   findPrev,
@@ -10,7 +9,7 @@ import {
   replaceAll,
 } from 'prosemirror-search';
 
-export { SearchQuery, getSearchState };
+export { SearchQuery };
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {


### PR DESCRIPTION
## Summary

- Remove unused `getSearchState` re-export from `frontend/src/shared/components/article/search-extension.ts`
- Drop the corresponding `getSearchState` import from `prosemirror-search`
- `SearchQuery` re-export is retained — `SearchAndReplace.tsx` consumes it

## EE consumer note

Verified no consumer in CE (`grep -rn "getSearchState"` returned only the file's own import + re-export). EE repo (`compendiq-enterprise`) ships the unmodified CE frontend image per ADR (no EE frontend bundle), so there is no EE consumer to break.

Closes #434

## Test plan

- [x] `npm run build -w packages/contracts` — passes
- [x] `npm run typecheck -w frontend` — passes
- [x] `npm run lint -w frontend` — passes (`--max-warnings=0`)
- [x] No dedicated test file exists for `search-extension.ts`; behavior is covered indirectly by `SearchAndReplace.test.tsx` which does not reference `getSearchState`

🤖 Generated with [Claude Code](https://claude.com/claude-code)