### PR TITLE
chore(#432): remove unused exports from drawio-save-drain.ts

### DIFF
--- a/frontend/src/shared/components/article/drawio-save-drain.ts
+++ b/frontend/src/shared/components/article/drawio-save-drain.ts
@@ -29,7 +29,7 @@
 import type { Editor } from '@tiptap/core';
 import { apiFetch } from '../../lib/api';
 
-export interface DrainOptions {
+interface DrainOptions {
   /**
    * Attachment-store page id. For Confluence pages this is the
    * `confluenceId`; for standalone pages it's the numeric DB id. Combined
@@ -47,7 +47,7 @@ export interface DrainOptions {
   pageSource: 'confluence' | 'standalone';
 }
 
-export interface DrainResult {
+interface DrainResult {
   uploaded: number;
   skipped: number;
   failed: number;


### PR DESCRIPTION
Closes #432

## Summary

`DrainOptions` and `DrainResult` in `frontend/src/shared/components/article/drawio-save-drain.ts` were exported but only consumed internally by `drainPendingDrawioUploads` in the same file. Drop the `export` keyword on both interfaces.

## EE consumer check

`grep -rn "DrainOptions\|DrainResult" --include='*.ts' --include='*.tsx' frontend/ packages/` returns only the four self-references inside `drawio-save-drain.ts` (declaration + parameter/return type + local result variable). No EE consumer — the drawio drain is a CE-only TipTap concern.

## Validation

- `npm run build -w packages/contracts` — clean
- `npm run typecheck -w frontend` — clean
- `npm run lint -w frontend` — clean (`--max-warnings=0`)
- `npx vitest run src/shared/components/article/drawio-save-drain.test.ts` — 6/6 pass

## Test plan

- [x] Contracts build green
- [x] Frontend typecheck green
- [x] Frontend lint green (zero warnings)
- [x] drawio-save-drain.test.ts green (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)