### PR TITLE
chore(#431): remove unused exports from vim-extension.ts

### DIFF
--- a/frontend/src/shared/components/article/vim-extension.ts
+++ b/frontend/src/shared/components/article/vim-extension.ts
@@ -679,14 +679,14 @@ function handleVisualKey(
 // Change callback type for mode notifications
 // ---------------------------------------------------------------------------
 
-export type VimModeChangeCallback = (mode: VimMode) => void;
-export type VimStateChangeCallback = (state: VimState) => void;
+type VimModeChangeCallback = (mode: VimMode) => void;
+type VimStateChangeCallback = (state: VimState) => void;
 
 // ---------------------------------------------------------------------------
 // TipTap Extension
 // ---------------------------------------------------------------------------
 
-export interface VimExtensionOptions {
+interface VimExtensionOptions {
   /** Callback when the vim mode changes (used to update React state). */
   onModeChange?: VimModeChangeCallback;
   /** Callback when full vim state changes (mode, pending keys, command buffer). */


### PR DESCRIPTION
## Summary

Removes `export` from three identifiers in `frontend/src/shared/components/article/vim-extension.ts` that have no external consumers:

- `VimModeChangeCallback` (type)
- `VimStateChangeCallback` (type)
- `VimExtensionOptions` (interface)

All three are still referenced inside `vim-extension.ts` itself (the callback types are field types on `VimExtensionOptions`; the interface is the generic parameter to `Extension.create<...>`), so they are kept as internal declarations — only the `export` keyword is dropped.

## EE consumer check

No EE consumer — frontend has no EE bundle (per CE CLAUDE.md, both editions ship the same unmodified CE frontend image). Verified with `grep` across `frontend/` and `packages/`: no matches outside the file itself.

## Validation

- `npm run build -w packages/contracts` — pass
- `npm run typecheck -w frontend` — pass
- `npm run lint -w frontend` — pass (0 warnings)
- `npx vitest run src/shared/components/article/vim-extension.test.ts` — 9/9 pass

Closes #431