### PR TITLE
chore(#504): remove unused exports from mcp-docs-client.ts

### DIFF
--- a/backend/src/core/services/mcp-docs-client.ts
+++ b/backend/src/core/services/mcp-docs-client.ts
@@ -53,7 +53,7 @@ async function disconnect(): Promise<void> {
   connectedUrl = null;
 }
 
-export interface McpDocResult {
+interface McpDocResult {
   markdown: string;
   title: string;
   url: string;
@@ -62,7 +62,7 @@ export interface McpDocResult {
   truncated: boolean;
 }
 
-export interface McpSearchResult {
+interface McpSearchResult {
   title: string;
   url: string;
   snippet: string;


### PR DESCRIPTION
## Summary

Drops the `export` keyword from `McpDocResult` and `McpSearchResult` interfaces in `backend/src/core/services/mcp-docs-client.ts`. Both types are only consumed inside that same file (used as return types for the file-local `fetchDocumentation` and `searchDocumentation` functions and for assembling intermediate results in `parseSearchResults`), so there's no need for them to live on the module's public surface.

## Verification

- Repo-wide grep across `backend/`, `frontend/`, `packages/`, `e2e/`, `scripts/` (`*.ts`/`*.tsx`) returns only same-file references — no external CE consumer.
- EE no-consumer note: `@compendiq/enterprise` does not import either symbol; this is a CE-internal cleanup with no shared-API impact.
- `npm run build -w @compendiq/contracts` — passes.
- `npm run typecheck -w backend` — passes.
- `npm run lint -w backend` — passes (`--max-warnings=0`).
- No existing test file for `mcp-docs-client.ts`; behavior unchanged (purely a visibility narrowing).

Closes #504

## Test plan

- [x] Contracts build green
- [x] Backend typecheck green
- [x] Backend lint green (max-warnings=0)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)