### PR TITLE
chore(#438): remove unused useAvailableSpaces export from use-spaces.ts

### DIFF
--- a/frontend/src/shared/hooks/use-spaces.ts
+++ b/frontend/src/shared/hooks/use-spaces.ts
@@ -12,24 +12,10 @@ interface Space {
   source: 'confluence' | 'local';
 }
 
-interface AvailableSpace {
-  key: string;
-  name: string;
-  type: string;
-}
-
 export function useSpaces() {
   return useQuery<Space[]>({
     queryKey: ['spaces'],
     queryFn: () => apiFetch('/spaces'),
-  });
-}
-
-export function useAvailableSpaces() {
-  return useQuery<AvailableSpace[]>({
-    queryKey: ['spaces', 'available'],
-    queryFn: () => apiFetch('/spaces/available'),
-    enabled: false, // Only fetch when triggered
   });
 }
 


### PR DESCRIPTION
## Summary

Removes the unused `useAvailableSpaces` hook and its companion `AvailableSpace` interface from `frontend/src/shared/hooks/use-spaces.ts`. Verified zero consumers via `grep -rn "useAvailableSpaces" --include='*.ts' --include='*.tsx' frontend/ packages/` — only the export site itself matched.

EE has no consumer of this hook (frontend hook, not part of the EE backend extension surface).

Closes #438

## Test plan

- [x] Contracts build (`npm run build -w @compendiq/contracts`)
- [x] Frontend typecheck (`npm run typecheck -w frontend`)
- [x] Frontend lint (`npm run lint -w frontend`, `--max-warnings=0`)
- [x] Targeted vitest: `frontend/src/shared/hooks/use-spaces.test.ts` (4/4 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)