### PR TITLE
chore(#440): remove unused PDF_TEXT_TRUNCATION_THRESHOLD export from GenerateMode.tsx

### DIFF
--- a/frontend/src/features/ai/modes/GenerateMode.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.tsx
@@ -12,7 +12,7 @@ import { marked } from 'marked';
 import { cn } from '../../../shared/lib/cn';
 
 /** Threshold above which the backend truncates PDF text for the LLM context window. */
-export const PDF_TEXT_TRUNCATION_THRESHOLD = 80_000;
+const PDF_TEXT_TRUNCATION_THRESHOLD = 80_000;
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
Closes #440

## Summary

`PDF_TEXT_TRUNCATION_THRESHOLD` in `frontend/src/features/ai/modes/GenerateMode.tsx` is only consumed within the same file (line 249, the truncation cap UI hint). Drop `export` to keep it as a file-local constant.

## EE consumer check

No EE consumer. The constant is frontend-only and EE ships the unmodified CE frontend image (per CLAUDE.md), so there is no EE-side import path that could reach this symbol.

## Validation

- `npm run build -w @compendiq/contracts` — passed
- `npm run typecheck -w frontend` — passed
- `npm run lint -w frontend` — passed (max-warnings=0)
- `npx vitest run src/features/ai/modes/GenerateMode.test.tsx` — 31/31 passed

## Test plan

- [x] Frontend typecheck clean
- [x] Frontend lint clean
- [x] Targeted vitest suite green