### PR TITLE
chore(#436): remove unused OllamaTab export from SettingsPage.tsx

### DIFF
--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -40,10 +40,6 @@ import {
   SystemTab,
 } from './panels';
 
-// Re-export the backward-compatible alias for tests/consumers that import
-// `OllamaTab` from the SettingsPage module.
-export { OllamaTab } from './panels';
-
 type TabId = 'confluence' | 'sync' | 'sync-conflict-policy' | 'sync-conflicts' | 'ollama' | 'ai-prompts' | 'ai-safety' | 'rate-limits' | 'spaces' | 'theme' | 'labels' | 'errors' | 'embedding' | 'workers' | 'mcp-docs' | 'searxng' | 'email' | 'license' | 'sso' | 'ip-allowlist' | 'webhooks' | 'llm-policy' | 'retention' | 'compliance-reports' | 'llm-audit' | 'ai-reviews' | 'ai-review-policy' | 'pii-policy' | 'scim' | 'system';
 
 export function SettingsPage() {


### PR DESCRIPTION
Closes #436

## Summary

Removes the unused backward-compatible `OllamaTab` re-export from `frontend/src/features/settings/SettingsPage.tsx`. The alias is defined at its source in `panels/LlmTab.tsx` and is not imported from `SettingsPage` anywhere in the codebase.

## EE consumer note

No EE consumer references `OllamaTab` from `SettingsPage.tsx`. The CE frontend image is shipped unchanged in EE (per ADR/CLAUDE.md), and `OllamaTab` is not part of any documented extension surface.

## Validation

- `npm run build -w @compendiq/contracts` — passes
- `npm run typecheck -w frontend` — passes
- `npm run lint -w frontend` — passes (max-warnings=0)
- `npx vitest run src/features/settings/panels/LlmTab.test.tsx` — 7/7 passing
- `SettingsPage.test.tsx` fails to load on `dev` and on this branch with an unrelated missing `diff` module — pre-existing, not caused by this change.