### PR TITLE
chore(#439): remove unused hook exports from use-standalone.ts

### DIFF
--- a/frontend/src/shared/hooks/use-standalone.ts
+++ b/frontend/src/shared/hooks/use-standalone.ts
@@ -64,100 +64,6 @@ export function useComments(pageId: number) {
   });
 }
 
-export function useCreateComment(pageId: number) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (data: { body: string; parentId?: number }) =>
-      apiFetch<Comment>(`/pages/${pageId}/comments`, {
-        method: 'POST',
-        body: JSON.stringify(data),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['comments', pageId] });
-    },
-  });
-}
-
-export function useResolveComment() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ commentId, resolved }: { commentId: number; resolved: boolean }) =>
-      apiFetch(`/comments/${commentId}/resolve`, {
-        method: 'PUT',
-        body: JSON.stringify({ resolved }),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['comments'] });
-    },
-  });
-}
-
-export function useAddReaction() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ commentId, emoji }: { commentId: number; emoji: string }) =>
-      apiFetch(`/comments/${commentId}/reactions`, {
-        method: 'POST',
-        body: JSON.stringify({ emoji }),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['comments'] });
-    },
-  });
-}
-
-// ======== Drafts ========
-
-export function useDraft(pageId: number) {
-  return useQuery({
-    queryKey: ['drafts', pageId],
-    queryFn: () => apiFetch<Draft>(`/pages/${pageId}/draft`),
-    enabled: pageId > 0,
-  });
-}
-
-export function useSaveDraft(pageId: number) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (data: { bodyJson: string; bodyHtml: string }) =>
-      apiFetch<Draft>(`/pages/${pageId}/draft`, {
-        method: 'PUT',
-        body: JSON.stringify(data),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['drafts', pageId] });
-    },
-  });
-}
-
-export function usePublishDraft(pageId: number) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: () =>
-      apiFetch(`/pages/${pageId}/draft/publish`, {
-        method: 'POST',
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['drafts', pageId] });
-      queryClient.invalidateQueries({ queryKey: ['pages', String(pageId)] });
-      queryClient.invalidateQueries({ queryKey: ['pages'] });
-    },
-  });
-}
-
-export function useDiscardDraft(pageId: number) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: () =>
-      apiFetch(`/pages/${pageId}/draft`, {
-        method: 'DELETE',
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['drafts', pageId] });
-    },
-  });
-}
-
 // ======== Trash ========
 
 export function useTrash() {
@@ -203,19 +109,6 @@ export function useUnreadCount() {
   });
 }
 
-export function useMarkRead() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (notificationId: number) =>
-      apiFetch(`/notifications/${notificationId}/read`, {
-        method: 'PUT',
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['notifications'] });
-    },
-  });
-}
-
 export function useMarkAllRead() {
   const queryClient = useQueryClient();
   return useMutation({
@@ -248,37 +141,7 @@ export function useVerifyPage() {
   });
 }
 
-export function useSetPageOwner() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ pageId, ownerId }: { pageId: number; ownerId: string }) =>
-      apiFetch(`/pages/${pageId}/owner`, {
-        method: 'PUT',
-        body: JSON.stringify({ ownerId }),
-      }),
-    onSuccess: (_data, { pageId }) => {
-      queryClient.invalidateQueries({ queryKey: ['pages', String(pageId)] });
-    },
-  });
-}
-
-export function useVerificationHealth() {
-  return useQuery({
-    queryKey: ['verification', 'health'],
-    queryFn: () => apiFetch<VerificationHealth>('/verification/health'),
-    staleTime: 60_000,
-  });
-}
-
 // ======== Feedback ========
-
-export function usePageFeedback(pageId: number) {
-  return useQuery({
-    queryKey: ['feedback', pageId],
-    queryFn: () => apiFetch<PageFeedbackResponse>(`/pages/${pageId}/feedback`),
-    enabled: pageId > 0,
-  });
-}
 
 export function useSubmitFeedback(pageId: number) {
   const queryClient = useQueryClient();
@@ -290,48 +153,6 @@ export function useSubmitFeedback(pageId: number) {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['feedback', pageId] });
-    },
-  });
-}
-
-// ======== Knowledge Requests ========
-
-export function useKnowledgeRequests(filters?: { status?: string }) {
-  return useQuery({
-    queryKey: ['knowledge-requests', filters],
-    queryFn: () => {
-      const params = new URLSearchParams();
-      if (filters?.status) params.set('status', filters.status);
-      const qs = params.toString();
-      return apiFetch<{ items: KnowledgeRequest[]; total: number }>(`/knowledge-requests${qs ? `?${qs}` : ''}`);
-    },
-  });
-}
-
-export function useCreateKnowledgeRequest() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (data: { title: string; description: string; priority?: string }) =>
-      apiFetch<KnowledgeRequest>('/knowledge-requests', {
-        method: 'POST',
-        body: JSON.stringify(data),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['knowledge-requests'] });
-    },
-  });
-}
-
-export function useFulfillRequest() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ requestId, pageId }: { requestId: number; pageId: number }) =>
-      apiFetch(`/knowledge-requests/${requestId}/fulfill`, {
-        method: 'PUT',
-        body: JSON.stringify({ pageId }),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['knowledge-requests'] });
     },
   });
 }
@@ -354,37 +175,12 @@ export function useSearch(params: { q: string; source?: string; spaceKey?: strin
   });
 }
 
-export function useSearchSuggestions(prefix: string) {
-  return useQuery({
-    queryKey: ['search', 'suggestions', prefix],
-    queryFn: () => apiFetch<{ suggestions: string[] }>(`/search/suggestions?prefix=${encodeURIComponent(prefix)}`),
-    enabled: prefix.length >= 2,
-    staleTime: 10_000,
-  });
-}
-
 // ======== Analytics ========
 
 export function useTrending() {
   return useQuery({
     queryKey: ['analytics', 'trending'],
     queryFn: () => apiFetch<{ items: TrendingPage[] }>('/analytics/trending'),
-    staleTime: 60_000,
-  });
-}
-
-export function useContentQuality() {
-  return useQuery({
-    queryKey: ['analytics', 'content-quality'],
-    queryFn: () => apiFetch<ContentQualityReport>('/analytics/content-quality'),
-    staleTime: 60_000,
-  });
-}
-
-export function useContentGaps() {
-  return useQuery({
-    queryKey: ['analytics', 'content-gaps'],
-    queryFn: () => apiFetch<{ items: ContentGap[] }>('/analytics/content-gaps'),
     staleTime: 60_000,
   });
 }
@@ -426,17 +222,6 @@ export function useExportPdf() {
   return useMutation({
     mutationFn: (pageId: number) =>
       fetchPdfBlob(`/api/pages/${pageId}/export/pdf`, { method: 'POST' }),
-  });
-}
-
-export function useBatchExportPdf() {
-  return useMutation({
-    mutationFn: (pageIds: number[]) =>
-      fetchPdfBlob('/api/pages/export/pdf', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pageIds }),
-      }),
   });
 }
 
@@ -509,30 +294,6 @@ export function useDeleteLocalSpace() {
   });
 }
 
-export function useSpaceTree(spaceKey: string) {
-  return useQuery({
-    queryKey: ['space-tree', spaceKey],
-    queryFn: () => apiFetch<{ items: SpaceTreeNode[] }>(`/spaces/${spaceKey}/tree`),
-    enabled: !!spaceKey,
-  });
-}
-
-export function useMovePage() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ id, ...data }: { id: string; parentId: string | null; spaceKey?: string }) =>
-      apiFetch(`/pages/${id}/move`, {
-        method: 'PUT',
-        body: JSON.stringify(data),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['pages'] });
-      queryClient.invalidateQueries({ queryKey: ['space-tree'] });
-      queryClient.invalidateQueries({ queryKey: ['spaces'] });
-    },
-  });
-}
-
 export function useReorderPage() {
   const queryClient = useQueryClient();
   return useMutation({
@@ -550,7 +311,7 @@ export function useReorderPage() {
 
 // ======== Breadcrumb ========
 
-export interface BreadcrumbData {
+interface BreadcrumbData {
   spaceKey: string | null;
   spaceName: string | null;
   source: 'confluence' | 'local';
@@ -576,24 +337,9 @@ export function useRoles() {
   });
 }
 
-export function useGroups() {
-  return useQuery({
-    queryKey: ['rbac', 'groups'],
-    queryFn: () => apiFetch<{ items: Group[] }>('/rbac/groups'),
-  });
-}
-
-export function useSpaceRoles(spaceKey: string) {
-  return useQuery({
-    queryKey: ['rbac', 'space-roles', spaceKey],
-    queryFn: () => apiFetch<{ items: SpaceRole[] }>(`/rbac/spaces/${spaceKey}/roles`),
-    enabled: !!spaceKey,
-  });
-}
-
 // ======== Types ========
 
-export interface Template {
+interface Template {
   id: number;
   title: string;
   bodyJson: string;
@@ -605,7 +351,7 @@ export interface Template {
   updatedAt: string;
 }
 
-export interface Comment {
+interface Comment {
   id: number;
   pageId: number;
   authorId: string;
@@ -618,15 +364,7 @@ export interface Comment {
   reactions: { emoji: string; count: number; userReacted: boolean }[];
 }
 
-export interface Draft {
-  id: number;
-  pageId: number;
-  bodyJson: string;
-  bodyHtml: string;
-  savedAt: string;
-}
-
-export interface TrashItem {
+interface TrashItem {
   id: number;
   title: string;
   deletedAt: string;
@@ -634,7 +372,7 @@ export interface TrashItem {
   autoPurgeAt: string;
 }
 
-export interface Notification {
+interface Notification {
   id: number;
   type: string;
   message: string;
@@ -643,50 +381,7 @@ export interface Notification {
   createdAt: string;
 }
 
-export interface VerificationHealth {
-  totalPages: number;
-  verifiedPages: number;
-  overduePages: number;
-  averageAge: number;
-}
-
-export interface Feedback {
-  id: number;
-  pageId: number;
-  userId: string;
-  isHelpful: boolean;
-  comment: string | null;
-  createdAt: string;
-}
-
-export interface FeedbackSummary {
-  helpful: number;
-  notHelpful: number;
-  total: number;
-  helpfulPercentage: number;
-}
-
-/** Matches the GET /api/pages/:id/feedback backend response shape */
-export interface PageFeedbackResponse {
-  helpful: number;
-  notHelpful: number;
-  total: number;
-  userVote: { isHelpful: boolean; comment: string | null } | null;
-}
-
-export interface KnowledgeRequest {
-  id: number;
-  title: string;
-  description: string;
-  priority: string;
-  status: string;
-  requestedBy: string;
-  fulfilledByPageId: number | null;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface SearchResult {
+interface SearchResult {
   id: number;
   title: string;
   excerpt: string;
@@ -695,26 +390,14 @@ export interface SearchResult {
   score: number;
 }
 
-export interface TrendingPage {
+interface TrendingPage {
   id: number;
   title: string;
   viewCount: number;
   trend: 'up' | 'down' | 'stable';
 }
 
-export interface ContentQualityReport {
-  averageScore: number;
-  distribution: { range: string; count: number }[];
-  improvementSuggestions: { pageId: number; title: string; suggestion: string }[];
-}
-
-export interface ContentGap {
-  topic: string;
-  queryCount: number;
-  suggestedTitle: string;
-}
-
-export interface LocalSpace {
+interface LocalSpace {
   key: string;
   name: string;
   description: string | null;
@@ -725,27 +408,8 @@ export interface LocalSpace {
   source: 'local';
 }
 
-export interface SpaceTreeNode {
-  id: number;
-  title: string;
-  parentId: number | null;
-  children: SpaceTreeNode[];
-}
-
-export interface Role {
+interface Role {
   id: number;
   name: string;
   permissions: string[];
-}
-
-export interface Group {
-  id: number;
-  name: string;
-  memberCount: number;
-}
-
-export interface SpaceRole {
-  userId: string;
-  userName: string;
-  role: string;
 }


### PR DESCRIPTION
Closes #439

## Summary

Knip flagged 22 hooks and 19 types in `frontend/src/shared/hooks/use-standalone.ts` as unused exports. Audited every flagged symbol against `frontend/` and `packages/` — all "matches" were locally re-declared functions in feature files, no real imports.

**EE consumer note:** None of these hooks are consumed by the private `compendiq-enterprise` repo. The frontend image is shared between CE and EE (per `CLAUDE.md` enterprise section), so any EE usage would necessarily import from this CE module — there is none.

## Changes

**Deleted hooks** (no internal users, no external consumers):
`useCreateComment`, `useResolveComment`, `useAddReaction`, `useDraft`, `useSaveDraft`, `usePublishDraft`, `useDiscardDraft`, `useMarkRead`, `useSetPageOwner`, `useVerificationHealth`, `usePageFeedback`, `useKnowledgeRequests`, `useCreateKnowledgeRequest`, `useFulfillRequest`, `useSearchSuggestions`, `useContentQuality`, `useContentGaps`, `useBatchExportPdf`, `useSpaceTree`, `useMovePage`, `useGroups`, `useSpaceRoles`.

**Deleted types** (only referenced by deleted hooks):
`Draft`, `VerificationHealth`, `Feedback`, `FeedbackSummary`, `PageFeedbackResponse`, `KnowledgeRequest`, `ContentQualityReport`, `ContentGap`, `SpaceTreeNode`, `Group`, `SpaceRole`.

**De-exported types** (still used internally by retained hooks, no external imports):
`BreadcrumbData`, `Template`, `Comment`, `TrashItem`, `Notification`, `SearchResult`, `TrendingPage`, `LocalSpace`, `Role`.

Net: 1 file changed, +9 / -345 lines.

## Validation

- [x] `npm run build -w @compendiq/contracts`
- [x] `npm run typecheck -w frontend`
- [x] `npm run lint -w frontend`
- [ ] CI runs full frontend test suite

Per worktree time-box, full frontend Vitest suite skipped — typecheck + lint cover symbol-resolution; CI will run tests.