### PR TITLE
chore(#460): remove unused exports from theme-store.ts

### DIFF
--- a/frontend/src/stores/theme-store.ts
+++ b/frontend/src/stores/theme-store.ts
@@ -12,9 +12,9 @@ export const THEME_IDS = [
 
 export type ThemeId = (typeof THEME_IDS)[number];
 
-export type ThemeCategory = 'dark' | 'light';
+type ThemeCategory = 'dark' | 'light';
 
-export interface ThemeMeta {
+interface ThemeMeta {
   id: ThemeId;
   label: string;
   description: string;


### PR DESCRIPTION
Closes #460

## Summary

Knip flagged `ThemeCategory` (line 15) and `ThemeMeta` (line 17) in `frontend/src/stores/theme-store.ts` as unused exports.

Both types are referenced **only internally** within `theme-store.ts` itself (as the type annotation for `THEME_CATEGORIES` and the field type/interface for `THEMES`). No frontend consumer imports either name. The `useThemeStore` hook and other genuinely-used exports are untouched.

Fix: drop the `export` keyword from both declarations; keep the types as internal so the existing internal usages (`category: ThemeCategory`, `THEMES: ThemeMeta[]`) still typecheck.

## EE Consumer Check

None. `frontend/src/stores/theme-store.ts` is a pure CE Zustand store with no EE counterpart in `compendiq-enterprise`. Both flagged symbols are CE-internal types — there is no public API contract to preserve.

## Validation

- `npm run build -w @compendiq/contracts` — clean
- `npm run typecheck -w frontend` — clean
- `npm run lint -w frontend` — clean (max-warnings=0)
- `npx vitest run src/stores/theme-store.test.ts` — 27/27 pass