### PR TITLE
chore(#441): remove unused usePageLinksWithPreview export from PagePreview.tsx

### DIFF
--- a/frontend/src/shared/components/article/PagePreview.tsx
+++ b/frontend/src/shared/components/article/PagePreview.tsx
@@ -106,23 +106,3 @@ export function PagePreview({ pageId, children, className }: PagePreviewProps) {
     </span>
   );
 }
-
-/**
- * Wraps page links inside HTML content with PagePreview hover cards.
- * Returns an array of React elements with page links wrapped in PagePreview.
- */
-// eslint-disable-next-line react-refresh/only-export-components
-export function usePageLinksWithPreview(contentRef: React.RefObject<HTMLElement | null>) {
-  useEffect(() => {
-    if (!contentRef.current) return;
-    // Find all internal page links
-    const links = contentRef.current.querySelectorAll('a[href^="/pages/"]');
-    links.forEach((link) => {
-      const href = link.getAttribute('href') || '';
-      const match = href.match(/^\/pages\/(.+)$/);
-      if (match?.[1]) {
-        link.setAttribute('data-page-id', match[1]);
-      }
-    });
-  }, [contentRef]);
-}


### PR DESCRIPTION
Closes #441

Removes the unused `usePageLinksWithPreview` hook export from `frontend/src/shared/components/article/PagePreview.tsx`. A repo-wide grep across `frontend/` and `packages/` (`*.ts`, `*.tsx`) showed the only match was the definition itself — no internal or external consumers. The associated `eslint-disable-next-line react-refresh/only-export-components` directive and JSDoc were removed alongside the function.

## EE consumer note

No EE consumer. The `compendiq-enterprise` package consumes the CE backend, not frontend internals — the CE frontend image ships unmodified to both editions, and EE features are gated at runtime via `useEnterprise()`. Removing this frontend-only hook cannot affect EE.

## Validation

- `npm run build -w @compendiq/contracts` — pass
- `npm run typecheck -w frontend` — pass
- `npm run lint -w frontend` — pass (`--max-warnings=0`)
- `npx vitest run src/shared/components/article/PagePreview.test.tsx` — 8/8 pass

🤖 Generated with Claude Code