### PR TITLE
chore(#457): clean unused exports from ai/modes/index.ts

### DIFF
--- a/frontend/src/features/ai/modes/index.ts
+++ b/frontend/src/features/ai/modes/index.ts
@@ -1,7 +1,6 @@
 export { AskModeInput, AskExamplePrompts, ASK_EMPTY_TITLE, ASK_EMPTY_SUBTITLE } from './AskMode';
-export { ASK_EXAMPLE_PROMPTS } from './ask-example-prompts';
 export { ImproveTypeSelector, ImproveDiffView, ImproveModeInput, IMPROVE_EMPTY_TITLE, improveEmptySubtitle } from './ImproveMode';
-export { GenerateModeInput, GenerateSavePanel, GENERATE_EMPTY_TITLE, GENERATE_EMPTY_SUBTITLE } from './GenerateMode';
+export { GenerateModeInput, GENERATE_EMPTY_TITLE, GENERATE_EMPTY_SUBTITLE } from './GenerateMode';
 export { SummarizeModeInput, SUMMARIZE_EMPTY_TITLE, summarizeEmptySubtitle } from './SummarizeMode';
 export { DiagramTypeSelector, DiagramPreview, DiagramModeInput, DIAGRAM_EMPTY_TITLE, diagramEmptySubtitle } from './DiagramMode';
 export { QualityModeInput, QUALITY_EMPTY_TITLE, qualityEmptySubtitle } from './QualityMode';


### PR DESCRIPTION
## Summary

Knip (issue #457) flagged two re-exports in the `frontend/src/features/ai/modes/index.ts` barrel as unused:

- `ASK_EXAMPLE_PROMPTS` (re-exported from `./ask-example-prompts`)
- `GenerateSavePanel` (re-exported from `./GenerateMode`)

Both are still imported elsewhere — but exclusively via their underlying source files, never via the barrel:

- `ASK_EXAMPLE_PROMPTS` → consumed in `AskMode.tsx` and `AskMode.test.tsx` via `./ask-example-prompts`.
- `GenerateSavePanel` → consumed in `GenerateMode.tsx` (self) and `GenerateMode.test.tsx` via `./GenerateMode`.

The barrel itself stays — `AiAssistantPage.tsx` still imports many other symbols from it.

## EE

No EE consumer — these are CE-only frontend symbols, and EE ships the same unmodified CE frontend image.

## Validation

- `npm run typecheck -w frontend` clean
- `npm run lint -w frontend` clean
- `npx vitest run AskMode.test.tsx GenerateMode.test.tsx` — 41/41 passing
- `npx knip --reporter json` no longer reports `features/ai/modes/index.ts`

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)