### PR TITLE
chore(#442): remove unused exports from DrawioEditor.tsx

### DIFF
--- a/frontend/src/shared/components/diagrams/DrawioEditor.tsx
+++ b/frontend/src/shared/components/diagrams/DrawioEditor.tsx
@@ -9,7 +9,7 @@ const DRAWIO_URL = `${DRAWIO_ORIGIN}/drawio/?embed=1&proto=json&spin=1&ui=atlas&
 /** Timeout in ms to wait for the draw.io iframe 'init' event before showing the error state */
 const DRAWIO_INIT_TIMEOUT_MS = 15_000;
 
-export interface DrawioEditorProps {
+interface DrawioEditorProps {
   /** Raw draw.io XML of the diagram to edit */
   xml: string;
   /** Called when the user saves the diagram. Receives the exported PNG data URI and updated XML. */
@@ -257,4 +257,4 @@ export function DrawioEditor({ xml, onSave, onClose, drawioUrl }: DrawioEditorPr
   );
 }
 
-export { DRAWIO_ORIGIN, DRAWIO_URL };
+export { DRAWIO_ORIGIN };


### PR DESCRIPTION
## Summary

Removes two unused exports from `frontend/src/shared/components/diagrams/DrawioEditor.tsx` flagged by knip:

- `DRAWIO_URL` — only consumed inside the file itself (line 70). Dropped from the re-export at the bottom and kept as a module-local const.
- `DrawioEditorProps` — only used by the `DrawioEditor` function signature in the same file. Dropped the `export` keyword.

`DRAWIO_ORIGIN` remains exported because the colocated test file (`DrawioEditor.test.tsx`) imports it for postMessage origin verification.

## EE consumer check

`grep -rn "DRAWIO_URL\|DrawioEditorProps"` in `frontend/` and `packages/` returned only references inside `DrawioEditor.tsx` itself. The CE `compendiq-enterprise` repo ships no frontend bundle (per `CLAUDE.md`: "Both editions ship the same unmodified CE frontend image"), so there is no EE consumer for these frontend exports by construction.

## Validation

- `npm run build -w @compendiq/contracts` — pass
- `npm run typecheck -w frontend` — pass
- `npm run lint -w frontend` — pass (max-warnings=0)
- `npx vitest run src/shared/components/diagrams/DrawioEditor.test.tsx` — 29/29 pass

Closes #442