### PR TITLE
chore(#458): clean unused exports from settings/panels/index.ts

### DIFF
--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -40,10 +40,6 @@ import {
   SystemTab,
 } from './panels';
 
-// Re-export the backward-compatible alias for tests/consumers that import
-// `OllamaTab` from the SettingsPage module.
-export { OllamaTab } from './panels';
-
 type TabId = 'confluence' | 'sync' | 'sync-conflict-policy' | 'sync-conflicts' | 'ollama' | 'ai-prompts' | 'ai-safety' | 'rate-limits' | 'spaces' | 'theme' | 'labels' | 'errors' | 'embedding' | 'workers' | 'mcp-docs' | 'searxng' | 'email' | 'license' | 'sso' | 'ip-allowlist' | 'webhooks' | 'llm-policy' | 'retention' | 'compliance-reports' | 'llm-audit' | 'ai-reviews' | 'ai-review-policy' | 'pii-policy' | 'scim' | 'system';
 
 export function SettingsPage() {

--- a/frontend/src/features/settings/panels/LlmTab.tsx
+++ b/frontend/src/features/settings/panels/LlmTab.tsx
@@ -242,5 +242,3 @@ function diffUsecaseAssignments(
   }
   return diff;
 }
-
-export { LlmTab as OllamaTab };

--- a/frontend/src/features/settings/panels/index.ts
+++ b/frontend/src/features/settings/panels/index.ts
@@ -1,6 +1,6 @@
 export { ConfluenceTab } from './ConfluenceTab';
 export { SyncTab } from './SyncTab';
-export { LlmTab, OllamaTab } from './LlmTab';
+export { LlmTab } from './LlmTab';
 export { EmbeddingTab } from './EmbeddingTab';
 export { AiPromptsTab } from './AiPromptsTab';
 export { SystemTab } from './SystemTab';


### PR DESCRIPTION
Closes #458.

## Change

Knip flagged `OllamaTab` re-export from `frontend/src/features/settings/panels/index.ts` as unused. Removed it.

The barrel's `OllamaTab` alias was only kept as a backward-compat shim for tests/consumers, with a matching `export { OllamaTab } from './panels'` re-export in `SettingsPage.tsx` and an `export { LlmTab as OllamaTab }` alias at the bottom of `LlmTab.tsx`. A repo-wide `grep -rn "OllamaTab"` returns zero consumers outside that three-link chain — nothing imports the alias. Pulled all three threads in the same commit so the barrel, the wrapper module, and the source export stay consistent.

## Files

- `frontend/src/features/settings/panels/index.ts` — drop `OllamaTab` from the `LlmTab` re-export
- `frontend/src/features/settings/SettingsPage.tsx` — drop the now-broken `export { OllamaTab } from './panels'` and its comment
- `frontend/src/features/settings/panels/LlmTab.tsx` — drop the orphaned `export { LlmTab as OllamaTab }` alias

## EE consumer note

This is a CE frontend barrel file. The Enterprise repo (`compendiq-enterprise`) does not consume the CE frontend — both editions ship the same unmodified CE frontend image (per `CLAUDE.md` open-core section), so there is no EE consumer of `OllamaTab` to break. The actual `LlmTab` component continues to be exported under its real name and is unchanged behaviorally.

## Validation

- [x] `npm run typecheck -w frontend` — clean
- [x] `npm run lint -w frontend` — clean
- [x] `npx vitest run src/features/settings/panels/LlmTab.test.tsx` — 7/7 passing
- [x] `npx knip` — `OllamaTab` no longer flagged
- [x] `SettingsPage.test.tsx` failure on this branch is pre-existing on `origin/dev` (missing `diff` package, unrelated to this change)