### PR TITLE
chore(#463): remove unused exports from AuthorPendingBanner.tsx

### DIFF
--- a/frontend/src/features/ai/AuthorPendingBanner.tsx
+++ b/frontend/src/features/ai/AuthorPendingBanner.tsx
@@ -59,7 +59,7 @@ async function fetchJson<T>(path: string): Promise<T> {
   return res.json();
 }
 
-export interface AuthorPendingBannerProps {
+interface AuthorPendingBannerProps {
   /**
    * For tests — override the polling interval in ms. Default 60_000.
    */


### PR DESCRIPTION
Closes #463

## Summary

Knip flagged the `AuthorPendingBannerProps` interface as an unused export at `frontend/src/features/ai/AuthorPendingBanner.tsx:62`.

The interface is consumed only internally by the `AuthorPendingBanner` component (line 71), so the `export` keyword is dropped while the type itself is preserved.

## EE no-consumer note

No EE consumers reference `AuthorPendingBannerProps` — the EE bundle ships the same unmodified CE frontend image and gates AI-output-review UI at runtime via `useEnterprise()`. Searching for `AuthorPendingBannerProps` across the worktree found only the file's own declaration and self-use site.

## Validation

- `npm run typecheck -w frontend` — clean
- `npm run lint -w frontend` — clean