### PR TITLE
chore(#465): remove unused exports from TagEditor.tsx

### DIFF
--- a/frontend/src/shared/components/TagEditor.tsx
+++ b/frontend/src/shared/components/TagEditor.tsx
@@ -3,7 +3,7 @@ import { X, Plus, Tag } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { normalizeTag, MAX_TAG_LENGTH } from '../lib/tag-utils';
 
-export interface TagEditorProps {
+interface TagEditorProps {
   /** Current tags on the page */
   tags: string[];
   /** Called when a tag is added */


### PR DESCRIPTION
Closes #465

## Summary

Knip flagged `TagEditorProps` (interface, line 6) in `frontend/src/shared/components/TagEditor.tsx` as an unused export. The interface is consumed internally by the default-exported `TagEditor` component as a parameter type annotation, but no external module imports it. Dropped the `export` keyword; the type remains defined locally.

## EE consumer note

No EE consumer. `TagEditorProps` is a frontend-only React component prop type, and EE ships the same unmodified CE frontend image (per CLAUDE.md "Enterprise (Open-Core)"). Confirmed via repo-wide grep — only references are within `TagEditor.tsx` itself.

## Validation

- `npm run typecheck -w frontend` — clean
- `npm run lint -w frontend` — clean (max-warnings=0)
- `npx knip --reporter json` — `TagEditorProps` no longer reported

🤖 Generated with Claude Code