### PR TITLE
chore(#461): remove unused exports from CustomRoleEditor.tsx

### DIFF
--- a/frontend/src/features/admin/CustomRoleEditor.tsx
+++ b/frontend/src/features/admin/CustomRoleEditor.tsx
@@ -9,7 +9,7 @@ import { apiFetch } from '../../shared/lib/api';
 
 // --- Types ---
 
-export interface PermissionDefinition {
+interface PermissionDefinition {
   id: string;
   displayName: string;
   description: string;
@@ -37,7 +37,7 @@ interface RoleAssignment {
   createdAt: string;
 }
 
-export interface CustomRoleEditorProps {
+interface CustomRoleEditorProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** Existing role to edit; null = create mode */


### PR DESCRIPTION
## Summary

Knip reports two unused exported symbols in `frontend/src/features/admin/CustomRoleEditor.tsx`:

- `interface PermissionDefinition` (line 12)
- `interface CustomRoleEditorProps` (line 40)

`grep` across `frontend/**/*.{ts,tsx}` confirms both are consumed only inside `CustomRoleEditor.tsx`. Demoted from `export interface` to `interface` — minimal-diff fix (2 lines changed).

## EE consumer check

This is a CE frontend file. No EE consumer (the EE bundle does not ship a separate frontend — both editions ship the unmodified CE frontend image per CLAUDE.md). No external consumer in this repo.

## Validation

- `npm run build -w @compendiq/contracts` — clean
- `npm run typecheck -w frontend` — clean
- `npm run lint -w frontend` — clean (max-warnings=0)
- `npx vitest run src/features/admin/CustomRoleEditor.test.tsx` — 12/12 passed

Closes #461