### PR TITLE
chore(#464): remove unused exports from settings-nav.ts

### DIFF
--- a/frontend/src/features/settings/settings-nav.ts
+++ b/frontend/src/features/settings/settings-nav.ts
@@ -12,7 +12,7 @@
  * See docs/plans/215-settings-ia-reorg.md for the design rationale.
  */
 
-export type SettingsCategoryId =
+type SettingsCategoryId =
   | 'personal'
   | 'content'
   | 'ai'
@@ -33,7 +33,7 @@ export interface SettingsNavItem {
   requiresFeature?: string;
 }
 
-export interface SettingsNavGroup {
+interface SettingsNavGroup {
   id: SettingsCategoryId;
   label: string;
   items: SettingsNavItem[];


### PR DESCRIPTION
Closes #464.

## Change

Knip flagged two exported symbols in `frontend/src/features/settings/settings-nav.ts` as unused:

- `SettingsCategoryId` (line 15) — only consumed inside `SettingsNavGroup` in this file.
- `SettingsNavGroup` (line 36) — only consumed inside `SETTINGS_NAV` in this file.

Both had the `export` keyword dropped; the types themselves remain (still needed locally).

## What was preserved

- `legacyTabMap` is **not** removed. The user prompt asked to verify it carefully, and it is genuinely consumed by `SettingsLayout.tsx` (line 17, 57, 58, 167) and `settings-nav.test.ts` (lines 4, 25, 32, 36) for the legacy `?tab=<id>` route resolver. Knip did not flag it.
- All other exports (`SettingsNavItem`, `SETTINGS_NAV`, `legacyTabMap`, `AccessContext`, `canSeeItem`, `firstVisiblePath`) remain — they have external consumers.

## Validation

- `npm run typecheck -w frontend` — clean
- `npm run lint -w frontend` — clean
- `npx vitest run src/features/settings/settings-nav.test.ts` — 10/10 pass
- `npx knip --reporter json` — no longer reports these symbols

## EE consumer

None. `SettingsCategoryId` and `SettingsNavGroup` are CE-frontend-only types; EE consumes the resolved `SETTINGS_NAV` array (still exported) and `canSeeItem`/`firstVisiblePath` (still exported) — the dropped types were never part of the EE surface.