### PR TITLE
chore(#462): remove unused exports from AiContext.tsx

### DIFF
--- a/frontend/src/features/ai/AiContext.tsx
+++ b/frontend/src/features/ai/AiContext.tsx
@@ -27,7 +27,7 @@ export interface Message {
   sources?: Source[];
 }
 
-export interface Conversation {
+interface Conversation {
   id: string;
   title: string;
   model: string;
@@ -36,7 +36,7 @@ export interface Conversation {
 
 export type Mode = 'ask' | 'improve' | 'generate' | 'summarize' | 'diagram' | 'quality';
 
-export interface PageData {
+interface PageData {
   id: string;
   title: string;
   bodyHtml: string;
@@ -45,7 +45,7 @@ export interface PageData {
   hasChildren?: boolean;
 }
 
-export interface AiContextValue {
+interface AiContextValue {
   // Route / query state
   pageId: string | null;
   page: PageData | undefined;


### PR DESCRIPTION
Closes #462

## Summary

Knip flagged three exported symbols in `frontend/src/features/ai/AiContext.tsx` as unused:

- `Conversation` (line 30)
- `PageData` (line 39)
- `AiContextValue` (line 48)

All three are referenced internally inside `AiContext.tsx` (in the `AiContextValue` shape, the `useState<Conversation[]>` setter, the `page as PageData | undefined` cast, and the `AiCtx = createContext<AiContextValue | null>` declaration) but **never imported anywhere else** in `frontend/src/`. Dropped the `export` keyword on each, leaving them as file-local types.

External callers (verified via grep across `frontend/src/`) only import `AiProvider`, `useAiContext`, `nextMessageId`, `Mode`, and `Message` from this module — those remain exported.

## EE consumer

None. `frontend/src/features/ai/AiContext.tsx` is CE-only chat-mode UI plumbing and has no Enterprise consumer (EE ships the unmodified CE frontend image per ADR — Enterprise UI is gated at runtime, not by additional frontend imports of CE internals).

## Validation

- `npm run build -w @compendiq/contracts` — pass
- `npm run typecheck -w frontend` — pass
- `npm run lint -w frontend` — pass (max-warnings=0)
- `npx vitest run src/features/ai/AiAssistantPage.test.tsx` — 42/42 pass

🤖 Generated with Claude Code