### PR TITLE
chore(#469): remove unused exports from export-helpers.ts

### DIFF
--- a/frontend/src/shared/lib/export-helpers.ts
+++ b/frontend/src/shared/lib/export-helpers.ts
@@ -329,7 +329,7 @@ type PdfFont = Awaited<
 >;
 
 /** Result of the layout pass — what `renderDataPages` consumes. */
-export interface ColumnLayout {
+interface ColumnLayout {
   /** 'portrait' (A4 595×842) or 'landscape' (A4 842×595). */
   orientation: 'portrait' | 'landscape';
   /** Concrete [width, height] page size for the data pages. */


### PR DESCRIPTION
Closes #469

## Summary

Knip flagged `ColumnLayout` (line 332) in `frontend/src/shared/lib/export-helpers.ts` as an unused exported symbol. Verified no external consumers — the type is used only internally as a parameter/return type within the same file. The companion test imports the `computeColumnLayout` function, not the type.

Dropped the `export` keyword; kept the interface in place for internal use.

## EE consumer

None. Frontend symbol; EE ships the same unmodified CE frontend image (per ADR / Enterprise Open-Core docs), so no enterprise consumer to coordinate.

## Validation

- `npm run typecheck -w frontend` — passes
- `npx eslint src/shared/lib/export-helpers.ts` — clean
- `npx vitest run src/shared/lib/export-helpers.test.ts` — 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)