### PR TITLE
chore(#467): remove unused exports from use-search.ts

### DIFF
--- a/frontend/src/shared/hooks/use-search.ts
+++ b/frontend/src/shared/hooks/use-search.ts
@@ -40,14 +40,14 @@ function mapItems(response: SearchApiResponse): SearchResultItem[] {
   }));
 }
 
-export interface UseSearchParams {
+interface UseSearchParams {
   query: string;
   mode: 'keyword' | 'semantic' | 'hybrid';
   spaceKey?: string;
   page?: number;
 }
 
-export interface UseSearchResult {
+interface UseSearchResult {
   /** Fast keyword results — shown first while semantic is loading */
   immediateResults: SearchResultItem[];
   /** Semantic or hybrid results that augment/replace the immediate results */


### PR DESCRIPTION
Closes #467

## Summary

Knip flagged `UseSearchParams` and `UseSearchResult` (frontend/src/shared/hooks/use-search.ts:43, :50) as unused exports.

Both types are consumed only internally by the `useSearch` hook signature in the same file. Verified via repo-wide grep:

```
grep -rn "UseSearchParams\|UseSearchResult" --include="*.ts" --include="*.tsx" .
```

Only hits are the two declarations and the internal use on line 84. No external consumers in CE.

## EE consumer

None. The `useSearch` hook is a CE-only frontend hook; EE ships the same unmodified CE frontend image (per CLAUDE.md / ADR open-core model), and these types are not part of any cross-package contract.

## Change

Dropped the `export` keyword on both interfaces — kept the types themselves so the hook signature is unchanged.

## Validation

- `npm run typecheck -w frontend` — clean
- `npm run lint -w frontend` — clean