### PR TITLE
chore(#468): remove unused exports from use-streaming-content.ts

### DIFF
--- a/frontend/src/shared/hooks/use-streaming-content.ts
+++ b/frontend/src/shared/hooks/use-streaming-content.ts
@@ -7,7 +7,7 @@ import { useRef, useState, useCallback, useEffect } from 'react';
  */
 const FLUSH_INTERVAL_MS = 50;
 
-export interface StreamingContentHandle {
+interface StreamingContentHandle {
   /** The content string that React renders. Updated at most every FLUSH_INTERVAL_MS. */
   displayContent: string;
   /** Whether a stream is currently active. */


### PR DESCRIPTION
Closes #468.

Knip flagged `StreamingContentHandle` (interface, line 10) in `frontend/src/shared/hooks/use-streaming-content.ts` as an unused export.

## Change

Drop `export` from `StreamingContentHandle` — it is only referenced internally as the return-type annotation of `useStreamingContent` in the same file. No external consumers in CE; the EE repo has no consumer either (frontend hook, EE ships the same unmodified CE frontend image per ADR open-core split).

## Validation

- `npm run typecheck -w frontend` — clean
- `npm run lint -w frontend` — clean
- `npx vitest run src/shared/hooks/use-streaming-content` — 11/11 pass
- `npx knip --reporter json` — no longer reports the symbol