### PR TITLE
chore(#470): remove unused exports from shortcut-registry.ts

### DIFF
--- a/frontend/src/shared/lib/shortcut-registry.ts
+++ b/frontend/src/shared/lib/shortcut-registry.ts
@@ -7,9 +7,9 @@
  * a single source of truth.
  */
 
-export type ShortcutCategory = 'navigation' | 'actions' | 'editor' | 'panels' | 'formatting';
+type ShortcutCategory = 'navigation' | 'actions' | 'editor' | 'panels' | 'formatting';
 
-export interface ShortcutRegistryEntry {
+interface ShortcutRegistryEntry {
   /** Unique identifier used by ShortcutHint to look up a shortcut. */
   id: string;
   /** Human-readable key combo, e.g. "ctrl+k", "alt+n", "esc". */


### PR DESCRIPTION
## Summary

Knip flagged two exported symbols in `frontend/src/shared/lib/shortcut-registry.ts` as unused:

- `ShortcutCategory` (line 10)
- `ShortcutRegistryEntry` (line 12)

Both types are referenced internally within the same file (used by `SHORTCUTS`, `TIPTAP_SHORTCUTS`, `CATEGORY_LABELS`, `getCategoryLabel`, `getShortcutsByCategory`) but have **no external consumers**. Dropped the `export` keyword on both so they remain available for in-file typing.

### EE no-consumer note
Verified via grep across `frontend/`, `backend/`, and `packages/`: no EE consumer references either symbol. The `compendiq-enterprise` repo does not import from this frontend shared lib (CE/EE share the same unmodified CE frontend image — see ADR/Open-Core notes in `CLAUDE.md`).

## Validation

- `npm run typecheck -w frontend` clean
- `npx eslint src/shared/lib/shortcut-registry.ts` clean
- `npx vitest run frontend/src/shared/lib/shortcut-registry.test.ts` 43/43 passing
- `npx knip` no longer reports either symbol

Closes #470