### PR TITLE
chore(#466): remove unused exports from use-keyboard-shortcuts.ts

### DIFF
--- a/frontend/src/shared/hooks/use-keyboard-shortcuts.ts
+++ b/frontend/src/shared/hooks/use-keyboard-shortcuts.ts
@@ -44,7 +44,7 @@ function isEditableTarget(event: KeyboardEvent): boolean {
   return false;
 }
 
-export interface KeyboardShortcutOptions {
+interface KeyboardShortcutOptions {
   /**
    * When false, shortcuts that use a single key (no Ctrl/Cmd/Alt modifier)
    * are suppressed. Modifier shortcuts always fire regardless.


### PR DESCRIPTION
Closes #466

## Summary

Knip flagged `KeyboardShortcutOptions` (frontend/src/shared/hooks/use-keyboard-shortcuts.ts:47) as an unused export. Verified with `grep -rn "KeyboardShortcutOptions" frontend/ packages/` — it is only used internally as the type of the `options` parameter on `useKeyboardShortcuts`. Dropped the `export` keyword so the type stays available locally without leaking into the public surface.

## EE consumer check

No EE consumer. Symbol is frontend-only and only referenced inside its own module; no `import` of it exists anywhere in `frontend/` or `packages/`. The CE frontend bundle is the same image shipped to EE (per ADR), so no enterprise repo can be importing this module-private type.

## Validation

- `npm run build -w @compendiq/contracts` — pass
- `npm run typecheck -w frontend` — pass
- `npm run lint -w frontend` — pass (eslint --max-warnings=0)
- `npx vitest run src/shared/hooks/use-keyboard-shortcuts.test.ts` — 26/26 pass