### PR TITLE
chore(#474): remove unused exports from QualityScoreBadge.tsx

### DIFF
--- a/frontend/src/shared/components/badges/QualityScoreBadge.tsx
+++ b/frontend/src/shared/components/badges/QualityScoreBadge.tsx
@@ -2,7 +2,7 @@ import { cn } from '../../lib/cn';
 import { formatRelativeTime } from '../../lib/format-relative-time';
 import type { QualityStatus } from '../../hooks/use-pages';
 
-export interface QualityScoreBadgeProps {
+interface QualityScoreBadgeProps {
   qualityScore: number | null;
   qualityStatus: QualityStatus | null;
   qualityCompleteness?: number | null;


### PR DESCRIPTION
Closes #474.

## Change

Drop `export` from `QualityScoreBadgeProps` interface in `frontend/src/shared/components/badges/QualityScoreBadge.tsx`. Knip flagged it as unused; repo-wide grep confirms it's only referenced inside the same file (by `buildTooltip` and the `QualityScoreBadge` component itself).

## EE consumer

None. Verified `QualityScoreBadgeProps` has no consumer in the EE repo — symbol is component-internal and the badge is consumed by JSX, not by name.

## Validation

- `npm run typecheck -w frontend` clean
- `npx eslint src/shared/components/badges/QualityScoreBadge.tsx` clean