### PR TITLE
chore(#472): remove unused exports from EmbeddingStatusBadge.tsx

### DIFF
--- a/frontend/src/shared/components/badges/EmbeddingStatusBadge.tsx
+++ b/frontend/src/shared/components/badges/EmbeddingStatusBadge.tsx
@@ -109,5 +109,3 @@ export function EmbeddingStatusBadge(props: EmbeddingStatusBadgeProps) {
     </span>
   );
 }
-
-export type { EmbeddingStatusBadgeProps };


### PR DESCRIPTION
Closes #472

## Summary

Drops the unused `EmbeddingStatusBadgeProps` type re-export at the bottom of `frontend/src/shared/components/badges/EmbeddingStatusBadge.tsx`, flagged by knip. The interface is still declared (un-exported) at the top of the file and consumed internally by `resolveStatus` and the `EmbeddingStatusBadge` component.

The default-exported `EmbeddingStatusBadge` component is still consumed externally; only the auxiliary type re-export was unused.

## EE consumer note

No EE consumer. Grepped for `EmbeddingStatusBadgeProps` across the worktree — only the internal references in this same file matched. Frontend ships unmodified to both CE and EE (per `CLAUDE.md` open-core rules), so removing this CE-internal type re-export cannot break EE.

## Validation

- `npm run typecheck -w frontend` clean
- `npm run lint -w frontend` clean