### PR TITLE
chore(#475): remove unused exports from SidebarTreeView.tsx

### DIFF
--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -197,7 +197,7 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
   );
 });
 
-export interface SpaceOption {
+interface SpaceOption {
   key: string;
   name: string;
   pageCount: number;


### PR DESCRIPTION
## Summary

- Drop `export` from `SpaceOption` interface in `frontend/src/shared/components/layout/SidebarTreeView.tsx` — only used internally within the same file (lines 241-242).
- No external consumers in CE.
- **No EE consumer.** This is a frontend-only symbol; both editions ship the same unmodified CE frontend image (per `docs/ENTERPRISE-ARCHITECTURE.md`), so EE cannot consume frontend exports.

Closes #475

## Validation

- [x] `npm run typecheck -w frontend` — clean
- [x] `npm run lint -w frontend` — clean (max-warnings=0)
- [x] Grep confirmed no external consumers across `frontend/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)