### PR TITLE
chore(#471): remove unused exports from ConfidenceBadge.tsx

### DIFF
--- a/frontend/src/shared/components/badges/ConfidenceBadge.tsx
+++ b/frontend/src/shared/components/badges/ConfidenceBadge.tsx
@@ -1,6 +1,6 @@
 import { cn } from '../../lib/cn';
 
-export type ConfidenceLevel = 'high' | 'medium' | 'low';
+type ConfidenceLevel = 'high' | 'medium' | 'low';
 
 interface ConfidenceBadgeProps {
   /** Average similarity score from RAG sources (0-1 scale) */


### PR DESCRIPTION
Closes #471

## Summary

Knip flagged `ConfidenceLevel` (type alias at `frontend/src/shared/components/badges/ConfidenceBadge.tsx:3`) as an unused export. Verified by grepping `frontend/`, `backend/`, and `packages/` — the type is only referenced inside its declaring file (the `getConfidenceLevel` return type and the `levelConfig` `Record` key). No external consumer.

Fix: drop the `export` modifier; the type alias remains as a file-local helper.

The default named export `ConfidenceBadge` and the test-only export `getConfidenceLevel` were not flagged and remain exported.

## EE consumer note

No EE consumer — verified there are no enterprise references to `ConfidenceLevel` (this is a CE-only frontend badge component, and the EE repo ships no frontend bundle per the open-core architecture in `docs/ENTERPRISE-ARCHITECTURE.md`).

## Validation

- `npm run build -w @compendiq/contracts` passes
- `npm run typecheck -w frontend` passes
- `npm run lint -w frontend` passes (max-warnings=0)
- `npx vitest run src/shared/components/badges/ConfidenceBadge.test.tsx` — 15/15 tests pass

## Test plan

- [x] Contracts build clean
- [x] Frontend typecheck clean
- [x] Frontend lint clean (zero warnings)
- [x] ConfidenceBadge unit tests still pass

Co-Authored-By: Claude <noreply@anthropic.com>