### PR TITLE
chore(#473): remove unused exports from FreshnessBadge.tsx

### DIFF
--- a/frontend/src/shared/components/badges/FreshnessBadge.tsx
+++ b/frontend/src/shared/components/badges/FreshnessBadge.tsx
@@ -54,4 +54,3 @@ export function FreshnessBadge({ lastModified, className }: FreshnessBadgeProps)
 
 // eslint-disable-next-line react-refresh/only-export-components
 export { getFreshnessLevel };
-export type { FreshnessLevel, FreshnessBadgeProps };


### PR DESCRIPTION
## Summary

Knip flagged two unused type re-exports in `frontend/src/shared/components/badges/FreshnessBadge.tsx`:

- `type FreshnessLevel`
- `type FreshnessBadgeProps`

Both interfaces are referenced only inside `FreshnessBadge.tsx` itself. A repo-wide grep across `frontend/` and `packages/` confirms no other consumer imports them. They remain as private declarations; the trailing `export type { ... }` line is dropped.

**EE no-consumer note:** This is a CE frontend file. The frontend image is shipped unmodified to EE (no EE frontend bundle per `CLAUDE.md` open-core section), and the EE repo cannot consume frontend symbols at build time anyway. No EE consumer exists.

## Validation

- `npm run typecheck -w frontend` — clean
- `npm run lint -w frontend` — clean (0 warnings)
- `npm test -w frontend -- --run src/shared/components/badges/FreshnessBadge.test.tsx` — 16/16 passing
- `npx knip --reporter json` — no longer reports `FreshnessBadge.tsx`

Closes #473