### PR TITLE
chore(#405): add knip ignore for .lighthouserc.js

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,6 +1,10 @@
 import type { KnipConfig } from 'knip';
 
 const config: KnipConfig = {
+  // Root-level ignore: knip can't trace lhci autorun's convention-based
+  // resolution of .lighthouserc.js (consumed via `lighthouse: lhci autorun`
+  // in package.json scripts).
+  ignore: ['.lighthouserc.js'],
   workspaces: {
     'backend': {
       entry: ['src/index.ts', 'src/app.ts'],


### PR DESCRIPTION
Closes #405.

## Change

Added `.lighthouserc.js` to a new root-level `ignore` array in `knip.config.ts` with an inline rationale comment.

## Why ignore (not delete)

The file is a live entry point. The root `package.json` script

```json
"lighthouse": "lhci autorun"
```

invokes `lhci`, which discovers `.lighthouserc.js` by filename convention — a runtime/tooling resolution that knip cannot statically trace. Per the issue body's escape hatch ("If it is intentionally entry-pointed dynamically or via tooling Knip cannot see, add the narrowest Knip configuration/ignore with a short rationale"), this is the correct treatment.

## Validation

- `npx knip` — `.lighthouserc.js` no longer flagged (unused-files count drops 13 → 12).
- No production code or behavior touched; config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)