### PR TITLE
chore(#411): register smoke-presence-multipod.mjs as knip-ignored CLI harness

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,10 +1,16 @@
 import type { KnipConfig } from 'knip';
 
 const config: KnipConfig = {
-  // Root-level ignore: knip can't trace lhci autorun's convention-based
-  // resolution of .lighthouserc.js (consumed via `lighthouse: lhci autorun`
-  // in package.json scripts).
-  ignore: ['.lighthouserc.js'],
+  // Root-level ignore: assets knip can't trace.
+  ignore: [
+    // lhci autorun's convention-based resolution of .lighthouserc.js
+    // (consumed via `lighthouse: lhci autorun` in package.json scripts).
+    '.lighthouserc.js',
+    // Standalone CLI harnesses launched manually (documented smoke tests, not
+    // wired to npm scripts or CI). Multi-pod presence smoke test for issue #301
+    // — invoked manually per docs/releases/v0.4-presence-multipod-smoke.md.
+    'scripts/smoke-presence-multipod.mjs',
+  ],
   workspaces: {
     'backend': {
       entry: ['src/index.ts', 'src/app.ts'],


### PR DESCRIPTION
## Summary

Closes #411.

Knip flagged `scripts/smoke-presence-multipod.mjs` as an unused file. After tracing references, it is **not** orphan code: `docs/releases/v0.4-presence-multipod-smoke.md` documents it as the manual smoke harness for issue #301's multi-pod presence acceptance criterion ("two backend pods behind a load balancer correctly broadcast presence to clients on different pods").

### Decision: ignore, don't delete

The harness is intentionally not wired to npm or CI — it spins up two real backend processes against a shared Postgres + Redis (`docker rm -f compendiq-smoke-redis` cleanup, throwaway port `:6380`), which only makes sense as a manual post-merge verification. Deleting it would lose the only reproducible recipe for the #301 multi-pod check.

Cleanest fix: add a top-level `ignore` entry in `knip.config.ts` with a comment pointing at the release doc, so future contributors understand why the file exists outside the workspace graph.

### Verification

- `npx knip` — `scripts/smoke-presence-multipod.mjs` no longer appears in "Unused files" (count drops 13 → 12).
- `npm run lint` — passes across all workspaces.
- `npm run typecheck` — pre-existing baseline failures on `dev` (`p-limit` callable-signature errors in `llm-queue.ts` / `pages-crud.ts`, `ip-allowlist-hook` union-call error). Confirmed identical output on the unmodified branch tip; not introduced by this PR.

## Test plan

- [x] `npx knip` — file removed from unused-files report
- [x] `npm run lint` — clean
- [ ] CI green on `dev` target

🤖 Generated with [Claude Code](https://claude.com/claude-code)