### PR TITLE
chore(#412): knip-ignore scripts/vitest.config.ts (used dynamically)

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -10,6 +10,11 @@ const config: KnipConfig = {
     // wired to npm scripts or CI). Multi-pod presence smoke test for issue #301
     // — invoked manually per docs/releases/v0.4-presence-multipod-smoke.md.
     'scripts/smoke-presence-multipod.mjs',
+    // scripts/vitest.config.ts is invoked dynamically via
+    // `npx vitest run --config scripts/vitest.config.ts` (see perf/README.md)
+    // to exercise the pure helpers in scripts/perf-graph-bench.ts (#380).
+    // Knip cannot see this CLI flag so we ignore the config file explicitly.
+    'scripts/vitest.config.ts',
   ],
   workspaces: {
     'backend': {


### PR DESCRIPTION
## Summary

Knip flagged `scripts/vitest.config.ts` as unused, but it is genuinely used: it is invoked dynamically via `npx vitest run --config scripts/vitest.config.ts` (documented in `perf/README.md`) to run the unit tests in `scripts/perf-graph-bench.test.ts` for the pure helpers in `scripts/perf-graph-bench.ts` (#380).

Since Knip cannot see CLI `--config` flags, add a narrow root-level `ignore` entry with a comment explaining the dynamic entry point.

## Verification

- `npm run knip` — no longer reports `scripts/vitest.config.ts`
- `npm run typecheck` — passes
- `npm run lint` — passes

## Notes

The premise that `#408` had deleted the perf-graph-bench tests is incorrect — `scripts/perf-graph-bench.test.ts` and `scripts/perf-graph-bench.ts` are both still present and the config is the entry point for the test runner.

Closes #412