### PR TITLE
chore(#418): remove unused zod declaration from root package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,6 @@
         "frontend",
         "packages/contracts"
       ],
-      "dependencies": {
-        "zod": "^4.3.6"
-      },
       "devDependencies": {
         "@lhci/cli": "^0.15.1",
         "@playwright/test": "^1.58.2",
@@ -10346,6 +10343,16 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/cjs-module-lexer": {

--- a/package.json
+++ b/package.json
@@ -26,11 +26,7 @@
     "husky": "^9.1.7",
     "knip": "^6.3.0"
   },
-  "dependencies": {
-    "zod": "^4.3.6"
-  },
   "overrides": {
-    "zod": "^4.3.6",
     "protobufjs": "^7.5.5",
     "@fastify/static": "^9.1.1",
     "hono": "^4.12.14",


### PR DESCRIPTION
Closes #418

## Summary

Knip flagged `zod` as an unused dependency at the repo root. Confirmed false positive at the *root* level only — the root `package.json` has no source files, so Knip cannot see any direct import there. `zod` continues to be heavily used via:

- `packages/contracts/package.json` — the canonical home for shared schemas (`packages/contracts/src/schemas/*`)
- `backend/package.json` — direct consumer via `@compendiq/contracts`, `fastify-type-provider-zod`, etc.

Both workspaces declare `zod` directly, so removing it from the root is safe.

## Changes

- Removed `"zod": "^4.3.6"` from root `dependencies` (line 30)
- Removed `"zod": "^4.3.6"` from root `overrides` (was line 33) — redundant with the workspace-level direct declarations; transitive `zod` now resolves through the workspace deps
- `package-lock.json` updated: only effect is `chromium-bidi` (a Playwright/puppeteer dev transitive) now keeps its own `zod@3.25.76` nested instead of being hoisted to the root `^4`. No production-path impact.

## Validation

- `npm install` — clean
- `npm run typecheck` — passes (contracts build + backend `tsc --noEmit` + frontend `tsc --noEmit`)
- `npm run build -w packages/contracts` — passes
- `npm run test -w @compendiq/contracts` — 66/66 passing
- `npx knip 2>&1 | grep -A2 "unused dependency: zod"` — no matches
- `npm ls zod` — `@compendiq/contracts` and `backend` still resolve to `zod@4.3.6` (deduped)

## Test plan

- [ ] CI typecheck/lint/test pass on dev
- [ ] Knip job no longer reports `zod` as unused at the root

🤖 Generated with [Claude Code](https://claude.com/claude-code)