### PR TITLE
chore(#419): add knip ignore for @fontsource-variable/hanken-grotesk (CSS @import)

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -12,6 +12,10 @@ const config: KnipConfig = {
       entry: ['src/main.tsx'],
       project: ['src/**/*.{ts,tsx}'],
       ignore: ['src/**/*.test.{ts,tsx}'],
+      ignoreDependencies: [
+        // Consumed via CSS @import in src/index.css (knip cannot trace CSS @imports)
+        '@fontsource-variable/hanken-grotesk',
+      ],
     },
     'packages/contracts': {
       entry: ['src/index.ts'],


### PR DESCRIPTION
## Summary

Adds `@fontsource-variable/hanken-grotesk` to `knip.config.ts` `frontend.ignoreDependencies` with a one-line rationale.

## Why this is a false positive

The font is consumed via a CSS `@import` in `frontend/src/index.css:11`:

```css
@import "@fontsource-variable/hanken-grotesk/wght.css";
```

Knip statically analyses JS/TS imports and cannot trace CSS `@import` statements, so it incorrectly reports the package as unused. Removing it would break the dashboard's body font.

## Validation

- `npx knip 2>&1 | grep hanken-grotesk` → no output (no longer flagged)

Closes #419