### PR TITLE
chore(#420): add knip ignore for @fontsource-variable/jetbrains-mono (CSS @import)

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -24,6 +24,7 @@ const config: KnipConfig = {
       ignoreDependencies: [
         // Consumed via CSS @import in src/index.css (knip cannot trace CSS @imports)
         '@fontsource-variable/hanken-grotesk',
+        '@fontsource-variable/jetbrains-mono',
       ],
     },
     'packages/contracts': {


### PR DESCRIPTION
## Summary

Adds `@fontsource-variable/jetbrains-mono` to `knip.config.ts` `frontend.ignoreDependencies` with a one-line rationale.

## Why this is a false positive

The font is consumed via a CSS `@import` in `frontend/src/index.css`. Knip statically analyses JS/TS imports and cannot trace CSS `@import` statements, so it incorrectly reports the package as unused. Removing it would break the dashboard's monospace font.

## Validation

- `npx knip 2>&1 | grep jetbrains-mono` → no output (no longer flagged)

Closes #420