### PR TITLE
chore(#423): remove unused @types/diff

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,7 +68,6 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
-    "@types/diff": "^7.0.0",
     "@types/dompurify": "^3.0.5",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -157,7 +157,6 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
-        "@types/diff": "^7.0.0",
         "@types/dompurify": "^3.0.5",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.0.3",
@@ -8339,13 +8338,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/diff": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
-      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
## Summary
- Remove `@types/diff@^7.0.0` from frontend devDependencies
- The runtime `diff` package is on `^9.0.0`, which ships its own TypeScript declarations, so `@types/diff` (only types for older diff versions) is genuinely unused

## Verification
- `npm run typecheck -w frontend` passes
- `npm run lint -w frontend` passes
- `npm run build -w frontend` passes

Closes #423