### PR TITLE
chore(#421): add knip ignore for @fontsource-variable/newsreader (CSS @import)

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -31,6 +31,7 @@ const config: KnipConfig = {
         // Consumed via CSS @import in src/index.css (knip cannot trace CSS @imports)
         '@fontsource-variable/hanken-grotesk',
         '@fontsource-variable/jetbrains-mono',
+        '@fontsource-variable/newsreader',
       ],
     },
     'packages/contracts': {


### PR DESCRIPTION
## Summary

Adds `@fontsource-variable/newsreader` to `knip.config.ts` `frontend.ignoreDependencies` with a one-line rationale.

## Why this is a false positive

The font is consumed via a CSS `@import` in `frontend/src/index.css`. Knip statically analyses JS/TS imports and cannot trace CSS `@import` statements, so it incorrectly reports the package as unused. Removing it would break the dashboard's serif font.

## Validation

- `npx knip 2>&1 | grep newsreader` → no output (no longer flagged)

Closes #421