### PR TITLE
chore(#422): add knip ignore for @tailwindcss/typography (Tailwind v4 @plugin directive)

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -37,6 +37,8 @@ const config: KnipConfig = {
         '@fontsource-variable/hanken-grotesk',
         '@fontsource-variable/jetbrains-mono',
         '@fontsource-variable/newsreader',
+        // Loaded via Tailwind v4 @plugin directive in src/index.css (not a JS import)
+        '@tailwindcss/typography',
       ],
     },
     'packages/contracts': {


### PR DESCRIPTION
## Summary

Adds `@tailwindcss/typography` to `knip.config.ts` `frontend.ignoreDependencies` with a one-line rationale.

## Why this is a false positive

Tailwind v4 loads plugins via the CSS-first `@plugin` directive in `frontend/src/index.css:2`:

```css
@plugin "@tailwindcss/typography";
```

This is not a JS import, so knip cannot trace it. Removing the package would break `prose` utility classes used throughout markdown/article rendering.

## Validation

- `npx knip 2>&1 | grep tailwindcss/typography` → no output (no longer flagged)

Closes #422