### PR TITLE
chore(#427): add knip ignore for tailwindcss (Tailwind v4 CSS-first @import)

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -43,6 +43,8 @@ const config: KnipConfig = {
         '@fontsource-variable/newsreader',
         // Loaded via Tailwind v4 @plugin directive in src/index.css (not a JS import)
         '@tailwindcss/typography',
+        // Tailwind v4 CSS-first @import in src/index.css (knip cannot trace CSS @imports)
+        'tailwindcss',
       ],
     },
     'packages/contracts': {


### PR DESCRIPTION
## Summary

Adds `tailwindcss` to `knip.config.ts` `frontend.ignoreDependencies` with a one-line rationale.

## Why this is a false positive

Tailwind v4 uses CSS-first configuration. The framework is loaded via `@import` in `frontend/src/index.css:1`:

```css
@import "tailwindcss";
```

Knip statically analyses JS/TS imports and cannot trace CSS `@import` statements, so it incorrectly reports `tailwindcss` as unused. Removing it would obviously break the entire frontend.

## Validation

- `npx knip 2>&1 | grep tailwindcss` → only `@tailwindcss/typography` remains (covered by separate PR; bare `tailwindcss` no longer flagged)

Closes #427