### PR TITLE
chore(#425): remove unused autoprefixer

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,7 +74,6 @@
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^5.1.4",
     "@vitest/coverage-v8": "^4.1.4",
-    "autoprefixer": "^10.4.27",
     "eslint": "^9.27.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,7 +163,6 @@
         "@types/react-dom": "^19.0.3",
         "@vitejs/plugin-react": "^5.1.4",
         "@vitest/coverage-v8": "^4.1.4",
-        "autoprefixer": "^10.4.27",
         "eslint": "^9.27.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
@@ -9604,43 +9603,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/autoprefixer": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
-      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.28.2",
-        "caniuse-lite": "^1.0.30001787",
-        "fraction.js": "^5.3.4",
-        "picocolors": "^1.1.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/avvio": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
@@ -13080,20 +13042,6 @@
       "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
       "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
       "license": "MIT"
-    },
-    "node_modules/fraction.js": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
-      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/rawify"
-      }
     },
     "node_modules/framer-motion": {
       "version": "12.38.0",
@@ -17857,13 +17805,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",


### PR DESCRIPTION
## Summary
- Remove `autoprefixer@^10.4.27` from frontend devDependencies
- Tailwind v4's `@tailwindcss/vite` plugin internalizes vendor prefixing, and no `postcss.config.*` file exists in `frontend/` that would consume autoprefixer
- Confirmed there are zero source-code references to autoprefixer

## Verification
- `ls frontend/postcss.config.*` returns no matches
- `npm run typecheck -w frontend` passes
- `npm run lint -w frontend` passes
- `npm run build -w frontend` passes

Closes #425