### PR TITLE
chore(#430): declare vitest dependency for e2e/helpers/sse.test.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "@playwright/test": "^1.58.2",
         "concurrently": "^9.1.0",
         "husky": "^9.1.7",
-        "knip": "^6.3.0"
+        "knip": "^6.3.0",
+        "vitest": "^4.0.18"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@playwright/test": "^1.58.2",
     "concurrently": "^9.1.0",
     "husky": "^9.1.7",
-    "knip": "^6.3.0"
+    "knip": "^6.3.0",
+    "vitest": "^4.0.18"
   },
   "dependencies": {
     "zod": "^4.3.6"


### PR DESCRIPTION
## Summary

`e2e/helpers/sse.test.ts` imports `describe / it / expect` from `vitest`, but `e2e/` is a directory rather than a workspace, so knip flagged `vitest` as an unlisted dependency in the root scope.

## Decision

Chose **Option A** (add `vitest` to root `devDependencies`) — it's the least invasive of the available paths:

- **Option A (chosen):** one line in root `package.json`. Hoists vitest for any code path outside workspaces. Test is runnable via `npx vitest run e2e/helpers/sse.test.ts` from the repo root.
- **Option B (rejected):** moving the test under an existing workspace would also force moving `e2e/helpers/sse.ts` and updating any indirect usage; bigger churn for the same outcome.
- **Option C (rejected):** a knip ignore would silence the warning but wouldn't actually make vitest resolvable for the test.

Pinned `^4.0.18` to match `backend/package.json` for consistency.

## Verification

- `npx vitest run e2e/helpers/sse.test.ts` — **11/11 tests pass**
- `npx knip` — no longer reports vitest as unlisted

## References

- Closes #430

## Test plan

- [x] `npx vitest run e2e/helpers/sse.test.ts` passes locally
- [x] `npx knip` no longer flags vitest as unlisted in `e2e/helpers/sse.test.ts`
- [x] No changes to existing workspace `package.json`s or `vitest.config.ts`s