### PR TITLE
chore(#433): add knip ignore for @compendiq/enterprise (CE dynamic-import contract)

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -6,7 +6,12 @@ const config: KnipConfig = {
       entry: ['src/index.ts', 'src/app.ts'],
       project: ['src/**/*.ts'],
       ignore: ['src/**/*.test.ts', 'src/**/__fixtures__/**'],
-      ignoreDependencies: ['pino-pretty'],
+      ignoreDependencies: [
+        'pino-pretty',
+        // Dynamically imported in core/enterprise/loader.ts; intentionally absent
+        // from package.json (CE doesn't ship the EE package — falls back to noop.ts)
+        '@compendiq/enterprise',
+      ],
     },
     'frontend': {
       entry: ['src/main.tsx'],


### PR DESCRIPTION
## Summary

Adds `@compendiq/enterprise` to the **backend** workspace's `ignoreDependencies` in `knip.config.ts`, with a comment explaining why it is intentionally unlisted.

## Why this is a false positive

`@compendiq/enterprise` is the EE package, dynamically imported at `backend/src/core/enterprise/loader.ts:32`:

```ts
const ee = await import('@compendiq/enterprise');
```

Per the open-core architecture (`docs/ENTERPRISE-ARCHITECTURE.md` and the `## Enterprise (Open-Core)` section of `CLAUDE.md`), the CE repo deliberately does **not** declare `@compendiq/enterprise` in `backend/package.json`. The loader falls back to `noop.ts` when the package isn't installed, which is the normal CE runtime path. Adding it to `package.json` would break the open-core contract.

`ignoreDependencies` is knip's documented field for "this dep name is expected at runtime but not listed" — applies to both unused and unlisted-but-referenced names.

## Validation

- `npx knip 2>&1 | grep compendiq/enterprise` → no output (no longer flagged)

Closes #433