### PR TITLE
chore(#426): remove unused postcss

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,7 +79,6 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "jsdom": "^28.1.0",
-    "postcss": "^8.5.1",
     "tailwindcss": "^4.2.1",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.56.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,7 +168,6 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "jsdom": "^28.1.0",
-        "postcss": "^8.5.1",
         "tailwindcss": "^4.2.1",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.56.1",


### PR DESCRIPTION
## Summary
- Remove `postcss@^8.5.1` from frontend devDependencies
- Tailwind v4's `@tailwindcss/vite` plugin doesn't need a standalone PostCSS chain, and no `postcss.config.*` file exists in `frontend/`. Vite handles CSS processing internally
- The standalone `postcss` devDependency was unused

## Verification
- `ls frontend/postcss.config.*` returns no matches
- `npm run typecheck -w frontend` passes
- `npm run lint -w frontend` passes
- `npm run build -w frontend` passes

Closes #426