### PR TITLE
fix(#404): preserve LLM queue metrics/backpressure across concurrency hot-swap

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -252,10 +252,11 @@ export async function buildApp() {
   // LLM queue cluster-wide settings (Compendiq/compendiq-ee#113 Phase B-3).
   // Cold-loads `llm_concurrency` + `llm_max_queue_depth` from admin_settings
   // and subscribes to the `admin:llm:settings` cache-bus channel. Then
-  // primes the queue's `_limiter` from those cached values + wires the
-  // module-level subscriber that swaps `_limiter` on every PUT from any
-  // pod. Must run AFTER initCacheBus and BEFORE the queue starts handling
-  // traffic.
+  // primes the queue's limiter from those cached values + wires the
+  // module-level subscriber that updates `_limiter.concurrency` in place
+  // on every PUT from any pod (see #404 — preserves activeCount/pendingCount
+  // across hot-swaps). Must run AFTER initCacheBus and BEFORE the queue
+  // starts handling traffic.
   await initLlmQueueSettings();
   initLlmQueueClusterCoordination();
 

--- a/backend/src/core/services/admin-settings-service.ts
+++ b/backend/src/core/services/admin-settings-service.ts
@@ -120,8 +120,8 @@ export async function getPendingSyncVersionsRetentionDays(): Promise<number> {
 // These wrap `admin_settings.llm_concurrency` and `admin_settings.llm_max_queue_depth`
 // behind the cache-bus channel `admin:llm:settings`. A PUT on one pod publishes
 // on the channel; every other pod's subscriber re-reads from the DB and the
-// llm-queue swaps its `pLimit` limiter. See `domains/llm/services/llm-queue.ts`
-// for the swap logic.
+// llm-queue updates its `pLimit` limiter's `concurrency` in place (see #404).
+// See `domains/llm/services/llm-queue.ts` for the mutation logic.
 //
 // Defaults match the existing env-var fallbacks in `llm-queue.ts` (which the
 // cached-setting bypasses on cold-load when the admin_settings row is absent —

--- a/backend/src/domains/llm/services/llm-queue.test.ts
+++ b/backend/src/domains/llm/services/llm-queue.test.ts
@@ -105,6 +105,66 @@ describe('llm-queue', () => {
     expect(getMetrics().concurrency).toBe(100);
   });
 
+  // Regression for #404 — hot-swapping concurrency must NOT orphan in-flight
+  // or pending jobs from the metrics / backpressure view. Pre-fix,
+  // `setConcurrency` reassigned `_limiter = pLimit(val)`, so the new
+  // limiter's `pendingCount` was 0 and the old limiter's jobs were invisible
+  // to both `getMetrics()` and the `enqueue` queue-full check.
+  it('preserves in-flight + pending jobs in metrics across a concurrency hot-swap', async () => {
+    const { enqueue, setConcurrency, setMaxQueueDepth, getMetrics, QueueFullError } =
+      await import('./llm-queue.js');
+    setConcurrency(2);
+    setMaxQueueDepth(10); // generous now; tighten later for the backpressure check
+
+    // Manually-resolved promise so in-flight jobs stay pending for the
+    // entire test — no real timers, no flake risk.
+    const release: Array<() => void> = [];
+    const block = () => new Promise<void>((resolve) => { release.push(resolve); });
+    const flushMicrotasks = async () => {
+      for (let i = 0; i < 4; i++) await Promise.resolve();
+    };
+
+    // Fill the limiter: 2 active + 3 pending.
+    const inFlight = [
+      enqueue(block), enqueue(block),
+      enqueue(block), enqueue(block), enqueue(block),
+    ];
+    await flushMicrotasks();
+    expect(getMetrics().activeCount).toBe(2);
+    expect(getMetrics().pendingCount).toBe(3);
+
+    // Hot-swap UP. p-limit's `concurrency` setter mutates the same limiter
+    // and drains pending work on the next microtask, so all 5 jobs become
+    // active without disappearing from `getMetrics()`.
+    setConcurrency(5);
+    await flushMicrotasks();
+    expect(getMetrics().concurrency).toBe(5);
+    expect(getMetrics().activeCount).toBe(5);
+    expect(getMetrics().pendingCount).toBe(0);
+
+    // Hot-swap DOWN. The 5 in-flight jobs continue; new work must queue.
+    // Pre-fix this allocated a fresh pLimit(2) and the 5 active jobs
+    // disappeared from the metrics + backpressure view.
+    setConcurrency(2);
+    await flushMicrotasks();
+    expect(getMetrics().activeCount).toBe(5);
+
+    // Tighten max-queue-depth so backpressure can be exercised. The 3
+    // additional enqueues must queue (active=5 >= concurrency=2, no slot
+    // opens), then the 4th must reject — confirming backpressure correctly
+    // counts the in-flight 5 + queued 3 across the hot-swap.
+    setMaxQueueDepth(3);
+    const noop = () => Promise.resolve();
+    const queued = [enqueue(noop), enqueue(noop), enqueue(noop)];
+    await flushMicrotasks();
+    expect(getMetrics().pendingCount).toBe(3);
+    await expect(enqueue(noop)).rejects.toThrow(QueueFullError);
+
+    // Cleanup — release the in-flight 5; the queued noops then drain.
+    while (release.length) release.shift()!();
+    await Promise.allSettled([...inFlight, ...queued]);
+  }, 10_000);
+
   describe('env-var fallback defaults', () => {
     const originalEnv = { ...process.env };
 

--- a/backend/src/domains/llm/services/llm-queue.test.ts
+++ b/backend/src/domains/llm/services/llm-queue.test.ts
@@ -114,7 +114,9 @@ describe('llm-queue', () => {
     const { enqueue, setConcurrency, setMaxQueueDepth, getMetrics, QueueFullError } =
       await import('./llm-queue.js');
     setConcurrency(2);
-    setMaxQueueDepth(10); // generous now; tighten later for the backpressure check
+    // Start with generous depth so the initial fill isn't rejected;
+    // tightened later in the test to exercise backpressure.
+    setMaxQueueDepth(10);
 
     // Manually-resolved promise so in-flight jobs stay pending for the
     // entire test — no real timers, no flake risk.

--- a/backend/src/domains/llm/services/llm-queue.test.ts
+++ b/backend/src/domains/llm/services/llm-queue.test.ts
@@ -333,7 +333,7 @@ describe('llm-queue', () => {
         expect(m.maxQueueDepth).toBe(250);
       });
 
-      it('on incoming message, re-reads DB and swaps _limiter via setConcurrency', async () => {
+      it('on incoming message, re-reads DB and updates _limiter.concurrency via setConcurrency', async () => {
         // Initial state: 4. After the cache-bus message, the handler reads
         // `admin_settings` and finds llm_concurrency=20.
         const { initLlmQueueClusterCoordination, getMetrics, _resetClusterCoordinationForTests } =

--- a/backend/src/domains/llm/services/llm-queue.ts
+++ b/backend/src/domains/llm/services/llm-queue.ts
@@ -18,15 +18,15 @@
  *   - `initLlmQueueClusterCoordination` (called after `initCacheBus` + the
  *     cached-setting init in `admin-settings-service.ts`) subscribes to the
  *     same channel; on every invalidation, every pod re-reads the cached
- *     getter and atomically swaps `_limiter` with `pLimit(<new value>)`.
+ *     getter and updates `_limiter.concurrency` in place.
  *
- *   TODO(v0.5): swapping `_limiter` while jobs are in-flight on the previous
- *   limiter orphans those jobs on the old limiter (their `pendingCount` /
- *   `activeCount` no longer feed back into the queue's metrics or backpressure
- *   logic). This is a pre-existing race in `setConcurrency()` (the original
- *   per-pod setter has the same bug); this PR keeps the behaviour. Tracking
- *   issue: open in v0.5 to drain the old limiter before swap, e.g. by holding
- *   a queue of historical limiters and routing new work to the head.
+ *   Hot-swap safety (#404): we mutate `_limiter.concurrency` rather than
+ *   allocating a new `pLimit(...)`. p-limit 7's setter keeps the same
+ *   internal queue + activeCount, so in-flight and pending jobs continue to
+ *   feed `getMetrics()` and the `enqueue` backpressure check across
+ *   concurrency changes. Lowering the limit lets in-flight jobs finish
+ *   naturally before new work is admitted; raising it drains pending work
+ *   on the next microtask.
  */
 
 import pLimit, { type LimitFunction } from 'p-limit';
@@ -71,7 +71,7 @@ const DEFAULT_CONCURRENCY = envInt('LLM_CONCURRENCY') ?? HARDCODED_CONCURRENCY;
 const DEFAULT_MAX_QUEUE_DEPTH = envInt('LLM_MAX_QUEUE_DEPTH') ?? HARDCODED_MAX_QUEUE_DEPTH;
 const DEFAULT_TIMEOUT_MS = envInt('LLM_STREAM_TIMEOUT_MS') ?? HARDCODED_TIMEOUT_MS;
 
-let _limiter: LimitFunction = pLimit(DEFAULT_CONCURRENCY);
+const _limiter: LimitFunction = pLimit(DEFAULT_CONCURRENCY);
 let _concurrency = DEFAULT_CONCURRENCY;
 let _maxQueueDepth = DEFAULT_MAX_QUEUE_DEPTH;
 let _timeoutMs = DEFAULT_TIMEOUT_MS;
@@ -83,7 +83,7 @@ export function setConcurrency(n: number): void {
   const val = Math.max(1, Math.min(n, 100));
   if (val !== _concurrency) {
     _concurrency = val;
-    _limiter = pLimit(val);
+    _limiter.concurrency = val;
     logger.info({ concurrency: val }, 'LLM queue concurrency updated');
   }
 }
@@ -248,9 +248,9 @@ export function initLlmQueueClusterCoordination(): void {
           const val = parseInt(row.setting_value, 10);
           if (!Number.isFinite(val) || val < 1) continue;
           if (row.setting_key === 'llm_concurrency' && val !== _concurrency) {
-            // `setConcurrency` clamps to [1, 100] + logs.
-            // TODO(v0.5): see file header — in-flight jobs on the previous
-            // limiter become orphaned. Pre-existing race; not fixed here.
+            // `setConcurrency` clamps to [1, 100] + logs. The limiter is
+            // mutated in place (#404), so any in-flight jobs continue to
+            // count toward `getMetrics()` and backpressure.
             setConcurrency(val);
           }
           if (row.setting_key === 'llm_max_queue_depth' && val !== _maxQueueDepth) {

--- a/backend/src/domains/llm/services/llm-queue.ts
+++ b/backend/src/domains/llm/services/llm-queue.ts
@@ -189,9 +189,10 @@ let _unsubscribeClusterCoordination: (() => void) | null = null;
  * target and the authoritative cold-loaded value are both in place.
  *
  * On every invalidation message, this re-reads `admin_settings` directly
- * (NOT through the cached getter) and atomically swaps `_limiter` via the
- * existing `setConcurrency` clamp if the concurrency changed. The direct
- * read is intentional: the cached-setting in `admin-settings-service.ts`
+ * (NOT through the cached getter) and updates `_limiter.concurrency` in
+ * place via the existing `setConcurrency` clamp if the concurrency
+ * changed (#404 — see file header). The direct read is intentional: the
+ * cached-setting in `admin-settings-service.ts`
  * also subscribes to this channel and re-reads the same row, but the
  * cache-bus dispatcher does NOT await async handlers between them — going
  * through the cached getter would risk reading a stale value if our

--- a/backend/src/routes/foundation/admin.ts
+++ b/backend/src/routes/foundation/admin.ts
@@ -412,9 +412,10 @@ export async function adminRoutes(fastify: FastifyInstance) {
     // These do NOT go through the `updates` UPSERT loop above — the
     // dedicated setters in `llm-queue.ts` UPSERT the row AND publish on
     // the `admin:llm:settings` cache-bus channel so every other pod
-    // re-reads + swaps its `pLimit` limiter. The local pod's limiter is
-    // also swapped via the same subscriber path; the route handler does
-    // NOT call `setConcurrency()` directly.
+    // re-reads and updates its `pLimit` limiter's `concurrency` in place
+    // (see #404). The local pod's limiter is also updated via the same
+    // subscriber path; the route handler does NOT call `setConcurrency()`
+    // directly.
     //
     // Zod has already validated the ranges ([1, 100] and [1, 1000]); the
     // setters defensively clamp again to keep the queue safe even if a


### PR DESCRIPTION
Closes #404.

## Summary
- `setConcurrency()` mutates `_limiter.concurrency` in place instead of allocating a new `pLimit(...)`. p-limit 7's writable concurrency setter keeps the same internal queue + `activeCount`, so in-flight and pending jobs continue to feed `getMetrics()` and the `enqueue` backpressure check across the change.
- Removes the v0.5 TODO from the file header + the inline note in the cluster-coordination handler — the orphaning race is fixed at its root, not deferred.
- Adds a regression test that fills the limiter (2 active + 3 pending), hot-swaps up to 5 then down to 2, and asserts `activeCount` / `pendingCount` and `QueueFullError` still reflect the in-flight work. Verified to fail on the pre-fix code (`activeCount` reads 0 after the swap) and pass on the fix.

## Why this approach
The issue suggested keeping a queue of historical limiters and aggregating their counts. p-limit 7 already supports in-place concurrency changes via its `concurrency` setter (drains pending work on a microtask), which sidesteps the entire "old limiter drainage" problem. One limiter, one source of truth — no aggregation, no tracking of historical instances.

## Test plan
- [x] `npx vitest run src/domains/llm/services/llm-queue.test.ts` — 19/19 pass
- [x] Regression test fails on the pre-fix code (verified by `git stash` of the implementation, re-run: `expected +0 to be 5`)
- [x] `npx eslint src/domains/llm/services/llm-queue.{ts,test.ts}` — clean
- [x] `npx tsc --noEmit -p tsconfig.json` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)