### PR TITLE
refactor(#146): policy-override path cleanups in resolveUsecase

### DIFF
--- a/backend/src/domains/llm/services/llm-provider-resolver-enterprise.test.ts
+++ b/backend/src/domains/llm/services/llm-provider-resolver-enterprise.test.ts
@@ -91,6 +91,36 @@ describe.skipIf(!dbAvailable)('resolveUsecase — enterprise override', () => {
     });
 
     const { resolveUsecase } = await import('./llm-provider-resolver.js');
-    await expect(resolveUsecase('chat')).rejects.toThrow(/no default provider/i);
+    await expect(resolveUsecase('chat')).rejects.toThrow(
+      /Org LLM policy refers to provider .* which no longer exists/,
+    );
+  });
+
+  it('falls back to provider default_model when override.model is empty', async () => {
+    const a = await seedProvider({
+      name: 'A',
+      baseUrl: 'http://a/v1',
+      defaultModel: 'a-default',
+      isDefault: true,
+    });
+
+    vi.doMock('../../../core/enterprise/loader.js', () => {
+      const overridePlugin = {
+        ...noopPlugin,
+        resolveUsecaseOverride: async () => ({ providerId: a, model: '' }),
+      };
+      return {
+        loadEnterprisePlugin: async () => overridePlugin,
+        getEnterprisePlugin: () => overridePlugin,
+        setCurrentLicense: () => {},
+        isFeatureEnabled: () => false,
+        _resetForTesting: () => {},
+      };
+    });
+
+    const { resolveUsecase } = await import('./llm-provider-resolver.js');
+    const result = await resolveUsecase('chat');
+    expect(result.config.id).toBe(a);
+    expect(result.model).toBe('a-default');
   });
 });

--- a/backend/src/domains/llm/services/llm-provider-resolver.ts
+++ b/backend/src/domains/llm/services/llm-provider-resolver.ts
@@ -57,6 +57,30 @@ function decryptSafe(s: string | null): string | null {
   try { return decryptPat(s); } catch { return null; }
 }
 
+function loadProviderFromRow(
+  row: ResolveRow,
+): ProviderConfig & { id: string; name: string; defaultModel: string | null } {
+  const cacheKey = row.provider_id;
+  let cached = configCache.get(cacheKey);
+  if (!cached || cached.version !== getProviderCacheVersion()) {
+    cached = {
+      version: getProviderCacheVersion(),
+      cfg: {
+        providerId: row.provider_id,
+        id: row.provider_id,
+        name: row.provider_name,
+        baseUrl: row.provider_base_url,
+        apiKey: decryptSafe(row.provider_api_key),
+        authType: row.provider_auth_type,
+        verifySsl: row.provider_verify_ssl,
+        defaultModel: row.provider_default_model,
+      },
+    };
+    configCache.set(cacheKey, cached);
+  }
+  return cached.cfg;
+}
+
 export async function resolveUsecase(usecase: LlmUsecase): Promise<Resolved> {
   // Enterprise override: when org LLM policy is enabled, EE returns the
   // policy's (providerId, model). CE noop always returns null.
@@ -79,27 +103,16 @@ export async function resolveUsecase(usecase: LlmUsecase): Promise<Resolved> {
     );
     const orow = overrideRows.rows[0];
     if (!orow) {
-      throw new Error('No default provider configured — set one in Settings → LLM.');
+      throw new Error(
+        `Org LLM policy refers to provider ${override.providerId} which no longer exists. Update the policy in Settings → LLM Policy.`,
+      );
     }
-    const cacheKey = orow.provider_id;
-    let cached = configCache.get(cacheKey);
-    if (!cached || cached.version !== getProviderCacheVersion()) {
-      cached = {
-        version: getProviderCacheVersion(),
-        cfg: {
-          providerId: orow.provider_id,
-          id: orow.provider_id,
-          name: orow.provider_name,
-          baseUrl: orow.provider_base_url,
-          apiKey: decryptSafe(orow.provider_api_key),
-          authType: orow.provider_auth_type,
-          verifySsl: orow.provider_verify_ssl,
-          defaultModel: orow.provider_default_model,
-        },
-      };
-      configCache.set(cacheKey, cached);
-    }
-    return { config: cached.cfg, model: override.model };
+    const cfg = loadProviderFromRow(orow);
+    // Mirror the CTE path's empty-string defense: if the policy's `model` is
+    // empty (UI shouldn't allow this, but defend anyway), fall back to the
+    // provider's `default_model`, then to `''`.
+    const model = override.model || cfg.defaultModel || '';
+    return { config: cfg, model };
   }
 
   // One round-trip: pull the use-case row + the default provider + the chosen
@@ -137,25 +150,7 @@ export async function resolveUsecase(usecase: LlmUsecase): Promise<Resolved> {
   const row = r.rows[0];
   if (!row) throw new Error('No default provider configured — set one in Settings → LLM.');
 
-  const cacheKey = row.provider_id;
-  let cached = configCache.get(cacheKey);
-  if (!cached || cached.version !== getProviderCacheVersion()) {
-    cached = {
-      version: getProviderCacheVersion(),
-      cfg: {
-        providerId: row.provider_id,
-        id: row.provider_id,
-        name: row.provider_name,
-        baseUrl: row.provider_base_url,
-        apiKey: decryptSafe(row.provider_api_key),
-        authType: row.provider_auth_type,
-        verifySsl: row.provider_verify_ssl,
-        defaultModel: row.provider_default_model,
-      },
-    };
-    configCache.set(cacheKey, cached);
-  }
-
-  const model = row.usecase_model ?? cached.cfg.defaultModel ?? '';
-  return { config: cached.cfg, model };
+  const cfg = loadProviderFromRow(row);
+  const model = row.usecase_model ?? cfg.defaultModel ?? '';
+  return { config: cfg, model };
 }


### PR DESCRIPTION
## Summary

Three follow-up cleanups raised in the PR Compendiq/compendiq-ce#609 review (INFO findings, none blocking the merge that already happened):

1. **Specific error when override.providerId no longer exists** — admin deleted the provider after locking the policy. Surface the providerId and point at the policy UI instead of the generic "No default provider configured" message that misleads users into the LLM-providers settings page.
2. **Empty-string defense on override.model** — mirror the CTE path's `?? cfg.defaultModel ?? ''` fallback so an unexpected empty model string falls back to the provider's `default_model` rather than passing through to the OpenAI-compatible client. The EE route schema (`z.string().min(1)`) shouldn't allow an empty model, but defending here keeps the resolver consistent and makes the override path safer for any future caller bypassing the route.
3. **Extract duplicated row → ProviderConfig + cache mapping** into `loadProviderFromRow()`. Called from both the override path and the CTE path. Net: −16 lines of duplication.

## Diff

`backend/src/domains/llm/services/llm-provider-resolver.ts`:
- New `loadProviderFromRow()` helper.
- Override path: specific error message when `overrideRows.rows[0]` is missing; `model = override.model || cfg.defaultModel || ''`.
- CTE path: uses `loadProviderFromRow()`.

`backend/src/domains/llm/services/llm-provider-resolver-enterprise.test.ts`:
- Updated the existing "throws when override providerId no longer exists" assertion to match the new specific message.
- New test: falls back to provider's `default_model` when `override.model` is empty.

## Test plan

- [x] Targeted vitest: 2 files, 10 tests pass (resolver truth-table + enterprise override).
- [x] `npm run typecheck -w backend` clean.
- [x] `npm run lint -w backend` clean.
- [ ] CI

## Reference

Followups from review on #609:
- INFO #1: Misleading error message when override points at deleted provider.
- INFO #2: Duplicated row → ProviderConfig mapping between override and CTE paths.
- INFO #3: \`override.model\` not defended against empty string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)