### PR TITLE
feat(EE#113 sub-PR 1e): POST /api/admin/health-api/rotate

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -14,7 +14,7 @@ import authPlugin from './core/plugins/auth.js';
 import redisPlugin from './core/plugins/redis.js';
 // Foundation routes
 import { healthRoutes } from './routes/foundation/health.js';
-import { healthApiRoutes } from './routes/foundation/health-api.js';
+import { healthApiRoutes, healthApiAdminRoutes } from './routes/foundation/health-api.js';
 import { authRoutes } from './routes/foundation/auth.js';
 import { settingsRoutes } from './routes/foundation/settings.js';
 import { adminRoutes } from './routes/foundation/admin.js';
@@ -349,6 +349,7 @@ export async function buildApp() {
   // Foundation routes
   await app.register(healthRoutes, { prefix: '/api' });
   await app.register(healthApiRoutes, { prefix: '/api' });
+  await app.register(healthApiAdminRoutes, { prefix: '/api' });
   await app.register(authRoutes, { prefix: '/api/auth' });
   await app.register(settingsRoutes, { prefix: '/api' });
   await app.register(adminRoutes, { prefix: '/api' });

--- a/backend/src/core/services/audit-service.ts
+++ b/backend/src/core/services/audit-service.ts
@@ -131,7 +131,13 @@ export type AuditAction =
   // implicit `inherit_perms=false` flip when present (recorded in metadata).
   | 'BULK_PAGE_TAGGED'
   | 'BULK_PAGE_TAGS_REPLACED'
-  | 'BULK_PAGE_PERMISSION_CHANGED';
+  | 'BULK_PAGE_PERMISSION_CHANGED'
+  // Multi-instance readiness — Compendiq/compendiq-ee#113. Emitted by the
+  // admin-gated POST /api/admin/health-api/rotate route when an admin
+  // rotates the per-instance health-API bearer token. Deliberate admin
+  // action — not counted in `errorRate24h` (see ERROR_AUDIT_ACTIONS in
+  // routes/foundation/health-api.ts).
+  | 'HEALTH_API_TOKEN_ROTATED';
 
 interface AuditLogEntry {
   id: string;

--- a/backend/src/routes/foundation/health-api.integration.test.ts
+++ b/backend/src/routes/foundation/health-api.integration.test.ts
@@ -1,5 +1,17 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
+
+// Short-circuit DNS lookups performed by the SSRF guard during `buildApp()`
+// boot. Mirrors `admin-embedding-locks.test.ts` — no integration test should
+// hit external DNS.
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async () => {
+    const err = new Error('getaddrinfo ENOTFOUND (mocked)') as NodeJS.ErrnoException;
+    err.code = 'ENOTFOUND';
+    throw err;
+  }),
+}));
+
 import {
   setupTestDb,
   truncateAllTables,
@@ -7,6 +19,8 @@ import {
   isDbAvailable,
 } from '../../test-db-helper.js';
 import { query } from '../../core/db/postgres.js';
+import { buildApp } from '../../app.js';
+import { generateAccessToken } from '../../core/plugins/auth.js';
 import { healthApiRoutes } from './health-api.js';
 
 /**
@@ -189,3 +203,200 @@ describe.skipIf(!dbAvailable)('health-api integration — Compendiq/compendiq-ee
     expect(body.errorRate24h).toBe(0);
   });
 });
+
+/**
+ * Token-rotation route — Compendiq/compendiq-ee#113 sub-PR 1e.
+ *
+ * The rotation route lives in the same module as GET, but is registered
+ * separately in `app.ts` because it requires `fastify.authenticate +
+ * fastify.requireAdmin` while the GET path is a public bearer-token
+ * endpoint. We test it against `buildApp()` (full Fastify wiring) rather
+ * than the bare `Fastify({ logger: false })` instance the GET integration
+ * test uses, so the auth decorators are real.
+ */
+const dbAvailableForRotate = await isDbAvailable();
+
+describe.skipIf(!dbAvailableForRotate)(
+  'POST /api/admin/health-api/rotate — Compendiq/compendiq-ee#113 sub-PR 1e',
+  () => {
+    let rotateApp: FastifyInstance;
+    let adminToken: string;
+    let adminUserId: string;
+    let memberToken: string;
+
+    async function createUserWithRole(
+      username: string,
+      role: 'admin' | 'member',
+    ): Promise<{ token: string; userId: string }> {
+      const r = await query<{ id: string }>(
+        `INSERT INTO users (username, password_hash, role)
+         VALUES ($1, 'fakehash', $2) RETURNING id`,
+        [username, role],
+      );
+      const userId = r.rows[0]!.id;
+      await query('INSERT INTO user_settings (user_id) VALUES ($1)', [userId]);
+      const token = await generateAccessToken({ sub: userId, username, role });
+      return { token, userId };
+    }
+
+    async function readPersistedToken(): Promise<string | null> {
+      const r = await query<{ setting_value: string }>(
+        `SELECT setting_value FROM admin_settings WHERE setting_key = 'health_api_token'`,
+      );
+      return r.rows[0]?.setting_value ?? null;
+    }
+
+    beforeAll(async () => {
+      await setupTestDb();
+      rotateApp = await buildApp();
+      await rotateApp.ready();
+    }, 30_000);
+
+    afterAll(async () => {
+      await rotateApp?.close();
+      await teardownTestDb();
+    });
+
+    beforeEach(async () => {
+      await truncateAllTables();
+      // Re-seed the row migration 072 normally provides — truncate wipes it.
+      await query(
+        `INSERT INTO admin_settings (setting_key, setting_value, updated_at)
+         VALUES ('health_api_token', encode(gen_random_bytes(32), 'hex'), NOW())
+         ON CONFLICT (setting_key) DO NOTHING`,
+      );
+      ({ token: adminToken, userId: adminUserId } = await createUserWithRole(
+        'rotate_admin',
+        'admin',
+      ));
+      ({ token: memberToken } = await createUserWithRole('rotate_member', 'member'));
+    });
+
+    // (a) Unauthenticated → 401
+    it('returns 401 when no Authorization header is supplied', async () => {
+      const r = await rotateApp.inject({
+        method: 'POST',
+        url: '/api/admin/health-api/rotate',
+      });
+      expect(r.statusCode).toBe(401);
+    });
+
+    // (b) Authenticated but non-admin → 403
+    it('returns 403 for a non-admin (member) caller', async () => {
+      const r = await rotateApp.inject({
+        method: 'POST',
+        url: '/api/admin/health-api/rotate',
+        headers: { authorization: `Bearer ${memberToken}` },
+      });
+      expect(r.statusCode).toBe(403);
+    });
+
+    // (c) Admin rotates → 200, response shape { token: 64-hex, rotatedAt: ISO }
+    it('returns 200 with the new token and ISO rotatedAt on admin rotation', async () => {
+      const before = await readPersistedToken();
+      expect(before).toBeTruthy();
+
+      const r = await rotateApp.inject({
+        method: 'POST',
+        url: '/api/admin/health-api/rotate',
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+      expect(r.statusCode).toBe(200);
+      const body = r.json() as Record<string, unknown>;
+
+      // Shape
+      expect(typeof body.token).toBe('string');
+      expect(body.token).toMatch(/^[0-9a-f]{64}$/);
+      expect(typeof body.rotatedAt).toBe('string');
+      // ISO 8601 round-trip stable (Date.parse → toISOString)
+      const parsed = new Date(body.rotatedAt as string);
+      expect(Number.isNaN(parsed.getTime())).toBe(false);
+      expect(parsed.toISOString()).toBe(body.rotatedAt);
+
+      // Rotation actually persisted: response token equals DB row.
+      const after = await readPersistedToken();
+      expect(after).toBe(body.token);
+      expect(after).not.toBe(before);
+    });
+
+    // (d) Round-trip: old token → 401, new token → 200
+    it('rejects the old token and accepts the new one on subsequent GET', async () => {
+      const oldToken = await readPersistedToken();
+      expect(oldToken).toBeTruthy();
+
+      const rot = await rotateApp.inject({
+        method: 'POST',
+        url: '/api/admin/health-api/rotate',
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+      expect(rot.statusCode).toBe(200);
+      const newToken = (rot.json() as { token: string }).token;
+      expect(newToken).not.toBe(oldToken);
+
+      const oldRes = await rotateApp.inject({
+        method: 'GET',
+        url: `/api/internal/health?token=${oldToken}`,
+      });
+      expect(oldRes.statusCode).toBe(401);
+
+      const newRes = await rotateApp.inject({
+        method: 'GET',
+        url: `/api/internal/health?token=${newToken}`,
+      });
+      expect(newRes.statusCode).toBe(200);
+    });
+
+    // (e) Audit row written with HEALTH_API_TOKEN_ROTATED + actor user_id
+    it('writes a HEALTH_API_TOKEN_ROTATED audit row for the rotating admin', async () => {
+      const r = await rotateApp.inject({
+        method: 'POST',
+        url: '/api/admin/health-api/rotate',
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+      expect(r.statusCode).toBe(200);
+      const { rotatedAt } = r.json() as { rotatedAt: string };
+
+      const { rows } = await query<{
+        user_id: string;
+        action: string;
+        resource_type: string;
+        resource_id: string | null;
+        metadata: Record<string, unknown>;
+      }>(
+        `SELECT user_id, action, resource_type, resource_id, metadata::jsonb AS metadata
+           FROM audit_log
+          WHERE action = 'HEALTH_API_TOKEN_ROTATED'
+          ORDER BY created_at DESC
+          LIMIT 1`,
+      );
+      expect(rows).toHaveLength(1);
+      const audit = rows[0]!;
+      expect(audit.user_id).toBe(adminUserId);
+      expect(audit.action).toBe('HEALTH_API_TOKEN_ROTATED');
+      expect(audit.resource_type).toBe('health_api_token');
+      expect(audit.resource_id).toBeNull();
+      expect(audit.metadata).toMatchObject({ rotatedAt });
+    });
+
+    // (f) Migration row missing → 503 (mirrors GET behaviour)
+    it('returns 503 when admin_settings.health_api_token row is absent', async () => {
+      // Wipe the seeded row so the UPDATE affects 0 rows.
+      await query(`DELETE FROM admin_settings WHERE setting_key = 'health_api_token'`);
+
+      const r = await rotateApp.inject({
+        method: 'POST',
+        url: '/api/admin/health-api/rotate',
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+      expect(r.statusCode).toBe(503);
+      expect(r.json()).toEqual({ error: 'health token not initialised' });
+
+      // No audit row written when the rotation failed (the route returns
+      // before logAuditEvent).
+      const { rows } = await query<{ c: string }>(
+        `SELECT COUNT(*)::text AS c FROM audit_log WHERE action = 'HEALTH_API_TOKEN_ROTATED'`,
+      );
+      expect(rows[0]!.c).toBe('0');
+    });
+  },
+);

--- a/backend/src/routes/foundation/health-api.ts
+++ b/backend/src/routes/foundation/health-api.ts
@@ -39,6 +39,22 @@ import { query } from '../../core/db/postgres.js';
 import { logger } from '../../core/utils/logger.js';
 import { APP_VERSION, APP_BUILD_INFO } from '../../core/utils/version.js';
 import { logAuditEvent } from '../../core/services/audit-service.js';
+import { getRateLimits } from '../../core/services/rate-limit-service.js';
+
+/**
+ * Admin-route rate limit config. Mirrors the convention used by other
+ * `routes/foundation/admin-*.ts` modules so that destructive/security-
+ * sensitive admin actions all share the same per-IP throttling envelope
+ * (the global default is 100/min; admin uses the configured admin cap).
+ */
+const ADMIN_RATE_LIMIT = {
+  config: {
+    rateLimit: {
+      max: async () => (await getRateLimits()).admin.max,
+      timeWindow: '1 minute',
+    },
+  },
+};
 
 interface HealthQueryString {
   token?: unknown;
@@ -235,7 +251,7 @@ export async function healthApiAdminRoutes(fastify: FastifyInstance) {
 
   fastify.post(
     '/admin/health-api/rotate',
-    { preHandler: fastify.requireAdmin },
+    { preHandler: fastify.requireAdmin, ...ADMIN_RATE_LIMIT },
     async (request, reply) => {
       const newToken = randomBytes(32).toString('hex');
 

--- a/backend/src/routes/foundation/health-api.ts
+++ b/backend/src/routes/foundation/health-api.ts
@@ -34,10 +34,11 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { timingSafeEqual } from 'node:crypto';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { query } from '../../core/db/postgres.js';
 import { logger } from '../../core/utils/logger.js';
 import { APP_VERSION, APP_BUILD_INFO } from '../../core/utils/version.js';
+import { logAuditEvent } from '../../core/services/audit-service.js';
 
 interface HealthQueryString {
   token?: unknown;
@@ -200,6 +201,78 @@ export async function healthApiRoutes(fastify: FastifyInstance) {
         logger.error({ err }, 'health-api: failed to assemble report');
         return reply.status(500).send({ error: 'failed to assemble health report' });
       }
+    },
+  );
+}
+
+/**
+ * Admin-only token-rotation route — Compendiq/compendiq-ee#113 sub-PR 1e.
+ *
+ * `POST /api/admin/health-api/rotate`
+ *   Auth:    fastify.authenticate (onRequest hook) + fastify.requireAdmin (preHandler)
+ *   Body:    (none)
+ *   Effect:  generates a fresh 64-hex token via `crypto.randomBytes(32)`,
+ *            UPDATEs `admin_settings.health_api_token` (the row is seeded by
+ *            migration 072; if it is somehow missing we 503 like the GET path),
+ *            and writes a `HEALTH_API_TOKEN_ROTATED` audit row.
+ *   Returns: 200 { token, rotatedAt } where `rotatedAt` is the ISO timestamp
+ *            written to `admin_settings.updated_at`.
+ *
+ * Why no broadcast / cache-bus message: `readHealthApiToken()` (GET path)
+ * hits Postgres on every inbound request — the rotation is therefore
+ * atomically observable on the next call on every replica without bus
+ * interaction. See plan §1.2 ("Why no broadcast").
+ *
+ * Why this isn't in the same plugin as the GET path: the GET path is
+ * unauthenticated (machine-to-machine bearer token), while rotation MUST be
+ * gated by `fastify.authenticate + fastify.requireAdmin`. Co-locating both
+ * inside one plugin would require per-route auth opt-outs which is more
+ * error-prone than splitting the registration. The admin route is registered
+ * alongside the public route in `app.ts`.
+ */
+export async function healthApiAdminRoutes(fastify: FastifyInstance) {
+  fastify.addHook('onRequest', fastify.authenticate);
+
+  fastify.post(
+    '/admin/health-api/rotate',
+    { preHandler: fastify.requireAdmin },
+    async (request, reply) => {
+      const newToken = randomBytes(32).toString('hex');
+
+      // UPDATE not UPSERT: migration 072 seeded the row. If it is missing
+      // the deployment is broken in the same way the GET path's 503 reports;
+      // surface the same fail-closed signal here rather than silently
+      // INSERT-ing and pretending all is well.
+      const { rowCount } = await query(
+        `UPDATE admin_settings
+            SET setting_value = $1, updated_at = NOW()
+          WHERE setting_key = 'health_api_token'`,
+        [newToken],
+      );
+
+      if (!rowCount) {
+        logger.error(
+          'health-api: rotate called but admin_settings.health_api_token row missing',
+        );
+        return reply.status(503).send({ error: 'health token not initialised' });
+      }
+
+      const rotatedAt = new Date().toISOString();
+
+      // Audit row — actor is request.userId (set by `fastify.authenticate`).
+      // Pattern mirrors `admin-embedding-locks.ts`'s release route and
+      // `admin-users.ts`. Audit failure never blocks the response (the
+      // helper swallows its own errors per `audit-service.ts:178`).
+      await logAuditEvent(
+        request.userId,
+        'HEALTH_API_TOKEN_ROTATED',
+        'health_api_token',
+        undefined,
+        { rotatedAt },
+        request,
+      );
+
+      return reply.status(200).send({ token: newToken, rotatedAt });
     },
   );
 }


### PR DESCRIPTION
## Summary

Sub-PR 1e of [EE#113](https://github.com/Compendiq/compendiq-ee/issues/113) — Part A health-API token lifecycle. Adds `POST /api/admin/health-api/rotate` so admins can rotate the token without manual SQL. Pairs with the existing `GET /api/internal/health` token-gated probe.

## What changed

- `backend/src/routes/foundation/health-api.ts` — new `healthApiAdminRoutes` exporting `POST /admin/health-api/rotate`. Auth: `[fastify.authenticate, fastify.requireAdmin]` via the existing CE pattern (onRequest hook + preHandler). Generates 64-char hex via `crypto.randomBytes(32)`. Returns `{ token, rotatedAt }`. 503 if migration row absent.
- `backend/src/core/services/audit-service.ts` — adds `'HEALTH_API_TOKEN_ROTATED'` to the closed `AuditAction` union with a doc comment explaining it is excluded from `errorRate24h` (deliberate admin action, not an operational error).
- `backend/src/app.ts` — registers `healthApiAdminRoutes` under `/api` so the full path is `POST /api/admin/health-api/rotate`.
- `backend/src/routes/foundation/health-api.integration.test.ts` — adds 6 cases: unauthenticated → 401, non-admin → 403, admin → 200 with shape, round-trip (old → 401 / new → 200), audit row written with actor user_id, 503 when row absent.

## Why no cluster broadcast

The GET path reads `admin_settings` on every request — there is no in-process cache to invalidate. Rotation is therefore atomically observable on every replica without bus interaction. Documented in [ADR-024](docs/ARCHITECTURE-DECISIONS.md#adr-024-multi-instance-readiness-horizontally-scaled-backend) (lands in companion PR #612).

## Test plan

- [x] `npm test -- health-api` — 25 passed (15 unit-mocked + 10 integration; 5 GET + 5 rotation)
- [x] `npm test -- admin auth audit` adjacent sweep — 107 passed
- [x] `npm test -- audit-service` — 34 passed (no AuditAction consumer broke)
- [x] `tsc --noEmit` + eslint clean
- [ ] CI passes on \`dev\` rebase

## Companion PRs

- Sibling: Compendiq/compendiq-ce#612 (sub-PR 1d cache-bus delegation + ADR-024)
- Mgmt-side: Compendiq/compendiq-mgmt PR will call this rotation route from the admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)