### PR TITLE
feat(frontend): trial banner driven by /api/license/info

### DIFF
--- a/frontend/src/shared/components/banners/TrialBanner.test.tsx
+++ b/frontend/src/shared/components/banners/TrialBanner.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { TrialBanner } from './TrialBanner';
+
+interface MockLicense {
+  tier: string;
+  type: 'trial' | 'paid' | null;
+  expiresAt: string | null;
+  daysRemaining: number | null;
+  isValid: boolean;
+}
+
+function mockLicenseFetch(value: MockLicense | null, status = 200) {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(value ? JSON.stringify(value) : '', {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+describe('TrialBanner', () => {
+  beforeEach(() => {
+    // Default: no fetch mock — individual tests configure as needed.
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when /api/license/info 404s (CE deployment)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 404 }));
+    render(<TrialBanner />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(screen.queryByTestId('trial-banner')).toBeNull();
+  });
+
+  it('renders nothing for a paid license', async () => {
+    mockLicenseFetch({
+      tier: 'enterprise',
+      type: 'paid',
+      expiresAt: '2027-12-31T23:59:59Z',
+      daysRemaining: 365,
+      isValid: true,
+    });
+    render(<TrialBanner />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(screen.queryByTestId('trial-banner')).toBeNull();
+  });
+
+  it('renders nothing for community (no key set)', async () => {
+    mockLicenseFetch({
+      tier: 'community',
+      type: null,
+      expiresAt: null,
+      daysRemaining: null,
+      isValid: false,
+    });
+    render(<TrialBanner />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(screen.queryByTestId('trial-banner')).toBeNull();
+  });
+
+  it('renders an info banner for an active trial with > 7 days remaining', async () => {
+    mockLicenseFetch({
+      tier: 'business',
+      type: 'trial',
+      expiresAt: '2026-06-04T23:59:59Z',
+      daysRemaining: 28,
+      isValid: true,
+    });
+    render(<TrialBanner />);
+    const banner = await screen.findByTestId('trial-banner');
+    expect(banner).toHaveTextContent('Trial — 28 days remaining');
+  });
+
+  it('renders a warning banner when 1 < daysRemaining ≤ 7', async () => {
+    mockLicenseFetch({
+      tier: 'business',
+      type: 'trial',
+      expiresAt: '2026-05-09T23:59:59Z',
+      daysRemaining: 4,
+      isValid: true,
+    });
+    render(<TrialBanner />);
+    const banner = await screen.findByTestId('trial-banner');
+    expect(banner).toHaveTextContent('only 4 days left');
+  });
+
+  it('singularizes "1 day left" at the boundary', async () => {
+    mockLicenseFetch({
+      tier: 'business',
+      type: 'trial',
+      expiresAt: '2026-05-06T23:59:59Z',
+      daysRemaining: 1,
+      isValid: true,
+    });
+    render(<TrialBanner />);
+    const banner = await screen.findByTestId('trial-banner');
+    expect(banner).toHaveTextContent('only 1 day left');
+    expect(banner).not.toHaveTextContent('days');
+  });
+
+  it('renders a destructive banner when daysRemaining is 0', async () => {
+    mockLicenseFetch({
+      tier: 'community',
+      type: 'trial',
+      expiresAt: '2026-05-05T23:59:59Z',
+      daysRemaining: 0,
+      isValid: false,
+    });
+    render(<TrialBanner />);
+    const banner = await screen.findByTestId('trial-banner');
+    expect(banner).toHaveTextContent('Trial expired 0 days ago');
+  });
+
+  it('renders a destructive banner with absolute days when daysRemaining is negative', async () => {
+    mockLicenseFetch({
+      tier: 'community',
+      type: 'trial',
+      expiresAt: '2026-05-01T23:59:59Z',
+      daysRemaining: -4,
+      isValid: false,
+    });
+    render(<TrialBanner />);
+    const banner = await screen.findByTestId('trial-banner');
+    expect(banner).toHaveTextContent('Trial expired 4 days ago');
+  });
+
+  it('singularizes "expired 1 day ago" at the boundary', async () => {
+    mockLicenseFetch({
+      tier: 'community',
+      type: 'trial',
+      expiresAt: '2026-05-04T23:59:59Z',
+      daysRemaining: -1,
+      isValid: false,
+    });
+    render(<TrialBanner />);
+    const banner = await screen.findByTestId('trial-banner');
+    expect(banner).toHaveTextContent('Trial expired 1 day ago');
+    expect(banner).not.toHaveTextContent('days');
+  });
+
+  it('renders nothing when fetch rejects (network error)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'));
+    render(<TrialBanner />);
+    // Allow the promise rejection to propagate
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByTestId('trial-banner')).toBeNull();
+  });
+});

--- a/frontend/src/shared/components/banners/TrialBanner.test.tsx
+++ b/frontend/src/shared/components/banners/TrialBanner.test.tsx
@@ -101,7 +101,7 @@ describe('TrialBanner', () => {
     expect(banner).not.toHaveTextContent('days');
   });
 
-  it('renders a destructive banner when daysRemaining is 0', async () => {
+  it('renders a destructive banner with "today" copy when daysRemaining is 0', async () => {
     mockLicenseFetch({
       tier: 'community',
       type: 'trial',
@@ -111,7 +111,8 @@ describe('TrialBanner', () => {
     });
     render(<TrialBanner />);
     const banner = await screen.findByTestId('trial-banner');
-    expect(banner).toHaveTextContent('Trial expired 0 days ago');
+    expect(banner).toHaveTextContent('Trial expired today');
+    expect(banner).not.toHaveTextContent('0 days');
   });
 
   it('renders a destructive banner with absolute days when daysRemaining is negative', async () => {

--- a/frontend/src/shared/components/banners/TrialBanner.tsx
+++ b/frontend/src/shared/components/banners/TrialBanner.tsx
@@ -54,13 +54,15 @@ export function TrialBanner() {
   const Icon = tone === 'destructive' ? AlertTriangle : Clock;
 
   const message =
-    days <= 0
-      ? `Trial expired ${Math.abs(days)} day${Math.abs(days) === 1 ? '' : 's'} ago — contact sales to upgrade.`
-      : days === 1
-        ? 'Trial — only 1 day left. Contact sales to keep enterprise features.'
-        : days <= 7
-          ? `Trial — only ${days} days left. Contact sales to keep enterprise features.`
-          : `Trial — ${days} days remaining.`;
+    days === 0
+      ? 'Trial expired today — contact sales to upgrade.'
+      : days < 0
+        ? `Trial expired ${Math.abs(days)} day${Math.abs(days) === 1 ? '' : 's'} ago — contact sales to upgrade.`
+        : days === 1
+          ? 'Trial — only 1 day left. Contact sales to keep enterprise features.'
+          : days <= 7
+            ? `Trial — only ${days} days left. Contact sales to keep enterprise features.`
+            : `Trial — ${days} days remaining.`;
 
   return (
     <div

--- a/frontend/src/shared/components/banners/TrialBanner.tsx
+++ b/frontend/src/shared/components/banners/TrialBanner.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { Clock, AlertTriangle } from 'lucide-react';
+import { cn } from '../../lib/cn';
+
+/**
+ * Response shape from `GET /api/license/info` (EE-only endpoint).
+ * In CE deployments the endpoint returns 404 and the banner stays hidden.
+ *
+ * Producer: compendiq-ee/overlay/backend/src/enterprise/plugin.ts.
+ */
+interface LicenseInfoResponse {
+  tier: 'community' | 'business' | 'enterprise' | 'team';
+  type: 'trial' | 'paid' | null;
+  expiresAt: string | null;
+  daysRemaining: number | null;
+  isValid: boolean;
+}
+
+/**
+ * Banner shown only when the active license is a trial. Three visual states:
+ *
+ *   daysRemaining  > 7  → subtle informational banner ("Trial — N days remaining")
+ *   daysRemaining  1..7 → warning banner ("Trial — only N day(s) left")
+ *   daysRemaining  <= 0 → destructive banner ("Trial expired N days ago")
+ *
+ * Self-fetching, single shot on mount. Trial state changes day-to-day at
+ * coarse granularity, so a 24h-stale banner is fine — and avoids the
+ * polling overhead of `<ServiceStatus />`. Page reload picks up changes
+ * issued via /api/admin/license.
+ */
+export function TrialBanner() {
+  const [info, setInfo] = useState<LicenseInfoResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/license/info')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: LicenseInfoResponse | null) => {
+        if (!cancelled) setInfo(data);
+      })
+      .catch(() => {
+        // Network error or CE deployment without EE — banner stays hidden.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!info || info.type !== 'trial' || info.daysRemaining === null) return null;
+
+  const days = info.daysRemaining;
+  const tone =
+    days <= 0 ? 'destructive' : days <= 7 ? 'warning' : 'info';
+  const Icon = tone === 'destructive' ? AlertTriangle : Clock;
+
+  const message =
+    days <= 0
+      ? `Trial expired ${Math.abs(days)} day${Math.abs(days) === 1 ? '' : 's'} ago — contact sales to upgrade.`
+      : days === 1
+        ? 'Trial — only 1 day left. Contact sales to keep enterprise features.'
+        : days <= 7
+          ? `Trial — only ${days} days left. Contact sales to keep enterprise features.`
+          : `Trial — ${days} days remaining.`;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="trial-banner"
+      className={cn(
+        'mt-2 flex items-center gap-2 rounded-md border px-3 py-2 text-sm',
+        tone === 'destructive' && 'border-destructive/30 bg-destructive/15 text-destructive',
+        tone === 'warning' && 'border-amber-500/30 bg-amber-500/15 text-amber-900 dark:text-amber-200',
+        tone === 'info' && 'border-border bg-muted/50 text-muted-foreground',
+      )}
+    >
+      <Icon size={16} aria-hidden="true" />
+      <span>{message}</span>
+    </div>
+  );
+}

--- a/frontend/src/shared/components/layout/AppLayout.tsx
+++ b/frontend/src/shared/components/layout/AppLayout.tsx
@@ -9,6 +9,7 @@ import { useKeyboardShortcuts, type ShortcutDefinition } from '../../hooks/use-k
 import { CommandPalette } from './CommandPalette';
 import { KeyboardShortcutsModal } from './KeyboardShortcutsModal';
 import { ServiceStatus } from '../badges/ServiceStatus';
+import { TrialBanner } from '../banners/TrialBanner';
 import { Breadcrumb } from './Breadcrumb';
 import { UserMenu } from './UserMenu';
 import { SidebarTreeView } from './SidebarTreeView';
@@ -272,6 +273,7 @@ export function AppLayout({ children }: { children: ReactNode }) {
       {/* Service status banner (Ollama, etc.) — sits between header and panels */}
       <div className="shrink-0 px-4 sm:px-6">
         <ServiceStatus />
+        <TrialBanner />
       </div>
 
       {/* Below header: sidebar + content area, edge-to-edge with borders. */}


### PR DESCRIPTION
## Summary

User-visible payoff for the trial system shipped in `compendiq-ee#158` (CQEE1 parser + `/api/license/info`). A banner appears above the page chrome whenever the active license is a trial:

- **`> 7` days remaining** → subtle info: `Trial — N days remaining.`
- **1–7 days remaining** → warning: `Trial — only N day(s) left. Contact sales to keep enterprise features.`
- **`≤ 0` days remaining** → destructive: `Trial expired N day(s) ago — contact sales to upgrade.`

Negative-`daysRemaining` rendering depends on the EE-side change in `compendiq-ee#158` to *preserve* `expiresAt`/`daysRemaining` after a trial expires (rather than nulling them when `tier` downgrades to `community`). That coordination is intentional.

## Where it lives

- `frontend/src/shared/components/banners/TrialBanner.tsx`
- Mounted in `AppLayout.tsx` immediately after `<ServiceStatus />`, sharing the "between header and panels" slot. Same visual register, same horizontal padding.

## Graceful degradation

- `/api/license/info` 404 (CE deployment, no EE backend) → banner hidden silently.
- `type !== 'trial'` (paid or no key set) → banner hidden.
- Network error → banner hidden, no console noise.

## Why a separate fetch (vs reading from `EnterpriseProvider`)

`EnterpriseProvider` already fetches `/api/admin/license`, but that endpoint follows the canonical `LicenseInfoResponseSchema` from `@compendiq/contracts` — which doesn't expose `type` or `issuedAt`. Widening the contract for an EE-only concept would force a CE/contracts change with no CE-side benefit. Banner reads the EE-only `/api/license/info` instead and stays self-contained. Single-shot fetch on mount is correct because trial state changes at day granularity — a stale banner survives a page reload.

## Test plan

- [x] 10 new component tests in `TrialBanner.test.tsx`: 404, paid, community-no-key, > 7d active, 1≤n≤7 warning, 1-day singular, 0d expired, negative expired, 1-day-ago singular, network error.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean (`--max-warnings=0`).
- [x] Full frontend suite still passes: **2078 / 2078 tests across 170 files**.

## Out of scope

- Showing the banner to non-admin users only — deliberately excluded. Trial expiration is a deployment-level fact every user benefits from seeing; gating it would surprise free-tier users on a trial deployment by hiding why their access changed.
- Internationalization. Strings are English only, matching the rest of the SPA.
- Dismiss/snooze. Trials are short-lived; any "x" button would be re-shown 24h later anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)