### PR TITLE
docs(EE#113 followup): correct ADR-024 cite + cluster-mode read-after-write semantics

### DIFF
--- a/backend/src/domains/llm/services/cache-bus.ts
+++ b/backend/src/domains/llm/services/cache-bus.ts
@@ -30,15 +30,32 @@
 //    we depend on here.
 //
 // 3. **Per-pod version counter (Option A).** `getProviderCacheVersion()`
-//    returns a strictly-increasing per-pod counter. It is incremented
-//    locally on every direct `bumpProviderCacheVersion()` call AND inside
-//    the cluster-bus subscribe handler when a remote bump arrives, so
-//    every pod observes "version went up — invalidate" deterministically.
+//    returns a strictly-increasing per-pod counter.
+//
+//    * **Single-pod mode** (`isCacheBusActive() === false`): the bump
+//      increments `version` and fires listeners synchronously inside the
+//      `bumpProviderCacheVersion()` call. A subsequent
+//      `getProviderCacheVersion()` on the same call stack observes the
+//      new value.
+//    * **Cluster mode** (`isCacheBusActive() === true`): the bump only
+//      publishes; the local `version++` happens inside the subscribe
+//      handler when the publish round-trips back through Redis. There is
+//      a brief window — between the `await publish()` resolving and the
+//      pub/sub callback firing — during which the publishing pod's
+//      `getProviderCacheVersion()` still returns the OLD value. This is
+//      eventually consistent on the order of a Redis round-trip
+//      (sub-millisecond on a healthy network).
+//
+//    The resolver's `configCache` uses this counter as a "did anything
+//    change since I last looked?" tripwire on the next call, which is
+//    correct for both modes. Any future caller that needs synchronous
+//    read-after-write must either run in single-pod mode or bump
+//    locally before publishing AND deduplicate the round-tripped event
+//    by publisher ID.
+//
 //    The number itself is NOT cluster-coherent (pod A's version 7 may
 //    align to pod B's version 4); only its monotone-increasing property
-//    on a given pod is contractual. The resolver's configCache uses this
-//    counter as a "did anything change since I last looked?" tripwire,
-//    which works fine with per-pod monotonicity.
+//    on a given pod is contractual.
 //
 // 4. **Boot-path subscribe-vs-publish race (benign).** `subscribe()` is
 //    fire-and-forget — node-redis acks the SUBSCRIBE asynchronously. If a
@@ -134,14 +151,23 @@ export function initProviderCacheBus(): void {
 }
 
 /**
- * Bump the provider-config version. In multi-pod mode publishes on
- * `provider:cache:bump`; the local subscriber path bumps the per-pod
- * counter and fires local listeners. In single-pod mode (`isCacheBusActive()
- * === false`) we bump + fan out locally with no publish.
+ * Bump the provider-config version. In cluster mode publishes on
+ * `provider:cache:bump` only; the local `version++` and listener
+ * fan-out happen when the publish round-trips through Redis to this
+ * pod's subscriber. In single-pod mode (`isCacheBusActive() === false`)
+ * we bump + fan out locally with no publish.
  *
  * Returns a Promise<void> because the cluster publish is async; callers
  * must `await` so a publish failure surfaces in logs from the calling
  * context rather than as an unhandled rejection.
+ *
+ * **Read-after-write caveat (cluster mode):** awaiting this Promise
+ * does NOT mean a subsequent `getProviderCacheVersion()` on the same
+ * stack will see the new value — that requires the pub/sub round-trip
+ * to complete. See the module-level note (3) for details. Today's only
+ * consumer (the resolver) re-checks on the next call, so the lag is
+ * invisible; future synchronous read-after-write callers need to
+ * coordinate explicitly.
  */
 export async function bumpProviderCacheVersion(): Promise<void> {
   if (isCacheBusActive()) {

--- a/docs/ARCHITECTURE-DECISIONS.md
+++ b/docs/ARCHITECTURE-DECISIONS.md
@@ -1194,7 +1194,7 @@ The challenge is to deliver multi-replica correctness **without** introducing a 
 
 CE-side primitives (the bus, the BullMQ migration, the p-limit hot-swap, the SSRF allowlist bus) are implemented in CE so the same scale-safety applies to community deployments that choose to run multi-replica. EE does not carry a parallel implementation; it only consumes the primitives.
 
-**Already shipped (verified at CE submodule `9c39311`, EE `2b3aeea`):**
+**Already shipped (per-row Issue/PR citations in the right column are the canonical reference; do not re-cite branch-tip hashes here, they rot every merge):**
 
 | Component | Where | Issue |
 |---|---|---|


### PR DESCRIPTION
## Summary

Two doc-only fixes for findings the gh-pr-reviewer flagged on the EE#113 epic that landed with the merges. **No behavior change** — both are correctness improvements to misleading documentation.

## Findings vs reality

The reviewer flagged four issues on PR #612. Three are already fixed in subsequent commits or were never present in the merged version (duplicate ADR registry rows, dead `__resetProviderCacheBusForTests` export, missing rate-limit on PR#613's rotate endpoint). This PR addresses the two that survived.

### 1. Wrong commit hashes in `ARCHITECTURE-DECISIONS.md`

`docs/ARCHITECTURE-DECISIONS.md:1197` claimed the ADR-024 components were "verified at CE submodule `9c39311`, EE `2b3aeea`". Neither hash holds up: `9c39311` does not exist in CE; `2b3aeea` is unrelated `feat(#143): real JWKS-backed Teams Bot Framework JWT verifier` work in EE. Replaced the broken preamble with a note pointing at the per-row Issue/PR citations in the right column — those are immutable and already canonical.

### 2. Cache-bus module overpromises synchronous semantics

`backend/src/domains/llm/services/cache-bus.ts` note (3) claimed `version` is "incremented locally on every direct `bumpProviderCacheVersion()` call AND inside the cluster-bus subscribe handler". In cluster mode this is wrong: the direct call only publishes; the `version++` happens via the round-tripped subscribe handler. There's a window between `await publish()` resolving and the pub/sub callback firing during which the publishing pod's `getProviderCacheVersion()` still returns the OLD value.

Resolver consumers are unaffected because they re-check on the next call. But any future synchronous read-after-write caller would silently observe a stale version. Tightened both the module note and the `bumpProviderCacheVersion` docstring to spell this out and call out the requirement for explicit coordination if a caller needs synchronous semantics.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] `cache-bus` test suite: 9/9 pass.
- [x] No code paths changed; only doc comments and one markdown table preamble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)