### PR TITLE
chore(release): bump mcp-docs to 0.5.0 (caught omission from #618)

### DIFF
--- a/mcp-docs/package.json
+++ b/mcp-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq-mcp-docs",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

PR #618 bumped 4 of 5 \`package.json\`s to \`0.5.0\` (root, backend, frontend, packages/contracts) but missed \`mcp-docs/package.json\` — still at \`0.4.0\`. This one-line bump completes the version-lockstep for the v0.5.0 cycle.

## What changed

- \`mcp-docs/package.json\` — \`"version": "0.4.0"\` → \`"0.5.0"\`

## Test plan

- [x] All 5 package.jsons now report \`0.5.0\` consistently
- [ ] CI passes

## Sequencing

After this lands, PR #617 (\`dev → main\`) carries the full v0.5.0 release. Tag \`v0.5.0\` lands on CE \`main\` after #617 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)