### PR TITLE
release: v0.5.0 follow-up — mcp-docs version lockstep

### DIFF
--- a/mcp-docs/package.json
+++ b/mcp-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq-mcp-docs",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

One-commit follow-up to PR #617 (the v0.5.0 release that landed earlier). PR #619 caught that PR #618's bump missed \`mcp-docs/package.json\`; this dev → main PR carries that single fix to main so the v0.5.0 tag lands on a state with all 5 package.jsons consistent.

## What changed

- \`mcp-docs/package.json\`: \`"version": "0.4.0"\` → \`"0.5.0"\` (per PR #619 / commit \`53bdb08\`)

## Pre-tag state

- main HEAD before this PR: \`0a80f3a\` (PR #617 merge commit) — 4 of 5 package.jsons at 0.5.0
- After this PR: all 5 at 0.5.0
- \`v0.5.0\` tag will be cut on the merge commit of this PR

## Test plan

- [x] PR #619 was reviewed + merged on dev (gh-pr-reviewer APPROVE'd)
- [x] CHANGELOG `[0.5.0]` already on main from PR #617
- [ ] CI green on this PR
- [ ] Tag `v0.5.0` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)