### PR TITLE
ci(docker): tag :latest on main pushes (not on default branch)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,7 +38,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Set up QEMU
@@ -88,7 +88,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Set up QEMU
@@ -138,7 +138,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Set up QEMU
@@ -186,7 +186,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Set up QEMU


### PR DESCRIPTION
## Summary

Pin the `:latest` floating GHCR tag to `refs/heads/main` instead of the docker/metadata-action `is_default_branch` keyword. The repo's default branch is `dev`, not `main`, so the keyword was producing two unintended effects:

1. **`:latest` was tracking `dev`, not `main`.** Opposite of the documented intent — `:latest` should follow the latest stable release; `:dev` is the nightly. The resulting `:latest` image was always one step ahead of any actual release tag.
2. **`main` pushes failed all four Backend / Frontend / SearXNG / MCP-Docs Image jobs** with `ERROR: failed to build: tag is needed when pushing to registry`. `is_default_branch` resolved to false on main, none of the other rules fire on a plain branch push, so the metadata step produced an empty tag list and the build-push step refused. Has been failing on every `dev → main` release merge since `dev` became the default branch — surfaced loudly during the v0.4.0 consolidation work earlier today (PR #623).

After this change:
| Trigger | Tags applied |
|---|---|
| Push to `main` | `:latest` |
| Push to `dev` | `:dev` |
| Push of `v*` tag | `:{{version}}`, `:{{major}}.{{minor}}` |

## Companion PR

[Compendiq/compendiq-ee#171](https://github.com/Compendiq/compendiq-ee/pull/171) — same metadata-action fix on the EE workflow, plus adds `main` to the trigger branches (EE previously only built on `dev` + tag pushes, so `:latest` only refreshed at tag time).

## Test plan

- [x] Local diff inspected: only the `value=latest` line's `enable=` clause changed; all four job blocks updated identically (`replace_all` Edit).
- [ ] CI green (Tests, Typecheck & Lint, Analyze, MCP Docs Sidecar, semgrep).
- [ ] After dev → main release: confirm `ghcr.io/compendiq/compendiq-ce-backend:latest` digest matches main HEAD's build, and that `:dev` digest matches dev HEAD's build, with no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)