### PR TITLE
release: dev → main (Docker :latest pinned to main)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,7 +38,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Set up QEMU
@@ -88,7 +88,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Set up QEMU
@@ -138,7 +138,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Set up QEMU
@@ -186,7 +186,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Set up QEMU


### PR DESCRIPTION
## Summary

Brings `main` in line with `dev` — picks up the docker-build.yml fix (#625) so future `:latest` tag publishes target main, and so future `dev → main` release merges no longer fail the four Docker Image jobs.

Pairs with [Compendiq/compendiq-ee#172](https://github.com/Compendiq/compendiq-ee/pull/172) (EE companion).

## Commits

- #625 — `ci(docker): tag :latest on main pushes (not on default branch)`

## Test plan

- [x] CI green on `dev` (CE #625 merged with all required checks SUCCESS)
- [ ] **First validation of the fix** happens on the merge of THIS PR — the docker-build workflow runs on the resulting main push and should produce the `:latest` tag this time instead of failing with "tag is needed". Watch the `Backend Image` / `Frontend Image` / `SearXNG Image` / `MCP Docs Image` runs.
- [ ] After merge, open `main → dev` back-merge to clear the GitHub banner per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)