### PR TITLE
docs: refresh Docker tag guidance + nav release link post-v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="#architecture">Architecture</a> &middot;
   <a href="docs/USER-GUIDE.md">Docs</a> &middot;
   <a href="docs/integrations/README.md">Integration guides</a> &middot;
-  <a href="docs/releases/v0.3.0.md">v0.3 release notes</a> &middot;
+  <a href="https://github.com/Compendiq/compendiq-ce/releases">Releases</a> &middot;
   <a href="docs/ROADMAP.md">Roadmap</a> &middot;
   <a href="docs/STEWARDSHIP.md">Stewardship</a> &middot;
   <a href="https://github.com/Compendiq/compendiq-ce/discussions">Community</a> &middot;

--- a/docs/architecture/02-container.md
+++ b/docs/architecture/02-container.md
@@ -66,6 +66,8 @@ flowchart TB
 | mcp-docs  | MCP server (Node) | 3100 | `ghcr.io/compendiq/compendiq-ce-mcp-docs` |
 | searxng   | Python meta search | 8080 | `ghcr.io/compendiq/compendiq-ce-searxng` |
 
+Each Compendiq image carries three tag classes published by the GitHub Actions Docker workflow: `:latest` (refreshed on every push to `main` — recommended default for production), `:0.4.0` and `:0.4` (refreshed on every `v*` release tag — pin these for exact-version reproducibility), and `:dev` (refreshed on every push to `dev` — useful for staging / smoke environments). The shared `compendiq-ce-frontend` image is consumed by both Community and Enterprise editions; there is no separate `compendiq-ee-frontend` image.
+
 ## Background workers
 
 Workers run **inside the backend process** — there is no separate worker

--- a/docs/architecture/05-deployment.md
+++ b/docs/architecture/05-deployment.md
@@ -180,7 +180,10 @@ flowchart LR
 # docker/docker-compose.ee.yml — excerpt
 services:
   backend:
-    image: ghcr.io/compendiq/compendiq-ee-backend:dev
+    # `:latest` tracks the latest stable release on `main`; pin to a
+    # versioned tag like `:0.4.0` for reproducible production deploys,
+    # or `:dev` for staging environments that want dev-branch nightlies.
+    image: ghcr.io/compendiq/compendiq-ee-backend:latest
     stop_grace_period: 60s   # SIGTERM → drain → SIGKILL
     environment:
       # Trusted-proxy CIDRs are NOT an env var — set them via


### PR DESCRIPTION
## Summary

Three small documentation refreshes after this morning's v0.5.0-tag retirement and `:latest`-tag fix:

1. **README nav** — replace `<a href="docs/releases/v0.3.0.md">v0.3 release notes</a>` with `<a href="https://github.com/Compendiq/compendiq-ce/releases">Releases</a>` so the link is durable across future tags. The v0.3.0 release-notes file isn't being deleted; it just isn't the default header link anymore.
2. **`docs/architecture/02-container.md`** — append a paragraph explaining the three tag classes (`:latest`, `:0.4.0`/`:0.4`, `:dev`) below the per-container image table, so a reader picking which tag to pin has a meaningful story rather than just an untagged image name.
3. **`docs/architecture/05-deployment.md`** — 2-replica EE compose example now uses `:latest` instead of `:dev` (with an inline comment about the alternatives). `:dev` was the wrong default for a documented *production* deployment example.

Pairs with [Compendiq/compendiq-ee#174](https://github.com/Compendiq/compendiq-ee/pull/174) (EE README — Registry Tags + Version Compatibility tables refreshed).

## Test plan

- [x] Local diff inspected: 3 files, +7/−2 lines, all documentation.
- [ ] CI green (no code paths touched, expect Tests/Typecheck/etc. to pass clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)