### PR TITLE
release: dev → main (docs refresh post-v0.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="#architecture">Architecture</a> &middot;
   <a href="docs/USER-GUIDE.md">Docs</a> &middot;
   <a href="docs/integrations/README.md">Integration guides</a> &middot;
-  <a href="docs/releases/v0.3.0.md">v0.3 release notes</a> &middot;
+  <a href="https://github.com/Compendiq/compendiq-ce/releases">Releases</a> &middot;
   <a href="docs/ROADMAP.md">Roadmap</a> &middot;
   <a href="docs/STEWARDSHIP.md">Stewardship</a> &middot;
   <a href="https://github.com/Compendiq/compendiq-ce/discussions">Community</a> &middot;

--- a/docs/architecture/02-container.md
+++ b/docs/architecture/02-container.md
@@ -66,6 +66,8 @@ flowchart TB
 | mcp-docs  | MCP server (Node) | 3100 | `ghcr.io/compendiq/compendiq-ce-mcp-docs` |
 | searxng   | Python meta search | 8080 | `ghcr.io/compendiq/compendiq-ce-searxng` |
 
+Each Compendiq image carries three tag classes published by the GitHub Actions Docker workflow: `:latest` (refreshed on every push to `main` — recommended default for production), `:0.4.0` and `:0.4` (refreshed on every `v*` release tag — pin these for exact-version reproducibility), and `:dev` (refreshed on every push to `dev` — useful for staging / smoke environments). The shared `compendiq-ce-frontend` image is consumed by both Community and Enterprise editions; there is no separate `compendiq-ee-frontend` image.
+
 ## Background workers
 
 Workers run **inside the backend process** — there is no separate worker

--- a/docs/architecture/05-deployment.md
+++ b/docs/architecture/05-deployment.md
@@ -180,7 +180,10 @@ flowchart LR
 # docker/docker-compose.ee.yml — excerpt
 services:
   backend:
-    image: ghcr.io/compendiq/compendiq-ee-backend:dev
+    # `:latest` tracks the latest stable release on `main`; pin to a
+    # versioned tag like `:0.4.0` for reproducible production deploys,
+    # or `:dev` for staging environments that want dev-branch nightlies.
+    image: ghcr.io/compendiq/compendiq-ee-backend:latest
     stop_grace_period: 60s   # SIGTERM → drain → SIGKILL
     environment:
       # Trusted-proxy CIDRs are NOT an env var — set them via


### PR DESCRIPTION
Brings docs refresh from #628 onto main. Pairs with Compendiq/compendiq-ee#176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)