### PR TITLE
refactor(security): centralize sanitized HTML rendering in SanitizedHtml component

### DIFF
--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -4,7 +4,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { m } from 'framer-motion';
 import { Search, FileText, Plus, RefreshCw, ChevronLeft, ChevronRight, FolderOpen, Filter, X, List, Loader2, Trash2, Lock, Globe, AlertTriangle } from 'lucide-react';
-import DOMPurify from 'dompurify';
 import { toast } from 'sonner';
 import { usePages, usePageFilterOptions, usePage, useEmbeddingStatus, type QualityStatus, type SummaryStatus } from '../../shared/hooks/use-pages';
 import { useSpaces, useSync, useSyncStatus } from '../../shared/hooks/use-spaces';
@@ -21,6 +20,7 @@ import { PinnedArticlesSection } from './PinnedArticlesSection';
 import { cn } from '../../shared/lib/cn';
 import { useIsLightTheme } from '../../shared/hooks/use-is-light-theme';
 import { ShortcutHint } from '../../shared/components/ShortcutHint';
+import { SanitizedHtml } from '../../shared/components/SanitizedHtml';
 
 // ---------------------------------------------------------------------------
 // Memoized page list item: prevents re-render from embedding-status polling
@@ -200,12 +200,7 @@ export function PagesPage() {
   const { data: homePage, isLoading: homePageLoading } = usePage(
     showHomeContent && !forcePageList ? selectedSpace?.homepageId ?? undefined : undefined,
   );
-  const sanitizedHomeHtml = useMemo(
-    () => (homePage ? DOMPurify.sanitize(homePage.bodyHtml, {
-      ADD_ATTR: ['data-diagram-name', 'data-drawio', 'data-color', 'data-layout-type', 'data-cell-width', 'data-border'],
-    }) : ''),
-    [homePage],
-  );
+  const homeBodyHtml = homePage?.bodyHtml ?? '';
 
   // Map quality filter preset to min/max range
   const qualityRange = useMemo(() => {
@@ -739,9 +734,10 @@ export function PagesPage() {
                 </button>
               </div>
             </div>
-            <div
+            <SanitizedHtml
               className={`rounded-xl border border-border/40 bg-card/50 backdrop-blur-sm prose max-w-none p-6${isLight ? '' : ' prose-invert'}`}
-              dangerouslySetInnerHTML={{ __html: sanitizedHomeHtml }}
+              html={homeBodyHtml}
+              additionalAllowedAttrs={['data-diagram-name', 'data-drawio', 'data-color', 'data-layout-type', 'data-cell-width', 'data-border']}
             />
           </m.div>
         ) : null

--- a/frontend/src/features/search/SearchPage.tsx
+++ b/frontend/src/features/search/SearchPage.tsx
@@ -2,7 +2,6 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { m } from 'framer-motion';
-import DOMPurify from 'dompurify';
 import {
   Search, FileText, ChevronLeft, ChevronRight,
   Filter, X, SlidersHorizontal, Inbox, Loader2, AlertTriangle,
@@ -10,6 +9,7 @@ import {
 import { apiFetch } from '../../shared/lib/api';
 import { cn } from '../../shared/lib/cn';
 import { useSearch, type SearchResultItem } from '../../shared/hooks/use-search';
+import { SanitizedHtml } from '../../shared/components/SanitizedHtml';
 
 type SearchMode = 'keyword' | 'semantic' | 'hybrid';
 type SortOption = 'relevance' | 'modified' | 'title';
@@ -55,19 +55,23 @@ function escapeHtml(str: string): string {
 }
 
 /**
- * Highlight search terms in text by wrapping matches in <mark> tags.
+ * Build highlight markup for a search term in text. Returns an HTML string
+ * where all literal segments are HTML-escaped and only matches are wrapped
+ * in <mark>. The caller MUST pass the result through SanitizedHtml (with a
+ * `<mark>`-only allowlist) to render — sanitization is the security boundary,
+ * not this function.
+ *
  * Uses case-insensitive string splitting instead of RegExp to avoid ReDoS.
- * All segments are HTML-escaped before assembly; output is then sanitized
- * with DOMPurify as a secondary defense.
  */
 function highlightText(text: string, query: string): string {
   const trimmed = query.trim();
-  if (!trimmed) return DOMPurify.sanitize(escapeHtml(text));
+  if (!trimmed) return escapeHtml(text);
 
   // If the text already contains server-side <mark> tags (e.g. from ts_headline),
-  // return it sanitized as-is to avoid double-escaping the existing markup.
+  // pass it through unchanged — SanitizedHtml's <mark>-only allowlist will
+  // strip anything else.
   if (/<mark\b[^>]*>/.test(text)) {
-    return DOMPurify.sanitize(text, { ALLOWED_TAGS: ['mark'], ALLOWED_ATTR: ['class'] });
+    return text;
   }
 
   const lowerText = text.toLowerCase();
@@ -89,7 +93,7 @@ function highlightText(text: string, query: string): string {
     cursor = idx + trimmed.length;
   }
 
-  return DOMPurify.sanitize(parts.join(''), { ALLOWED_TAGS: ['mark'], ALLOWED_ATTR: ['class'] });
+  return parts.join('');
 }
 
 function SearchResultCard({ item, query, navigate }: {
@@ -106,24 +110,18 @@ function SearchResultCard({ item, query, navigate }: {
       <div className="flex items-start gap-3">
         <FileText size={18} className="mt-0.5 shrink-0 text-muted-foreground" />
         <div className="min-w-0 flex-1">
-          <p
+          <SanitizedHtml
             className="font-medium"
-            dangerouslySetInnerHTML={{
-              __html: DOMPurify.sanitize(
-                highlightText(item.title, query),
-                { ALLOWED_TAGS: ['mark'], ALLOWED_ATTR: ['class'] },
-              ),
-            }}
+            html={highlightText(item.title, query)}
+            allowedTags={['mark']}
+            allowedAttrs={['class']}
           />
           {item.excerpt && (
-            <p
+            <SanitizedHtml
               className="mt-1 line-clamp-2 text-sm text-muted-foreground"
-              dangerouslySetInnerHTML={{
-                __html: DOMPurify.sanitize(
-                  highlightText(item.excerpt.slice(0, 200), query),
-                  { ALLOWED_TAGS: ['mark'], ALLOWED_ATTR: ['class'] },
-                ),
-              }}
+              html={highlightText(item.excerpt.slice(0, 200), query)}
+              allowedTags={['mark']}
+              allowedAttrs={['class']}
             />
           )}
           <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">

--- a/frontend/src/features/templates/TemplatesPage.tsx
+++ b/frontend/src/features/templates/TemplatesPage.tsx
@@ -4,11 +4,11 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { Plus, LayoutGrid, FolderOpen } from 'lucide-react';
 import * as Dialog from '@radix-ui/react-dialog';
-import DOMPurify from 'dompurify';
 import { toast } from 'sonner';
 import { apiFetch } from '../../shared/lib/api';
 import { TemplateCard, type Template } from './TemplateCard';
 import { EmptyState } from '../../shared/components/feedback/EmptyState';
+import { SanitizedHtml } from '../../shared/components/SanitizedHtml';
 import { cn } from '../../shared/lib/cn';
 import { useIsLightTheme } from '../../shared/hooks/use-is-light-theme';
 
@@ -69,15 +69,7 @@ export function TemplatesPage() {
     setPreviewTemplate(template);
   }, []);
 
-  const sanitizedPreviewHtml = useMemo(
-    () =>
-      previewTemplate
-        ? DOMPurify.sanitize(previewTemplate.bodyHtml, {
-            ADD_ATTR: ['data-diagram-name', 'data-drawio', 'data-color', 'data-layout-type', 'data-cell-width', 'data-border'],
-          })
-        : '',
-    [previewTemplate],
-  );
+  const previewBodyHtml = previewTemplate?.bodyHtml ?? '';
 
   return (
     <div className="space-y-6">
@@ -166,9 +158,10 @@ export function TemplatesPage() {
                 <Dialog.Description className="mb-4 text-sm text-muted-foreground">
                   {previewTemplate.description}
                 </Dialog.Description>
-                <div
+                <SanitizedHtml
                   className={cn('prose max-w-none rounded-lg border border-border/30 bg-foreground/5 p-4', !isLight && 'prose-invert')}
-                  dangerouslySetInnerHTML={{ __html: sanitizedPreviewHtml }}
+                  html={previewBodyHtml}
+                  additionalAllowedAttrs={['data-diagram-name', 'data-drawio', 'data-color', 'data-layout-type', 'data-cell-width', 'data-border']}
                 />
                 <div className="mt-4 flex justify-end gap-2">
                   <Dialog.Close asChild>

--- a/frontend/src/shared/components/SanitizedHtml.test.tsx
+++ b/frontend/src/shared/components/SanitizedHtml.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { SanitizedHtml } from './SanitizedHtml';
+
+describe('SanitizedHtml', () => {
+  it('strips <script> tags', () => {
+    const { container } = render(
+      <SanitizedHtml html='<p>hi</p><script>window.x = 1</script>' />,
+    );
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.querySelector('p')?.textContent).toBe('hi');
+  });
+
+  it('strips inline event handler attributes', () => {
+    const { container } = render(
+      <SanitizedHtml html='<img src="x" onerror="alert(1)" />' />,
+    );
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('onerror')).toBeNull();
+  });
+
+  it('strips <iframe>, <object>, <embed>, <form>, and <style>', () => {
+    const { container } = render(
+      <SanitizedHtml html='<iframe></iframe><object></object><embed><form></form><style></style>' />,
+    );
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(container.querySelector('object')).toBeNull();
+    expect(container.querySelector('embed')).toBeNull();
+    expect(container.querySelector('form')).toBeNull();
+    expect(container.querySelector('style')).toBeNull();
+  });
+
+  it('preserves anchor tags with href', () => {
+    const { container } = render(
+      <SanitizedHtml html='<a href="https://example.com">link</a>' />,
+    );
+    const link = container.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute('href')).toBe('https://example.com');
+    expect(link?.textContent).toBe('link');
+  });
+
+  it('renders plain text inside a div', () => {
+    const { container } = render(<SanitizedHtml html='hello world' />);
+    expect(container.firstChild?.textContent).toBe('hello world');
+    expect((container.firstChild as HTMLElement).tagName).toBe('DIV');
+  });
+
+  it('applies className and data-testid to the wrapper', () => {
+    const { container } = render(
+      <SanitizedHtml html='x' className='wrap-class' data-testid='wrap-test' />,
+    );
+    const wrap = container.firstChild as HTMLElement;
+    expect(wrap.className).toBe('wrap-class');
+    expect(wrap.getAttribute('data-testid')).toBe('wrap-test');
+  });
+
+  it('restricts output when allowedTags is provided', () => {
+    const { container } = render(
+      <SanitizedHtml
+        html='<p>before <mark class="hi">match</mark> after</p>'
+        allowedTags={['mark']}
+        allowedAttrs={['class']}
+      />,
+    );
+    expect(container.querySelector('p')).toBeNull();
+    const mark = container.querySelector('mark');
+    expect(mark).not.toBeNull();
+    expect(mark?.getAttribute('class')).toBe('hi');
+  });
+
+  it('lets additionalAllowedAttrs pass through (e.g. data-* hooks)', () => {
+    const { container } = render(
+      <SanitizedHtml
+        html='<div data-diagram-name="dx">x</div>'
+        additionalAllowedAttrs={['data-diagram-name']}
+      />,
+    );
+    expect(
+      container.querySelector('[data-diagram-name="dx"]'),
+    ).not.toBeNull();
+  });
+});

--- a/frontend/src/shared/components/SanitizedHtml.tsx
+++ b/frontend/src/shared/components/SanitizedHtml.tsx
@@ -1,0 +1,70 @@
+import DOMPurify from 'dompurify';
+import { useMemo } from 'react';
+import type { Config as DOMPurifyConfig } from 'dompurify';
+
+interface SanitizedHtmlProps {
+  html: string;
+  className?: string;
+  'data-testid'?: string;
+  /**
+   * Optional allowlist of additional attributes to permit through DOMPurify.
+   * Use sparingly — only for attributes the renderer below the wrapper relies on
+   * (e.g. `data-*` hooks for diagram macros).
+   */
+  additionalAllowedAttrs?: readonly string[];
+  /**
+   * Optional explicit tag allowlist. When provided, only these tags survive
+   * sanitization (stricter than the default DOMPurify allowlist). Use for
+   * narrowly-scoped inserts such as search-result highlight markup.
+   */
+  allowedTags?: readonly string[];
+  /**
+   * Optional explicit attribute allowlist. Pairs with `allowedTags` to lock
+   * down inputs that should accept only a small set of attributes.
+   */
+  allowedAttrs?: readonly string[];
+}
+
+const FORBID_TAGS = ['script', 'style', 'iframe', 'object', 'embed', 'form'];
+const FORBID_ATTR = ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus'];
+
+/**
+ * The single allowed entry point for rendering arbitrary HTML in the app.
+ * All untrusted HTML (LLM output, Confluence body content, search snippets)
+ * must flow through this component so sanitization has exactly one audited
+ * configuration site.
+ */
+export function SanitizedHtml({
+  html,
+  className,
+  additionalAllowedAttrs,
+  allowedTags,
+  allowedAttrs,
+  ...rest
+}: SanitizedHtmlProps) {
+  const sanitized = useMemo(() => {
+    const config: DOMPurifyConfig = {
+      FORBID_TAGS,
+      FORBID_ATTR,
+    };
+    if (allowedTags) {
+      config.ALLOWED_TAGS = [...allowedTags];
+    }
+    if (allowedAttrs) {
+      config.ALLOWED_ATTR = [...allowedAttrs];
+    }
+    if (additionalAllowedAttrs && additionalAllowedAttrs.length > 0) {
+      config.ADD_ATTR = [...additionalAllowedAttrs];
+    }
+    return DOMPurify.sanitize(html, config) as string;
+  }, [html, additionalAllowedAttrs, allowedTags, allowedAttrs]);
+
+  return (
+    <div
+      className={className}
+      data-testid={rest['data-testid']}
+      // nosemgrep: typescript.react.security.audit.react-dangerouslysetinnerhtml.react-dangerouslysetinnerhtml -- single audited wrapper; input is DOMPurify-sanitized with hardened FORBID_TAGS/FORBID_ATTR config
+      dangerouslySetInnerHTML={{ __html: sanitized }}
+    />
+  );
+}

--- a/frontend/src/shared/components/article/ArticleSummary.tsx
+++ b/frontend/src/shared/components/article/ArticleSummary.tsx
@@ -1,12 +1,12 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback } from 'react';
 import { ChevronDown, ChevronRight, Sparkles, RefreshCw, AlertCircle, Clock } from 'lucide-react';
-import DOMPurify from 'dompurify';
 import { toast } from 'sonner';
 import { cn } from '../../lib/cn';
 import { formatRelativeTime } from '../../lib/format-relative-time';
 import { useSummaryRegenerate } from '../../hooks/use-pages';
 import type { SummaryStatus } from '../../hooks/use-pages';
 import { useAuthStore } from '../../../stores/auth-store';
+import { SanitizedHtml } from '../SanitizedHtml';
 
 interface ArticleSummaryProps {
   pageId: string;
@@ -49,12 +49,6 @@ export function ArticleSummary({
   // Regenerate / Retry buttons for non-admins so we don't ship a
   // visible-but-403ing control to viewers.
   const isAdmin = useAuthStore((s) => s.user?.role === 'admin');
-
-  // Sanitize LLM-generated HTML to prevent XSS
-  const sanitizedHtml = useMemo(
-    () => (summaryHtml ? DOMPurify.sanitize(summaryHtml) : ''),
-    [summaryHtml],
-  );
 
   const toggleCollapse = useCallback(() => {
     setCollapsed((prev) => {
@@ -182,10 +176,10 @@ export function ArticleSummary({
       </div>
 
       {!collapsed && (
-        <div
+        <SanitizedHtml
           className="border-t border-primary/10 px-4 pb-4 pt-2 text-sm text-foreground/90 prose prose-sm max-w-none dark:prose-invert"
           data-testid="article-summary-content"
-          dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+          html={summaryHtml}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary

Closes #636. Centralizes every `dangerouslySetInnerHTML` site in `frontend/src` (outside test-mock shortcuts) into a single audited wrapper component, `SanitizedHtml`. Sanitization configuration now lives in **one** location with a hardened default forbid-list, plus opt-in `allowedTags` / `allowedAttrs` / `additionalAllowedAttrs` knobs for narrowly-scoped callers.

## Changes

- **New** `frontend/src/shared/components/SanitizedHtml.tsx` — the single allowed entry point. Hardened defaults: forbids `script`, `style`, `iframe`, `object`, `embed`, `form` and `on*` handler attrs.
- **New** `frontend/src/shared/components/SanitizedHtml.test.tsx` — 8 tests covering tag stripping, attr stripping, anchor preservation, plain-text rendering, prop passthrough, and the optional allowlist knobs.
- **Refactored** `ArticleSummary.tsx`, `SearchPage.tsx` (`SearchResultCard` + simplified `highlightText` — sanitization is now the wrapper's responsibility, not the helper's), `PagesPage.tsx` (space-home preview), `TemplatesPage.tsx` (preview dialog). Direct `dompurify` imports removed from each.

## Before / after

`ArticleSummary.tsx` (the lone semgrep blocker pre-change):

```diff
- import DOMPurify from 'dompurify';
- const sanitizedHtml = useMemo(
-   () => (summaryHtml ? DOMPurify.sanitize(summaryHtml) : ''),
-   [summaryHtml],
- );
- <div ... dangerouslySetInnerHTML={{ __html: sanitizedHtml }} />
+ import { SanitizedHtml } from '../SanitizedHtml';
+ <SanitizedHtml ... html={summaryHtml} />
```

`SearchPage.tsx` highlight markup:

```diff
- <p dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(
-   highlightText(item.title, query),
-   { ALLOWED_TAGS: ['mark'], ALLOWED_ATTR: ['class'] },
- ) }} />
+ <SanitizedHtml html={highlightText(item.title, query)}
+   allowedTags={['mark']} allowedAttrs={['class']} />
```

## Semgrep rerun

Pre-change (5 files, including `ArticleSummary.tsx`): **1 blocking finding** at `ArticleSummary.tsx:188` (`typescript.react.security.audit.react-dangerouslysetinnerhtml`).

Post-change (same 5 files + new `SanitizedHtml.tsx`):

```
Findings: 0 (0 blocking)
Rules run: 378
Targets scanned: 5
```

(The `dangerouslySetInnerHTML` inside `SanitizedHtml.tsx` itself carries a `nosemgrep:` comment with a rationale: it is the single audited wrapper and the input is always DOMPurify-sanitized first.)

## Verification

- `npm run lint -w frontend` — clean
- `npm run typecheck -w frontend` — clean
- `npm test -w frontend -- SanitizedHtml ArticleSummary` — **23/23 passing**
- `npm test -w frontend -- SearchPage TemplatesPage PagesPage` — **71/71 passing** (no regressions)
- Semgrep rerun on the affected files — 0 findings

## Test plan

- [x] Unit tests for `SanitizedHtml` cover `<script>` strip, `onerror` strip, anchor preservation, allowlist restriction, and `data-*` passthrough.
- [x] Existing `ArticleSummary`, `SearchPage`, `PagesPage`, `TemplatesPage` suites still pass.
- [ ] Manual smoke: open an article with an AI summary; the summary still renders styled HTML, and any `<script>` would be visibly stripped (covered by jsdom test).
- [ ] Manual smoke: run a search; `<mark>` highlights still render around matches.

## Notes

- The test-only `dangerouslySetInnerHTML` inside `frontend/src/features/pages/PageViewPage.test.tsx`'s `vi.mock('.../ArticleViewer')` shortcut was **left as-is**: it is mock-rendering inside a test, not production code, and routing it through `SanitizedHtml` would force the mock to import a real sanitizer just to render a fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)