### PR TITLE
refactor(security): centralize unsafe TLS bypass into single audited helper

### DIFF
--- a/backend/src/core/utils/llm-config.ts
+++ b/backend/src/core/utils/llm-config.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { Agent, fetch as undiciFetch, type Dispatcher } from 'undici';
 import { logger } from './logger.js';
+import { unsafeDisableTlsVerification } from './unsafe-tls.js';
 
 /**
  * Shared LLM/Ollama connection configuration.
@@ -100,7 +101,7 @@ export interface LlmConnectOptions {
  */
 export function buildLlmConnectOptions(): LlmConnectOptions | undefined {
   if (!verifySsl) {
-    return { rejectUnauthorized: false };
+    return unsafeDisableTlsVerification();
   }
   if (caBundleContents) {
     return { ca: caBundleContents };

--- a/backend/src/core/utils/tls-config.ts
+++ b/backend/src/core/utils/tls-config.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { Agent, Dispatcher, interceptors } from 'undici';
 import { logger } from './logger.js';
+import { unsafeDisableTlsVerification } from './unsafe-tls.js';
 
 /**
  * Load custom CA certificates for undici (which doesn't respect NODE_EXTRA_CA_CERTS).
@@ -63,7 +64,7 @@ if (!verifySsl) {
  */
 export function buildConnectOptions(): Record<string, unknown> | undefined {
   if (!verifySsl) {
-    return { rejectUnauthorized: false };
+    return unsafeDisableTlsVerification();
   }
   if (caBundleContents) {
     return { ca: caBundleContents };

--- a/backend/src/core/utils/unsafe-tls.test.ts
+++ b/backend/src/core/utils/unsafe-tls.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { unsafeDisableTlsVerification } from './unsafe-tls.js';
+
+describe('unsafeDisableTlsVerification', () => {
+  it('returns { rejectUnauthorized: false }', () => {
+    expect(unsafeDisableTlsVerification()).toEqual({ rejectUnauthorized: false });
+  });
+
+  it('returns a fresh object on each call (no shared mutable state)', () => {
+    const a = unsafeDisableTlsVerification();
+    const b = unsafeDisableTlsVerification();
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+});

--- a/backend/src/core/utils/unsafe-tls.ts
+++ b/backend/src/core/utils/unsafe-tls.ts
@@ -1,0 +1,23 @@
+/**
+ * Returns TLS connect options that disable certificate verification.
+ *
+ * INTENTIONALLY UNSAFE. This is the single, audited helper used by the
+ * documented TLS escape hatches:
+ *   - `LLM_VERIFY_SSL=false`        (consumed by `llm-config.ts`)
+ *   - `CONFLUENCE_VERIFY_SSL=false` (consumed by `tls-config.ts`)
+ *
+ * Both flags default to verification-on; an operator must explicitly opt
+ * in to the bypass. Each call site also logs a runtime warning and is
+ * documented in `CLAUDE.md` / `.env.example`. Prefer `NODE_EXTRA_CA_CERTS`
+ * (or the OS CA bundle, which both modules auto-detect) over disabling
+ * verification.
+ *
+ * Centralising the unsafe object literal here means semgrep needs to
+ * suppress exactly one line in the codebase — every other module gets to
+ * stay clean — and any future audit of "where do we drop TLS verification?"
+ * is a single grep for callers of this function.
+ */
+export function unsafeDisableTlsVerification(): { rejectUnauthorized: false } {
+  // nosemgrep: problem-based-packs.insecure-transport.js-node.bypass-tls-verification.bypass-tls-verification -- single, audited usage; gating happens at callsite via env var, runtime warning logged, NODE_EXTRA_CA_CERTS preferred
+  return { rejectUnauthorized: false };
+}


### PR DESCRIPTION
## Summary

Closes #634.

Both `tls-config.ts` and `llm-config.ts` previously inlined `return { rejectUnauthorized: false };` when their respective `*_VERIFY_SSL=false` escape hatches were active, which tripped semgrep `problem-based-packs.insecure-transport.js-node.bypass-tls-verification` at two call sites.

The bypass itself is intentional (documented in `CLAUDE.md` / `.env.example` for on-prem Confluence DC + self-hosted LLM proxies with self-signed corporate CAs), gated behind env vars that default to verification-on, and accompanied by a runtime warning when disabled. Rather than annotate every call site with `nosemgrep`, this PR extracts a single helper `unsafeDisableTlsVerification()` in `backend/src/core/utils/unsafe-tls.ts`. The helper holds the **only** `nosemgrep` suppression in the codebase for this rule and a doc comment explaining the gating + the operator opt-in story; both modules now call it.

This makes any future audit of "where do we drop TLS verification?" a single grep for callers of one function.

### Before / After

`backend/src/core/utils/tls-config.ts` (and equivalent in `llm-config.ts`):

```diff
 export function buildConnectOptions(): Record<string, unknown> | undefined {
   if (!verifySsl) {
-    return { rejectUnauthorized: false };
+    return unsafeDisableTlsVerification();
   }
   if (caBundleContents) {
     return { ca: caBundleContents };
   }
   return undefined;
 }
```

New helper (single source of truth, single suppression):

```ts
export function unsafeDisableTlsVerification(): { rejectUnauthorized: false } {
  // nosemgrep: problem-based-packs.insecure-transport.js-node.bypass-tls-verification.bypass-tls-verification -- single, audited usage; gating happens at callsite via env var, runtime warning logged, NODE_EXTRA_CA_CERTS preferred
  return { rejectUnauthorized: false };
}
```

### Behaviour

No change. Same env-var checks, same warnings, same return shape. Existing `tls-config.test.ts` and `llm-config.test.ts` assertions about the `{ rejectUnauthorized: false }` shape still pass unchanged.

### Verification

- `npm run lint -w backend` — clean
- `npm run typecheck -w backend` — clean
- `npx vitest run src/core/utils/unsafe-tls.test.ts src/core/utils/tls-config.test.ts src/core/utils/llm-config.test.ts` — **30/30 pass**
- `semgrep scan --config=p/security-audit --config=p/owasp-top-ten backend/src/core/utils/{tls-config,llm-config,unsafe-tls,unsafe-tls.test}.ts` — **0 findings**
- `semgrep scan --config=auto …` — **0 findings** (full rule set, which would have included the `problem-based-packs` rule that originally fired)

## Test plan

- [x] Unit tests for the new helper (`unsafe-tls.test.ts`) — return shape + fresh-object guarantee
- [x] Existing `tls-config.test.ts` and `llm-config.test.ts` still green
- [x] Semgrep rerun on the four affected files shows 0 findings
- [x] Lint + typecheck clean

## Notes for review

- The `nosemgrep` comment placement matters — semgrep matches it line-anchored against the offending line, so it sits immediately above the `return` statement inside the helper body, not on the function signature.
- The helper deliberately uses a literal return type `{ rejectUnauthorized: false }` (not `boolean`) so TS narrows correctly at call sites and any drift toward `true` would fail compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)