### PR TITLE
refactor(security): document public nginx endpoints + suppress missing-internal rule

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -48,19 +48,34 @@ http {
         index index.html;
 
         # Security headers are defined in an external snippet and included per
-        # location block. They are NOT set at the server level because nginx
-        # silently drops all server-level add_header directives whenever a
-        # location block defines its own add_header (CWE-16).
+        # location block. They are intentionally NOT set at the server level,
+        # because nginx silently overrides server-context response headers
+        # whenever any location block declares its own (CWE-16). See docs/
+        # architecture/14-frontend-edge-and-runtime-config.md for the design.
 
         # Use Docker DNS resolver so nginx resolves "backend" at request time,
         # not startup. Prevents crash-loop when DNS isn't ready yet.
         resolver 127.0.0.11 valid=10s ipv6=off;
+
+        # Single host:port source for the backend service. We use a per-server
+        # `set $var ...;` rather than an http-context upstream block because
+        # the OSS nginx upstream module resolves hostnames once at startup,
+        # which defeats the runtime resolver pattern above (the `resolve`
+        # keyword on upstream servers is nginx-plus only).
         set $backend_upstream http://backend:3051;
 
         # API proxy — ^~ ensures this beats the static-asset regex below,
         # so requests like /api/attachments/…/image.png get proxied to the backend.
+        #
+        # The `missing-internal` semgrep rule is intentionally suppressed
+        # below: this endpoint is public by design. It proxies to authenticated
+        # backend routes (the backend's `fastify.authenticate` decorator
+        # guards every protected route; public exceptions are limited to
+        # /api/health and /api/auth/*). Marking the location `internal`
+        # would block ALL client traffic to the API and break the app.
         location ^~ /api/ {
             include /etc/nginx/security-headers.conf;
+            # nosemgrep: generic.nginx.security.missing-internal.missing-internal
             proxy_pass $backend_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -73,9 +88,14 @@ http {
             proxy_read_timeout 300;
         }
 
-        # Health proxy
+        # Health proxy — public liveness/readiness endpoint for orchestrators
+        # (docker healthcheck, k8s probes, uptime monitors). Returns the
+        # backend's /health JSON without auth so probes can reach it. Public
+        # by design; same rationale as the /api/ block above — see the
+        # `missing-internal` suppression note there.
         location /health {
             include /etc/nginx/security-headers.conf;
+            # nosemgrep: generic.nginx.security.missing-internal.missing-internal
             proxy_pass $backend_upstream;
             proxy_set_header Host $host;
         }


### PR DESCRIPTION
## Summary

Closes #638. Suppresses the `generic.nginx.security.missing-internal.missing-internal` semgrep finding on `frontend/nginx.conf`'s two public `proxy_pass` blocks (`/api/` and `/health`) with **per-line `# nosemgrep:` comments and a multi-line design rationale** above each `location` block.

Both endpoints are intentionally externally reachable — auth happens at the backend (`fastify.authenticate` on every protected route) and `/health` is consumed by container/orchestrator health probes. Adding `internal;` to either block would break the app. Refactoring to an http-context `upstream { server backend:3051 resolve; }` block was attempted and rejected: the `resolve` keyword on upstream servers is nginx-plus only; OSS nginx resolves upstream hostnames once at startup, which defeats the existing runtime `resolver 127.0.0.11 …` design.

## Before / after

`location ^~ /api/`:

```diff
+ # The `missing-internal` semgrep rule is intentionally suppressed
+ # below: this endpoint is public by design. It proxies to authenticated
+ # backend routes (the backend's `fastify.authenticate` decorator
+ # guards every protected route; public exceptions are limited to
+ # /api/health and /api/auth/*). Marking the location `internal`
+ # would block ALL client traffic to the API and break the app.
  location ^~ /api/ {
      include /etc/nginx/security-headers.conf;
+     # nosemgrep: generic.nginx.security.missing-internal.missing-internal
      proxy_pass \$backend_upstream;
      ...
  }
```

`location /health`:

```diff
+ # Health proxy — public liveness/readiness endpoint for orchestrators
+ # (docker healthcheck, k8s probes, uptime monitors). Returns the
+ # backend's /health JSON without auth so probes can reach it. Public
+ # by design; same rationale as the /api/ block above — see the
+ # `missing-internal` suppression note there.
  location /health {
      include /etc/nginx/security-headers.conf;
+     # nosemgrep: generic.nginx.security.missing-internal.missing-internal
      proxy_pass \$backend_upstream;
      proxy_set_header Host \$host;
  }
```

(Plus a small comment-only rewrite around the server-context block to keep semgrep's pattern-matching off the comment text — earlier wording accidentally contained \`proxy_pass\` / \`add_header\` substrings that triggered false-positive rule hits inside a comment.)

The other three `location` blocks (`/drawio/`, `= /index.html`, `~* \.(...)$`, `/`) serve static files / SPA fallback — no `proxy_pass`, no SSRF surface, no rule trigger.

**Functional diff**: zero. `proxy_pass \$backend_upstream;`, `set \$backend_upstream http://backend:3051;`, `resolver 127.0.0.11 valid=10s ipv6=off;`, every header and timeout — byte-for-byte identical pre/post.

## Semgrep rerun

Pre-change:

```
Findings: 2 (2 blocking)
  generic.nginx.security.missing-internal.missing-internal
    64┆ proxy_pass \$backend_upstream;
    79┆ proxy_pass \$backend_upstream;
```

Post-change:

```
Findings: 0 (0 blocking)
Rules run: 58
Targets scanned: 1
```

## Verification

- **nginx syntax check** (`nginx -t` inside `nginx:alpine` with `nginx.conf`, `security-headers.conf`, `cache-drawio.conf`, `cache-immutable.conf`, `cache-nocache.conf` mounted at `/etc/nginx/`):
  ```
  nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
  nginx: configuration file /etc/nginx/nginx.conf test is successful
  ```
  Reproducer (run from the worktree root):
  ```bash
  mkdir -p /tmp/nginx-test && cp frontend/nginx.conf frontend/nginx-security-headers.conf \
    frontend/nginx-cache-drawio.conf frontend/nginx-cache-immutable.conf \
    frontend/nginx-cache-nocache.conf /tmp/nginx-test/
  docker run --rm \
    -v /tmp/nginx-test/nginx.conf:/etc/nginx/nginx.conf:ro \
    -v /tmp/nginx-test/nginx-security-headers.conf:/etc/nginx/security-headers.conf:ro \
    -v /tmp/nginx-test/nginx-cache-drawio.conf:/etc/nginx/cache-drawio.conf:ro \
    -v /tmp/nginx-test/nginx-cache-immutable.conf:/etc/nginx/cache-immutable.conf:ro \
    -v /tmp/nginx-test/nginx-cache-nocache.conf:/etc/nginx/cache-nocache.conf:ro \
    nginx:alpine nginx -t
  ```
- `npm run build -w frontend` — success.
- Semgrep rerun on `frontend/nginx.conf` — 0 findings.

## Test plan

- [x] `nginx -t` passes with the production include set.
- [x] Semgrep clean (0 findings) on `frontend/nginx.conf`.
- [x] Frontend production build still succeeds.
- [ ] Smoke: `docker compose up`, hit `/api/health` and `/health` via the nginx layer — both reachable, backend auth still gates `/api/*` non-public routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)