### PR TITLE
refactor(security): use constant format string in FeatureErrorBoundary logger

### DIFF
--- a/frontend/src/shared/components/feedback/FeatureErrorBoundary.test.tsx
+++ b/frontend/src/shared/components/feedback/FeatureErrorBoundary.test.tsx
@@ -132,11 +132,14 @@ describe('FeatureErrorBoundary', () => {
     );
 
     // React itself calls console.error, and our componentDidCatch also logs.
-    // Verify our specific log message was included.
+    // Verify our specific log was included. The boundary now uses a constant
+    // format string with `%s` interpolation (the feature name is passed as
+    // the second argument) — see #640 / unsafe-formatstring lint rule.
     const ourLog = consoleSpy.mock.calls.find(
       (call) =>
         typeof call[0] === 'string' &&
-        call[0].includes('[FeatureErrorBoundary] Article Viewer crashed:'),
+        call[0] === '[FeatureErrorBoundary] %s crashed:' &&
+        call[1] === 'Article Viewer',
     );
     expect(ourLog).toBeDefined();
   });

--- a/frontend/src/shared/components/feedback/FeatureErrorBoundary.tsx
+++ b/frontend/src/shared/components/feedback/FeatureErrorBoundary.tsx
@@ -37,7 +37,8 @@ export class FeatureErrorBoundary extends Component<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     console.error(
-      `[FeatureErrorBoundary] ${this.props.featureName} crashed:`,
+      '[FeatureErrorBoundary] %s crashed:',
+      this.props.featureName,
       error,
       errorInfo,
     );


### PR DESCRIPTION
## Summary

Closes #640. `FeatureErrorBoundary.componentDidCatch` previously passed a template literal as the format-position argument to `console.error`, with the feature name interpolated into the string. Any feature whose `featureName` prop contained `%s` / `%d` / `%o` would have those specifiers consumed by `console.error`'s util.format-style formatter, allowing log forgery (semgrep `javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring`, CWE-117 / CWE-134).

The format string is now a constant; the feature name is passed as a positional `%s` argument.

## Before / after

```diff
  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
    console.error(
-     \`[FeatureErrorBoundary] \${this.props.featureName} crashed:\`,
+     '[FeatureErrorBoundary] %s crashed:',
+     this.props.featureName,
      error,
      errorInfo,
    );
  }
```

The matching test was updated to assert against the new argument layout (`call[0]` is the constant format string, `call[1]` is the feature name).

## Scope check

`grep -rn 'console\.(error|log|warn)(\`' frontend/src/shared/components/feedback frontend/src/shared/lib frontend/src/shared/hooks` — no other instances of the same anti-pattern in the immediate scope. A broader `semgrep --config=p/javascript` over those three directories also returns 0 unsafe-formatstring findings, so nothing else needs the same fix in this PR.

## Semgrep rerun

Pre-change:

```
Findings: 1 (1 blocking)
  javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring
    40┆ \`[FeatureErrorBoundary] \${this.props.featureName} crashed:\`,
```

Post-change on the same file:

```
Findings: 0 (0 blocking)
Rules run: 378
Targets scanned: 1
```

## Verification

- `npm run lint -w frontend` — clean
- `npm run typecheck -w frontend` — clean
- `npm test -w frontend -- FeatureErrorBoundary` — **10/10 passing**
- Semgrep rerun on `FeatureErrorBoundary.tsx` — 0 findings

## Test plan

- [x] Unit test still asserts that our specific componentDidCatch log was emitted, now matching the format-string layout.
- [x] Lint, typecheck, semgrep all pass.
- [ ] Manual smoke: render a feature that throws — verify the dev-tools console shows the boundary's `[FeatureErrorBoundary] <name> crashed:` line plus the React error and ErrorInfo (jsdom test already covers this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)