### PR TITLE
fix(deps): bump fast-uri to ^3.1.2 (CVE-2026-6321, CVE-2026-6322)

### DIFF
--- a/mcp-docs/package-lock.json
+++ b/mcp-docs/package-lock.json
@@ -2033,9 +2033,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/mcp-docs/package.json
+++ b/mcp-docs/package.json
@@ -30,6 +30,9 @@
     "typescript": "^5.7.3",
     "vitest": "^4.0.18"
   },
+  "overrides": {
+    "fast-uri": "^3.1.2"
+  },
   "engines": {
     "node": ">=22.0.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12561,9 +12561,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "overrides": {
     "protobufjs": "^7.5.5",
     "@fastify/static": "^9.1.1",
+    "fast-uri": "^3.1.2",
     "hono": "^4.12.14",
     "tmp": "^0.2.4",
     "uuid": "^14.0.0"


### PR DESCRIPTION
## Summary
Bumps transitive `fast-uri` from `3.1.0` to `3.1.2` via npm `overrides` in both root and `mcp-docs/` workspaces to remediate two upstream CVEs.

## CVEs
- **CVE-2026-6321** — ReDoS in fast-uri URI parsing — high
- **CVE-2026-6322** — scheme confusion in fast-uri resolution — high

## Why overrides
`fast-uri` is not a direct dependency — it ships transitively through Fastify 5.x (`@fastify/ajv-compiler`, `fast-json-stringify`, `@fastify/swagger` → `json-schema-resolver`) and `@modelcontextprotocol/sdk` → `ajv@8`. Override is the smallest-blast-radius way to force-resolve away from 3.1.0 without bumping framework majors.

## Verification
- Lockfile (root): `fast-uri@3.1.2`
  ```
  $ jq '.packages["node_modules/fast-uri"].version' package-lock.json
  "3.1.2"
  ```
- Lockfile (mcp-docs): `fast-uri@3.1.2`
  ```
  $ jq '.packages["node_modules/fast-uri"].version' mcp-docs/package-lock.json
  "3.1.2"
  ```
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm test -w @compendiq/contracts` — 66/66 pass
- `npm test -w backend` — vitest run progressed through TLS/Confluence/LLM suites, no FAIL/Error patterns observed (broad-pattern Monitor never fired)
- `npm audit` after install: root vuln count 8 → 3 (the 5 resolved are fast-uri advisories)

## Test plan
- [ ] CI green on `dev` target
- [ ] No transitive dep still resolves to vulnerable range (`npm ls fast-uri` from both workspaces)

Closes #637
Closes #639