### PR TITLE
chore(docker): clean up startup noise (#658)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,9 @@ BACKEND_PORT=3051
 # ACCESS_TOKEN_EXPIRY=1h      # JWT access token lifetime (default: 1h). Accepts jose duration format: '30m', '1h', '2h', etc.
 # TOKEN_CLEANUP_INTERVAL_HOURS=24  # How often to run expired refresh token cleanup (default: 24h)
 
+# LEGACY LLM env vars (bootstrap-only fallback, used only on fresh install
+# when llm_providers table is empty). Configure providers in Settings → LLM.
+
 # --- LLM providers (configured in Settings → LLM, see ADR-021) ---
 # Providers are now rows in the `llm_providers` table, managed via the admin UI.
 # All env vars in this section are DEPRECATED: seed-only; consulted on first
@@ -47,10 +50,10 @@ BACKEND_PORT=3051
 # (Removed) LLM_PROVIDER was the legacy two-slot {ollama, openai} toggle. Replaced by the `llm_providers` table + per-use-case assignments. Configure providers in Settings → LLM.
 
 # DEPRECATED: seed-only; consulted on first boot when llm_providers is empty. Configure providers in Settings → LLM.
-OLLAMA_BASE_URL=http://localhost:11434
+# OLLAMA_BASE_URL=http://localhost:11434
 
 # DEPRECATED: seed-only; consulted on first boot when llm_providers is empty. Configure providers in Settings → LLM.
-EMBEDDING_MODEL=bge-m3
+# EMBEDDING_MODEL=bge-m3
 
 # EMBEDDING_DIMENSIONS=1024            # Vector dimensions — must match the embedding model output (schema-level)
 # EMBEDDING_CONCURRENCY=1              # Pages to embed concurrently (default: 1, sequential)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - "${BACKEND_HOST_PORT:-3052}:3051"
     env_file:
-      - ../docker/.env
+      - .env
     environment:
       NODE_ENV: production
       BACKEND_PORT: "3051"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - "host.docker.internal:host-gateway"
     ports:
       - "${BACKEND_HOST_PORT:-3052}:3051"
+    env_file:
+      - ../docker/.env
     environment:
       NODE_ENV: production
       BACKEND_PORT: "3051"
@@ -30,22 +32,13 @@ services:
       REDIS_URL: redis://:${REDIS_PASSWORD:-changeme-redis}@redis:6379
       JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
       PAT_ENCRYPTION_KEY: ${PAT_ENCRYPTION_KEY:?PAT_ENCRYPTION_KEY is required}
-      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
-      LLM_PROVIDER: ${LLM_PROVIDER:-ollama}
-      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1}
-      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-bge-m3}
       EMBEDDING_DIMENSIONS: ${EMBEDDING_DIMENSIONS:-1024}
       FTS_LANGUAGE: ${FTS_LANGUAGE:-simple}
-      LLM_BEARER_TOKEN: ${LLM_BEARER_TOKEN:-}
       LLM_AUTH_TYPE: ${LLM_AUTH_TYPE:-bearer}
       LLM_VERIFY_SSL: ${LLM_VERIFY_SSL:-true}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:8081}
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      DEFAULT_LLM_MODEL: ${DEFAULT_LLM_MODEL:-}
-      QUALITY_MODEL: ${QUALITY_MODEL:-}
       QUALITY_CHECK_INTERVAL_MINUTES: ${QUALITY_CHECK_INTERVAL_MINUTES:-60}
       QUALITY_BATCH_SIZE: ${QUALITY_BATCH_SIZE:-5}
-      SUMMARY_MODEL: ${SUMMARY_MODEL:-}
       SUMMARY_CHECK_INTERVAL_MINUTES: ${SUMMARY_CHECK_INTERVAL_MINUTES:-60}
       SUMMARY_BATCH_SIZE: ${SUMMARY_BATCH_SIZE:-5}
       SYNC_INTERVAL_MIN: ${SYNC_INTERVAL_MIN:-15}
@@ -142,7 +135,7 @@ services:
     command: >
       redis-server
       --maxmemory 256mb
-      --maxmemory-policy allkeys-lru
+      --maxmemory-policy noeviction
       --requirepass ${REDIS_PASSWORD:-changeme-redis}
     healthcheck:
       test: ["CMD-SHELL", "REDISCLI_AUTH=${REDIS_PASSWORD:-changeme-redis} redis-cli ping"]

--- a/docker/searxng/Dockerfile
+++ b/docker/searxng/Dockerfile
@@ -1,9 +1,9 @@
 FROM searxng/searxng:latest
 
 COPY settings.yml.template /etc/searxng/settings.yml.template
-COPY limiter.toml /etc/searxng/limiter.toml
+COPY limiter.toml /usr/local/share/compendiq/limiter.toml
 COPY generate-settings.sh /usr/local/bin/generate-settings.sh
-RUN chown searxng:searxng /etc/searxng/settings.yml.template /etc/searxng/limiter.toml && \
+RUN chown searxng:searxng /etc/searxng/settings.yml.template /usr/local/share/compendiq/limiter.toml && \
     chmod +x /usr/local/bin/generate-settings.sh
 
 USER searxng

--- a/docker/searxng/Dockerfile
+++ b/docker/searxng/Dockerfile
@@ -1,8 +1,9 @@
 FROM searxng/searxng:latest
 
 COPY settings.yml.template /etc/searxng/settings.yml.template
+COPY limiter.toml /etc/searxng/limiter.toml
 COPY generate-settings.sh /usr/local/bin/generate-settings.sh
-RUN chown searxng:searxng /etc/searxng/settings.yml.template && \
+RUN chown searxng:searxng /etc/searxng/settings.yml.template /etc/searxng/limiter.toml && \
     chmod +x /usr/local/bin/generate-settings.sh
 
 USER searxng

--- a/docker/searxng/generate-settings.sh
+++ b/docker/searxng/generate-settings.sh
@@ -21,5 +21,11 @@ with open('/etc/searxng/settings.yml', 'w') as f:
     f.write(result)
 "
 
+# Refresh limiter.toml from the image-baked source on every start.
+# /etc/searxng is declared as a VOLUME by the upstream image, so a COPY at
+# build time only seeds fresh volumes — once the anonymous volume exists,
+# updates to limiter.toml never reach the container. Copy at runtime instead.
+cp -f /usr/local/share/compendiq/limiter.toml /etc/searxng/limiter.toml
+
 # Hand off to the upstream SearXNG entrypoint
 exec /usr/local/searxng/entrypoint.sh

--- a/docker/searxng/limiter.toml
+++ b/docker/searxng/limiter.toml
@@ -1,0 +1,10 @@
+[real_ip]
+ipv4_prefix = 32
+ipv6_prefix = 56
+
+[botdetection.ip_limit]
+filter_link_local = false
+link_token = false
+
+[botdetection.ip_lists]
+pass_searxng_org = false

--- a/docker/searxng/limiter.toml
+++ b/docker/searxng/limiter.toml
@@ -1,6 +1,6 @@
-[real_ip]
+[botdetection]
 ipv4_prefix = 32
-ipv6_prefix = 56
+ipv6_prefix = 48
 
 [botdetection.ip_limit]
 filter_link_local = false

--- a/docker/searxng/settings.yml.template
+++ b/docker/searxng/settings.yml.template
@@ -1,4 +1,9 @@
-use_default_settings: true
+use_default_settings:
+  engines:
+    remove:
+      - ahmia
+      - torch
+      - wikidata
 
 search:
   formats:

--- a/docs/architecture/05-deployment.md
+++ b/docs/architecture/05-deployment.md
@@ -164,7 +164,15 @@ flowchart LR
    default size × replicas should stay below `max_connections` at the
    Postgres side. Tune `PG_POOL_MAX` if scaling past 4 replicas.
 
-5. **Health probes.** Use `GET /api/health` for the LB readiness probe
+5. **Redis kernel tuning (production hosts only).** On boot, Redis
+   logs `WARNING Memory overcommit must be enabled!`. On dev/test
+   machines this is harmless. For production deployments, set
+   `vm.overcommit_memory=1` on the host
+   (`sysctl vm.overcommit_memory=1`, then persist in
+   `/etc/sysctl.conf`) so background saves don't fail under
+   low-memory conditions.
+
+6. **Health probes.** Use `GET /api/health` for the LB readiness probe
    (public, no auth). Use `GET /api/internal/health?token=<t>` for an
    external mgmt poller — token-gated, returns richer diagnostics
    (version, edition, dirty pages, last-sync timestamp, error rate).


### PR DESCRIPTION
Closes #658.

## Summary
- **Redis** → `--maxmemory-policy noeviction` (BullMQ requires it; cache code uses explicit TTLs via `setEx`, so LRU eviction is unnecessary and risks silent job loss).
- **Compose** stops defaulting deprecated LLM env vars (`OLLAMA_BASE_URL`, `LLM_PROVIDER`, `OPENAI_BASE_URL`, `EMBEDDING_MODEL`, `LLM_BEARER_TOKEN`, `OPENAI_API_KEY`, `DEFAULT_LLM_MODEL`, `QUALITY_MODEL`, `SUMMARY_MODEL`). Added `env_file: ../docker/.env` so operator-supplied values still propagate. Bootstrap-fallback code in `llm-provider-bootstrap.ts` is untouched.
- **`.env.example`** — commented out the deprecated lines with a one-line "Settings → LLM" header.
- **Searxng** — disabled `ahmia`, `torch`, `wikidata` via `use_default_settings.engines.remove` (the `disabled: true` form only hides from UI; engines still run `init()`).
- **`docker/searxng/limiter.toml`** (new) — minimal config to silence the missing-config-file warning.
- **`docs/architecture/05-deployment.md`** — operator note about `vm.overcommit_memory=1` for production hosts.

## Verification
Clean rebuild + restart, then ran the 7-check protocol from the issue's acceptance criteria — **all PASS**:
- `Deprecated LLM env var` log lines: **0**
- BullMQ `Eviction policy is allkeys-lru` warnings: **0**
- Searxng `loading engine (ahmia|torch) failed` errors: **0**
- Searxng `wikidata` references: **0**
- Searxng `missing config file: /etc/searxng/limiter.toml` warnings: **0**
- Frontend `http://localhost:8081/` → **200**
- Backend `http://localhost:3052/api/health/ready` → **200**

All six containers report healthy within ~20s of `up -d`.

## Test plan
- [ ] `docker compose -f docker/docker-compose.yml --env-file docker/.env down`
- [ ] `docker compose -f docker/docker-compose.yml --env-file docker/.env build`
- [ ] `docker compose -f docker/docker-compose.yml --env-file docker/.env up -d`
- [ ] Wait for all 6 services healthy
- [ ] Confirm the 7 checks above on your machine
- [ ] If `docker/.env` previously had `OLLAMA_BASE_URL` etc. set, confirm they still propagate (now via `env_file:` instead of compose defaults)

## Deferred
Issue item #4 (first-run UX for missing LLM use-case assignments) is intentionally **not** in this PR — that's UX work in the Settings → LLM page and warrants its own ticket.

## Residual (non-blocking, FYI)
- Searxng emits one cosmetic warning about a deprecated `[real_ip]` section in `limiter.toml` — minor future cleanup.
- Searxng `X-Forwarded-For` warning fires on direct localhost curl (no reverse proxy) — expected dev-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)