### PR TITLE
fix(routing): prevent stuck exit layer in PageTransition under rapid back/forward

### DIFF
--- a/frontend/src/shared/components/layout/PageTransition.test.tsx
+++ b/frontend/src/shared/components/layout/PageTransition.test.tsx
@@ -83,9 +83,12 @@ describe('PageTransition', () => {
     expect(motionDiv).not.toBeNull();
   });
 
-  it('mounts new content immediately on navigation (mode=sync)', () => {
-    // mode="sync" ensures the entering page mounts right away instead of
-    // waiting 220ms for the exiting page to finish its animation.
+  it('renders new content after navigation', () => {
+    // Under mode="wait" the exiting layer must finish before the new one
+    // mounts. In jsdom animations resolve synchronously, so a rerender
+    // immediately yields the new content — this test guards against a
+    // regression where the new content never appears at all (e.g. a stuck
+    // exit, or AnimatePresence dropping the entering child).
     const { rerender } = render(
       <Wrapper initialPath="/">
         <PageTransition>
@@ -102,7 +105,6 @@ describe('PageTransition', () => {
         </PageTransition>
       </Wrapper>,
     );
-    // New content must be in the DOM immediately, without waiting for exit animation
     expect(screen.getByTestId('page-b')).toBeInTheDocument();
   });
 
@@ -117,21 +119,47 @@ describe('PageTransition', () => {
     expect(screen.getByText('Page view')).toBeInTheDocument();
   });
 
-  it('exit motion variant disables pointer-events so transition overlay does not swallow real clicks', async () => {
-    // Regression test for the Settings/AI panel click-loss bug. AnimatePresence
-    // mode="sync" keeps the exiting page mounted with `position: absolute;
-    // inset: 0` for ~220 ms while opacity fades out. Because <Outlet> reads
-    // from the *current* router context, both layers render the same panel —
-    // a real user click during the transition window lands on the
-    // soon-to-unmount overlay and is dropped when React unmounts the node.
-    // The fix is to set `pointerEvents: 'none'` on the exit variant so the
-    // overlay is invisible to hit-testing. Read the source directly so the
-    // test fails loudly if the property is removed by future refactors.
+  it('uses AnimatePresence mode="wait" so exiting and entering layers never overlap', async () => {
+    // Regression test for the Pages-list click-stuck bug. With mode="sync"
+    // the exiting page sat absolutely positioned over the new one for ~220 ms.
+    // If the same key (location.pathname) reappeared mid-exit (rapid
+    // back/forward), framer-motion could cancel the exit but leave the
+    // inline exit styles (position: absolute; pointer-events: none) applied
+    // to a child that then rendered the current route's content — making
+    // every visible article unclickable.
+    //
+    // The fix is mode="wait": the previous layer must finish exiting before
+    // the next mounts, so the two layers never overlap and the race is
+    // impossible. Read the source directly so the test fails loudly if the
+    // mode is reverted by a future refactor.
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
     const url = await import('node:url');
     const here = path.dirname(url.fileURLToPath(import.meta.url));
     const src = await fs.readFile(path.join(here, 'PageTransition.tsx'), 'utf-8');
-    expect(src).toMatch(/exit=\{[^}]*pointerEvents:\s*['"]none['"]/);
+    expect(src).toMatch(/<AnimatePresence[^>]*mode=["']wait["']/);
+    // The old workaround must not creep back in: with mode="wait" there is
+    // no overlap, so position:absolute / pointer-events:none on exit would
+    // only mask the wrong fix.
+    expect(src).not.toMatch(/exit=\{[^}]*pointerEvents:\s*['"]none['"]/);
+    expect(src).not.toMatch(/exit=\{[^}]*position:\s*['"]absolute['"]/);
+  });
+
+  it('updates prevDepthRef via a commit-phase effect, not inside useMemo', async () => {
+    // Mutating a ref inside useMemo is unsafe in React 19 + StrictMode:
+    // memos may re-run with the same deps, double-mutating the ref and
+    // corrupting the previous-depth tracking that drives slide direction.
+    // The ref update must live in useEffect so it runs exactly once per
+    // commit. Regression test in source form.
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const src = await fs.readFile(path.join(here, 'PageTransition.tsx'), 'utf-8');
+    // prevDepthRef.current = ... must appear inside a useEffect, never inside useMemo.
+    const memoBlock = src.match(/useMemo<[^>]*>\(\(\)\s*=>\s*\{[\s\S]*?\}\s*,\s*\[location\.pathname\]\)/);
+    expect(memoBlock).toBeTruthy();
+    expect(memoBlock![0]).not.toMatch(/prevDepthRef\.current\s*=/);
+    expect(src).toMatch(/useEffect\(\(\)\s*=>\s*\{\s*prevDepthRef\.current\s*=/);
   });
 });

--- a/frontend/src/shared/components/layout/PageTransition.tsx
+++ b/frontend/src/shared/components/layout/PageTransition.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useRef, useState, useMemo } from 'react';
+import { type ReactNode, useRef, useState, useMemo, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { AnimatePresence, m } from 'framer-motion';
 import { useReducedMotion } from 'framer-motion';
@@ -49,21 +49,20 @@ export function PageTransition({ children }: PageTransitionProps) {
 
   // Compute direction synchronously during render so animation reads
   // the correct value on the same frame the location changes.
-  const direction = useMemo(() => {
+  // Note: prevDepthRef is updated in a commit-phase effect below to avoid
+  // mutating a ref inside useMemo (which can re-run in React 19 + StrictMode
+  // and corrupt the direction calculation).
+  const direction = useMemo<'forward' | 'backward' | 'neutral'>(() => {
     const currentDepth = routeDepth(location.pathname);
     const prevDepth = prevDepthRef.current;
 
-    let dir: 'forward' | 'backward' | 'neutral';
-    if (currentDepth > prevDepth) {
-      dir = 'forward';
-    } else if (currentDepth < prevDepth) {
-      dir = 'backward';
-    } else {
-      dir = 'neutral';
-    }
+    if (currentDepth > prevDepth) return 'forward';
+    if (currentDepth < prevDepth) return 'backward';
+    return 'neutral';
+  }, [location.pathname]);
 
-    prevDepthRef.current = currentDepth;
-    return dir;
+  useEffect(() => {
+    prevDepthRef.current = routeDepth(location.pathname);
   }, [location.pathname]);
 
   // Slide offset based on direction (GPU-composited via translateX)
@@ -77,19 +76,17 @@ export function PageTransition({ children }: PageTransitionProps) {
 
   return (
     <div className="flex flex-1 flex-col" style={{ position: 'relative' }}>
-      <AnimatePresence mode="sync" initial={false}>
+      <AnimatePresence mode="wait" initial={false}>
         <m.div
           key={location.pathname}
           initial={{ opacity: 0, x: slideX }}
           animate={{ opacity: 1, x: 0 }}
-          // pointerEvents:'none' on exit: AnimatePresence keeps the exiting
-          // element absolutely positioned over the new one for ~220ms. Because
-          // <Outlet> always reads the current router context, both layers
-          // render the same panel — and a real user click during the
-          // transition window lands on the soon-to-unmount overlay, so focus
-          // never sticks. Disabling pointer events on the exit lets clicks
-          // pass through to the live page underneath.
-          exit={{ opacity: 0, x: -slideX, position: 'absolute', top: 0, left: 0, right: 0, pointerEvents: 'none' }}
+          // mode="wait" + simple opacity/x exit: the previous layer must finish
+          // exiting before the new one mounts, so the two layers never overlap.
+          // This prevents the back/forward race where an interrupted exit could
+          // leave a layer stuck in the DOM with pointer-events:none, blocking
+          // all clicks on the visually-current page.
+          exit={{ opacity: 0, x: -slideX }}
           transition={{
             duration: reducedMotion ? 0.1 : DURATION,
             ease: [0.25, 0.1, 0.25, 1], // cubic-bezier for smooth deceleration


### PR DESCRIPTION
## Summary

- Switch `PageTransition`'s `AnimatePresence` from `mode=\"sync\"` to `mode=\"wait\"` so the previous route's exit animation finishes before the new route mounts — eliminates the back/forward race that left a layer stuck in exit-state styles (`position: absolute`, `pointer-events: none`) and blocked all clicks while still rendering the current content.
- Drop the now-unnecessary `position/top/left/right/pointerEvents:'none'` workaround from `exit={...}`.
- Move `prevDepthRef.current = …` out of `useMemo` into `useEffect`. Mutating refs inside `useMemo` is unsafe in React 19 + StrictMode — memos can re-run and corrupt the previous-depth value that drives slide direction.

## Repro (pre-fix)

1. Open `/` (Pages list).
2. Click an article → `/pages/:id`, then hit browser **Back**, then **Forward**, then **Back** — repeat 5–10 times.
3. Articles on the list page are visually rendered but become unclickable.

DOM inspection in the stuck state shows the PageTransition has a single child still wearing its exit-state inline styles. Every ancestor from the article button up through that child computes `pointer-events: none`, so the browser's hit test never reaches any handler.

## Tradeoff

`mode=\"wait\"` introduces a ~220 ms gap between routes during transition instead of the previous slide-overlap. The overlap was the proximate cause of the bug; the gap is the simplest safe trade.

## Test plan

- [x] `npx vitest run src/shared/components/layout/AppLayout.test.tsx` — 22/22 pass.
- [x] Manual Playwright reproduction (12-cycle aggressive back/forward + interrupt): pre-fix shows the stuck `pos: absolute, pe: none` PageTransition child; post-fix shows clean `pos: static, pe: auto` and clicks navigate normally.
- [ ] Reviewer to manually click-through routes and confirm transition feel is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)