### PR TITLE
fix(pages): surface query errors + reduce rate-limit pressure

### DIFF
--- a/backend/src/core/services/rate-limit-service.ts
+++ b/backend/src/core/services/rate-limit-service.ts
@@ -19,7 +19,11 @@ interface RateLimits {
 // ─── Defaults (hardcoded fallbacks) ───────────────────────────────────────────
 
 const DEFAULTS: RateLimits = {
-  global:       { max: 100, timeWindow: '1 minute' },
+  // 100/min was too tight for a SPA: each Pages-list mount fires ~6 GETs
+  // (list, filters, spaces, settings, pinned, embeddings status), so ~17
+  // navigations in a minute already exhausted the budget and left
+  // TanStack queries stuck in error state after retry exhaustion.
+  global:       { max: 300, timeWindow: '1 minute' },
   auth:         { max: 5,   timeWindow: '1 minute' },
   admin:        { max: 20,  timeWindow: '1 minute' },
   llmStream:    { max: 10,  timeWindow: '1 minute' },

--- a/backend/src/routes/foundation/rate-limit.test.ts
+++ b/backend/src/routes/foundation/rate-limit.test.ts
@@ -142,16 +142,18 @@ describe.skipIf(!dbAvailable)('Per-route rate limiting', () => {
     });
   });
 
-  describe('Global rate limit (100/min)', () => {
+  describe('Global rate limit (300/min)', () => {
     it('should have global fallback rate limit on health endpoint', async () => {
       const response = await app.inject({
         method: 'GET',
         url: '/api/health',
       });
 
-      // Health route should use global limit (100)
+      // Health route should use global limit (300/min — see DEFAULTS
+      // in rate-limit-service.ts). 100/min was too tight for a SPA where
+      // each Pages-list mount fires ~6 GETs.
       if (response.headers['x-ratelimit-limit']) {
-        expect(parseInt(response.headers['x-ratelimit-limit'] as string, 10)).toBe(100);
+        expect(parseInt(response.headers['x-ratelimit-limit'] as string, 10)).toBe(300);
       }
     });
   });

--- a/frontend/src/features/pages/PagesPage.test.tsx
+++ b/frontend/src/features/pages/PagesPage.test.tsx
@@ -456,6 +456,95 @@ describe('PagesPage', () => {
     expect(comparison & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  describe('error state (pages query failed)', () => {
+    /** Mock fetch where /pages errors with the given status, but all other
+     *  endpoints return their normal mock responses. */
+    function mockFetchWithPagesError(status: number, message: string) {
+      return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        if (url.includes('/embeddings/status')) {
+          return new Response(JSON.stringify(mockEmbeddingStatusIdle), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/pages/filters')) {
+          return new Response(JSON.stringify(mockFilterOptions), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/spaces')) {
+          return new Response(JSON.stringify(mockSpaces), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/sync/status')) {
+          return new Response(JSON.stringify({ status: 'idle' }), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/pages/pinned')) {
+          return new Response(JSON.stringify({ items: [], total: 0 }), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/settings')) {
+          return new Response(JSON.stringify({}), { headers: { 'Content-Type': 'application/json' } });
+        }
+        // /api/pages list query — fail with the requested status
+        return new Response(JSON.stringify({ message }), {
+          status,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+    }
+
+    it('renders the error panel (not "No pages found") when the pages query fails', async () => {
+      vi.restoreAllMocks();
+      mockFetchWithPagesError(429, 'Rate limit exceeded, retry in 9 seconds');
+      render(<PagesPage />, { wrapper: createWrapper() });
+
+      // The error panel must render with the API message — NOT the misleading
+      // "No pages found" empty state (which historically appeared for any
+      // undefined pagesData and tricked users into thinking they had zero
+      // articles when the real cause was a transient 429).
+      expect(await screen.findByTestId('pages-error-state')).toBeInTheDocument();
+      expect(screen.getByText("Couldn't load pages")).toBeInTheDocument();
+      expect(screen.getByText('Rate limit exceeded, retry in 9 seconds')).toBeInTheDocument();
+      expect(screen.queryByTestId('empty-state-title')).not.toBeInTheDocument();
+    });
+
+    it('does not show the misleading empty state even when items array would also be missing', async () => {
+      vi.restoreAllMocks();
+      mockFetchWithPagesError(500, 'Internal Server Error');
+      render(<PagesPage />, { wrapper: createWrapper() });
+
+      await screen.findByTestId('pages-error-state');
+      // "No pages found" was the historical lie — never both UIs at once,
+      // and not the empty state when the real issue is a failed fetch.
+      expect(screen.queryByText('No pages found')).not.toBeInTheDocument();
+    });
+
+    it('shows a Retry button that calls refetch (and recovers when the server starts responding again)', async () => {
+      vi.restoreAllMocks();
+      let shouldFail = true;
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        if (url.includes('/embeddings/status')) return new Response(JSON.stringify(mockEmbeddingStatusIdle), { headers: { 'Content-Type': 'application/json' } });
+        if (url.includes('/pages/filters')) return new Response(JSON.stringify(mockFilterOptions), { headers: { 'Content-Type': 'application/json' } });
+        if (url.includes('/spaces')) return new Response(JSON.stringify(mockSpaces), { headers: { 'Content-Type': 'application/json' } });
+        if (url.includes('/sync/status')) return new Response(JSON.stringify({ status: 'idle' }), { headers: { 'Content-Type': 'application/json' } });
+        if (url.includes('/pages/pinned')) return new Response(JSON.stringify({ items: [], total: 0 }), { headers: { 'Content-Type': 'application/json' } });
+        if (url.includes('/settings')) return new Response(JSON.stringify({}), { headers: { 'Content-Type': 'application/json' } });
+        if (shouldFail) {
+          return new Response(JSON.stringify({ message: 'Rate limited' }), {
+            status: 429, headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify(mockPagesResponse), { headers: { 'Content-Type': 'application/json' } });
+      });
+
+      render(<PagesPage />, { wrapper: createWrapper() });
+      const retry = await screen.findByTestId('pages-error-retry');
+
+      shouldFail = false;
+      fireEvent.click(retry);
+
+      // After successful refetch the error panel goes away and the article list renders
+      await screen.findByText('Test Page');
+      expect(screen.queryByTestId('pages-error-state')).not.toBeInTheDocument();
+    });
+  });
+
   describe('empty state (no pages)', () => {
     const emptyPages = { items: [], total: 0, page: 1, limit: 50, totalPages: 0 };
 

--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -213,7 +213,7 @@ export function PagesPage() {
     }
   }, [qualityFilter]);
 
-  const { data: pagesData, isLoading, error: pagesError, refetch: refetchPages } = usePages({
+  const { data: pagesData, isLoading, isFetching: isFetchingPages, error: pagesError, refetch: refetchPages } = usePages({
     spaceKey: spaceKey || undefined,
     search: search || undefined,
     author: author || undefined,
@@ -846,10 +846,12 @@ export function PagesPage() {
               </div>
               <button
                 onClick={() => refetchPages()}
-                className="rounded-md bg-destructive/10 px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/20"
+                disabled={isFetchingPages}
+                className="flex items-center gap-1.5 rounded-md bg-destructive/10 px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/20 disabled:cursor-not-allowed disabled:opacity-60"
                 data-testid="pages-error-retry"
               >
-                Retry
+                {isFetchingPages && <Loader2 size={12} className="animate-spin" />}
+                {isFetchingPages ? 'Retrying…' : 'Retry'}
               </button>
             </div>
           ) : !pagesData?.items.length ? (

--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -213,7 +213,7 @@ export function PagesPage() {
     }
   }, [qualityFilter]);
 
-  const { data: pagesData, isLoading } = usePages({
+  const { data: pagesData, isLoading, error: pagesError, refetch: refetchPages } = usePages({
     spaceKey: spaceKey || undefined,
     search: search || undefined,
     author: author || undefined,
@@ -833,6 +833,24 @@ export function PagesPage() {
               {Array.from({ length: 5 }).map((_, i) => (
                 <div key={i} className="rounded-xl border border-border/40 bg-card/50 backdrop-blur-sm h-16 animate-pulse" />
               ))}
+            </div>
+          ) : pagesError && !pagesData ? (
+            <div
+              className="flex items-start gap-3 rounded-xl border border-destructive/40 bg-destructive/5 p-4 text-sm"
+              data-testid="pages-error-state"
+            >
+              <AlertTriangle size={18} className="mt-0.5 shrink-0 text-destructive" />
+              <div className="flex-1">
+                <p className="font-medium text-destructive">Couldn't load pages</p>
+                <p className="mt-1 text-muted-foreground">{pagesError.message}</p>
+              </div>
+              <button
+                onClick={() => refetchPages()}
+                className="rounded-md bg-destructive/10 px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/20"
+                data-testid="pages-error-retry"
+              >
+                Retry
+              </button>
             </div>
           ) : !pagesData?.items.length ? (
             <EmptyState

--- a/frontend/src/shared/hooks/use-pages.ts
+++ b/frontend/src/shared/hooks/use-pages.ts
@@ -109,6 +109,11 @@ export function usePages(params: PageFilters = {}) {
   return useQuery<PaginatedPages>({
     queryKey,
     queryFn: () => apiFetch(`/pages${qs ? `?${qs}` : ''}`),
+    // Cache list responses for 30s so rapid back/forward between list and
+    // detail pages reuses cached data instead of firing a fresh request on
+    // every remount — that pattern can otherwise trip the backend's global
+    // rate limit and leave the query in an unrecoverable error state.
+    staleTime: 30_000,
   });
 }
 


### PR DESCRIPTION
## Summary

After rapid back/forward between the Pages list and article views, users saw a misleading **\"No pages found\"** empty state — even though articles still existed and the only problem was that TanStack Query had exhausted its retries against a 429-rate-limited `/api/pages`. Three related fixes:

1. **`PagesPage.tsx`** — read `error` from `usePages` and render a real error panel (\"Couldn't load pages — _\<message\>_\" + Retry button) instead of conflating \"no data\" with \"empty list\". Stops the UI from silently lying about the data state.
2. **`use-pages.ts`** — add `staleTime: 30_000` to the `usePages` list query. Rapid back/forward now reuses cached data instead of firing a fresh request on every remount — removes the trigger that hits the rate limit.
3. **`rate-limit-service.ts`** — raise the **global** default from **100 → 300 / minute**. The old default was too tight for a SPA where a single Pages mount can fire ~6 idempotent GETs (list, filters, spaces, settings, pinned, embeddings status). Admins can still tighten it via the settings UI. Per-route limits (auth/admin/llmStream/llmEmbedding) are unchanged.

## Diagnostic evidence (pre-fix)

Captured directly from the TanStack Query cache in a stuck browser session via `getQueryCache().getAll()`:

\`\`\`
key:     [\"pages\",{\"page\":1,\"sort\":\"modified\"}]
status:  error
error:   { name: \"ApiError\", message: \"Rate limit exceeded, retry in 9 seconds\", statusCode: 429 }
fetchFailureCount: 3
dataUpdateCount:   0
\`\`\`

PagesPage's rendering branch `!pagesData?.items.length ? <EmptyState title=\"No pages found\" /> : ...` then displayed the empty state because `pagesData` was \`undefined\`.

## Test plan

- [x] \`npx vitest run src/shared/hooks/use-pages.test.ts\` — 12/12 pass.
- [x] \`npx vitest run src/features/pages/PagesPage.test.tsx\` — 46/46 pass.
- [x] Playwright manual reproduction: 50-cycle maniac click+back test. Pre-fix produced \`status=error, fetchFailureCount=3\`. Post-fix produces \`status=success, fetchFailureCount=0, itemsCount=4\`.
- [ ] Reviewer: confirm 300/min global default is acceptable; tighten in the settings UI if the deployment is multi-tenant with abuse concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)