### PR TITLE
fix(ui): WCAG-AA contrast pass + amber-as-AI semantic rule

### DIFF
--- a/docs/ARCHITECTURE-DECISIONS.md
+++ b/docs/ARCHITECTURE-DECISIONS.md
@@ -585,6 +585,22 @@ stores/
 
 The v0.3-era glassmorphic surfaces (`backdrop-filter: blur` + alpha bg + thin top-light highlight) are retired as of v0.4 in favour of a neumorphic theme system that mirrors the public landing page (`compendiq-landing/src/styles/tokens.css`) for cross-surface brand parity. Two themes ship — **Graphite Honey** (dark, default) and **Honey Linen** (light) — both anchored on the brand palette (black `#0A0A0A` + honey `#F9C74F`) with theme-tinted neumorphic shadow recipes rather than backdrop blur. Eleven `nm-*` `@utility` classes (`nm-card`, `nm-card-elevated`, `nm-card-interactive`, `nm-toolbar`, `nm-sidebar`, `nm-header`, `nm-pill-active`, `nm-button-primary`, `nm-button-ghost`, `nm-icon-button`, `nm-input`) replace the glass equivalents one-to-one. **Hybrid neumorphism is mandatory**: every interactive surface carries a 1px solid border so chrome remains visible at 3:1 contrast under WCAG 1.4.11, in `forced-colors: active` mode (where `box-shadow` is zeroed by the browser — each utility falls back to a `ButtonText` system border), and on edge-case display calibrations. Focus rings live on `:focus-visible` with `outline-offset` so they don't visually merge with the surface shadow; press states swap raised → inset shadow. `prefers-reduced-motion: reduce` strips the press transform/transition. Status colours have been lifted to `--color-status-*` semantic tokens (`connected` / `syncing` / `embedding` / `ai` / `disconnected` / `inactive`) so badges shift correctly between dark and light themes; `--color-primary-ink` provides a darkened honey for AA-safe accent-as-text use on cream surfaces. The animated gradient mesh on the setup wizard is preserved (it sits behind the neumorphic surfaces without conflict). Migration of persisted theme preferences: any retired theme ID (`void-indigo`, `obsidian-violet`, `polar-slate`, `parchment-glow`, plus older legacy IDs) silently falls back to `graphite-honey` on first load — no data migration is required.
 
+### Amendment v0.5 (2026-05-17) — Amber-as-AI
+
+The brand palette stays black `#0A0A0A` + honey `#F9C74F`, but **honey is reassigned a single semantic meaning across the product: "AI is involved here."** It is no longer used as the primary affordance color.
+
+Three rules:
+
+1. **Honey appears only on AI surfaces** — AI affordances (Ask / Generate / Summarize / Improve / Diagram / Quality / Think / chat composer / duplicate detection), AI-state status (`--color-status-ai` is honey-amber for "AI is processing this"), the AI tab's icon when active in the main rail, and the brand mark's Q-magnifier strokes.
+2. **Primary affordance becomes ink** — `--color-action` (#0A0A0A light, #ECE9E2 dark). Non-AI primary buttons use an outline-fills-on-hover treatment. Active sidebar/tab/article-row pills use ink-fill.
+3. **Focus ring is the one allowed exception** — `--color-ring` stays honey across all surfaces for brand-mark continuity. Focus is intentionally loud.
+
+Status indicators retain their domain palette (green=connected, red=disconnected, yellow=syncing, blue=embedding, purple=AI-processing, gray=inactive) — these are state colors, not affordance colors, and the new rule does not collide.
+
+Badge palette unified: every status pill (Local / Shared / Private / Failed / Skipped / Not Embedded / Recent / Draft) uses a tinted-pill recipe with AA-pass text in both themes. "Private" moves from amber to neutral gray; "Recent" moves from amber to sage; "Draft" moves from orange to neutral gray.
+
+WCAG-AA regression guard: `e2e/contrast.spec.ts` audits 6 routes × 2 themes; any text-on-bg pair below AA fails CI.
+
 ---
 
 ## ADR-011: Docker Deployment Architecture

--- a/e2e/contrast.spec.ts
+++ b/e2e/contrast.spec.ts
@@ -1,0 +1,216 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * E2E: WCAG-AA contrast audit (accessibility + amber-as-AI bundle, task 6/6)
+ *
+ * Audits every visible text element across 6 routes × 2 themes and fails if any
+ * text-on-background pair falls below the WCAG-AA contrast minimum:
+ *   - 4.5:1 for normal text
+ *   - 3:1 for large text (>= 18px, or >= 14px with font-weight >= 700)
+ *
+ * Locks the bundle's accessibility fixes in against future regressions.
+ * Audit logic mirrors the in-browser script used for design evidence gathering
+ * on 2026-05-17.
+ */
+
+const TEST_USER = `e2e_contrast_${Date.now()}`;
+const TEST_PASS = 'TestPassword123!';
+
+const ROUTES = [
+  '/',
+  '/graph',
+  '/ai',
+  '/settings',
+  '/settings/system/license',
+  '/admin/analytics',
+];
+
+interface ContrastViolation {
+  route: string;
+  theme: 'light' | 'dark';
+  text: string;
+  ratio: number;
+  fg: string;
+  bg: string;
+  selector: string;
+}
+
+async function auditPage(
+  page: Page,
+  route: string,
+  theme: 'light' | 'dark',
+): Promise<ContrastViolation[]> {
+  return await page.evaluate(
+    ({ route, theme }) => {
+      function parse(c: string) {
+        const m = c.match(/rgba?\(([^)]+)\)/);
+        if (!m) return null;
+        const p = m[1].split(',').map((s) => parseFloat(s));
+        return { r: p[0], g: p[1], b: p[2], a: p[3] ?? 1 };
+      }
+      function L(c: { r: number; g: number; b: number }) {
+        const f = (v: number) => {
+          v /= 255;
+          return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+        };
+        return 0.2126 * f(c.r) + 0.7152 * f(c.g) + 0.0722 * f(c.b);
+      }
+      function ratio(
+        fg: { r: number; g: number; b: number },
+        bg: { r: number; g: number; b: number },
+      ) {
+        const l1 = L(fg),
+          l2 = L(bg);
+        return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+      }
+      function bgOf(el: HTMLElement): { r: number; g: number; b: number; a: number } {
+        let n: HTMLElement | null = el;
+        while (n) {
+          const c = getComputedStyle(n).backgroundColor;
+          const p = parse(c);
+          if (p && p.a > 0) return p;
+          n = n.parentElement;
+        }
+        return theme === 'dark'
+          ? { r: 18, g: 18, b: 18, a: 1 }
+          : { r: 247, g: 247, b: 247, a: 1 };
+      }
+      function describe(el: HTMLElement): string {
+        const id = el.id ? `#${el.id}` : '';
+        const cls =
+          el.className && typeof el.className === 'string'
+            ? '.' + el.className.split(/\s+/).slice(0, 2).join('.')
+            : '';
+        return `${el.tagName.toLowerCase()}${id}${cls}`.slice(0, 80);
+      }
+      const out: ContrastViolation[] = [];
+      const all = Array.from(
+        document.querySelectorAll<HTMLElement>('body *'),
+      ).filter((el) => {
+        if (!el.offsetParent) return false;
+        const t = Array.from(el.childNodes)
+          .filter((n) => n.nodeType === 3 && (n.textContent ?? '').trim())
+          .map((n) => (n.textContent ?? '').trim())
+          .join(' ');
+        return t.length > 0;
+      });
+      for (const el of all) {
+        const s = getComputedStyle(el);
+        const fg = parse(s.color);
+        if (!fg) continue;
+        const bg = bgOf(el);
+        const r = ratio(fg, bg);
+        const fs = parseFloat(s.fontSize);
+        const fw = parseInt(s.fontWeight);
+        const isLarge = fs >= 18 || (fs >= 14 && fw >= 700);
+        const min = isLarge ? 3 : 4.5;
+        if (r < min) {
+          const text = Array.from(el.childNodes)
+            .filter((n) => n.nodeType === 3)
+            .map((n) => (n.textContent ?? '').trim())
+            .join(' ')
+            .slice(0, 40);
+          if (!text) continue;
+          out.push({
+            route,
+            theme,
+            text,
+            ratio: +r.toFixed(2),
+            fg: `rgb(${fg.r},${fg.g},${fg.b})`,
+            bg: `rgb(${bg.r},${bg.g},${bg.b})`,
+            selector: describe(el),
+          });
+        }
+      }
+      return out;
+    },
+    { route, theme },
+  );
+}
+
+test.describe('WCAG-AA contrast audit', () => {
+  let authToken: string;
+  let authUser: { id: string; username: string; role: string };
+
+  test.beforeEach(async ({ page }) => {
+    // Same registration + localStorage auth pattern as themes.spec.ts.
+    const registerRes = await page.request.post('/api/auth/register', {
+      data: {
+        username: TEST_USER + Math.random().toString(36).slice(2, 6),
+        password: TEST_PASS,
+      },
+    });
+
+    if (!registerRes.ok()) {
+      test.skip();
+      return;
+    }
+
+    const data = await registerRes.json();
+    authToken = data.accessToken;
+    authUser = data.user;
+
+    await page.goto('/login');
+    await page.evaluate(
+      ({ accessToken, user }) => {
+        const authState = {
+          state: { accessToken, user, isAuthenticated: true },
+          version: 0,
+        };
+        localStorage.setItem('compendiq-auth', JSON.stringify(authState));
+      },
+      { accessToken: authToken, user: authUser },
+    );
+  });
+
+  for (const route of ROUTES) {
+    for (const theme of ['light', 'dark'] as const) {
+      test(`contrast: ${route} (${theme})`, async ({ page }) => {
+        // 1. Set theme. graphite-honey is the default after fresh visit; flip
+        //    to honey-linen via the header toggle if light is requested.
+        await page.goto('/');
+        await expect(page.locator('html')).toHaveAttribute(
+          'data-theme',
+          'graphite-honey',
+        );
+
+        if (theme === 'light') {
+          await page
+            .getByRole('button', { name: /switch to light mode/i })
+            .click();
+          await expect(page.locator('html')).toHaveAttribute(
+            'data-theme',
+            'honey-linen',
+          );
+        }
+
+        // 2. Navigate to the target route under the chosen theme.
+        await page.goto(route);
+        await page.waitForLoadState('networkidle');
+
+        // 3. Run the audit.
+        const violations = await auditPage(page, route, theme);
+
+        // 4. If anything failed, dump a compact summary to test output so the
+        //    failure is actionable without re-running with --trace.
+        if (violations.length > 0) {
+          // eslint-disable-next-line no-console
+          console.log(
+            `\nWCAG-AA violations on ${route} (${theme}): ${violations.length}\n` +
+              violations
+                .map(
+                  (v) =>
+                    `  - [${v.ratio}:1] ${v.selector}\n      fg=${v.fg} bg=${v.bg} text="${v.text}"`,
+                )
+                .join('\n'),
+          );
+        }
+
+        expect(
+          violations,
+          `WCAG-AA violations on ${route} (${theme})`,
+        ).toHaveLength(0);
+      });
+    }
+  }
+});

--- a/e2e/contrast.spec.ts
+++ b/e2e/contrast.spec.ts
@@ -129,27 +129,35 @@ async function auditPage(
 }
 
 test.describe('WCAG-AA contrast audit', () => {
-  let authToken: string;
-  let authUser: { id: string; username: string; role: string };
+  // Single shared auth across all 12 tests. The audit is read-only against
+  // the rendered DOM — there's no per-test state to isolate — and reusing one
+  // user avoids tripping the backend's per-IP registration rate limit, which
+  // kicks in around ~5 registrations and was silently skipping the remaining
+  // tests.
+  let authToken: string | null = null;
+  let authUser: { id: string; username: string; role: string } | null = null;
 
-  test.beforeEach(async ({ page }) => {
-    // Same registration + localStorage auth pattern as themes.spec.ts.
-    const registerRes = await page.request.post('/api/auth/register', {
+  test.beforeAll(async ({ request }) => {
+    const registerRes = await request.post('/api/auth/register', {
       data: {
-        username: TEST_USER + Math.random().toString(36).slice(2, 6),
+        username: `${TEST_USER}_${Math.random().toString(36).slice(2, 8)}`,
         password: TEST_PASS,
       },
     });
-
     if (!registerRes.ok()) {
-      test.skip();
+      // Leave auth* null; per-test beforeEach will call test.skip().
       return;
     }
-
     const data = await registerRes.json();
     authToken = data.accessToken;
     authUser = data.user;
+  });
 
+  test.beforeEach(async ({ page }) => {
+    if (!authToken || !authUser) {
+      test.skip();
+      return;
+    }
     await page.goto('/login');
     await page.evaluate(
       ({ accessToken, user }) => {

--- a/frontend/src/features/admin/AiReviewPolicyTab.tsx
+++ b/frontend/src/features/admin/AiReviewPolicyTab.tsx
@@ -430,7 +430,7 @@ function AiReviewPolicyTabInner() {
           type="button"
           onClick={handleSave}
           disabled={!dirty || saveMutation.isPending || is404}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           data-testid="ai-review-policy-save-btn"
         >
           {saveMutation.isPending ? (

--- a/frontend/src/features/admin/BulkUserImportModal.tsx
+++ b/frontend/src/features/admin/BulkUserImportModal.tsx
@@ -244,7 +244,7 @@ function BulkUserImportModalInner({
         >
           <div className="flex items-center justify-between border-b border-border/50 px-5 py-4">
             <Dialog.Title className="flex items-center gap-2 text-base font-semibold">
-              <Users size={16} className="text-primary" />
+              <Users size={16} className="text-action" />
               Bulk import users
             </Dialog.Title>
             <Dialog.Close asChild>
@@ -525,7 +525,7 @@ function PreviewStep({
           type="button"
           onClick={onSubmit}
           disabled={applying || summary.valid === 0}
-          className="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-md border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           data-testid="bulk-import-submit"
         >
           {applying && <Loader2 size={14} className="animate-spin" />}

--- a/frontend/src/features/admin/ComplianceReportsTab.tsx
+++ b/frontend/src/features/admin/ComplianceReportsTab.tsx
@@ -306,7 +306,7 @@ function ReportCard({
     >
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-start gap-3">
-          <FileText size={18} className="mt-0.5 shrink-0 text-primary" />
+          <FileText size={18} className="mt-0.5 shrink-0 text-action" />
           <div>
             <h3 className="text-sm font-medium tracking-tight">{entry.title}</h3>
             <p className="mt-1 text-xs text-muted-foreground">{entry.controls}</p>
@@ -411,7 +411,7 @@ export function ComplianceReportsTab() {
           className="nm-card p-6"
         >
           <div className="flex items-start gap-3">
-            <ShieldCheck size={20} className="mt-0.5 text-primary" />
+            <ShieldCheck size={20} className="mt-0.5 text-action" />
             <div>
               <h2 className="text-base font-medium">Compliance reports require an Enterprise license</h2>
               <p className="mt-1 text-sm text-muted-foreground">

--- a/frontend/src/features/admin/CustomRoleEditor.tsx
+++ b/frontend/src/features/admin/CustomRoleEditor.tsx
@@ -254,7 +254,7 @@ export function CustomRoleEditor({ open, onOpenChange, editRole }: CustomRoleEdi
           {/* Header */}
           <div className="flex items-center justify-between border-b border-border/50 px-5 py-4">
             <Dialog.Title className="flex items-center gap-2 text-base font-semibold text-foreground">
-              <Shield size={18} className="text-primary" />
+              <Shield size={18} className="text-action" />
               {isEditMode ? `Edit Role: ${editRole.displayName}` : 'Create Custom Role'}
             </Dialog.Title>
             <Dialog.Close asChild>
@@ -275,7 +275,7 @@ export function CustomRoleEditor({ open, onOpenChange, editRole }: CustomRoleEdi
                 onClick={() => setActiveSection('edit')}
                 className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
                   activeSection === 'edit'
-                    ? 'bg-primary/15 text-primary font-medium'
+                    ? 'bg-action/15 text-action font-medium'
                     : 'text-muted-foreground hover:bg-foreground/5'
                 }`}
                 data-testid="tab-permissions"
@@ -286,7 +286,7 @@ export function CustomRoleEditor({ open, onOpenChange, editRole }: CustomRoleEdi
                 onClick={() => setActiveSection('assignments')}
                 className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
                   activeSection === 'assignments'
-                    ? 'bg-primary/15 text-primary font-medium'
+                    ? 'bg-action/15 text-action font-medium'
                     : 'text-muted-foreground hover:bg-foreground/5'
                 }`}
                 data-testid="tab-assignments"
@@ -421,7 +421,7 @@ export function CustomRoleEditor({ open, onOpenChange, editRole }: CustomRoleEdi
                             <td className="px-4 py-2">{a.spaceKey}</td>
                             <td className="px-4 py-2">
                               <span className={`rounded px-2 py-0.5 text-xs font-medium ${
-                                a.principalType === 'group' ? 'bg-primary/10 text-primary' : 'bg-blue-500/10 text-blue-500'
+                                a.principalType === 'group' ? 'bg-action/10 text-action' : 'bg-blue-500/10 text-blue-500'
                               }`}>
                                 {a.principalType === 'group' ? 'Group' : 'User'}
                               </span>
@@ -485,7 +485,7 @@ export function CustomRoleEditor({ open, onOpenChange, editRole }: CustomRoleEdi
                 <button
                   onClick={handleSubmit}
                   disabled={!canSubmit}
-                  className="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                  className="inline-flex items-center gap-2 rounded-md border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
                   data-testid="submit-role-btn"
                 >
                   {isPending && <Loader2 size={14} className="animate-spin" />}

--- a/frontend/src/features/admin/DataRetentionTab.tsx
+++ b/frontend/src/features/admin/DataRetentionTab.tsx
@@ -124,7 +124,7 @@ function AdminAccessDeniedRetentionSection() {
               type="button"
               onClick={() => draft !== undefined && save.mutate(draft)}
               disabled={!hasChange || save.isPending}
-              className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-md border border-action bg-transparent px-3 py-1.5 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               data-testid="admin-denied-retention-save-btn"
             >
               {save.isPending ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
@@ -496,7 +496,7 @@ export function DataRetentionTab() {
         <button
           onClick={handleSave}
           disabled={saveMutation.isPending}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           data-testid="data-retention-save-btn"
         >
           {saveMutation.isPending ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}

--- a/frontend/src/features/admin/IpAllowlistTab.tsx
+++ b/frontend/src/features/admin/IpAllowlistTab.tsx
@@ -344,7 +344,7 @@ export function IpAllowlistTab() {
         <Switch.Root
           checked={enabled}
           onCheckedChange={(v) => setEnabled(v)}
-          className="relative h-5 w-9 shrink-0 rounded-full bg-foreground/10 transition-colors outline-none data-[state=checked]:bg-primary"
+          className="relative h-5 w-9 shrink-0 rounded-full bg-foreground/10 transition-colors outline-none data-[state=checked]:bg-action"
           data-testid="ip-allowlist-enabled-toggle"
           aria-label="Enable IP allowlist enforcement"
         >
@@ -536,7 +536,7 @@ export function IpAllowlistTab() {
           disabled={!saveEnabled || saveMutation.isPending}
           title={saveDisabledReason || undefined}
           aria-label="Save IP allowlist configuration"
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           data-testid="ip-allowlist-save-btn"
         >
           {saveMutation.isPending ? (

--- a/frontend/src/features/admin/LicenseStatusCard.tsx
+++ b/frontend/src/features/admin/LicenseStatusCard.tsx
@@ -207,7 +207,7 @@ export function LicenseStatusCard() {
             <button
               onClick={handleSave}
               disabled={!keyInput.trim() || saveMutation.isPending || clearMutation.isPending}
-              className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               data-testid="license-key-save-btn"
             >
               {saveMutation.isPending ? (

--- a/frontend/src/features/admin/LlmAuditPage.tsx
+++ b/frontend/src/features/admin/LlmAuditPage.tsx
@@ -211,7 +211,7 @@ export function LlmAuditPage() {
             onClick={() => setShowFilters((v) => !v)}
             className={cn(
               'flex items-center gap-1.5 rounded-md px-3 py-2 text-sm transition-colors',
-              showFilters ? 'bg-primary/15 text-primary' : 'bg-foreground/5 text-muted-foreground hover:bg-foreground/10',
+              showFilters ? 'bg-action/15 text-action' : 'bg-foreground/5 text-muted-foreground hover:bg-foreground/10',
             )}
             data-testid="toggle-filters-btn"
           >
@@ -347,7 +347,7 @@ export function LlmAuditPage() {
                       {entry.user_id ? entry.user_id.slice(0, 8) : '—'}
                     </td>
                     <td className="px-4 py-2.5">
-                      <span className="rounded bg-primary/10 px-2 py-0.5 text-xs text-primary">
+                      <span className="rounded bg-[#ececea] px-2 py-0.5 text-xs text-[#4a4a48] dark:bg-[#2a2925] dark:text-[#c5bea9]">
                         {entry.action}
                       </span>
                     </td>

--- a/frontend/src/features/admin/LlmPolicyTab.tsx
+++ b/frontend/src/features/admin/LlmPolicyTab.tsx
@@ -197,7 +197,7 @@ export function LlmPolicyTab() {
         <button
           onClick={handleSave}
           disabled={saveMutation.isPending}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           data-testid="llm-policy-save-btn"
         >
           {saveMutation.isPending ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}

--- a/frontend/src/features/admin/OidcSettingsPage.tsx
+++ b/frontend/src/features/admin/OidcSettingsPage.tsx
@@ -375,7 +375,7 @@ function ProviderTab({ disabled }: { disabled?: boolean }) {
         <button
           onClick={handleSave}
           disabled={disabled || saveMutation.isPending}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           data-testid="oidc-save-btn"
         >
           {saveMutation.isPending && <Loader2 size={14} className="animate-spin" />}
@@ -456,7 +456,7 @@ function MappingsTab({ disabled }: { disabled?: boolean }) {
         <button
           onClick={() => setShowForm(true)}
           disabled={disabled}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           data-testid="create-mapping-btn"
         >
           <Plus size={16} />
@@ -520,7 +520,7 @@ function MappingsTab({ disabled }: { disabled?: boolean }) {
             <button
               onClick={handleCreate}
               disabled={!oidcGroup.trim() || !roleId || createMutation.isPending}
-              className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-md border border-action bg-transparent px-3 py-1.5 text-sm text-action transition-colors hover:bg-action hover:text-action-foreground disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               data-testid="submit-mapping"
             >
               {createMutation.isPending && <Loader2 size={14} className="animate-spin" />}
@@ -564,7 +564,7 @@ function MappingsTab({ disabled }: { disabled?: boolean }) {
                 >
                   <td className="px-4 py-2.5 font-mono text-xs">{mapping.oidcGroup}</td>
                   <td className="px-4 py-2.5">
-                    <span className="rounded bg-primary/10 px-2 py-0.5 text-xs text-primary">
+                    <span className="rounded bg-[#ececea] px-2 py-0.5 text-xs text-[#4a4a48] dark:bg-[#2a2925] dark:text-[#c5bea9]">
                       {mapping.roleName ?? `Role #${mapping.roleId}`}
                     </span>
                   </td>
@@ -643,7 +643,7 @@ export function OidcSettingsPage() {
               className={cn(
                 'flex items-center gap-1.5 rounded-md px-4 py-2 text-sm transition-colors',
                 activeTab === key
-                  ? 'bg-primary/15 text-primary font-medium'
+                  ? 'bg-action/15 text-action font-medium'
                   : 'text-muted-foreground hover:bg-foreground/5',
               )}
               data-testid={`oidc-tab-${key}`}

--- a/frontend/src/features/admin/PiiPolicyTab.tsx
+++ b/frontend/src/features/admin/PiiPolicyTab.tsx
@@ -543,7 +543,7 @@ function PiiPolicyTabInner() {
           type="button"
           onClick={handleSave}
           disabled={!dirty || saveMutation.isPending || is404}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           data-testid="pii-policy-save-btn"
         >
           {saveMutation.isPending ? (

--- a/frontend/src/features/admin/RbacPage.tsx
+++ b/frontend/src/features/admin/RbacPage.tsx
@@ -225,7 +225,7 @@ function RolesTab() {
         {advancedRbac && (
           <button
             onClick={handleCreate}
-            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
             data-testid="create-custom-role-btn"
           >
             <Plus size={16} />
@@ -251,7 +251,7 @@ function RolesTab() {
       {advancedRbac && (
         <button
           onClick={handleCreate}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           data-testid="create-custom-role-btn"
         >
           <Plus size={16} />
@@ -268,10 +268,10 @@ function RolesTab() {
           data-testid={`role-${role.id}`}
         >
           <div className="flex items-center gap-2">
-            <Lock size={14} className="text-primary" />
+            <Lock size={14} className="text-action" />
             <h3 className="font-medium">{role.displayName}</h3>
             {role.isSystem && (
-              <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+              <span className="rounded bg-[#ececea] px-1.5 py-0.5 text-[10px] font-medium text-[#4a4a48] dark:bg-[#2a2925] dark:text-[#c5bea9]">
                 System
               </span>
             )}
@@ -367,7 +367,7 @@ function GroupsTab() {
       {!showCreateForm ? (
         <button
           onClick={() => setShowCreateForm(true)}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           data-testid="create-group-btn"
         >
           <Plus size={16} />
@@ -396,7 +396,7 @@ function GroupsTab() {
             <button
               onClick={handleCreateGroup}
               disabled={!newGroupName.trim() || createMutation.isPending}
-              className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-md border border-action bg-transparent px-3 py-1.5 text-sm text-action transition-colors hover:bg-action hover:text-action-foreground disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               data-testid="submit-group"
             >
               {createMutation.isPending && <Loader2 size={14} className="animate-spin" />}
@@ -430,7 +430,7 @@ function GroupsTab() {
             <div className="flex items-center justify-between">
               <div>
                 <div className="flex items-center gap-2">
-                  <Users size={14} className="text-primary" />
+                  <Users size={14} className="text-action" />
                   <h3 className="font-medium">{group.name}</h3>
                   <span className="text-xs text-muted-foreground">
                     ({group.memberCount} {group.memberCount === 1 ? 'member' : 'members'})
@@ -482,7 +482,7 @@ function GroupsTab() {
                   <button
                     onClick={() => handleAddMember(group.id)}
                     disabled={!selectedUserId || addMemberMutation.isPending}
-                    className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                    className="rounded-md border border-action bg-transparent px-3 py-1.5 text-sm text-action transition-colors hover:bg-action hover:text-action-foreground disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
                     data-testid={`add-member-btn-${group.id}`}
                   >
                     Add
@@ -583,7 +583,7 @@ function SpacePermissionsTab() {
           {!showAssignForm ? (
             <button
               onClick={() => setShowAssignForm(true)}
-              className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
               data-testid="add-assignment-btn"
             >
               <Plus size={16} />
@@ -639,7 +639,7 @@ function SpacePermissionsTab() {
                 <button
                   onClick={handleAssign}
                   disabled={!principalId || !roleId || assignMutation.isPending}
-                  className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                  className="inline-flex items-center gap-2 rounded-md border border-action bg-transparent px-3 py-1.5 text-sm text-action transition-colors hover:bg-action hover:text-action-foreground disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
                   data-testid="submit-assignment"
                 >
                   {assignMutation.isPending && <Loader2 size={14} className="animate-spin" />}
@@ -677,7 +677,7 @@ function SpacePermissionsTab() {
                       <td className="px-4 py-2.5">
                         <span className={cn(
                           'rounded px-2 py-0.5 text-xs font-medium',
-                          assignment.principalType === 'group' ? 'bg-primary/10 text-primary' : 'bg-info/10 text-info',
+                          assignment.principalType === 'group' ? 'bg-action/10 text-action' : 'bg-info/10 text-info',
                         )}>
                           {assignment.principalType === 'group' ? 'Group' : 'User'}
                         </span>
@@ -715,7 +715,7 @@ function AdminBadge() {
   if (user?.role !== 'admin') return null;
 
   return (
-    <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+    <span className="inline-flex items-center gap-1 rounded-full bg-action/10 px-2.5 py-1 text-xs font-medium text-action">
       <ShieldCheck size={12} />
       System Admin
     </span>
@@ -756,7 +756,7 @@ export function RbacPage() {
               className={cn(
                 'flex items-center gap-1.5 rounded-md px-4 py-2 text-sm transition-colors',
                 activeTab === key
-                  ? 'bg-primary/15 text-primary font-medium'
+                  ? 'bg-action/15 text-action font-medium'
                   : 'text-muted-foreground hover:bg-foreground/5',
               )}
               data-testid={`rbac-tab-${key}`}

--- a/frontend/src/features/admin/ScimSettingsPage.tsx
+++ b/frontend/src/features/admin/ScimSettingsPage.tsx
@@ -246,7 +246,7 @@ export function ScimSettingsPage() {
             <button
               onClick={handleDismiss}
               disabled={!copiedConfirmed}
-              className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               data-testid="scim-dismiss-token"
             >
               <CheckCircle2 size={14} />
@@ -260,7 +260,7 @@ export function ScimSettingsPage() {
       {!showCreateForm ? (
         <button
           onClick={() => setShowCreateForm(true)}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           data-testid="generate-token-btn"
         >
           <Plus size={16} />
@@ -307,7 +307,7 @@ export function ScimSettingsPage() {
             <button
               onClick={handleCreate}
               disabled={!tokenName.trim() || createMutation.isPending}
-              className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-md border border-action bg-transparent px-3 py-1.5 text-sm text-action transition-colors hover:bg-action hover:text-action-foreground disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               data-testid="scim-create-submit"
             >
               {createMutation.isPending && <Loader2 size={14} className="animate-spin" />}

--- a/frontend/src/features/admin/SyncConflictPolicyTab.tsx
+++ b/frontend/src/features/admin/SyncConflictPolicyTab.tsx
@@ -301,7 +301,7 @@ function SyncConflictPolicyTabInner() {
           type="button"
           onClick={handleSave}
           disabled={!dirty || saveMutation.isPending || is404}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           data-testid="sync-conflict-policy-save-btn"
         >
           {saveMutation.isPending ? (

--- a/frontend/src/features/admin/SyncConflictResolveDialog.tsx
+++ b/frontend/src/features/admin/SyncConflictResolveDialog.tsx
@@ -148,7 +148,7 @@ export function SyncConflictResolveDialog({ conflict, onClose, onResolved }: Pro
               type="button"
               onClick={() => resolveMutation.mutate({ resolution: 'remote' })}
               disabled={isPending}
-              className="flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              className="inline-flex items-center gap-1.5 rounded-md border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               data-testid="sync-conflict-resolve-take-remote-btn"
             >
               {isPending ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}

--- a/frontend/src/features/admin/SyncConflictsPage.tsx
+++ b/frontend/src/features/admin/SyncConflictsPage.tsx
@@ -206,7 +206,7 @@ function SyncConflictsPageInner() {
               <button
                 type="button"
                 onClick={() => setSelected(c)}
-                className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                className="inline-flex items-center gap-1.5 rounded-md border border-action bg-transparent px-3 py-1.5 text-xs font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                 data-testid={`sync-conflict-review-btn-${c.id}`}
               >
                 <GitMerge size={12} />

--- a/frontend/src/features/admin/UserBulkActionDialog.tsx
+++ b/frontend/src/features/admin/UserBulkActionDialog.tsx
@@ -223,7 +223,7 @@ function UserBulkActionDialogInner({
         >
           <div className="flex items-center justify-between border-b border-border/50 px-5 py-4">
             <Dialog.Title className="flex items-center gap-2 text-base font-semibold">
-              <Users size={16} className="text-primary" />
+              <Users size={16} className="text-action" />
               Bulk action ({selectedUserIds.length} selected)
             </Dialog.Title>
             <Dialog.Close asChild>
@@ -382,7 +382,7 @@ function UserBulkActionDialogInner({
                   });
                 }}
                 disabled={submitDisabled}
-                className="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                className="inline-flex items-center gap-2 rounded-md border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
                 data-testid="bulk-action-submit"
               >
                 {submitMutation.isPending && (

--- a/frontend/src/features/admin/UsersAdminPage.tsx
+++ b/frontend/src/features/admin/UsersAdminPage.tsx
@@ -175,7 +175,7 @@ export function UsersAdminPage() {
           <button
             type="button"
             onClick={() => setShowCreate(true)}
-            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+            className="rounded-md border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           >
             Create user
           </button>
@@ -480,7 +480,7 @@ function UserCreateDialog({ onClose, onSubmit, isSubmitting }: UserCreateDialogP
           </button>
           <button
             type="submit"
-            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+            className="rounded-md border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
             disabled={isSubmitting}
           >
             {isSubmitting ? 'Creating…' : 'Create'}

--- a/frontend/src/features/admin/WebhooksTab.tsx
+++ b/frontend/src/features/admin/WebhooksTab.tsx
@@ -214,7 +214,7 @@ function WebhooksTabInner() {
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="flex items-center gap-2 text-2xl font-bold">
-            <Webhook size={22} className="text-primary" />
+            <Webhook size={22} className="text-action" />
             Webhook endpoints
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
@@ -226,7 +226,7 @@ function WebhooksTabInner() {
         <button
           type="button"
           onClick={() => setModal({ kind: 'create' })}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           data-testid="webhooks-new-btn"
         >
           <Plus size={14} />
@@ -379,7 +379,7 @@ function SubscriptionRow({
               checked={sub.active}
               onCheckedChange={(v) => onToggle(v)}
               disabled={toggleBusy}
-              className="relative h-5 w-9 shrink-0 rounded-full bg-foreground/10 transition-colors outline-none data-[state=checked]:bg-primary disabled:opacity-50"
+              className="relative h-5 w-9 shrink-0 rounded-full bg-foreground/10 transition-colors outline-none data-[state=checked]:bg-action disabled:opacity-50"
               data-testid={`webhook-toggle-${sub.id}`}
               aria-label={`${sub.active ? 'Disable' : 'Enable'} webhook ${sub.label ?? sub.url}`}
             >
@@ -739,7 +739,7 @@ function CreateEditDialog({
                   className={cn(
                     'flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-xs transition-colors',
                     checked
-                      ? 'bg-primary/10 text-primary'
+                      ? 'bg-action/10 text-action'
                       : 'text-muted-foreground hover:bg-foreground/5',
                   )}
                   data-testid={`webhook-event-option-${ev}`}
@@ -837,7 +837,7 @@ function CreateEditDialog({
             mutation.mutate();
           }}
           disabled={!canSubmit || mutation.isPending}
-          className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-md border border-action bg-transparent px-3 py-1.5 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           data-testid="webhook-save-btn"
         >
           {mutation.isPending && <Loader2 size={14} className="animate-spin" />}
@@ -993,7 +993,7 @@ function RotateSecretDialog({
               mutation.mutate();
             }}
             disabled={!canSubmit || mutation.isPending}
-            className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex items-center gap-2 rounded-md border border-action bg-transparent px-3 py-1.5 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
             data-testid="webhook-rotate-submit-btn"
           >
             {mutation.isPending && <Loader2 size={14} className="animate-spin" />}
@@ -1139,7 +1139,7 @@ function TestDeliveryDialog({ subscription, onClose }: TestDialogProps) {
             mutation.mutate();
           }}
           disabled={!eventType || mutation.isPending}
-          className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-md border border-action bg-transparent px-3 py-1.5 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           data-testid="webhook-test-submit-btn"
         >
           {mutation.isPending ? (

--- a/frontend/src/features/ai/AiAssistantPage.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.tsx
@@ -241,7 +241,7 @@ function AiAssistantInner() {
               className={cn(
                 'flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-colors',
                 mode === key
-                  ? 'bg-primary/12 font-medium text-primary'
+                  ? 'bg-primary font-medium text-primary-foreground'
                   : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
               )}
             >

--- a/frontend/src/features/ai/AiAssistantPage.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.tsx
@@ -280,7 +280,7 @@ function AiAssistantInner() {
           <label
             className={cn(
               'flex cursor-pointer items-center gap-1 rounded-md px-2 py-0.5 text-xs transition-colors',
-              includeSubPages ? 'bg-primary/12 text-primary' : 'text-muted-foreground hover:bg-foreground/5',
+              includeSubPages ? 'bg-primary/12 text-primary-ink' : 'text-muted-foreground hover:bg-foreground/5',
             )}
             title="Include sub-pages in the AI context"
           >

--- a/frontend/src/features/ai/CitationChips.tsx
+++ b/frontend/src/features/ai/CitationChips.tsx
@@ -29,7 +29,7 @@ export function CitationChips({ sources, className }: CitationChipsProps) {
           title={source.pageTitle}
           className={cn(
             'inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded',
-            'bg-primary/15 px-1.5 text-[10px] font-semibold tabular-nums text-primary',
+            'bg-primary/15 px-1.5 text-[10px] font-semibold tabular-nums text-primary-ink',
             'transition-colors hover:bg-primary/25 focus:outline-none focus:ring-1 focus:ring-primary',
           )}
           data-testid={`citation-chip-${i + 1}`}

--- a/frontend/src/features/ai/ReviewDetailPage.tsx
+++ b/frontend/src/features/ai/ReviewDetailPage.tsx
@@ -364,7 +364,7 @@ function ReviewDetailContent({
             className={cn(
               'flex items-center gap-1 px-2 py-1',
               !showHtml
-                ? 'bg-primary/15 text-primary'
+                ? 'bg-primary/15 text-primary-ink'
                 : 'text-muted-foreground hover:bg-foreground/5',
             )}
             data-testid="ai-review-detail-text-toggle"
@@ -377,7 +377,7 @@ function ReviewDetailContent({
             className={cn(
               'flex items-center gap-1 px-2 py-1',
               showHtml
-                ? 'bg-primary/15 text-primary'
+                ? 'bg-primary/15 text-primary-ink'
                 : 'text-muted-foreground hover:bg-foreground/5',
             )}
             data-testid="ai-review-detail-html-toggle"

--- a/frontend/src/features/ai/modes/AskMode.tsx
+++ b/frontend/src/features/ai/modes/AskMode.tsx
@@ -111,7 +111,7 @@ export function AskModeInput() {
           {externalUrls.map((url) => (
             <span
               key={url}
-              className="inline-flex items-center gap-1 rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-xs text-primary"
+              className="inline-flex items-center gap-1 rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-xs text-primary-ink"
             >
               <Link2 size={10} />
               {new URL(url).hostname}
@@ -137,7 +137,7 @@ export function AskModeInput() {
           />
           <button
             onClick={addUrl}
-            className="shrink-0 rounded-md px-2 py-1 text-xs text-primary hover:bg-primary/10"
+            className="shrink-0 rounded-md px-2 py-1 text-xs text-primary-ink hover:bg-primary/10"
           >
             <Plus size={12} />
           </button>
@@ -158,7 +158,7 @@ export function AskModeInput() {
             title="Attach external documentation URL"
             className={`shrink-0 rounded-md p-1.5 transition-colors ${
               showUrlInput || externalUrls.length > 0
-                ? 'bg-primary/15 text-primary'
+                ? 'bg-primary/15 text-primary-ink'
                 : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground'
             }`}
             data-testid="attach-url-button"

--- a/frontend/src/features/ai/modes/DiagramMode.tsx
+++ b/frontend/src/features/ai/modes/DiagramMode.tsx
@@ -33,7 +33,7 @@ export function DiagramTypeSelector() {
           onClick={() => setDiagramType(type)}
           className={cn(
             'rounded-md px-2.5 py-1 text-xs capitalize',
-            diagramType === type ? 'bg-primary/15 text-primary' : 'text-muted-foreground hover:bg-foreground/5',
+            diagramType === type ? 'bg-primary/15 text-primary-ink' : 'text-muted-foreground hover:bg-foreground/5',
           )}
         >
           {type}

--- a/frontend/src/features/ai/modes/GenerateMode.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.tsx
@@ -132,7 +132,7 @@ function ParentPagePicker({
               }}
               className={cn(
                 'w-full rounded-md px-3 py-1.5 text-left text-sm transition-colors hover:bg-foreground/5',
-                !parentId && 'bg-primary/10 text-primary',
+                !parentId && 'bg-primary/10 text-primary-ink',
               )}
             >
               None (root level)
@@ -153,7 +153,7 @@ function ParentPagePicker({
                 }}
                 className={cn(
                   'w-full rounded-md px-3 py-1.5 text-left text-sm transition-colors hover:bg-foreground/5',
-                  parentId === page.id && 'bg-primary/10 text-primary',
+                  parentId === page.id && 'bg-primary/10 text-primary-ink',
                 )}
               >
                 {page.title}
@@ -292,7 +292,7 @@ function PdfUploadZone({
         className={cn(
           'flex w-full items-center justify-center gap-2 rounded-lg border border-dashed px-4 py-3 text-sm transition-colors',
           isDragOver
-            ? 'border-primary bg-primary/10 text-primary'
+            ? 'border-primary bg-primary/10 text-primary-ink'
             : 'border-border/40 text-muted-foreground hover:border-border/60 hover:text-foreground',
           (isExtracting || disabled) && 'pointer-events-none opacity-50',
         )}

--- a/frontend/src/features/ai/modes/ImproveMode.tsx
+++ b/frontend/src/features/ai/modes/ImproveMode.tsx
@@ -34,7 +34,7 @@ export function ImproveTypeSelector() {
             title={IMPROVEMENT_DESCRIPTIONS[type]}
             className={cn(
               'rounded-md px-2.5 py-1 text-xs capitalize',
-              improvementType === type ? 'bg-primary/15 text-primary' : 'text-muted-foreground hover:bg-foreground/5',
+              improvementType === type ? 'bg-primary/15 text-primary-ink' : 'text-muted-foreground hover:bg-foreground/5',
             )}
           >
             {type}

--- a/frontend/src/features/graph/GraphPage.tsx
+++ b/frontend/src/features/graph/GraphPage.tsx
@@ -353,7 +353,7 @@ export function GraphPage() {
     return (
       <div className="flex h-full items-center justify-center">
         <div className="nm-card flex flex-col items-center gap-4 p-8">
-          <RefreshCw className="h-8 w-8 animate-spin text-primary" />
+          <RefreshCw className="h-8 w-8 animate-spin text-action" />
           <p className="text-muted-foreground">Loading knowledge graph...</p>
         </div>
       </div>
@@ -408,7 +408,7 @@ export function GraphPage() {
                 onClick={() => setViewMode('individual')}
                 className={cn(
                   'nm-icon-button p-2',
-                  viewMode === 'individual' && 'bg-primary/15 text-primary',
+                  viewMode === 'individual' && 'bg-action/15 text-action',
                 )}
                 aria-label="Individual view"
                 data-testid="graph-view-individual"
@@ -420,7 +420,7 @@ export function GraphPage() {
                 onClick={() => setViewMode('clustered')}
                 className={cn(
                   'nm-icon-button p-2',
-                  viewMode === 'clustered' && 'bg-primary/15 text-primary',
+                  viewMode === 'clustered' && 'bg-action/15 text-action',
                 )}
                 aria-label="Cluster view"
                 data-testid="graph-view-clustered"
@@ -894,7 +894,7 @@ export function GraphFilterSidebar({
                 className={cn(
                   'rounded-full px-2 py-0.5 text-[10px] transition-colors',
                   labels.includes(label)
-                    ? 'bg-primary/20 text-primary'
+                    ? 'bg-action/20 text-action'
                     : 'bg-foreground/5 text-muted-foreground hover:text-foreground',
                 )}
                 data-testid="filter-label-chip"

--- a/frontend/src/features/knowledge-requests/KnowledgeRequestsPage.tsx
+++ b/frontend/src/features/knowledge-requests/KnowledgeRequestsPage.tsx
@@ -160,7 +160,7 @@ export function KnowledgeRequestsPage() {
         </div>
         <button
           onClick={() => setShowCreateModal(true)}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           data-testid="create-request-btn"
         >
           <Plus size={16} />
@@ -180,7 +180,7 @@ export function KnowledgeRequestsPage() {
                 className={cn(
                   'rounded-md px-3 py-1.5 text-sm transition-colors',
                   activeTab === key
-                    ? 'bg-primary/15 text-primary font-medium'
+                    ? 'bg-action/15 text-action font-medium'
                     : 'text-muted-foreground hover:bg-foreground/5',
                 )}
                 data-testid={`tab-${key}`}
@@ -278,7 +278,7 @@ export function KnowledgeRequestsPage() {
                         setFulfillRequestId(request.id);
                         setFulfillPageId('');
                       }}
-                      className="flex shrink-0 items-center gap-1 rounded-md bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary hover:bg-primary/20 transition-colors"
+                      className="inline-flex shrink-0 items-center gap-1 rounded-md border border-action bg-transparent px-2.5 py-1 text-xs font-medium text-action transition-colors hover:bg-action hover:text-action-foreground"
                       data-testid={`fulfill-${request.id}`}
                     >
                       <LinkIcon size={12} />
@@ -353,7 +353,7 @@ export function KnowledgeRequestsPage() {
                 <button
                   onClick={handleCreate}
                   disabled={!newTitle.trim() || createMutation.isPending}
-                  className="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                  className="inline-flex items-center gap-2 rounded-md border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
                   data-testid="submit-request"
                 >
                   {createMutation.isPending && <Loader2 size={14} className="animate-spin" />}
@@ -403,7 +403,7 @@ export function KnowledgeRequestsPage() {
                 <button
                   onClick={handleFulfill}
                   disabled={!fulfillPageId.trim() || fulfillMutation.isPending}
-                  className="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                  className="inline-flex items-center gap-2 rounded-md border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
                   data-testid="submit-fulfill"
                 >
                   {fulfillMutation.isPending && <Loader2 size={14} className="animate-spin" />}

--- a/frontend/src/features/pages/AutoTagger.tsx
+++ b/frontend/src/features/pages/AutoTagger.tsx
@@ -144,7 +144,7 @@ export function AutoTagger({ pageId, currentLabels, model, className }: AutoTagg
                       className={cn(
                         'flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-colors',
                         selectedTags.has(tag)
-                          ? 'bg-primary/20 text-primary ring-1 ring-primary/30'
+                          ? 'bg-primary/20 text-primary-ink ring-1 ring-primary/30'
                           : 'bg-foreground/5 text-muted-foreground hover:bg-foreground/10',
                       )}
                     >

--- a/frontend/src/features/pages/BulkOperations.tsx
+++ b/frontend/src/features/pages/BulkOperations.tsx
@@ -238,7 +238,7 @@ export function BulkOperations({
                   className={cn(
                     'rounded px-2 py-1 text-xs font-medium transition-colors',
                     tagAction === 'add'
-                      ? 'bg-primary/15 text-primary'
+                      ? 'bg-action/15 text-action'
                       : 'text-muted-foreground hover:text-foreground',
                   )}
                   data-testid="tag-action-add"
@@ -299,7 +299,7 @@ export function BulkOperations({
                     bulkTag.isPending ||
                     bulkReplaceTags.isPending
                   }
-                  className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                  className="inline-flex items-center justify-center rounded-md border border-action bg-transparent px-3 py-1.5 text-xs font-medium text-action transition-colors hover:bg-action hover:text-action-foreground disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
                   data-testid="tag-submit"
                 >
                   Apply

--- a/frontend/src/features/pages/BulkPagePermissionDialog.tsx
+++ b/frontend/src/features/pages/BulkPagePermissionDialog.tsx
@@ -124,7 +124,7 @@ function BulkPagePermissionDialogInner({
       >
         <div className="mb-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <Shield size={18} className="text-primary" />
+            <Shield size={18} className="text-action" />
             <h2 className="text-lg font-semibold">Bulk Page Permission</h2>
           </div>
           <button
@@ -155,7 +155,7 @@ function BulkPagePermissionDialogInner({
                 className={cn(
                   'flex-1 rounded-md px-3 py-1.5 text-xs font-medium capitalize transition-colors',
                   action === a
-                    ? 'bg-primary/15 text-primary'
+                    ? 'bg-action/15 text-action'
                     : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
                 )}
                 data-testid={`action-${a}`}
@@ -244,7 +244,7 @@ function BulkPagePermissionDialogInner({
           <button
             onClick={() => apply.mutate()}
             disabled={!canSubmit}
-            className="rounded-md bg-primary px-4 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            className="inline-flex items-center justify-center rounded-md border border-action bg-transparent px-4 py-1.5 text-xs font-medium text-action transition-colors hover:bg-action hover:text-action-foreground disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
             data-testid="apply-btn"
           >
             {apply.isPending ? 'Applying…' : 'Apply'}

--- a/frontend/src/features/pages/DuplicateDetector.tsx
+++ b/frontend/src/features/pages/DuplicateDetector.tsx
@@ -104,7 +104,7 @@ export function DuplicateDetector({ pageId, pageTitle }: DuplicateDetectorProps)
                 // Keep amber per spec semantic rule.
                 <button
                   onClick={handleScan}
-                  className="flex items-center gap-1.5 rounded-md bg-primary/10 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/20 transition-colors"
+                  className="flex items-center gap-1.5 rounded-md bg-primary/10 px-3 py-1.5 text-xs font-medium text-primary-ink hover:bg-primary/20 transition-colors"
                 >
                   <Search size={12} /> Find Duplicates
                 </button>

--- a/frontend/src/features/pages/DuplicateDetector.tsx
+++ b/frontend/src/features/pages/DuplicateDetector.tsx
@@ -100,6 +100,8 @@ export function DuplicateDetector({ pageId, pageTitle }: DuplicateDetectorProps)
             </div>
             <div className="flex items-center gap-2">
               {!scanning && (
+                // AI affordance: duplicate detection runs on vector embeddings (semantic similarity).
+                // Keep amber per spec semantic rule.
                 <button
                   onClick={handleScan}
                   className="flex items-center gap-1.5 rounded-md bg-primary/10 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/20 transition-colors"

--- a/frontend/src/features/pages/FlowchartGenerator.test.tsx
+++ b/frontend/src/features/pages/FlowchartGenerator.test.tsx
@@ -150,7 +150,7 @@ describe('FlowchartGenerator', () => {
 
     await waitFor(() => {
       const flowchartBtn = screen.getByText('flowchart');
-      expect(flowchartBtn).toHaveClass('bg-primary/15', 'text-primary');
+      expect(flowchartBtn).toHaveClass('bg-primary/15', 'text-primary-ink');
     });
   });
 
@@ -211,7 +211,7 @@ describe('FlowchartGenerator', () => {
     fireEvent.click(screen.getByText('sequence'));
 
     // Sequence should now be active
-    expect(screen.getByText('sequence')).toHaveClass('bg-primary/15', 'text-primary');
+    expect(screen.getByText('sequence')).toHaveClass('bg-primary/15', 'text-primary-ink');
     // Flowchart should be inactive
     expect(screen.getByText('flowchart')).not.toHaveClass('bg-primary/15');
   });

--- a/frontend/src/features/pages/FlowchartGenerator.tsx
+++ b/frontend/src/features/pages/FlowchartGenerator.tsx
@@ -165,7 +165,7 @@ export function FlowchartGenerator({
             className={cn(
               'rounded-md px-2.5 py-1 text-xs capitalize',
               diagramType === type
-                ? 'bg-primary/15 text-primary'
+                ? 'bg-primary/15 text-primary-ink'
                 : 'text-muted-foreground hover:bg-foreground/5',
             )}
           >

--- a/frontend/src/features/pages/ForceEmbedTree.tsx
+++ b/frontend/src/features/pages/ForceEmbedTree.tsx
@@ -113,7 +113,7 @@ export function ForceEmbedTree({ pageId, hasChildren }: ForceEmbedTreeProps) {
               {/* Progress bar */}
               <div className="h-1 w-full rounded-full bg-foreground/10">
                 <div
-                  className="h-1 rounded-full bg-primary transition-all duration-300"
+                  className="h-1 rounded-full bg-action transition-all duration-300"
                   style={{ width: `${progress.total > 0 ? (progress.completed / progress.total) * 100 : 0}%` }}
                 />
               </div>

--- a/frontend/src/features/pages/KPICards.tsx
+++ b/frontend/src/features/pages/KPICards.tsx
@@ -139,7 +139,7 @@ export function KPICards({ embeddingStatus, spacesCount, lastSynced }: KPICardsP
       label: 'Spaces Synced',
       value: String(spacesCount),
       numericValue: spacesCount,
-      color: 'text-primary',
+      color: 'text-action',
       testId: 'kpi-spaces-synced',
     },
     {

--- a/frontend/src/features/pages/PageViewPage.test.tsx
+++ b/frontend/src/features/pages/PageViewPage.test.tsx
@@ -606,5 +606,22 @@ describe('PageViewPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/ai?mode=improve&pageId=page-1');
   });
 
+  // Task 5 — drafts read as a personal/private state, not an AI affordance, so
+  // the Draft badge must use the neutral private-tier palette (no
+  // orange/amber/primary). The Playwright contrast spec in Task 6 will catch
+  // the colour combo at run-time; this guards the contract at the unit level.
+  it('Draft badge uses neutral private-tier palette, not orange/amber', () => {
+    currentMockPage = { ...mockPage, hasDraft: true } as typeof mockPage;
+    try {
+      render(<PageViewPage />, { wrapper: createWrapper() });
+      const badge = screen.getByTestId('badge-draft');
+      expect(badge.className).not.toMatch(/orange|amber|primary|warning|yellow/);
+      expect(badge.className).toMatch(/bg-\[#ececea\]/);
+      expect(badge.className).toMatch(/text-\[#4a4a48\]/);
+    } finally {
+      currentMockPage = mockPage;
+    }
+  });
+
 });
 

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -546,7 +546,10 @@ export function PageViewPage() {
                 Local
               </span>
             ) : (
-              <span className="inline-flex items-center gap-1 rounded-full bg-blue-500/15 px-2 py-0.5 text-[10px] font-medium text-blue-500" data-testid="source-badge">
+              <span
+                className="inline-flex items-center gap-1 rounded-full bg-blue-500/15 px-2 py-0.5 text-[10px] font-medium text-blue-500"
+                data-testid="badge-confluence"
+              >
                 Confluence
               </span>
             )}

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -449,7 +449,7 @@ export function PageViewPage() {
         </p>
         <button
           onClick={() => navigate('/')}
-          className="rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          className="rounded-xl border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
         >
           Return to pages
         </button>
@@ -513,7 +513,7 @@ export function PageViewPage() {
             <button
               onClick={handleSave}
               disabled={updateMutation.isPending}
-              className="shrink-0 flex items-center gap-1 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-60"
+              className="shrink-0 inline-flex items-center gap-1 rounded-md border border-action bg-transparent px-3 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
             >
               {updateMutation.isPending ? 'Saving…' : 'Save'}
               {!updateMutation.isPending && <ShortcutHint shortcutId="save" />}
@@ -569,9 +569,12 @@ export function PageViewPage() {
                 </span>
               )
             )}
-            {/* Draft indicator */}
+            {/* Draft indicator — neutral private-tier palette (drafts read as personal/private state, not AI). */}
             {'hasDraft' in page && Boolean((page as Record<string, unknown>).hasDraft) && (
-              <span className="inline-flex items-center gap-1 rounded-full bg-orange-500/15 px-2 py-0.5 text-[10px] font-medium text-orange-500" data-testid="draft-indicator">
+              <span
+                className="inline-flex items-center gap-1 rounded-full bg-[#ececea] px-2 py-0.5 text-[10px] font-medium text-[#4a4a48] dark:bg-[#2a2925] dark:text-[#c5bea9]"
+                data-testid="badge-draft"
+              >
                 <AlertCircle size={10} /> Draft
               </span>
             )}
@@ -665,7 +668,7 @@ export function PageViewPage() {
               <p className="text-muted-foreground">This page has no content yet.</p>
               <button
                 onClick={handleStartEditing}
-                className="rounded-xl bg-primary/15 px-4 py-2 text-sm font-medium text-primary transition-colors hover:bg-primary/25"
+                className="rounded-xl border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                 data-testid="add-content-btn"
               >
                 Add content

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -539,7 +539,10 @@ export function PageViewPage() {
             {page.spaceKey !== '__local__' && <span className="truncate">{page.spaceKey}</span>}
             {/* Source badge */}
             {page.source === 'standalone' ? (
-              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-500" data-testid="source-badge">
+              <span
+                className="inline-flex items-center gap-1 rounded-full bg-[#e7f2e8] px-2 py-0.5 text-[10px] font-medium text-[#1f5a2a] dark:bg-[#1a2a1d] dark:text-[#9ad4a8]"
+                data-testid="badge-local"
+              >
                 Local
               </span>
             ) : (
@@ -550,11 +553,18 @@ export function PageViewPage() {
             {/* Visibility badge for standalone articles */}
             {page.source === 'standalone' && (
               page.visibility === 'shared' ? (
-                <span className="inline-flex items-center gap-1 rounded-full bg-sky-500/15 px-2 py-0.5 text-[10px] font-medium text-sky-500" data-testid="visibility-badge">
+                <span
+                  className="inline-flex items-center gap-1 rounded-full bg-[#e6effb] px-2 py-0.5 text-[10px] font-medium text-[#1c3e72] dark:bg-[#162236] dark:text-[#a4c2eb]"
+                  data-testid="badge-shared"
+                >
                   <Globe size={10} /> Shared
                 </span>
               ) : (
-                <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-500" data-testid="visibility-badge">
+                // Private = neutral gray. Was amber, but privacy carries no AI semantic.
+                <span
+                  className="inline-flex items-center gap-1 rounded-full bg-[#ececea] px-2 py-0.5 text-[10px] font-medium text-[#4a4a48] dark:bg-[#2a2925] dark:text-[#c5bea9]"
+                  data-testid="badge-private"
+                >
                   <Lock size={10} /> Private
                 </span>
               )

--- a/frontend/src/features/pages/PagesPage.test.tsx
+++ b/frontend/src/features/pages/PagesPage.test.tsx
@@ -826,4 +826,110 @@ describe('PagesPage', () => {
       expect(item.className).toContain('border-primary');
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Status-pill accessibility (Task 4 of amber-as-AI bundle, bug 1c)
+  //
+  // Three pill variants previously failed WCAG-AA: Recent (3.37:1),
+  // Not Embedded (2.67:1 light), Private (borrowed amber w/o AI semantic).
+  // These tests verify the swap to AA-pass palettes.
+  // ---------------------------------------------------------------------------
+  describe('page row status badges (accessibility)', () => {
+    function makeStandalonePage(visibility: 'private' | 'shared') {
+      return {
+        items: [
+          {
+            id: 'std-1',
+            spaceKey: '__local__',
+            title: 'Standalone Page',
+            version: 1,
+            parentId: null,
+            labels: [],
+            author: 'Alice',
+            lastModifiedAt: '2025-01-15T00:00:00Z',
+            lastSynced: '2025-01-16T00:00:00Z',
+            embeddingDirty: false,
+            embeddingStatus: 'embedded',
+            embeddedAt: '2025-01-16T00:00:00Z',
+            source: 'standalone',
+            visibility,
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 50,
+        totalPages: 1,
+      };
+    }
+
+    function mockPagesWithStandalone(visibility: 'private' | 'shared') {
+      vi.restoreAllMocks();
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        if (url.includes('/embeddings/status')) {
+          return new Response(JSON.stringify(mockEmbeddingStatusIdle), {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        if (url.includes('/pages/filters')) {
+          return new Response(JSON.stringify(mockFilterOptions), {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        if (url.includes('/spaces')) {
+          return new Response(JSON.stringify(mockSpaces), {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        if (url.includes('/sync/status')) {
+          return new Response(JSON.stringify({ status: 'idle' }), {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        if (url.includes('/pages/pinned')) {
+          return new Response(JSON.stringify({ items: [], total: 0 }), {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        if (url.includes('/settings')) {
+          return new Response(JSON.stringify({}), {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify(makeStandalonePage(visibility)), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+    }
+
+    it('Local badge uses sage tint (AA-pass), not emerald-500', async () => {
+      mockPagesWithStandalone('private');
+      render(<PagesPage />, { wrapper: createWrapper() });
+      const badge = await screen.findByTestId('badge-local');
+      expect(badge).toHaveTextContent('Local');
+      expect(badge.className).toMatch(/bg-\[#e7f2e8\]/);
+      expect(badge.className).toMatch(/text-\[#1f5a2a\]/);
+      expect(badge.className).not.toMatch(/emerald-500|amber|warning|yellow/);
+    });
+
+    it('Private badge uses neutral gray tint, not amber/primary/warning', async () => {
+      mockPagesWithStandalone('private');
+      render(<PagesPage />, { wrapper: createWrapper() });
+      const badge = await screen.findByTestId('badge-private');
+      expect(badge).toHaveTextContent('Private');
+      expect(badge.className).not.toMatch(/amber|warning|yellow|primary/);
+      expect(badge.className).toMatch(/bg-\[#ececea\]/);
+      expect(badge.className).toMatch(/text-\[#4a4a48\]/);
+    });
+
+    it('Shared badge uses cool-blue tinted pill (AA-pass), not sky-500', async () => {
+      mockPagesWithStandalone('shared');
+      render(<PagesPage />, { wrapper: createWrapper() });
+      const badge = await screen.findByTestId('badge-shared');
+      expect(badge).toHaveTextContent('Shared');
+      expect(badge.className).toMatch(/bg-\[#e6effb\]/);
+      expect(badge.className).toMatch(/text-\[#1c3e72\]/);
+      expect(badge.className).not.toMatch(/sky-500|amber|warning|yellow/);
+    });
+  });
 });

--- a/frontend/src/features/pages/PagesPage.test.tsx
+++ b/frontend/src/features/pages/PagesPage.test.tsx
@@ -754,7 +754,8 @@ describe('PagesPage', () => {
       render(<PagesPage />, { wrapper: createWrapper() });
       const keyword = screen.getByTestId('search-mode-keyword');
       expect(keyword).toHaveAttribute('aria-pressed', 'true');
-      expect(keyword.className).toContain('bg-primary');
+      // Active mode uses ink-action fill (Task 5 — amber reserved for AI affordances; search-mode toggle is non-AI selection).
+      expect(keyword.className).toContain('bg-action');
       expect(keyword.className).toContain('shadow-md');
       expect(keyword.className).toContain('ring-1');
     });
@@ -773,7 +774,8 @@ describe('PagesPage', () => {
       fireEvent.click(semantic);
 
       expect(semantic).toHaveAttribute('aria-pressed', 'true');
-      expect(semantic.className).toContain('bg-primary');
+      // Active mode uses ink-action fill (Task 5).
+      expect(semantic.className).toContain('bg-action');
       expect(semantic.className).toContain('shadow-md');
 
       const keyword = screen.getByTestId('search-mode-keyword');

--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -101,7 +101,11 @@ const PageListItem = memo(function PageListItem({
                   Local
                 </span>
               ) : (
-                <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-blue-500/15 px-2 py-0.5 text-[10px] font-medium text-blue-500" data-testid={`source-badge-${pageItem.id}`}>
+                <span
+                  className="inline-flex shrink-0 items-center gap-1 rounded-full bg-blue-500/15 px-2 py-0.5 text-[10px] font-medium text-blue-500"
+                  data-testid="badge-confluence"
+                  data-source-badge={pageItem.id}
+                >
                   Confluence
                 </span>
               )}

--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -68,7 +68,7 @@ const PageListItem = memo(function PageListItem({
       <div
         className={cn(
           'rounded-xl border border-border/40 bg-card/50 backdrop-blur-sm transition-all hover:border-primary/50 flex w-full items-center gap-3 p-4 text-left',
-          isSelected && 'border-primary/40 bg-primary/5',
+          isSelected && 'border-action/40 bg-action/5',
         )}
         data-testid={`article-hover-${pageItem.id}`}
       >
@@ -80,7 +80,7 @@ const PageListItem = memo(function PageListItem({
           aria-label={`Select ${pageItem.title}`}
         >
           {isSelected && (
-            <div className="h-3 w-3 rounded-sm bg-primary" />
+            <div className="h-3 w-3 rounded-sm bg-action" />
           )}
         </button>
 
@@ -155,7 +155,11 @@ const PageListItem = memo(function PageListItem({
           {pageItem.labels.length > 0 && (
             <div className="flex gap-1">
               {pageItem.labels.slice(0, 3).map((label) => (
-                <span key={label} className="rounded bg-primary/10 px-2 py-0.5 text-xs text-primary">
+                <span
+                  key={label}
+                  className="rounded bg-[#ececea] px-2 py-0.5 text-xs text-[#4a4a48] dark:bg-[#2a2925] dark:text-[#c5bea9]"
+                  data-testid="label-chip"
+                >
                   {label}
                 </span>
               ))}
@@ -390,11 +394,11 @@ export function PagesPage() {
           </button>
           <button
             onClick={() => navigate('/pages/new')}
-            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           >
             <Plus size={16} />
             <span className="hidden sm:inline">New Page</span>
-            <span className="hidden sm:inline"><ShortcutHint shortcutId="new-page" className="border-primary-foreground/30 text-primary-foreground/80" /></span>
+            <span className="hidden sm:inline"><ShortcutHint shortcutId="new-page" className="border-action/30 text-action/80" /></span>
           </button>
         </div>
       </div>
@@ -415,7 +419,7 @@ export function PagesPage() {
           </div>
           <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-foreground/10">
             <div
-              className="h-full rounded-full bg-primary transition-all"
+              className="h-full rounded-full bg-action transition-all"
               style={{ width: `${(syncStatus.progress.current / syncStatus.progress.total) * 100}%` }}
             />
           </div>
@@ -425,14 +429,14 @@ export function PagesPage() {
       {/* Embedding progress */}
       {embeddingStatusData?.isProcessing && (
         <div className="rounded-xl border border-border/40 bg-card/50 backdrop-blur-sm flex items-center gap-3 p-3 border border-primary/30" data-testid="embedding-progress-banner">
-          <Loader2 size={16} className="animate-spin text-primary" />
+          <Loader2 size={16} className="animate-spin text-action" />
           <span className="text-sm">
             Embedding in progress — {embeddingStatusData.dirtyPages} pages remaining
           </span>
           <div className="ml-auto flex items-center gap-2">
             <div className="h-1.5 w-32 overflow-hidden rounded-full bg-foreground/10">
               <div
-                className="h-full rounded-full bg-primary transition-all"
+                className="h-full rounded-full bg-action transition-all"
                 style={{ width: `${(embeddingStatusData.embeddedPages / Math.max(embeddingStatusData.totalPages, 1)) * 100}%` }}
               />
             </div>
@@ -492,7 +496,7 @@ export function PagesPage() {
                   className={cn(
                     'rounded-full px-3 py-1 text-xs font-medium transition-all capitalize',
                     searchMode === m
-                      ? 'bg-primary text-primary-foreground shadow-md shadow-primary/25 ring-1 ring-primary/50'
+                      ? 'bg-action text-action-foreground shadow-md shadow-action/25 ring-1 ring-action/50'
                       : 'bg-foreground/5 text-muted-foreground hover:bg-foreground/10 border border-transparent hover:border-border/40',
                   )}
                 >
@@ -500,7 +504,7 @@ export function PagesPage() {
                 </button>
               ))}
               {searchResults.isLoadingEnhanced && (
-                <Loader2 size={14} className="ml-1 animate-spin text-primary" data-testid="search-enhanced-loading" />
+                <Loader2 size={14} className="ml-1 animate-spin text-action" data-testid="search-enhanced-loading" />
               )}
             </div>
 
@@ -547,7 +551,7 @@ export function PagesPage() {
             className={cn(
               'flex items-center gap-1.5 rounded-md px-3 py-2 text-sm transition-colors',
               showAdvancedFilters || activeFilterCount > 0
-                ? 'bg-primary/15 text-primary'
+                ? 'bg-action/15 text-action'
                 : 'bg-foreground/5 text-muted-foreground hover:bg-foreground/10',
             )}
             data-testid="advanced-filters-toggle"
@@ -555,7 +559,7 @@ export function PagesPage() {
             <Filter size={14} />
             Filters
             {activeFilterCount > 0 && (
-              <span className="ml-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
+              <span className="ml-1 flex h-5 w-5 items-center justify-center rounded-full bg-action text-[10px] font-bold text-action-foreground">
                 {activeFilterCount}
               </span>
             )}
@@ -690,7 +694,7 @@ export function PagesPage() {
               <button
                 key={f.key}
                 onClick={() => clearFilter(f.key)}
-                className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary"
+                className="inline-flex items-center gap-1 rounded-full bg-action/10 px-2.5 py-0.5 text-xs font-medium text-action"
                 aria-label={`Remove ${f.label} filter`}
                 data-testid={`filter-pill-${f.key}`}
               >

--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -93,7 +93,11 @@ const PageListItem = memo(function PageListItem({
               <p className="truncate font-medium">{pageItem.title}</p>
               {/* Source badge */}
               {pageItem.source === 'standalone' ? (
-                <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-500" data-testid={`source-badge-${pageItem.id}`}>
+                <span
+                  className="inline-flex shrink-0 items-center gap-1 rounded-full bg-[#e7f2e8] px-2 py-0.5 text-[10px] font-medium text-[#1f5a2a] dark:bg-[#1a2a1d] dark:text-[#9ad4a8]"
+                  data-testid="badge-local"
+                  data-source-badge={pageItem.id}
+                >
                   Local
                 </span>
               ) : (
@@ -104,11 +108,20 @@ const PageListItem = memo(function PageListItem({
               {/* Visibility badge for standalone articles */}
               {pageItem.source === 'standalone' && (
                 (pageItem.visibility === 'shared') ? (
-                  <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-sky-500/15 px-2 py-0.5 text-[10px] font-medium text-sky-500" data-testid={`visibility-badge-${pageItem.id}`}>
+                  <span
+                    className="inline-flex shrink-0 items-center gap-1 rounded-full bg-[#e6effb] px-2 py-0.5 text-[10px] font-medium text-[#1c3e72] dark:bg-[#162236] dark:text-[#a4c2eb]"
+                    data-testid="badge-shared"
+                    data-visibility-badge={pageItem.id}
+                  >
                     <Globe size={10} /> Shared
                   </span>
                 ) : (
-                  <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-500" data-testid={`visibility-badge-${pageItem.id}`}>
+                  // Private = neutral gray. Was amber, but privacy carries no AI semantic.
+                  <span
+                    className="inline-flex shrink-0 items-center gap-1 rounded-full bg-[#ececea] px-2 py-0.5 text-[10px] font-medium text-[#4a4a48] dark:bg-[#2a2925] dark:text-[#c5bea9]"
+                    data-testid="badge-private"
+                    data-visibility-badge={pageItem.id}
+                  >
                     <Lock size={10} /> Private
                   </span>
                 )

--- a/frontend/src/features/pages/PinnedArticlesSection.tsx
+++ b/frontend/src/features/pages/PinnedArticlesSection.tsx
@@ -33,7 +33,7 @@ export function PinnedArticlesSection() {
   return (
     <div data-testid="pinned-articles-section">
       <div className="mb-3 flex items-center gap-2">
-        <Pin size={16} className="text-primary" />
+        <Pin size={16} className="text-action" />
         <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
           Pinned Articles
         </h2>
@@ -70,7 +70,7 @@ export function PinnedArticlesSection() {
 
               {/* Metadata row */}
               <div className="flex items-center gap-3 text-xs text-muted-foreground">
-                <span className="rounded bg-primary/10 px-1.5 py-0.5 text-primary">
+                <span className="rounded bg-[#ececea] px-1.5 py-0.5 text-[#4a4a48] dark:bg-[#2a2925] dark:text-[#c5bea9]">
                   {item.spaceKey}
                 </span>
                 {item.author && (

--- a/frontend/src/features/pages/PresenceAvatarStack.tsx
+++ b/frontend/src/features/pages/PresenceAvatarStack.tsx
@@ -81,7 +81,7 @@ export function PresenceAvatarStack({
               <span
                 data-testid="presence-editing-badge"
                 aria-label="editing"
-                className="absolute -bottom-0.5 -right-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-primary text-primary-foreground ring-2 ring-card"
+                className="absolute -bottom-0.5 -right-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-action text-action-foreground ring-2 ring-card"
               >
                 <Pencil size={8} strokeWidth={2.5} />
               </span>

--- a/frontend/src/features/pages/VersionHistory.tsx
+++ b/frontend/src/features/pages/VersionHistory.tsx
@@ -122,7 +122,7 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
           {/* Header */}
           <div className="flex items-center justify-between border-b border-border/50 px-5 py-4">
             <div className="flex items-center gap-2">
-              <History size={16} className="text-primary" />
+              <History size={16} className="text-action" />
               <Dialog.Title className="font-semibold">Version History</Dialog.Title>
               {versions.length > 0 && (
                 <span className="rounded bg-foreground/5 px-1.5 py-0.5 text-xs text-muted-foreground">
@@ -159,7 +159,7 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
                     className={cn(
                       'flex items-center gap-3 px-5 py-2.5',
                       i !== versions.length - 1 && 'border-b border-border/30',
-                      selectedVersion === version.versionNumber && 'bg-primary/5',
+                      selectedVersion === version.versionNumber && 'bg-action/5',
                     )}
                   >
                     {/* Timeline dot */}
@@ -212,7 +212,7 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
                           </button>
                           <button
                             onClick={() => handleSemanticDiff(versions[i + 1]!.versionNumber, version.versionNumber)}
-                            className="rounded p-1 text-muted-foreground hover:bg-foreground/5 hover:text-primary"
+                            className="rounded p-1 text-muted-foreground hover:bg-foreground/5 hover:text-action"
                             title="AI semantic diff with previous version"
                           >
                             <Sparkles size={12} />

--- a/frontend/src/features/search/SearchPage.tsx
+++ b/frontend/src/features/search/SearchPage.tsx
@@ -89,7 +89,7 @@ function highlightText(text: string, query: string): string {
       parts.push(escapeHtml(text.slice(cursor, idx)));
     }
     const matched = text.slice(idx, idx + trimmed.length);
-    parts.push(`<mark class="bg-primary/20 text-foreground rounded px-0.5">${escapeHtml(matched)}</mark>`);
+    parts.push(`<mark class="bg-action/20 text-foreground rounded px-0.5">${escapeHtml(matched)}</mark>`);
     cursor = idx + trimmed.length;
   }
 
@@ -240,7 +240,7 @@ export function SearchPage() {
               size={18}
               className={cn(
                 'absolute left-3 top-1/2 -translate-y-1/2',
-                (isLoadingImmediate || isLoadingEnhanced) ? 'text-primary animate-pulse' : 'text-muted-foreground',
+                (isLoadingImmediate || isLoadingEnhanced) ? 'text-action animate-pulse' : 'text-muted-foreground',
               )}
             />
             <input
@@ -281,7 +281,7 @@ export function SearchPage() {
             className={cn(
               'flex items-center gap-1.5 rounded-md px-3 py-3 text-sm transition-colors',
               showFilters || activeFilterCount > 0
-                ? 'bg-primary/15 text-primary'
+                ? 'bg-action/15 text-action'
                 : 'bg-foreground/5 text-muted-foreground hover:bg-foreground/10',
             )}
             data-testid="search-filters-toggle"
@@ -289,7 +289,7 @@ export function SearchPage() {
             <SlidersHorizontal size={14} />
             Filters
             {activeFilterCount > 0 && (
-              <span className="ml-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
+              <span className="ml-1 flex h-5 w-5 items-center justify-center rounded-full bg-action text-[10px] font-bold text-action-foreground">
                 {activeFilterCount}
               </span>
             )}
@@ -308,7 +308,7 @@ export function SearchPage() {
                 'rounded-full px-3 py-1 text-xs font-medium transition-colors capitalize',
                 'disabled:cursor-not-allowed disabled:opacity-40',
                 searchMode === m
-                  ? 'bg-primary text-primary-foreground'
+                  ? 'bg-action text-action-foreground'
                   : 'bg-foreground/5 text-muted-foreground hover:bg-foreground/10',
               )}
             >
@@ -319,7 +319,7 @@ export function SearchPage() {
           {isLoadingEnhanced && (
             <Loader2
               size={14}
-              className="ml-1 animate-spin text-primary"
+              className="ml-1 animate-spin text-action"
               data-testid="enhanced-loading-indicator"
             />
           )}
@@ -490,7 +490,7 @@ export function SearchPage() {
           </p>
           <button
             onClick={() => navigate(`/knowledge-requests?title=${encodeURIComponent(activeQuery)}`)}
-            className="mt-4 flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            className="mt-4 inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
             data-testid="request-content-cta"
           >
             <Filter size={14} />

--- a/frontend/src/features/settings/ErrorDashboard.tsx
+++ b/frontend/src/features/settings/ErrorDashboard.tsx
@@ -125,7 +125,7 @@ export function ErrorDashboard() {
             className={cn(
               'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
               filterResolved === tab
-                ? 'bg-primary/15 text-primary'
+                ? 'bg-action/15 text-action'
                 : 'text-muted-foreground hover:text-foreground',
             )}
             data-testid={`filter-${tab}`}

--- a/frontend/src/features/settings/LabelManager.tsx
+++ b/frontend/src/features/settings/LabelManager.tsx
@@ -105,7 +105,7 @@ export function LabelManager() {
       {mergeSource && (
         <div className="rounded-lg border border-border/50 bg-foreground/5 p-3" data-testid="merge-dialog">
           <p className="mb-2 text-sm">
-            Merge <span className="font-medium text-primary">{mergeSource}</span> into:
+            Merge <span className="font-medium text-action">{mergeSource}</span> into:
           </p>
           <div className="flex gap-2">
             <select
@@ -126,7 +126,7 @@ export function LabelManager() {
             <button
               onClick={handleMerge}
               disabled={!mergeTarget || renameLabel.isPending}
-              className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              className="rounded-md border border-action bg-transparent px-3 py-1.5 text-xs font-medium text-action transition-colors hover:bg-action hover:text-action-foreground disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               data-testid="merge-confirm-btn"
             >
               Merge

--- a/frontend/src/features/settings/LoginPage.tsx
+++ b/frontend/src/features/settings/LoginPage.tsx
@@ -88,7 +88,7 @@ export function LoginPage() {
           {isRegister ? 'Already have an account?' : "Don't have an account?"}{' '}
           <button
             onClick={() => setIsRegister(!isRegister)}
-            className="text-primary hover:underline"
+            className="text-action hover:underline"
           >
             {isRegister ? 'Sign in' : 'Create one'}
           </button>

--- a/frontend/src/features/settings/McpDocsTab.tsx
+++ b/frontend/src/features/settings/McpDocsTab.tsx
@@ -100,7 +100,7 @@ export function McpDocsTab() {
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3">
-        <Globe size={20} className="text-primary" />
+        <Globe size={20} className="text-action" />
         <div>
           <h3 className="text-base font-semibold">MCP Documentation Sidecar</h3>
           <p className="text-sm text-muted-foreground">
@@ -117,7 +117,7 @@ export function McpDocsTab() {
         </div>
         <button
           onClick={() => updateField('enabled', !form.enabled)}
-          className={`relative h-6 w-11 rounded-full transition-colors ${form.enabled ? 'bg-primary' : 'bg-muted'}`}
+          className={`relative h-6 w-11 rounded-full transition-colors ${form.enabled ? 'bg-action' : 'bg-muted'}`}
           role="switch"
           aria-checked={form.enabled}
           data-testid="mcp-docs-toggle"
@@ -267,7 +267,7 @@ export function McpDocsTab() {
           <button
             onClick={() => saveMutation.mutate(form)}
             disabled={saveMutation.isPending}
-            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+            className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
             data-testid="mcp-docs-save"
           >
             {saveMutation.isPending && <Loader2 size={14} className="animate-spin" />}

--- a/frontend/src/features/settings/NotificationPreferences.tsx
+++ b/frontend/src/features/settings/NotificationPreferences.tsx
@@ -153,7 +153,7 @@ export function NotificationPreferences() {
               <Switch.Root
                 checked={currentPrefs[key]}
                 onCheckedChange={(checked) => handleToggle(key, checked)}
-                className="relative h-5 w-9 shrink-0 rounded-full bg-foreground/10 transition-colors data-[state=checked]:bg-primary outline-none"
+                className="relative h-5 w-9 shrink-0 rounded-full bg-foreground/10 transition-colors data-[state=checked]:bg-action outline-none"
                 data-testid={`pref-toggle-${key}`}
               >
                 <Switch.Thumb className="block h-4 w-4 translate-x-0.5 rounded-full bg-white transition-transform data-[state=checked]:translate-x-4" />

--- a/frontend/src/features/settings/SearxngTab.tsx
+++ b/frontend/src/features/settings/SearxngTab.tsx
@@ -54,7 +54,7 @@ export function SearxngTab() {
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3">
-        <Search size={20} className="text-primary" />
+        <Search size={20} className="text-action" />
         <div>
           <h3 className="text-base font-semibold">SearXNG Web Search Engine</h3>
           <p className="text-sm text-muted-foreground">Self-hosted meta-search engine used by the MCP sidecar for web search queries.</p>
@@ -121,7 +121,7 @@ export function SearxngTab() {
       {isDirty && (
         <div className="sticky bottom-0 flex justify-end border-t border-border/40 bg-card/80 pt-4 backdrop-blur-sm">
           <button onClick={() => saveMutation.mutate(form)} disabled={saveMutation.isPending}
-            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50" data-testid="searxng-save">
+            className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground" data-testid="searxng-save">
             {saveMutation.isPending && <Loader2 size={14} className="animate-spin" />}
             Save SearXNG Settings
           </button>

--- a/frontend/src/features/settings/SpaceHomePicker.tsx
+++ b/frontend/src/features/settings/SpaceHomePicker.tsx
@@ -100,7 +100,7 @@ export function SpaceHomePicker({
             canManage
               ? 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground'
               : 'cursor-not-allowed opacity-50',
-            customHomePageId != null && 'border-primary/40 text-primary',
+            customHomePageId != null && 'border-action/40 text-action',
           )}
         >
           <Home size={12} />
@@ -134,7 +134,7 @@ export function SpaceHomePicker({
               className="mb-2 flex items-center gap-2 rounded-md bg-foreground/5 px-2 py-1.5"
               data-testid="space-home-picker-current"
             >
-              <Check size={12} className="text-primary" />
+              <Check size={12} className="text-action" />
               <p className="min-w-0 truncate text-xs">
                 <span className="text-muted-foreground">Current: </span>
                 <span className="font-medium">
@@ -193,12 +193,12 @@ export function SpaceHomePicker({
                         className={cn(
                           'flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors',
                           'hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
-                          isCurrent && 'bg-primary/10 text-primary',
+                          isCurrent && 'bg-action/10 text-action',
                         )}
                         data-testid={`space-home-picker-result-${p.id}`}
                       >
                         <span className="flex-1 truncate">{p.title}</span>
-                        {isCurrent && <Check size={12} className="shrink-0 text-primary" />}
+                        {isCurrent && <Check size={12} className="shrink-0 text-action" />}
                       </button>
                     </li>
                   );

--- a/frontend/src/features/settings/SpacesTab.tsx
+++ b/frontend/src/features/settings/SpacesTab.tsx
@@ -125,7 +125,7 @@ export function SpacesTab({ selectedSpaces: initialSelected = EMPTY_SPACES, show
           onClick={() => onSave({ showSpaceHomeContent: !showSpaceHomeContent })}
           className={cn(
             'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
-            showSpaceHomeContent ? 'bg-primary' : 'bg-foreground/20',
+            showSpaceHomeContent ? 'bg-action' : 'bg-foreground/20',
           )}
           data-testid="toggle-space-home-content"
         >
@@ -153,7 +153,7 @@ export function SpacesTab({ selectedSpaces: initialSelected = EMPTY_SPACES, show
                 className={cn(
                   'flex w-full items-center gap-3 rounded-lg border px-4 py-3 text-left transition-colors',
                   isSelected
-                    ? 'border-primary/30 bg-primary/10'
+                    ? 'border-action/30 bg-action/10'
                     : 'border-border/50 bg-foreground/5 hover:bg-foreground/10',
                 )}
                 role="listitem"
@@ -166,7 +166,7 @@ export function SpacesTab({ selectedSpaces: initialSelected = EMPTY_SPACES, show
                   aria-label={`${isSelected ? 'Deselect' : 'Select'} ${space.name}`}
                 >
                   {isSelected ? (
-                    <CheckSquare size={18} className="shrink-0 text-primary" />
+                    <CheckSquare size={18} className="shrink-0 text-action" />
                   ) : (
                     <Square size={18} className="shrink-0 text-muted-foreground" />
                   )}

--- a/frontend/src/features/settings/ThemeTab.tsx
+++ b/frontend/src/features/settings/ThemeTab.tsx
@@ -36,7 +36,7 @@ export function ThemeTab({ onSave }: ThemeTabProps) {
                     data-testid={`theme-${t.id}`}
                     className={`group relative flex flex-col rounded-lg border p-4 text-left transition-all ${
                       isActive
-                        ? 'border-primary bg-primary/10 ring-1 ring-primary'
+                        ? 'border-action bg-action/10 ring-1 ring-action'
                         : 'border-border/50 hover:border-border hover:bg-muted/50'
                     }`}
                   >
@@ -66,7 +66,7 @@ export function ThemeTab({ onSave }: ThemeTabProps) {
                     <span className="text-sm font-medium">{t.label}</span>
                     <span className="mt-0.5 text-xs text-muted-foreground">{t.description}</span>
                     {isActive && (
-                      <span className="absolute top-2 right-2 text-xs text-primary" data-testid="theme-active-badge">
+                      <span className="absolute top-2 right-2 text-xs text-action" data-testid="theme-active-badge">
                         Active
                       </span>
                     )}

--- a/frontend/src/features/settings/WorkersTab.tsx
+++ b/frontend/src/features/settings/WorkersTab.tsx
@@ -198,7 +198,7 @@ function ProgressBar({ completed, total }: { completed: number; total: number })
     <div className="flex items-center gap-3" data-testid="progress-bar">
       <div className="h-1.5 flex-1 rounded-full bg-foreground/10 overflow-hidden">
         <m.div
-          className="h-full rounded-full bg-primary"
+          className="h-full rounded-full bg-action"
           animate={{ width: `${percentage}%` }}
           transition={shouldReduce ? { duration: 0 } : { type: 'spring', stiffness: 100, damping: 20 }}
         />
@@ -246,7 +246,7 @@ function WorkerCard({ title, statusKey, statusEndpoint, runEndpoint, rescanEndpo
           <button
             onClick={() => runNow.mutate()}
             disabled={runNow.isPending}
-            className="flex items-center gap-1 rounded-lg bg-primary/10 px-2.5 py-1.5 text-xs font-medium text-primary hover:bg-primary/20 transition-colors disabled:opacity-50"
+            className="inline-flex items-center gap-1 rounded-lg border border-action bg-transparent px-2.5 py-1.5 text-xs font-medium text-action transition-colors hover:bg-action hover:text-action-foreground disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
             title="Process pending items now"
             data-testid={`${statusKey}-run-now`}
           >

--- a/frontend/src/features/settings/panels/ProviderListSection.tsx
+++ b/frontend/src/features/settings/panels/ProviderListSection.tsx
@@ -63,7 +63,7 @@ export function ProviderListSection() {
               <div className="text-sm font-medium">
                 {p.name}{' '}
                 {p.isDefault && (
-                  <span className="bg-primary/15 text-primary ml-2 rounded px-1.5 text-xs">
+                  <span className="ml-2 rounded bg-[#ececea] px-1.5 text-xs text-[#4a4a48] dark:bg-[#2a2925] dark:text-[#c5bea9]">
                     default
                   </span>
                 )}

--- a/frontend/src/features/setup/SetupWizard.tsx
+++ b/frontend/src/features/setup/SetupWizard.tsx
@@ -172,9 +172,9 @@ export function SetupWizard() {
                   <div
                     className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium transition-colors ${
                       index < currentStep
-                        ? 'bg-primary text-primary-foreground'
+                        ? 'bg-action text-action-foreground'
                         : index === currentStep
-                          ? 'bg-primary/20 text-primary ring-2 ring-primary/40'
+                          ? 'bg-action/20 text-action ring-2 ring-action/40'
                           : 'bg-foreground/10 text-muted-foreground'
                     }`}
                     data-testid={`step-indicator-${step.id}`}
@@ -190,7 +190,7 @@ export function SetupWizard() {
                   {index < STEPS.length - 1 && (
                     <div
                       className={`mx-1 h-0.5 w-6 rounded transition-colors ${
-                        index < currentStep ? 'bg-primary' : 'bg-foreground/10'
+                        index < currentStep ? 'bg-action' : 'bg-foreground/10'
                       }`}
                     />
                   )}

--- a/frontend/src/features/spaces/NewSpacePage.test.tsx
+++ b/frontend/src/features/spaces/NewSpacePage.test.tsx
@@ -141,12 +141,12 @@ describe('NewSpacePage', () => {
     renderPage();
     const codeButton = screen.getByTitle('Code');
 
-    // Select
+    // Select — icon selection is non-AI chrome (Task 5 — amber reserved for AI affordances).
     fireEvent.click(codeButton);
-    expect(codeButton.className).toContain('border-primary');
+    expect(codeButton.className).toContain('border-action');
 
     // Deselect
     fireEvent.click(codeButton);
-    expect(codeButton.className).not.toContain('border-primary');
+    expect(codeButton.className).not.toContain('border-action');
   });
 });

--- a/frontend/src/features/spaces/NewSpacePage.tsx
+++ b/frontend/src/features/spaces/NewSpacePage.tsx
@@ -76,8 +76,8 @@ export function NewSpacePage() {
 
       <div className="rounded-xl border border-border/50 bg-card/80 p-6 shadow-lg backdrop-blur-md">
         <div className="mb-6 flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <HardDrive size={20} className="text-primary" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-action/10">
+            <HardDrive size={20} className="text-action" />
           </div>
           <div>
             <h1 className="text-lg font-semibold text-foreground">Create Local Space</h1>
@@ -160,7 +160,7 @@ export function NewSpacePage() {
                   onClick={() => setSelectedIcon(selectedIcon === icon.value ? undefined : icon.value)}
                   className={`rounded-md border px-2 py-1 text-[10px] transition-colors ${
                     selectedIcon === icon.value
-                      ? 'border-primary bg-primary/10 text-primary font-medium'
+                      ? 'border-action bg-action/10 text-action font-medium'
                       : 'border-border/30 text-muted-foreground hover:bg-foreground/5 hover:text-foreground'
                   }`}
                   title={icon.label}
@@ -183,7 +183,7 @@ export function NewSpacePage() {
             <button
               type="submit"
               disabled={!name.trim() || !key.trim() || createSpace.isPending}
-              className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
             >
               {createSpace.isPending ? 'Creating...' : 'Create Space'}
             </button>

--- a/frontend/src/features/spaces/SpaceSettingsPage.tsx
+++ b/frontend/src/features/spaces/SpaceSettingsPage.tsx
@@ -69,7 +69,7 @@ export function SpaceSettingsPage() {
         <p className="text-muted-foreground">Space not found or is not a local space.</p>
         <button
           onClick={() => navigate(-1)}
-          className="mt-4 text-sm text-primary hover:text-primary/80 transition-colors"
+          className="mt-4 text-sm text-action hover:text-action/80 transition-colors"
         >
           Go back
         </button>
@@ -89,8 +89,8 @@ export function SpaceSettingsPage() {
 
       <div className="rounded-xl border border-border/50 bg-card/80 p-6 shadow-lg backdrop-blur-md">
         <div className="mb-6 flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <Settings size={20} className="text-primary" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-action/10">
+            <Settings size={20} className="text-action" />
           </div>
           <div>
             <h1 className="text-lg font-semibold text-foreground">Space Settings</h1>
@@ -107,7 +107,7 @@ export function SpaceSettingsPage() {
               Space Key
             </label>
             <div className="flex items-center gap-2 rounded-lg border border-border/30 bg-foreground/5 px-3 py-2">
-              <HardDrive size={14} className="text-primary/70" />
+              <HardDrive size={14} className="text-action/70" />
               <span className="font-mono text-sm text-muted-foreground">{key}</span>
             </div>
             <p className="mt-1 text-[10px] text-muted-foreground">
@@ -155,7 +155,7 @@ export function SpaceSettingsPage() {
             <button
               type="submit"
               disabled={!name.trim() || updateSpace.isPending}
-              className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
             >
               {updateSpace.isPending ? 'Saving...' : 'Save Changes'}
             </button>

--- a/frontend/src/features/templates/TemplateCard.tsx
+++ b/frontend/src/features/templates/TemplateCard.tsx
@@ -40,7 +40,7 @@ export function TemplateCard({ template, index, onUse, onPreview }: TemplateCard
     >
       {/* Header row */}
       <div className="flex items-start gap-3 mb-3">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-action/10 text-action">
           <FileText size={20} />
         </div>
         <div className="min-w-0 flex-1">
@@ -67,7 +67,7 @@ export function TemplateCard({ template, index, onUse, onPreview }: TemplateCard
       <div className="flex items-center gap-2">
         <button
           onClick={() => onUse(template)}
-          className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-action bg-transparent px-3 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           data-testid={`template-use-${template.id}`}
         >
           <Play size={14} />

--- a/frontend/src/features/templates/TemplatesPage.tsx
+++ b/frontend/src/features/templates/TemplatesPage.tsx
@@ -83,7 +83,7 @@ export function TemplatesPage() {
         </div>
         <button
           onClick={() => navigate('/pages/new')}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          className="inline-flex items-center gap-2 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
         >
           <Plus size={16} />
           Create Template
@@ -99,7 +99,7 @@ export function TemplatesPage() {
             className={cn(
               'rounded-md px-3.5 py-1.5 text-sm transition-colors',
               activeCategory === cat
-                ? 'bg-primary/15 font-medium text-primary'
+                ? 'bg-action/15 font-medium text-action'
                 : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
             )}
             data-testid={`category-tab-${cat.toLowerCase()}`}
@@ -175,7 +175,7 @@ export function TemplatesPage() {
                         void handleUse(previewTemplate);
                       }
                     }}
-                    className="flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                   >
                     Use Template
                   </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -470,7 +470,14 @@ h1, h2, h3, h4, h5, h6,
   padding: 0.625rem 1.25rem;
   border-radius: var(--radius-md);
   border: 1px solid oklch(from var(--color-primary) calc(l - 0.06) c h);
-  background: linear-gradient(
+  /* Set background-color as a solid fallback in addition to the gradient
+     overlay. Gradients live in background-image only; without an explicit
+     background-color the rendered surface appears amber to users but reads
+     as transparent to automated contrast auditors (which only inspect
+     background-color, not background-image). The visible look is unchanged
+     — the gradient renders on top of the solid color. */
+  background-color: var(--color-primary);
+  background-image: linear-gradient(
     145deg,
     oklch(from var(--color-primary) calc(l + 0.04) c h),
     var(--color-primary)

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -103,10 +103,17 @@ h1, h2, h3, h4, h5, h6,
   --color-primary-gradient-start: #fdd56d;
   --color-primary-gradient-end: #f2b72e;
   --color-primary-glow: rgba(249, 199, 79, 0.35);
-  /* On graphite the brand honey is ~11:1 against text — already AA-safe.
-     --color-primary-ink aliases to --color-primary in dark mode and exists
-     for parity with the light theme where the brand honey must darken. */
-  --color-primary-ink: #f9c74f;
+  /* In dark mode --color-primary-ink is the SAME-INTENT amber but tuned for
+     amber-text-on-near-black contexts where the brand honey reads slightly
+     too "fluorescent". --color-primary-gradient-start (#fdd56d) gives a
+     softer amber that still hits >7:1 against #121212. */
+  --color-primary-ink: #fdd56d;
+  /* Action ink — primary affordance color for non-AI buttons & active states.
+     Inverted from light mode: light ink on graphite. Reads premium and leaves
+     --color-primary (honey) free to mean "AI is involved here". */
+  --color-action: #ece9e2;             /* matches --color-foreground */
+  --color-action-foreground: #0a0a0a;  /* near-black text on action ink */
+  --color-action-hover: #ffffff;       /* pure white lift on hover */
   --color-secondary: #2a2925;
   --color-secondary-foreground: #c5bea9;
   --color-muted: #2a2925;
@@ -134,7 +141,7 @@ h1, h2, h3, h4, h5, h6,
   --color-status-embedding: #8ab4e8;    /* blue */
   --color-status-ai: #b89ae0;           /* purple */
   --color-status-disconnected: #e88888; /* red */
-  --color-status-inactive: #6a6458;     /* warm gray */
+  --color-status-inactive: #8a8474;     /* warm gray, lifted for AA on #121212 */
 
   /* Brand typography — self-hosted via @fontsource (privacy-safe).
      Tailwind 4 exposes these as font-display / font-sans / font-mono
@@ -247,6 +254,12 @@ h1, h2, h3, h4, h5, h6,
      check marks, anywhere honey is a *text* color. Keep --color-primary for
      fills (buttons, pills, borders). */
   --color-primary-ink: #8a6016;
+  /* Action ink — primary affordance for non-AI buttons & active states.
+     Near-black on linen reads premium (Vercel/Linear style) and leaves
+     --color-primary (honey) free to mean "AI is involved here". */
+  --color-action: #0a0a0a;             /* matches --color-foreground */
+  --color-action-foreground: #ffffff;  /* white text on ink */
+  --color-action-hover: #1f1f1f;       /* slightly lifted ink on hover */
   --color-secondary: #efeeea;
   --color-secondary-foreground: #4a4a48;
   --color-muted: #efeeea;
@@ -264,7 +277,7 @@ h1, h2, h3, h4, h5, h6,
   --color-border: #dedcd4;
   --color-ring: #f9c74f;
   --color-success: #2f7a3a;
-  --color-warning: #b77a1a;
+  --color-warning: #945e0a;             /* darkened from #b77a1a — 5.2:1 vs #f7f7f7, AA-pass */
   --color-info: #2a5bb0;
 
   /* Status colors — tuned for AA contrast on linen */
@@ -273,7 +286,7 @@ h1, h2, h3, h4, h5, h6,
   --color-status-embedding: #2a5bb0;
   --color-status-ai: #6a4ea8;
   --color-status-disconnected: #b0322e;
-  --color-status-inactive: #a0988a;
+  --color-status-inactive: #6b6757;     /* darkened from #a0988a — 5.5:1 vs #f7f7f7, AA-pass */
 
   /* Code colors — per-language, matched against --code-bg #efe7d0 */
   --color-code-bg: #efe7d0;

--- a/frontend/src/shared/components/LocationPicker.tsx
+++ b/frontend/src/shared/components/LocationPicker.tsx
@@ -147,7 +147,7 @@ const PickerTreeNode = memo(function PickerTreeNode({
         className={cn(
           'group flex w-full items-center gap-1.5 rounded-md py-1.5 pr-2 text-sm transition-colors',
           isSelected
-            ? 'bg-primary/15 text-primary font-medium'
+            ? 'bg-action/15 text-action font-medium'
             : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
         )}
         style={{ paddingLeft: `${level * 16 + 8}px` }}
@@ -167,16 +167,16 @@ const PickerTreeNode = memo(function PickerTreeNode({
         )}
         {hasChildren ? (
           isExpanded ? (
-            <FolderOpen size={15} className="shrink-0 text-primary/80" />
+            <FolderOpen size={15} className="shrink-0 text-action/80" />
           ) : (
-            <Folder size={15} className="shrink-0 text-primary/70" />
+            <Folder size={15} className="shrink-0 text-action/70" />
           )
         ) : (
           <FileText size={15} className="shrink-0 text-muted-foreground/70" />
         )}
         <span className="truncate">{node.page.title}</span>
         {isSelected && (
-          <Check size={14} className="ml-auto shrink-0 text-primary" />
+          <Check size={14} className="ml-auto shrink-0 text-action" />
         )}
       </button>
 
@@ -358,7 +358,7 @@ export function LocationPicker({
           )}
           aria-label="Select page location"
         >
-          <MapPin size={14} className="shrink-0 text-primary/70" />
+          <MapPin size={14} className="shrink-0 text-action/70" />
           <span className="flex-1 truncate">
             {spaceKey ? (
               <span className="flex items-center gap-1 text-xs">
@@ -431,13 +431,13 @@ export function LocationPicker({
                     className={cn(
                       'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs transition-colors',
                       !selectedParentId
-                        ? 'bg-primary/15 text-primary font-medium'
+                        ? 'bg-action/15 text-action font-medium'
                         : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
                     )}
                   >
                     <Folder size={14} className="shrink-0" />
                     <span>Root level (no parent)</span>
-                    {!selectedParentId && <Check size={12} className="ml-auto text-primary" />}
+                    {!selectedParentId && <Check size={12} className="ml-auto text-action" />}
                   </button>
                 </div>
 

--- a/frontend/src/shared/components/Logo.test.tsx
+++ b/frontend/src/shared/components/Logo.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Logo } from './Logo';
+
+describe('Logo', () => {
+  it('renders an accessible image with role and aria-label', () => {
+    const { getByRole } = render(<Logo />);
+    const svg = getByRole('img', { name: /compendiq/i });
+    expect(svg.tagName.toLowerCase()).toBe('svg');
+  });
+
+  it('uses currentColor for the wordmark fill so it inherits text color in both themes', () => {
+    const { container } = render(<Logo className="text-foreground" />);
+    const svg = container.querySelector('svg')!;
+    const wordmark = svg.querySelector('text');
+    expect(wordmark).not.toBeNull();
+    expect(wordmark!.getAttribute('fill')).toBe('currentColor');
+  });
+
+  it('keeps the amber magnifier stroke hard-coded (the AI signal must NOT inherit)', () => {
+    const { container } = render(<Logo />);
+    const ambers = container.querySelectorAll('[stroke="#f9c74f"], [stroke="#F9C74F"]');
+    expect(ambers.length).toBe(2);
+  });
+
+  it('forwards className to the root svg', () => {
+    const { container } = render(<Logo className="h-8 w-auto text-foreground" />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('class')).toContain('h-8');
+    expect(svg.getAttribute('class')).toContain('text-foreground');
+  });
+});

--- a/frontend/src/shared/components/Logo.tsx
+++ b/frontend/src/shared/components/Logo.tsx
@@ -1,0 +1,60 @@
+interface LogoProps {
+  className?: string;
+  title?: string;
+}
+
+/**
+ * Compendiq wordmark + Q-glyph + magnifier.
+ *
+ * Two color regions:
+ * - Wordmark "Compendiq" text + Q outline → `currentColor` (inherits from
+ *   the host's text color so it stays readable in BOTH themes).
+ * - The two amber magnifier strokes → hard-coded #f9c74f. They are the
+ *   brand AI signal and must not invert with theme.
+ *
+ * Geometry copied verbatim from public/compendiq-lockup-horizontal.svg
+ * (kept on disk for favicon / OG image / non-React consumers).
+ */
+export function Logo({ className, title = 'Compendiq' }: LogoProps) {
+  return (
+    <svg
+      role="img"
+      aria-label={title}
+      viewBox="0 0 4000 1000"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      style={{ fillRule: 'evenodd', clipRule: 'evenodd', strokeLinecap: 'round' }}
+    >
+      <title>{title}</title>
+      <path
+        d="M1000,115l0,770c0,63.47 -51.53,115 -115,115l-770,0c-63.47,0 -115,-51.53 -115,-115l0,-770c0,-63.47 51.53,-115 115,-115l770,0c63.47,0 115,51.53 115,115Z"
+        fill="#1a1a1a"
+      />
+      <path
+        d="M500,95c222.176,-0 405,182.824 405,405c0,222.176 -182.824,405 -405,405c-222.176,0 -405,-182.824 -405,-405c-0,-222.176 182.824,-405 405,-405Zm285.424,301.118c-43.57,-119.717 -158.035,-199.868 -285.434,-199.868c-166.632,0 -303.75,137.118 -303.75,303.75c0,166.632 137.118,303.75 303.75,303.75c127.399,0 241.863,-80.151 285.434,-199.868l-95.074,-48.532c-24.669,86.814 -104.537,147.15 -194.789,147.15c-111.088,0 -202.5,-91.412 -202.5,-202.5c0,-111.088 91.412,-202.5 202.5,-202.5c90.251,0 170.12,60.336 194.789,147.15l95.074,-48.532Z"
+        fill="#fff8e9"
+      />
+      <path d="M618.125,618.125l165.375,165.375" fill="none" stroke="#f9c74f" strokeWidth="67.5" />
+      <text
+        x="1064.82"
+        y="692.255"
+        fill="currentColor"
+        style={{ fontFamily: 'Helvetica', fontSize: '537.02px' }}
+      >
+        C
+        <tspan
+          x="1444.583 1735.193 2174.48 2465.089 2755.699 3046.309 3336.919"
+          y="692.255 692.255 692.255 692.255 692.255 692.255 692.255"
+        >
+          ompendi
+        </tspan>
+      </text>
+      <g>
+        <path d="M3761.869,554.017l0,138.238" fill="none" stroke="currentColor" strokeWidth="40.28" strokeLinecap="butt" />
+        <path d="M3627.682,692.207l138.238,0.057" fill="none" stroke="currentColor" strokeWidth="40.28" strokeLinecap="butt" />
+        <circle cx="3623.631" cy="554.017" r="138.238" fill="none" stroke="currentColor" strokeWidth="40.28" strokeLinecap="butt" />
+        <path d="M3723.288,649.755l101.86,101.86" fill="none" stroke="#f9c74f" strokeWidth="40.28" strokeLinejoin="bevel" />
+      </g>
+    </svg>
+  );
+}

--- a/frontend/src/shared/components/TagEditor.tsx
+++ b/frontend/src/shared/components/TagEditor.tsx
@@ -201,7 +201,7 @@ export function TagEditor({
                 className={cn(
                   'cursor-pointer px-3 py-2 text-sm transition-colors',
                   index === highlightedIndex
-                    ? 'bg-primary/12 text-foreground'
+                    ? 'bg-action/12 text-foreground'
                     : 'text-muted-foreground hover:bg-background/60 hover:text-foreground',
                 )}
                 onMouseDown={(event) => {

--- a/frontend/src/shared/components/article/ArticleOutline.tsx
+++ b/frontend/src/shared/components/article/ArticleOutline.tsx
@@ -109,7 +109,7 @@ function OutlineItem({
               heading.level === 3 && 'pl-6 text-[13px]',
               heading.level >= 4 && 'pl-8 text-xs',
               activeId === heading.id
-                ? 'bg-primary/12 text-primary'
+                ? 'bg-action/12 text-action'
                 : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
             )}
           >
@@ -328,7 +328,7 @@ export function ArticleOutline({
 
       <div className="mb-4 h-1.5 overflow-hidden rounded-full bg-foreground/8">
         <m.div
-          className="h-full rounded-full bg-primary"
+          className="h-full rounded-full bg-action"
           style={{ width: `${readingProgress}%` }}
           transition={{ duration: 0.12 }}
         />
@@ -351,7 +351,7 @@ export function ArticleOutline({
 
       {pageId ? (
         <div className="mt-4 flex items-center gap-2 rounded-2xl bg-foreground/4 px-3 py-2 text-xs text-muted-foreground">
-          <ChevronDown size={12} className="text-primary/70" />
+          <ChevronDown size={12} className="text-action/70" />
           Synced to article {pageId}
         </div>
       ) : null}

--- a/frontend/src/shared/components/article/ArticleRightPane.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.tsx
@@ -114,7 +114,7 @@ const OutlineNodeItem = memo(function OutlineNodeItem({
         className={cn(
           'group flex items-center gap-1.5 rounded-[10px] h-9 pr-2 text-sm cursor-pointer transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background',
           isActive
-            ? 'nm-pill-active text-primary font-medium'
+            ? 'nm-pill-active text-action font-medium'
             : 'text-muted-foreground hover:bg-[var(--glass-pill-hover)] hover:text-foreground',
         )}
         style={{ paddingLeft: `${level * 16 + 8}px` }}
@@ -138,7 +138,7 @@ const OutlineNodeItem = memo(function OutlineNodeItem({
         ) : (
           <span className="w-[20px] shrink-0" />
         )}
-        <ListTree size={15} className={cn('shrink-0 opacity-70', isActive && 'text-primary opacity-100')} />
+        <ListTree size={15} className={cn('shrink-0 opacity-70', isActive && 'text-action opacity-100')} />
         <span className="truncate text-sm">{heading.text}</span>
       </div>
 
@@ -494,7 +494,7 @@ export function ArticleRightPane() {
             className={cn(
               'flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-sm transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background',
               isPinned
-                ? 'nm-pill-active text-primary font-medium'
+                ? 'nm-pill-active text-action font-medium'
                 : 'text-muted-foreground hover:bg-[var(--glass-pill-hover)] hover:text-foreground',
             )}
             title={`${isPinned ? 'Unpin' : 'Pin'} (${formatKeysForPlatform(getShortcutHint('pin-page') ?? '', detectMac())})`}
@@ -598,7 +598,7 @@ export function ArticleRightPane() {
             </div>
             <div className="mt-2 h-1 overflow-hidden rounded-full bg-foreground/8">
               <m.div
-                className="h-full rounded-full bg-primary"
+                className="h-full rounded-full bg-action"
                 style={{ width: `${readingProgress}%` }}
                 transition={{ duration: 0.12 }}
               />
@@ -636,8 +636,8 @@ export function ArticleRightPane() {
         aria-orientation="vertical"
         onMouseDown={handleResizeStart}
         className={cn(
-          'absolute left-0 top-2 bottom-2 w-1 cursor-col-resize rounded-full transition-colors hover:bg-primary/40',
-          isResizing && 'bg-primary/60',
+          'absolute left-0 top-2 bottom-2 w-1 cursor-col-resize rounded-full transition-colors hover:bg-action/40',
+          isResizing && 'bg-action/60',
         )}
       />
     </m.aside>

--- a/frontend/src/shared/components/article/AttachmentsMacroView.tsx
+++ b/frontend/src/shared/components/article/AttachmentsMacroView.tsx
@@ -122,7 +122,7 @@ export function AttachmentsMacroView({ editor }: NodeViewProps) {
                       href={att.url}
                       target="_blank"
                       rel="noreferrer"
-                      className="truncate text-primary hover:underline"
+                      className="truncate text-action hover:underline"
                     >
                       {att.filename}
                     </a>

--- a/frontend/src/shared/components/article/ChildrenMacroView.tsx
+++ b/frontend/src/shared/components/article/ChildrenMacroView.tsx
@@ -68,7 +68,7 @@ export function ChildrenMacroView({ node }: NodeViewProps) {
           <li key={child.id}>
             <Link
               to={`/pages/${child.id}`}
-              className="text-primary hover:underline"
+              className="text-action hover:underline"
             >
               {child.title}
             </Link>

--- a/frontend/src/shared/components/article/CommentForm.tsx
+++ b/frontend/src/shared/components/article/CommentForm.tsx
@@ -68,7 +68,7 @@ export function CommentForm({
         <button
           type="submit"
           disabled={!body.trim() || isSubmitting}
-          className="flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          className="inline-flex items-center gap-1.5 rounded-lg border border-action bg-transparent px-3 py-1.5 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           data-testid="comment-submit"
         >
           <Send size={14} />

--- a/frontend/src/shared/components/article/CommentThread.tsx
+++ b/frontend/src/shared/components/article/CommentThread.tsx
@@ -64,7 +64,7 @@ export function CommentThread({
     >
       {/* Top-level comment */}
       <div className="flex items-start gap-2.5">
-        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/20 text-xs font-medium text-primary">
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-action text-xs font-medium text-action-foreground">
           {comment.authorName.charAt(0).toUpperCase()}
         </div>
         <div className="min-w-0 flex-1">

--- a/frontend/src/shared/components/article/CommentsSidebar.tsx
+++ b/frontend/src/shared/components/article/CommentsSidebar.tsx
@@ -117,7 +117,7 @@ export function CommentsSidebar({ pageId, className }: CommentsSidebarProps) {
         onClick={() => setIsOpen((v) => !v)}
         className={cn(
           'nm-card flex items-center gap-1.5 px-3 py-1.5 text-sm hover:bg-foreground/5 transition-colors',
-          isOpen && 'nm-pill-active text-primary',
+          isOpen && 'nm-pill-active text-action',
         )}
         data-testid="comments-toggle"
         aria-label={isOpen ? 'Close comments' : 'Open comments'}
@@ -125,7 +125,7 @@ export function CommentsSidebar({ pageId, className }: CommentsSidebarProps) {
         <MessageSquare size={16} />
         Comments
         {totalCount > 0 && (
-          <span className="ml-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-primary/20 px-1 text-[11px] font-medium text-primary">
+          <span className="ml-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-action/20 px-1 text-[11px] font-medium text-action">
             {totalCount}
           </span>
         )}

--- a/frontend/src/shared/components/article/DiffView.tsx
+++ b/frontend/src/shared/components/article/DiffView.tsx
@@ -79,7 +79,7 @@ export function DiffView({ original, improved, onAccept, onReject, isAccepting =
               className={cn(
                 'flex items-center gap-1 px-2 py-1 text-xs transition-colors',
                 viewMode === 'unified'
-                  ? 'bg-primary/15 text-primary'
+                  ? 'bg-action/15 text-action'
                   : 'text-muted-foreground hover:bg-foreground/5',
               )}
               title="Unified view"
@@ -91,7 +91,7 @@ export function DiffView({ original, improved, onAccept, onReject, isAccepting =
               className={cn(
                 'flex items-center gap-1 px-2 py-1 text-xs transition-colors',
                 viewMode === 'side-by-side'
-                  ? 'bg-primary/15 text-primary'
+                  ? 'bg-action/15 text-action'
                   : 'text-muted-foreground hover:bg-foreground/5',
               )}
               title="Side-by-side view"
@@ -171,7 +171,7 @@ export function DiffView({ original, improved, onAccept, onReject, isAccepting =
             <button
               onClick={onAccept}
               disabled={isAccepting}
-              className="flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-action bg-transparent px-4 py-2 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:border-muted disabled:text-muted-foreground disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
             >
               {isAccepting ? (
                 <><Loader2 size={14} className="animate-spin" /> Applying…</>

--- a/frontend/src/shared/components/article/Editor.test.tsx
+++ b/frontend/src/shared/components/article/Editor.test.tsx
@@ -242,7 +242,8 @@ describe('EditorToolbar — header numbering toggle', () => {
     render(<EditorToolbar editor={editor} headerNumbering={true} onToggleHeaderNumbering={toggle} />);
 
     const btn = screen.getByTitle('Toggle Header Numbering');
-    expect(btn.className).toContain('bg-primary');
+    // Editor-toolbar active-state uses ink-action (Task 5 — amber reserved for AI affordances).
+    expect(btn.className).toContain('bg-action');
   });
 
   it('shows inactive styling when headerNumbering is false', () => {

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -139,7 +139,7 @@ function ToolbarButton({
       title={title}
       className={cn(
         'rounded p-1.5 transition-colors',
-        active ? 'bg-primary/20 text-primary ring-1 ring-primary/30' : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
+        active ? 'bg-action/20 text-action ring-1 ring-action/30' : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
         disabled && 'opacity-30 cursor-not-allowed',
       )}
     >
@@ -227,7 +227,7 @@ function StatusLabelInsert({ editor }: { editor: EditorType }) {
           />
           <button
             onClick={handleInsert}
-            className="w-full rounded-md bg-primary/20 px-2 py-1 text-xs text-primary hover:bg-primary/30"
+            className="w-full rounded-md border border-action bg-transparent px-2 py-1 text-xs text-action transition-colors hover:bg-action hover:text-action-foreground"
           >
             Insert
           </button>
@@ -601,9 +601,9 @@ export function TableContextToolbar({ editor }: { editor: EditorType }) {
   return (
     <div
       data-testid="table-context-toolbar"
-      className="flex flex-wrap items-center gap-0.5 border-t border-primary/20 bg-primary/5 px-2 py-1.5"
+      className="flex flex-wrap items-center gap-0.5 border-t border-action/20 bg-action/5 px-2 py-1.5"
     >
-      <span className="mr-1 text-xs font-semibold text-primary/70 select-none">Table</span>
+      <span className="mr-1 text-xs font-semibold text-action/70 select-none">Table</span>
 
       <ToolbarSeparator />
 
@@ -787,9 +787,9 @@ export function LayoutContextToolbar({ editor }: { editor: EditorType }) {
   return (
     <div
       data-testid="layout-context-toolbar"
-      className="flex flex-wrap items-center gap-0.5 border-t border-primary/20 bg-primary/5 px-2 py-1.5"
+      className="flex flex-wrap items-center gap-0.5 border-t border-action/20 bg-action/5 px-2 py-1.5"
     >
-      <span className="mr-1 text-xs font-semibold text-primary/70 select-none">Layout</span>
+      <span className="mr-1 text-xs font-semibold text-action/70 select-none">Layout</span>
 
       <ToolbarSeparator />
 
@@ -829,9 +829,9 @@ export function ColumnContextToolbar({ editor }: { editor: EditorType }) {
   return (
     <div
       data-testid="column-context-toolbar"
-      className="flex flex-wrap items-center gap-0.5 border-t border-primary/20 bg-primary/5 px-2 py-1.5"
+      className="flex flex-wrap items-center gap-0.5 border-t border-action/20 bg-action/5 px-2 py-1.5"
     >
-      <span className="mr-1 text-xs font-semibold text-primary/70 select-none">Columns</span>
+      <span className="mr-1 text-xs font-semibold text-action/70 select-none">Columns</span>
 
       <ToolbarSeparator />
 

--- a/frontend/src/shared/components/article/MermaidBlockExtension.tsx
+++ b/frontend/src/shared/components/article/MermaidBlockExtension.tsx
@@ -51,7 +51,7 @@ function MermaidBlockView({ node, updateAttributes, editor }: NodeViewProps) {
                   'flex items-center gap-1 rounded px-2 py-0.5 text-xs transition-colors',
                   showPreview
                     ? 'text-muted-foreground hover:bg-foreground/10 hover:text-foreground'
-                    : 'bg-primary/15 text-primary',
+                    : 'bg-action/15 text-action',
                 )}
                 title={showPreview ? 'Edit source code' : 'Show preview'}
                 type="button"

--- a/frontend/src/shared/components/article/PagePreview.tsx
+++ b/frontend/src/shared/components/article/PagePreview.tsx
@@ -79,7 +79,7 @@ export function PagePreview({ pageId, children, className }: PagePreviewProps) {
               ) : page ? (
                 <>
                   <div className="mb-2 flex items-start gap-2">
-                    <FileText size={14} className="mt-0.5 shrink-0 text-primary" />
+                    <FileText size={14} className="mt-0.5 shrink-0 text-action" />
                     <h4 className="text-sm font-medium leading-tight">{page.title}</h4>
                   </div>
                   {bodyPreview && (
@@ -88,7 +88,7 @@ export function PagePreview({ pageId, children, className }: PagePreviewProps) {
                     </p>
                   )}
                   <div className="flex items-center gap-2">
-                    <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] text-primary">
+                    <span className="rounded bg-[#ececea] px-1.5 py-0.5 text-[10px] text-[#4a4a48] dark:bg-[#2a2925] dark:text-[#c5bea9]">
                       {page.spaceKey}
                     </span>
                     {page.lastModifiedAt && (

--- a/frontend/src/shared/components/article/SearchAndReplace.test.tsx
+++ b/frontend/src/shared/components/article/SearchAndReplace.test.tsx
@@ -175,7 +175,8 @@ describe('SearchAndReplace', () => {
     fireEvent.click(caseBtn);
 
     // The button should now have the active style (primary ring)
-    expect(caseBtn.className).toContain('bg-primary/20');
+    // Search-and-replace toggles are non-AI chrome (Task 5 — amber reserved for AI affordances).
+    expect(caseBtn.className).toContain('bg-action/20');
   });
 
   it('toggles whole word matching', async () => {
@@ -192,7 +193,7 @@ describe('SearchAndReplace', () => {
     const wordBtn = screen.getByTitle('Match Whole Word');
     fireEvent.click(wordBtn);
 
-    expect(wordBtn.className).toContain('bg-primary/20');
+    expect(wordBtn.className).toContain('bg-action/20');
   });
 
   it('toggles regex mode', async () => {
@@ -209,7 +210,7 @@ describe('SearchAndReplace', () => {
     const regexBtn = screen.getByTitle('Use Regular Expression');
     fireEvent.click(regexBtn);
 
-    expect(regexBtn.className).toContain('bg-primary/20');
+    expect(regexBtn.className).toContain('bg-action/20');
   });
 
   it('toggles replace row visibility', async () => {

--- a/frontend/src/shared/components/article/SearchAndReplace.tsx
+++ b/frontend/src/shared/components/article/SearchAndReplace.tsx
@@ -266,7 +266,7 @@ export function SearchAndReplace({ editor }: SearchAndReplaceProps) {
           className={cn(
             'rounded p-0.5 transition-colors',
             showReplace
-              ? 'bg-primary/20 text-primary'
+              ? 'bg-action/20 text-action'
               : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
           )}
         >
@@ -335,7 +335,7 @@ function ToggleButton({
       className={cn(
         'rounded p-0.5 transition-colors',
         active
-          ? 'bg-primary/20 text-primary ring-1 ring-primary/30'
+          ? 'bg-action/20 text-action ring-1 ring-action/30'
           : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
       )}
     >

--- a/frontend/src/shared/components/article/StatusBadgeView.tsx
+++ b/frontend/src/shared/components/article/StatusBadgeView.tsx
@@ -120,7 +120,7 @@ export function StatusBadgeView({ node, updateAttributes, editor }: NodeViewProp
               <button
                 type="button"
                 onClick={handleApply}
-                className="w-full rounded-md bg-primary/20 px-2 py-1 text-xs font-medium text-primary hover:bg-primary/30 transition-colors"
+                className="w-full rounded-md border border-action bg-transparent px-2 py-1 text-xs font-medium text-action transition-colors hover:bg-action hover:text-action-foreground"
                 data-testid="status-apply-btn"
               >
                 Apply

--- a/frontend/src/shared/components/article/TableOfContents.tsx
+++ b/frontend/src/shared/components/article/TableOfContents.tsx
@@ -139,7 +139,7 @@ function TocNodeItem({ node, activeId, collapsedIds, onToggleCollapsed, scrollTo
               heading.level === 3 && 'pl-6 text-xs',
               heading.level === 4 && 'pl-8 text-xs',
               isActive
-                ? 'bg-primary/15 text-primary'
+                ? 'bg-action/15 text-action'
                 : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
             )}
           >
@@ -276,7 +276,7 @@ export function TableOfContents({ htmlContent, headings: headingsProp, contentRe
       {/* Reading progress bar */}
       <div className="fixed left-0 top-0 z-40 h-0.5 w-full" aria-hidden="true">
         <m.div
-          className="h-full bg-primary"
+          className="h-full bg-action"
           style={{ width: `${readingProgress}%` }}
           transition={{ duration: 0.1 }}
         />
@@ -285,7 +285,7 @@ export function TableOfContents({ htmlContent, headings: headingsProp, contentRe
       {/* Mobile toggle */}
       <button
         onClick={() => setIsMobileOpen(!isMobileOpen)}
-        className="fixed bottom-4 right-4 z-40 rounded-full bg-primary p-3 text-primary-foreground shadow-lg lg:hidden"
+        className="fixed bottom-4 right-4 z-40 rounded-full border border-action bg-transparent p-3 text-action shadow-lg transition-colors hover:bg-action hover:text-action-foreground lg:hidden"
         aria-label="Toggle table of contents"
       >
         {isMobileOpen ? <X size={20} /> : <List size={20} />}

--- a/frontend/src/shared/components/article/VimModeIndicator.tsx
+++ b/frontend/src/shared/components/article/VimModeIndicator.tsx
@@ -12,7 +12,7 @@ const MODE_LABELS: Record<VimMode, string> = {
 };
 
 const MODE_COLORS: Record<VimMode, string> = {
-  normal: 'bg-primary/15 text-primary',
+  normal: 'bg-action/15 text-action',
   insert: 'bg-emerald-500/15 text-emerald-400',
   visual: 'bg-amber-500/15 text-amber-400',
 };

--- a/frontend/src/shared/components/badges/EmbeddingStatusBadge.test.tsx
+++ b/frontend/src/shared/components/badges/EmbeddingStatusBadge.test.tsx
@@ -17,12 +17,14 @@ describe('EmbeddingStatusBadge', () => {
 
   // ---- New 4-state embeddingStatus prop ----
 
-  it('renders not_embedded state with gray styling', () => {
+  it('renders not_embedded state with neutral warm-gray styling (AA-pass)', () => {
     render(<EmbeddingStatusBadge embeddingStatus="not_embedded" />);
-    const badge = screen.getByTestId('embedding-status-badge');
+    const badge = screen.getByTestId('badge-not-embedded');
     expect(badge).toHaveTextContent('Not Embedded');
-    expect(badge.className).toContain('text-status-inactive');
-    expect(badge.className).toContain('bg-status-inactive/20');
+    // Was bg-status-inactive/20 + text-status-inactive (2.67:1 light / 3.19:1 dark, failed AA).
+    expect(badge.className).toContain('bg-[#efeeea]');
+    expect(badge.className).toContain('text-[#5f5c54]');
+    expect(badge.className).not.toMatch(/amber|warning|yellow|primary/);
     expect(badge).toHaveAttribute('data-status', 'not_embedded');
   });
 
@@ -99,7 +101,7 @@ describe('EmbeddingStatusBadge', () => {
 
   it('shows tooltip for not_embedded state', () => {
     render(<EmbeddingStatusBadge embeddingStatus="not_embedded" />);
-    const badge = screen.getByTestId('embedding-status-badge');
+    const badge = screen.getByTestId('badge-not-embedded');
     expect(badge.getAttribute('title')).toContain('not been indexed');
   });
 
@@ -171,7 +173,7 @@ describe('EmbeddingStatusBadge', () => {
 
   it('does not apply animate-pulse for non-embedding states', () => {
     const { rerender } = render(<EmbeddingStatusBadge embeddingStatus="not_embedded" />);
-    expect(screen.getByTestId('embedding-status-badge').className).not.toContain('animate-pulse');
+    expect(screen.getByTestId('badge-not-embedded').className).not.toContain('animate-pulse');
 
     rerender(<EmbeddingStatusBadge embeddingStatus="embedded" />);
     expect(screen.getByTestId('embedding-status-badge').className).not.toContain('animate-pulse');

--- a/frontend/src/shared/components/badges/EmbeddingStatusBadge.tsx
+++ b/frontend/src/shared/components/badges/EmbeddingStatusBadge.tsx
@@ -33,7 +33,9 @@ function getStatusConfig(
       return {
         label: 'Not Embedded',
         title: 'Content has not been indexed for AI search',
-        badgeClass: 'bg-status-inactive/20 text-status-inactive border border-status-inactive/30',
+        // Neutral warm-gray tinted pill, AA-pass in light + dark.
+        // Was bg-status-inactive/20 + text-status-inactive (2.67:1 light / 3.19:1 dark — failed AA).
+        badgeClass: 'bg-[#efeeea] text-[#5f5c54] dark:bg-[#262320] dark:text-[#a39e8c]',
         animate: false,
       };
     case 'embedding':
@@ -82,7 +84,7 @@ export function EmbeddingStatusBadge(props: EmbeddingStatusBadgeProps) {
   return (
     <span
       title={config.title}
-      data-testid="embedding-status-badge"
+      data-testid={status === 'not_embedded' ? 'badge-not-embedded' : 'embedding-status-badge'}
       data-status={status}
       className={cn(
         'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium',

--- a/frontend/src/shared/components/badges/FreshnessBadge.test.tsx
+++ b/frontend/src/shared/components/badges/FreshnessBadge.test.tsx
@@ -57,6 +57,17 @@ describe('FreshnessBadge', () => {
     expect(badge.className).toContain('text-destructive');
     expect(badge.className).toContain('bg-destructive/15');
   });
+
+  // Recent moved off amber to sage green (Task 4 — amber-as-AI bundle).
+  // Was bg-warning/15 + text-warning (3.37:1 — failed WCAG-AA).
+  it('Recent badge uses sage tint, not amber/primary/warning', () => {
+    render(<FreshnessBadge lastModified="2026-02-15T12:00:00Z" />);
+    const badge = screen.getByTestId('badge-recent');
+    expect(badge).toHaveTextContent('Recent');
+    expect(badge.className).not.toMatch(/amber|warning|yellow|primary/);
+    expect(badge.className).toMatch(/bg-\[#e7f2e8\]/);
+    expect(badge.className).toMatch(/text-\[#1f5a2a\]/);
+  });
 });
 
 describe('getFreshnessLevel', () => {

--- a/frontend/src/shared/components/badges/FreshnessBadge.tsx
+++ b/frontend/src/shared/components/badges/FreshnessBadge.tsx
@@ -10,6 +10,7 @@ interface FreshnessLevel {
   label: string;
   colorClass: string;
   bgClass: string;
+  testId?: string;
 }
 
 function getFreshnessLevel(lastModified: string): FreshnessLevel {
@@ -22,7 +23,15 @@ function getFreshnessLevel(lastModified: string): FreshnessLevel {
     return { label: 'Fresh', colorClass: 'text-success', bgClass: 'bg-success/15' };
   }
   if (diffDays < 30) {
-    return { label: 'Recent', colorClass: 'text-warning', bgClass: 'bg-warning/15' };
+    // Recent: sage green tinted pill, AA-pass in light + dark.
+    // Was amber (bg-warning/15 + text-warning) which read as a warning and
+    // failed WCAG-AA contrast (3.37:1). Sage reads as positive freshness.
+    return {
+      label: 'Recent',
+      colorClass: 'text-[#1f5a2a] dark:text-[#9ad4a8]',
+      bgClass: 'bg-[#e7f2e8] dark:bg-[#1a2a1d]',
+      testId: 'badge-recent',
+    };
   }
   if (diffDays < 90) {
     return { label: 'Aging', colorClass: 'text-status-syncing', bgClass: 'bg-status-syncing/15' };
@@ -40,6 +49,7 @@ export function FreshnessBadge({ lastModified, className }: FreshnessBadgeProps)
   return (
     <span
       title={`Last modified: ${formattedDate}`}
+      data-testid={level.testId}
       className={cn(
         'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
         level.bgClass,

--- a/frontend/src/shared/components/badges/QualityScoreBadge.test.tsx
+++ b/frontend/src/shared/components/badges/QualityScoreBadge.test.tsx
@@ -34,11 +34,13 @@ describe('QualityScoreBadge', () => {
 
   // ---- Failed state ----
 
-  it('renders "Analysis Failed" with red styling', () => {
+  it('renders "Analysis Failed" with soft-red tinted pill (AA-pass)', () => {
     render(<QualityScoreBadge qualityScore={null} qualityStatus="failed" />);
-    const badge = screen.getByTestId('quality-score-badge');
+    const badge = screen.getByTestId('badge-failed');
     expect(badge).toHaveTextContent('Analysis Failed');
-    expect(badge.className).toContain('text-status-disconnected');
+    expect(badge.className).toContain('bg-[#fae2e0]');
+    expect(badge.className).toContain('text-[#7a1e1a]');
+    expect(badge.className).not.toMatch(/amber|warning|yellow|primary/);
     expect(badge).toHaveAttribute('data-status', 'failed');
   });
 
@@ -50,17 +52,19 @@ describe('QualityScoreBadge', () => {
         qualityError="LLM connection timeout"
       />,
     );
-    const badge = screen.getByTestId('quality-score-badge');
+    const badge = screen.getByTestId('badge-failed');
     expect(badge.getAttribute('title')).toContain('LLM connection timeout');
   });
 
   // ---- Skipped state ----
 
-  it('renders "Skipped" with gray styling', () => {
+  it('renders "Skipped" with neutral warm-gray tint (AA-pass)', () => {
     render(<QualityScoreBadge qualityScore={null} qualityStatus="skipped" />);
-    const badge = screen.getByTestId('quality-score-badge');
+    const badge = screen.getByTestId('badge-skipped');
     expect(badge).toHaveTextContent('Skipped');
-    expect(badge.className).toContain('text-status-inactive');
+    expect(badge.className).toContain('bg-[#efeeea]');
+    expect(badge.className).toContain('text-[#5f5c54]');
+    expect(badge.className).not.toMatch(/amber|warning|yellow|primary/);
     expect(badge).toHaveAttribute('data-status', 'skipped');
   });
 
@@ -161,7 +165,7 @@ describe('QualityScoreBadge', () => {
 
   it('does not apply animate-pulse for failed state', () => {
     render(<QualityScoreBadge qualityScore={null} qualityStatus="failed" />);
-    expect(screen.getByTestId('quality-score-badge').className).not.toContain('animate-pulse');
+    expect(screen.getByTestId('badge-failed').className).not.toContain('animate-pulse');
   });
 
   // ---- Custom className ----

--- a/frontend/src/shared/components/badges/QualityScoreBadge.tsx
+++ b/frontend/src/shared/components/badges/QualityScoreBadge.tsx
@@ -20,6 +20,7 @@ interface ScoreConfig {
   label: string;
   badgeClass: string;
   animate: boolean;
+  testId?: string;
 }
 
 function getScoreConfig(
@@ -39,16 +40,20 @@ function getScoreConfig(
   if (status === 'failed') {
     return {
       label: 'Analysis Failed',
-      badgeClass: 'bg-status-disconnected/20 text-status-disconnected border border-status-disconnected/30',
+      // Soft-red tinted pill, AA-pass in light + dark.
+      badgeClass: 'bg-[#fae2e0] text-[#7a1e1a] dark:bg-[#2a1614] dark:text-[#e89c98]',
       animate: false,
+      testId: 'badge-failed',
     };
   }
 
   if (status === 'skipped') {
     return {
       label: 'Skipped',
-      badgeClass: 'bg-status-inactive/20 text-status-inactive border border-status-inactive/30',
+      // Neutral warm-gray tinted pill, AA-pass in light + dark.
+      badgeClass: 'bg-[#efeeea] text-[#5f5c54] dark:bg-[#262320] dark:text-[#a39e8c]',
       animate: false,
+      testId: 'badge-skipped',
     };
   }
 
@@ -150,7 +155,7 @@ export function QualityScoreBadge(props: QualityScoreBadgeProps) {
   return (
     <span
       title={tooltip}
-      data-testid="quality-score-badge"
+      data-testid={config.testId ?? 'quality-score-badge'}
       data-status={qualityStatus ?? 'pending'}
       data-score={qualityScore ?? ''}
       className={cn(

--- a/frontend/src/shared/components/feedback/FeatureErrorBoundary.tsx
+++ b/frontend/src/shared/components/feedback/FeatureErrorBoundary.tsx
@@ -75,7 +75,7 @@ export class FeatureErrorBoundary extends Component<
           )}
           <button
             onClick={this.handleReset}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-action bg-transparent px-3 py-1.5 text-sm font-medium text-action transition-colors hover:bg-action hover:text-action-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           >
             <RefreshCw size={14} />
             Try Again

--- a/frontend/src/shared/components/layout/AppLayout.tsx
+++ b/frontend/src/shared/components/layout/AppLayout.tsx
@@ -15,6 +15,7 @@ import { UserMenu } from './UserMenu';
 import { SidebarTreeView } from './SidebarTreeView';
 import { ArticleRightPane } from '../article/ArticleRightPane';
 import { ShortcutHint } from '../ShortcutHint';
+import { Logo } from '../Logo';
 import { ThemeToggle } from './ThemeToggle';
 import { PageTransition } from './PageTransition';
 import { cn } from '../../lib/cn';
@@ -197,11 +198,7 @@ export function AppLayout({ children }: { children: ReactNode }) {
 
         {/* Logo - always visible in header */}
         <Link to="/" aria-label="Compendiq home" className="mr-3 flex shrink-0 items-center group">
-          <img
-            src="/compendiq-lockup-horizontal.svg"
-            alt="Compendiq"
-            className="h-7 w-auto transition-transform duration-200 group-hover:scale-105 dark:invert"
-          />
+          <Logo className="h-[26px] w-auto text-foreground" title="Compendiq" />
         </Link>
 
         {/* Breadcrumb — gets full width now that nav pills moved to sidebar */}

--- a/frontend/src/shared/components/layout/Breadcrumb.tsx
+++ b/frontend/src/shared/components/layout/Breadcrumb.tsx
@@ -47,7 +47,7 @@ export function Breadcrumb() {
             <span className="flex items-center gap-1 text-muted-foreground">
               {breadcrumbData.source === 'confluence'
                 ? <Globe size={12} className="text-muted-foreground/70" />
-                : <HardDrive size={12} className="text-primary/70" />
+                : <HardDrive size={12} className="text-action/70" />
               }
               <span className="text-xs">{breadcrumbData.spaceName}</span>
             </span>

--- a/frontend/src/shared/components/layout/CommandPalette.tsx
+++ b/frontend/src/shared/components/layout/CommandPalette.tsx
@@ -289,7 +289,7 @@ export function CommandPalette() {
                           className={cn(
                             'flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors',
                             selectedIndex === idx
-                              ? 'bg-primary/15 text-primary'
+                              ? 'bg-action/15 text-action'
                               : 'text-foreground hover:bg-foreground/5',
                           )}
                         >
@@ -332,7 +332,7 @@ export function CommandPalette() {
                           className={cn(
                             'flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors',
                             selectedIndex === idx
-                              ? 'bg-primary/15 text-primary'
+                              ? 'bg-action/15 text-action'
                               : 'text-foreground hover:bg-foreground/5',
                           )}
                         >
@@ -364,7 +364,7 @@ export function CommandPalette() {
                           className={cn(
                             'flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors',
                             selectedIndex === baseIdx
-                              ? 'bg-primary/15 text-primary'
+                              ? 'bg-action/15 text-action'
                               : 'text-foreground hover:bg-foreground/5',
                           )}
                         >

--- a/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
+++ b/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
@@ -72,7 +72,7 @@ const DndSortableTreeNode = memo(function DndSortableTreeNode({
         className={cn(
           'group flex items-center gap-1.5 rounded-[10px] h-9 pr-2 text-sm cursor-pointer transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background',
           isActive
-            ? 'nm-pill-active text-primary font-medium scale-[1.01]'
+            ? 'nm-pill-active text-action font-medium scale-[1.01]'
             : 'text-muted-foreground hover:bg-[var(--glass-pill-hover)] hover:text-foreground',
         )}
         style={{ paddingLeft: `${level * 16 + 10}px` }}
@@ -92,7 +92,7 @@ const DndSortableTreeNode = memo(function DndSortableTreeNode({
         ) : (
           <span className="w-[20px] shrink-0" />
         )}
-        <FileText size={15} className={cn('shrink-0', isActive ? 'text-primary/80' : 'text-muted-foreground/70')} />
+        <FileText size={15} className={cn('shrink-0', isActive ? 'text-action/80' : 'text-muted-foreground/70')} />
         <span className="truncate text-sm">{node.page.title}</span>
       </div>
 

--- a/frontend/src/shared/components/layout/KeyboardShortcutsModal.tsx
+++ b/frontend/src/shared/components/layout/KeyboardShortcutsModal.tsx
@@ -55,7 +55,7 @@ export function KeyboardShortcutsModal() {
           {/* Header */}
           <div className="flex items-center justify-between border-b border-border/50 px-5 py-4">
             <Dialog.Title className="flex items-center gap-2 text-base font-semibold text-foreground">
-              <Keyboard size={18} className="text-primary" />
+              <Keyboard size={18} className="text-action" />
               Keyboard Shortcuts
             </Dialog.Title>
             <Dialog.Close asChild>
@@ -127,7 +127,7 @@ export function KeyboardShortcutsModal() {
                 checked={singleKeyEnabled}
                 onCheckedChange={setSingleKeyEnabled}
                 aria-label="Single-key shortcuts"
-                className="relative h-5 w-9 shrink-0 rounded-full bg-foreground/10 transition-colors data-[state=checked]:bg-primary outline-none"
+                className="relative h-5 w-9 shrink-0 rounded-full bg-foreground/10 transition-colors data-[state=checked]:bg-action outline-none"
               >
                 <Switch.Thumb className="block h-4 w-4 translate-x-0.5 rounded-full bg-white transition-transform data-[state=checked]:translate-x-4" />
               </Switch.Root>

--- a/frontend/src/shared/components/layout/NotificationBell.tsx
+++ b/frontend/src/shared/components/layout/NotificationBell.tsx
@@ -103,7 +103,7 @@ export function NotificationBell() {
           {unreadCount > 0 && (
             <span
               className={cn(
-                'absolute -right-0.5 -top-0.5 flex items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground',
+                'absolute -right-0.5 -top-0.5 flex items-center justify-center rounded-full bg-action text-[10px] font-bold text-action-foreground',
                 unreadCount > 9 ? 'h-4.5 min-w-4.5 px-1' : 'h-4 w-4',
               )}
               data-testid="notification-badge"

--- a/frontend/src/shared/components/layout/NotificationDropdown.tsx
+++ b/frontend/src/shared/components/layout/NotificationDropdown.tsx
@@ -99,7 +99,7 @@ export function NotificationDropdown({
         <div className="flex items-center justify-end border-b border-border/30 px-3 py-2">
           <button
             onClick={onMarkAllRead}
-            className="text-xs text-primary hover:text-primary/80 transition-colors"
+            className="text-xs text-action hover:text-action/80 transition-colors"
             data-testid="mark-all-read"
           >
             Mark all as read
@@ -126,7 +126,7 @@ export function NotificationDropdown({
                   onClick={() => onClickNotification(notification)}
                   className={cn(
                     'flex w-full items-start gap-3 px-3 py-2.5 text-left transition-colors hover:bg-foreground/5',
-                    !notification.read && 'bg-primary/5',
+                    !notification.read && 'bg-action/5',
                   )}
                   data-testid={`notification-item-${notification.id}`}
                 >
@@ -139,7 +139,7 @@ export function NotificationDropdown({
                         {notification.title}
                       </span>
                       {!notification.read && (
-                        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
+                        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-action" />
                       )}
                     </div>
                     <p className="mt-0.5 text-xs text-muted-foreground line-clamp-1">

--- a/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
@@ -96,6 +96,33 @@ describe('SidebarTreeView', () => {
     expect(screen.getByRole('link', { name: /AI/ })).toBeInTheDocument();
   });
 
+  it('active nav tab uses ink-action treatment, not amber text', () => {
+    // location.pathname === '/' => Pages tab is active.
+    render(<SidebarTreeView />, { wrapper: createWrapper('/') });
+    const pagesLink = screen.getByRole('link', { name: /Pages/ });
+    expect(pagesLink.className).toContain('bg-action');
+    expect(pagesLink.className).toContain('text-action-foreground');
+    expect(pagesLink.className).not.toContain('text-primary');
+  });
+
+  it('active AI tab keeps an amber icon as the AI signal even though pill is ink', () => {
+    render(<SidebarTreeView />, { wrapper: createWrapper('/ai') });
+    const aiLink = screen.getByRole('link', { name: /AI/ });
+    // At least one descendant element carries text-primary (the amber icon).
+    const amberDescendant = aiLink.querySelector('[class*="text-primary"]');
+    expect(amberDescendant).not.toBeNull();
+  });
+
+  it('inactive AI tab icon does not use amber (would fail 3:1 against light glass)', () => {
+    // Render with location.pathname === '/' so Pages is active, AI is inactive.
+    render(<SidebarTreeView />, { wrapper: createWrapper('/') });
+    const aiLink = screen.getByRole('link', { name: /AI/ });
+    // No descendant of the inactive AI link may carry text-primary — otherwise
+    // amber would sit on the light glass pill (~1.47:1 contrast, WCAG failure).
+    const amberDescendant = aiLink.querySelector('[class*="text-primary"]');
+    expect(amberDescendant).toBeNull();
+  });
+
   it('renders "Pages" label in sidebar header', () => {
     render(<SidebarTreeView />, { wrapper: createWrapper() });
     expect(screen.getAllByText('Pages').length).toBeGreaterThanOrEqual(1);

--- a/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
@@ -199,7 +199,8 @@ describe('SidebarTreeView', () => {
     render(<SidebarTreeView />, { wrapper: createWrapper('/ai?pageId=child-1') });
     const installRef = screen.getByText('Installation');
     const row = installRef.parentElement!;
-    expect(row.className).toContain('nm-pill-active');
+    expect(row.className).toContain('bg-action');
+    expect(row.className).toContain('text-action-foreground');
   });
 
   it('shows collapsed state with expand toggle and nav icons when treeSidebarCollapsed is true', () => {

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -142,7 +142,7 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
         className={cn(
           'group flex items-center gap-1.5 rounded-[10px] h-9 pr-2 text-sm cursor-pointer transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background',
           isActive
-            ? 'nm-pill-active text-primary font-medium scale-[1.01]'
+            ? 'bg-action text-action-foreground font-medium scale-[1.01]'
             : 'text-muted-foreground hover:bg-[var(--glass-pill-hover)] hover:text-foreground',
         )}
         style={{ paddingLeft: `${level * 16 + 10}px` }}
@@ -159,7 +159,7 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
         ) : (
           <span className="w-[20px] shrink-0" />
         )}
-        <FileText size={15} className={cn('shrink-0', isActive ? 'text-primary/80' : 'text-muted-foreground/70')} />
+        <FileText size={15} className={cn('shrink-0', isActive ? 'text-action-foreground/80' : 'text-muted-foreground/70')} />
         <span className="truncate text-sm">{node.page.title}</span>
       </div>
 
@@ -524,7 +524,7 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
               {selectedSpaceOption ? (
                 <>
                   {selectedSpaceOption.source === 'local'
-                    ? <HardDrive size={10} className="shrink-0 text-primary/70" />
+                    ? <HardDrive size={10} className="shrink-0 text-action/70" />
                     : <Globe size={10} className="shrink-0 text-muted-foreground/70" />
                   }
                   {selectedSpaceOption.name} ({selectedSpaceOption.key})
@@ -542,7 +542,7 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
                 }}
                 className={cn(
                   'flex w-full items-center rounded-lg px-2.5 py-1.5 text-xs transition-all duration-200',
-                  !treeSidebarSpaceKey ? 'nm-pill-active text-primary font-medium' : 'text-foreground hover:bg-[var(--glass-pill-hover)]',
+                  !treeSidebarSpaceKey ? 'nm-pill-active text-action font-medium' : 'text-foreground hover:bg-[var(--glass-pill-hover)]',
                 )}
               >
                 All Spaces
@@ -564,7 +564,7 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
                       className={cn(
                         'flex w-full items-center justify-between rounded-lg px-2.5 py-1.5 text-xs transition-all duration-200',
                         treeSidebarSpaceKey === space.key
-                          ? 'nm-pill-active text-primary font-medium'
+                          ? 'nm-pill-active text-action font-medium'
                           : 'text-foreground hover:bg-[var(--glass-pill-hover)]',
                       )}
                     >
@@ -594,12 +594,12 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
                       className={cn(
                         'flex w-full items-center justify-between rounded-lg px-2.5 py-1.5 text-xs transition-all duration-200',
                         treeSidebarSpaceKey === space.key
-                          ? 'nm-pill-active text-primary font-medium'
+                          ? 'nm-pill-active text-action font-medium'
                           : 'text-foreground hover:bg-[var(--glass-pill-hover)]',
                       )}
                     >
                       <span className="flex items-center gap-1.5 truncate">
-                        <HardDrive size={10} className="shrink-0 text-primary/70" />
+                        <HardDrive size={10} className="shrink-0 text-action/70" />
                         {space.name}
                       </span>
                       <span className="shrink-0 text-muted-foreground ml-2">{space.pageCount}</span>
@@ -614,7 +614,7 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
                   setSpaceDropdownOpen(false);
                   navigate('/spaces/new');
                 }}
-                className="flex w-full items-center gap-1.5 border-t border-[var(--glass-sidebar-divider)] mt-1 pt-1 rounded-lg px-2.5 py-1.5 text-xs text-primary hover:bg-[var(--glass-pill-hover)] transition-colors"
+                className="flex w-full items-center gap-1.5 border-t border-[var(--glass-sidebar-divider)] mt-1 pt-1 rounded-lg px-2.5 py-1.5 text-xs text-action hover:bg-[var(--glass-pill-hover)] transition-colors"
               >
                 <Plus size={10} />
                 New Space
@@ -631,7 +631,7 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
       {showNewFolderInput && (
         <div className="px-2 py-1.5" data-testid="new-folder-input">
           <div className="flex items-center gap-1.5">
-            <FolderPlus size={14} className="shrink-0 text-primary/70" />
+            <FolderPlus size={14} className="shrink-0 text-action/70" />
             <input
               ref={newFolderInputRef}
               value={newFolderName}
@@ -650,7 +650,7 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
             <button
               onClick={handleCreateFolder}
               disabled={!newFolderName.trim() || createPage.isPending}
-              className="rounded-md bg-primary/15 px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/25 disabled:opacity-40"
+              className="inline-flex items-center rounded-md border border-action bg-transparent px-2 py-1 text-xs font-medium text-action transition-colors hover:bg-action hover:text-action-foreground disabled:opacity-40"
             >
               {createPage.isPending ? '...' : 'Add'}
             </button>
@@ -684,7 +684,7 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
             {!treeSidebarSpaceKey && (
               <button
                 onClick={() => navigate('/settings')}
-                className="mt-3 flex items-center gap-1.5 rounded-lg bg-primary/10 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/15 transition-colors"
+                className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-action bg-transparent px-3 py-1.5 text-xs font-medium text-action hover:bg-action hover:text-action-foreground transition-colors"
               >
                 <Plus size={12} />
                 Sync a Space
@@ -738,8 +738,8 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
         aria-orientation="vertical"
         onMouseDown={handleResizeStart}
         className={cn(
-          'absolute right-0 top-2 bottom-2 w-1 cursor-col-resize rounded-full transition-colors hover:bg-primary/40',
-          isResizing && 'bg-primary/60',
+          'absolute right-0 top-2 bottom-2 w-1 cursor-col-resize rounded-full transition-colors hover:bg-action/40',
+          isResizing && 'bg-action/60',
         )}
       />
     </m.aside>

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -401,13 +401,22 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
                   className={cn(
                     'rounded-lg p-1.5 transition-all duration-200 active:scale-[0.95]',
                     active
-                      ? 'nm-pill-active text-primary'
+                      ? 'bg-action text-action-foreground'
                       : 'text-muted-foreground hover:bg-[var(--glass-pill-hover)] hover:text-foreground',
                   )}
                   title={`${label} (${shortcut})`}
                   aria-label={label}
                 >
-                  <Icon size={16} className={cn(active && 'drop-shadow-[0_1px_2px_oklch(from_var(--color-primary)_l_c_h_/_0.3)]')} />
+                  <Icon
+                    size={16}
+                    className={cn(
+                      active && 'drop-shadow-[0_1px_2px_oklch(0_0_0_/_0.25)]',
+                      // AI tab keeps amber on its icon as the AI signal, but only
+                      // when active (pill is ink) — otherwise amber on light glass
+                      // would fail 3:1 contrast.
+                      active && path === '/ai' && 'text-primary',
+                    )}
+                  />
                 </Link>
               );
             })}
@@ -448,11 +457,21 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
               className={cn(
                 'flex flex-1 items-center justify-center gap-1.5 rounded-lg px-2 py-1.5 text-xs transition-all duration-200 active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
                 active
-                  ? 'nm-pill-active text-primary font-medium'
+                  ? 'bg-action text-action-foreground font-medium'
                   : 'text-muted-foreground hover:bg-[var(--glass-pill-hover)] hover:text-foreground',
               )}
             >
-              <Icon size={14} className={cn(active && 'drop-shadow-[0_1px_2px_oklch(from_var(--color-primary)_l_c_h_/_0.3)]')} />
+              <Icon
+                size={14}
+                className={cn(
+                  active && 'drop-shadow-[0_1px_2px_oklch(0_0_0_/_0.25)]',
+                  // AI tab keeps amber on its icon as the AI signal when active
+                  // (pill is ink, ~7:1+ contrast). When inactive, the icon must
+                  // inherit muted-foreground — amber on light glass is 1.47:1,
+                  // a WCAG failure.
+                  active && path === '/ai' && 'text-primary',
+                )}
+              />
               {label}
             </Link>
           );

--- a/frontend/src/shared/components/layout/UserMenu.test.tsx
+++ b/frontend/src/shared/components/layout/UserMenu.test.tsx
@@ -222,4 +222,17 @@ describe('UserMenu', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/admin/analytics');
     });
   });
+
+  // Task 5 — avatar initial bubble is brand chrome (not an AI affordance), so
+  // it must route to ink-action and not amber. The Playwright contrast spec in
+  // Task 6 will catch the colour combo at run-time; this guards the contract
+  // at the unit level so a future regression can't quietly re-amber it.
+  it('user avatar uses ink-action, not amber (avatar is brand chrome, not AI)', () => {
+    mockUser = { username: 'simon', role: 'user' };
+    renderUserMenu();
+    const avatar = screen.getByTestId('user-avatar-initial');
+    expect(avatar.className).not.toMatch(/text-primary|bg-primary/);
+    expect(avatar.className).toMatch(/bg-action/);
+    expect(avatar.className).toMatch(/text-action-foreground/);
+  });
 });

--- a/frontend/src/shared/components/layout/UserMenu.tsx
+++ b/frontend/src/shared/components/layout/UserMenu.tsx
@@ -19,7 +19,7 @@ export function UserMenu() {
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
         <button className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-foreground/5 transition-colors outline-none">
-          <div className="flex h-7 w-7 items-center justify-center rounded-full bg-primary/20 text-xs font-medium text-primary">
+          <div className="flex h-7 w-7 items-center justify-center rounded-full bg-action text-xs font-medium text-action-foreground" data-testid="user-avatar-initial">
             {user?.username?.charAt(0).toUpperCase() ?? '?'}
           </div>
           <span className="text-sm font-medium">{user?.username}</span>
@@ -79,7 +79,7 @@ export function UserMenu() {
               checked={singleKeyEnabled}
               onCheckedChange={setSingleKeyEnabled}
               aria-label="Single-key shortcuts"
-              className="relative h-4 w-7 shrink-0 rounded-full bg-foreground/10 transition-colors data-[state=checked]:bg-primary outline-none"
+              className="relative h-4 w-7 shrink-0 rounded-full bg-foreground/10 transition-colors data-[state=checked]:bg-action outline-none"
               tabIndex={-1}
               onClick={(e) => e.stopPropagation()}
             >


### PR DESCRIPTION
## Summary
- Fixes four WCAG-AA contrast bugs across the CE frontend (logo invisible in dark, active-tab amber, badge text, primary-button-as-disabled).
- Reassigns the brand amber `#F9C74F` to a single semantic meaning: **"AI is involved here."** Non-AI primary affordances move to a new `--color-action` ink token.
- ADR-010 amended (v0.5) to record the new design-system rule.

## Bugs fixed
- **1a** — Compendiq wordmark invisible in graphite-honey theme (hard-coded `#1a1a1a` on `#121212`). Logo refactored to a React component using `currentColor`; the amber magnifier handle stays hard-coded as the AI signal.
- **1b** — Active nav-tab pill computed to amber `#f9c74f` on glass `#f7f7f7` (~1.47:1). Moved to `bg-action text-action-foreground` (>10:1 in both themes). AI tab keeps amber on its icon **only when active** (inactive amber-on-light-glass would re-introduce the same contrast failure).
- **1c** — "Recent" badge 3.37:1, "Not Embedded" 2.67:1 light / 3.19:1 dark, "Private" borrowed amber despite carrying no AI semantic. All seven status pills (Local/Shared/Private/Failed/Skipped/Not Embedded/Recent) rewritten with a tinted-pill recipe that hits AA in both themes; `data-testid="badge-{kind}"` added throughout (Confluence source pill aligned to the same convention).
- **1d** — "Save Key" and other primary buttons read as disabled because they shared amber with low-emphasis chips. Non-AI primary buttons now use an outline-fills-on-hover ink recipe; AI affordances (Ask / Generate / Summarize / Improve / Diagram / Quality) preserve `bg-primary` amber.

## Affordance contract (after this PR)
After this PR, amber appears **only** in: AI affordances, focus rings, the AI tab's icon (when active), and the Q-magnifier in the brand mark. Everything else uses the new ink tokens.

## Commits
- `5ffafe6` Part 1/6 — theme tokens (`--color-action`, AA-tuned warning/inactive, dark `--color-primary-ink` fix)
- `092b021` Part 2/6 — inline Logo component with `currentColor`
- `a677104` Part 3/6 — sidebar/tab active state off amber; AI icon stays amber when active
- `904716b` Part 4/6 — de-amber status pills, AA-tune all pill text
- `d162a5f` Part 5/6 — route non-AI buttons to ink (81 files), keep AI on amber, avatar to ink
- `f4591d0` Part 6/6 — Playwright WCAG-AA contrast guard (`e2e/contrast.spec.ts`)
- `f0e5ca6` ADR-010 v0.5 amendment
- `790cd69` Follow-up — align Confluence source-badge testid with new `badge-{kind}` convention

## Local validation
- ✅ `typecheck` clean
- ✅ `lint --max-warnings=0` clean
- ✅ `vitest run` — 2103/2103 tests pass across 172/172 suites

## Verification not yet run
The Playwright contrast spec (`e2e/contrast.spec.ts`) could not be produced from a Docker dev stack whose `ceCommit` was still `37156c9` (pre-amber-as-AI). Reviewer should rebuild the stack at this branch's tip, then:

```bash
cd ce/  # or repo root, depending on checkout
npx playwright test e2e/contrast.spec.ts
```

Before-screenshots from the design session are at the EE repo root: `ui-01-pages-dark.png` … `ui-10-page-detail.png`. After-screenshots TBD post-rebuild.

## ADR
ADR-010 v0.5 amendment included (`docs/ARCHITECTURE-DECISIONS.md`).

## Out of scope (filed for later cycles)
Ollama banner → header chip, `/pages` stats compression, full glassmorphism commit-or-remove, Settings IA split, status-as-system pass, composer-first AI redesign — tracked in the bundle's source spec at `docs/superpowers/specs/2026-05-17-ui-accessibility-and-amber-as-ai-design.md` (private repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)