### PR TITLE
feat(article): widen reading column 950px → 1200px

### DIFF
--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -635,10 +635,10 @@ export function PageViewPage() {
 
         {editing ? (
           <>
-            {/* Editable title — same 950px reading column as the body so they
+            {/* Editable title — same 1200px reading column as the body so they
                 visually align as one document. */}
             <div className="border-b border-border/25 px-5 py-5 sm:px-10">
-              <div className="mx-auto max-w-[950px]">
+              <div className="mx-auto max-w-[1200px]">
                 <input
                   value={editTitle}
                   onChange={(event) => setEditTitle(event.target.value)}
@@ -648,9 +648,9 @@ export function PageViewPage() {
               </div>
             </div>
 
-            {/* Editor body — same 950px reading column so the editing
+            {/* Editor body — same 1200px reading column so the editing
                 experience matches the reader's line length exactly. */}
-            <div className="mx-auto max-w-[950px]">
+            <div className="mx-auto max-w-[1200px]">
               <FeatureErrorBoundary featureName="Editor">
                 <Editor content={editHtml} onChange={setEditHtml} draftKey={draftKey} naked onEditorReady={setEditorInstance} hideToolbar pageId={id} onSave={handleSave} vimEnabled={vimEnabled} />
               </FeatureErrorBoundary>
@@ -660,7 +660,7 @@ export function PageViewPage() {
           /* Empty page — no content yet */
           <div
             ref={contentRef}
-            className="mx-auto max-w-[950px] px-5 pb-16 pt-10 sm:px-10 sm:pt-12"
+            className="mx-auto max-w-[1200px] px-5 pb-16 pt-10 sm:px-10 sm:pt-12"
             data-testid="article-content-shell"
           >
             <h1 className="mb-6 text-3xl font-bold leading-[1.2] tracking-[-0.02em] text-foreground sm:text-4xl">
@@ -679,11 +679,11 @@ export function PageViewPage() {
             </div>
           </div>
         ) : (
-          /* Reading view — constrained to 950px reading column for optimal
+          /* Reading view — constrained to 1200px reading column for optimal
              line length (60–75 characters at the default font scale). */
           <div
             ref={contentRef}
-            className="mx-auto max-w-[950px] px-5 pb-16 pt-10 sm:px-10 sm:pt-12"
+            className="mx-auto max-w-[1200px] px-5 pb-16 pt-10 sm:px-10 sm:pt-12"
             data-testid="article-content-shell"
           >
             <h1 className="mb-4 text-3xl font-bold leading-[1.2] tracking-[-0.02em] text-foreground sm:text-4xl">


### PR DESCRIPTION
## Summary
Follow-up to #665 (`71abe9a`). 950px still felt cramped with the right pane present and on wide displays. Bumps the article reading column to 1200px for more horizontal breathing room on code blocks, tables, and wide diagrams.

All 4 `max-w-[950px]` occurrences in `PageViewPage.tsx` swap together (reader body + editor body + editor title + view shell) so reader and editor stay lockstep. 3 source comments updated.

## Validation
- ✅ `typecheck` clean
- ✅ `lint --max-warnings=0` clean
- ✅ 27/27 PageViewPage tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)