### PR TITLE
fix(routing): unjam AnimatePresence by removing setAnimating state churn

### DIFF
--- a/frontend/src/shared/components/layout/PageTransition.test.tsx
+++ b/frontend/src/shared/components/layout/PageTransition.test.tsx
@@ -70,17 +70,28 @@ describe('PageTransition', () => {
     expect(content.parentElement).toBeInstanceOf(HTMLDivElement);
   });
 
-  it('sets will-change style for GPU compositing', () => {
-    render(
-      <Wrapper>
-        <PageTransition>
-          <span>GPU test</span>
-        </PageTransition>
-      </Wrapper>,
-    );
-    const content = screen.getByText('GPU test');
-    const motionDiv = content.closest('div[style]');
-    expect(motionDiv).not.toBeNull();
+  it('does not toggle a parent-rendering animating state during transitions', async () => {
+    // Regression guard. A previous version of PageTransition tracked an
+    // `animating` state via onAnimationStart/Complete to toggle a `willChange`
+    // style. Under framer-motion 12 + React 19 + mode="wait", that re-render
+    // during the exit animation jammed AnimatePresence: the exiting layer
+    // reached opacity:0 and never unmounted, so the new layer never mounted —
+    // the user saw a fully black article area on sidebar click. The fix is
+    // to drop the state machine entirely. Re-introducing useState/setState
+    // tied to animation lifecycle handlers re-introduces the bug.
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const src = await fs.readFile(path.join(here, 'PageTransition.tsx'), 'utf-8');
+    // Strip line comments so the regression matchers don't catch the
+    // explanatory comments above the m.div (which name the banned symbols
+    // intentionally as a warning to future editors).
+    const code = src.replace(/\/\/.*$/gm, '');
+    expect(code).not.toMatch(/useState\b/);
+    expect(code).not.toMatch(/onAnimationStart\s*=/);
+    expect(code).not.toMatch(/onAnimationComplete\s*=/);
+    expect(code).not.toMatch(/willChange/);
   });
 
   it('renders new content after navigation', () => {

--- a/frontend/src/shared/components/layout/PageTransition.test.tsx
+++ b/frontend/src/shared/components/layout/PageTransition.test.tsx
@@ -71,14 +71,10 @@ describe('PageTransition', () => {
   });
 
   it('does not toggle a parent-rendering animating state during transitions', async () => {
-    // Regression guard. A previous version of PageTransition tracked an
-    // `animating` state via onAnimationStart/Complete to toggle a `willChange`
-    // style. Under framer-motion 12 + React 19 + mode="wait", that re-render
-    // during the exit animation jammed AnimatePresence: the exiting layer
-    // reached opacity:0 and never unmounted, so the new layer never mounted —
-    // the user saw a fully black article area on sidebar click. The fix is
-    // to drop the state machine entirely. Re-introducing useState/setState
-    // tied to animation lifecycle handlers re-introduces the bug.
+    // Regression guard for the black-article-area bug — re-introducing
+    // useState + onAnimationStart/Complete + willChange in this file
+    // jams AnimatePresence under mode="wait". See PageTransition.tsx for
+    // the why.
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
     const url = await import('node:url');

--- a/frontend/src/shared/components/layout/PageTransition.tsx
+++ b/frontend/src/shared/components/layout/PageTransition.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useRef, useState, useMemo, useEffect } from 'react';
+import { type ReactNode, useRef, useMemo, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { AnimatePresence, m } from 'framer-motion';
 import { useReducedMotion } from 'framer-motion';
@@ -45,7 +45,6 @@ export function PageTransition({ children }: PageTransitionProps) {
   const location = useLocation();
   const reducedMotion = useReducedMotion();
   const prevDepthRef = useRef(routeDepth(location.pathname));
-  const [animating, setAnimating] = useState(false);
 
   // Compute direction synchronously during render so animation reads
   // the correct value on the same frame the location changes.
@@ -79,25 +78,23 @@ export function PageTransition({ children }: PageTransitionProps) {
       <AnimatePresence mode="wait" initial={false}>
         <m.div
           key={location.pathname}
-          // Enter at opacity:1 — initial.opacity:0 could pin the layer at 0
-          // ("black page" on sidebar click) if the enter tween was interrupted.
-          // Slide carries the transition; exit still fades.
+          // Enter at opacity:1 (slide only). Defensive — if anything ever pins
+          // the enter tween, the new layer is still visible the moment it mounts.
           initial={{ opacity: 1, x: slideX }}
           animate={{ opacity: 1, x: 0 }}
           // mode="wait" + simple opacity/x exit: the previous layer must finish
           // exiting before the new one mounts, so the two layers never overlap.
-          // This prevents the back/forward race where an interrupted exit could
-          // leave a layer stuck in the DOM with pointer-events:none, blocking
-          // all clicks on the visually-current page.
+          // No onAnimationStart/Complete handlers and no `style` prop: those
+          // re-rendered PageTransition during the exit, which (in framer-motion
+          // 12 + React 19) jammed AnimatePresence — the exiting layer reached
+          // opacity:0 and then never unmounted, blocking the new layer from
+          // ever mounting. User saw a fully black article area until reload.
           exit={{ opacity: 0, x: -slideX }}
           transition={{
             duration: reducedMotion ? 0.1 : DURATION,
             ease: [0.25, 0.1, 0.25, 1], // cubic-bezier for smooth deceleration
           }}
           className="flex w-full flex-1 flex-col"
-          style={animating ? { willChange: 'opacity, transform' } : undefined}
-          onAnimationStart={() => setAnimating(true)}
-          onAnimationComplete={() => setAnimating(false)}
         >
           {children}
         </m.div>

--- a/frontend/src/shared/components/layout/PageTransition.tsx
+++ b/frontend/src/shared/components/layout/PageTransition.tsx
@@ -78,17 +78,12 @@ export function PageTransition({ children }: PageTransitionProps) {
       <AnimatePresence mode="wait" initial={false}>
         <m.div
           key={location.pathname}
-          // Enter at opacity:1 (slide only). Defensive — if anything ever pins
-          // the enter tween, the new layer is still visible the moment it mounts.
+          // No onAnimationStart/Complete handlers and no reactive `style` prop:
+          // re-rendering this component during the exit tween jammed
+          // AnimatePresence under mode="wait" (exited layer never unmounted →
+          // black article area on sidebar click).
           initial={{ opacity: 1, x: slideX }}
           animate={{ opacity: 1, x: 0 }}
-          // mode="wait" + simple opacity/x exit: the previous layer must finish
-          // exiting before the new one mounts, so the two layers never overlap.
-          // No onAnimationStart/Complete handlers and no `style` prop: those
-          // re-rendered PageTransition during the exit, which (in framer-motion
-          // 12 + React 19) jammed AnimatePresence — the exiting layer reached
-          // opacity:0 and then never unmounted, blocking the new layer from
-          // ever mounting. User saw a fully black article area until reload.
           exit={{ opacity: 0, x: -slideX }}
           transition={{
             duration: reducedMotion ? 0.1 : DURATION,


### PR DESCRIPTION
## Summary

Reproduced the black-article-area bug end-to-end with Playwright on the merged dev tip and applied a fix that removes the most likely cause. Diff is small (+30 / −22), confined to `PageTransition.tsx` and its test.

## Observed failure

Clicking an article from `/` produces exactly **one** `m.div` inside the `AnimatePresence`, with its grandparent pinned at `opacity: 0` indefinitely. The new layer never mounts. User sees a fully black article area until reload.

DOM evidence:
```
[{
  index: 0,
  grandparentInlineStyle: "opacity: 0; transform: none;",
  parentClassName: "mx-auto flex w-full flex-1 flex-col max-w-7xl",
  ...
}]
```
(`max-w-7xl` is the `/` route's wrapper class — confirms this is the previous-route m.div whose `children` prop now resolves to the new route's `PageViewPage`.)

## Most likely cause

The `setAnimating` useState + `onAnimationStart`/`onAnimationComplete` handlers re-render `PageTransition` during the exit tween. Under framer-motion 12 + React 19 + `mode="wait"` (introduced in #660), the re-render appears to prevent AnimatePresence from completing the exit lifecycle — the layer reaches `opacity: 0` and then sits there, blocking the new layer from mounting.

**This isn't fully bisected.** Equally consistent stories: (a) the `style` prop flipping back to `undefined` after exit makes framer-motion treat the inline style as user-controlled and skip cleanup; (b) a framer-motion 12 + React 19 edge case in `mode="wait"` unrelated to this codebase. Either way, removing the state machine eliminates *all* of these failure surfaces, so the fix is correct even if the precise mechanism is one I haven't isolated.

## Fix

- Drop `useState`/`setAnimating`, `onAnimationStart`/`Complete`, and the `willChange` style toggle.
- AnimatePresence now runs cleanly: exit plays → layer unmounts → new layer mounts and slides in.
- `mode="wait"` from #660 stays. `initial.opacity:1` from #668 stays as defensive belt-and-suspenders.
- `willChange` was a micro-optimization; `transform` alone already triggers GPU promotion on modern browsers. No real perf regression.

## Open risk: React Router + AnimatePresence quirk

While the exiting layer is still mounted, React Router has already swapped the route, so the *old* m.div's `children` prop resolves to the *new* route's content. That's what makes the DOM evidence above show `article-page` inside a `max-w-7xl` wrapper. This fix doesn't address that quirk — it just makes sure the exiting layer unmounts so the visible artifact disappears. If new route content ever has render-time side effects that conflict with the previous route, this can return in a different shape. Documented here so it isn't silently load-bearing.

## Regression test

Source-grep guard that fails if `useState`, `onAnimationStart`/`Complete`, or `willChange` come back to this file. Consistent with the existing `mode="wait"` and `prevDepthRef` source-grep guards. Replaces the old `will-change style for GPU compositing` test, which had encoded the broken behavior as a requirement.

A behavioral test (assert DOM contains exactly one layer after a navigation cycle in jsdom) would be more durable; not added in this PR but worth considering.

## Verified via grep before merge

Other components using AnimatePresence: `SetupWizard`, `SourceCitations`, `AutoTagger`, `VersionHistory`, `PageViewPage`, `CommandPalette`, `LocationPicker`, `AppLayout`, `SidebarTreeView`, `CommentThread`, `PagePreview`, `CommentsSidebar`, `ArticleRightPane`, `ServiceStatus`. None of them combine `onAnimationStart`/`Complete` with `setState`, so no other latent jams to clean up in this PR.

## Test plan

- [x] `npx vitest run src/shared/components/layout` — 179/179 pass
- [ ] **Manual via Playwright once `:dev` image rebuilds**: click article from `/`, confirm content renders and no stuck `opacity: 0` layer in DOM
- [ ] **Manual**: rapid back/forward — confirms #660's stuck-pointer-events fix still holds with the state machine removed

Will not merge before the two manual boxes are ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)