### PR TITLE
fix(routing): remove PageTransition animation — second mode=wait fix didn't work

### DIFF
--- a/frontend/src/shared/components/layout/PageTransition.test.tsx
+++ b/frontend/src/shared/components/layout/PageTransition.test.tsx
@@ -1,16 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { LazyMotion, domAnimation } from 'framer-motion';
 import { PageTransition, routeDepth } from './PageTransition';
 
 function Wrapper({ children, initialPath = '/' }: { children: React.ReactNode; initialPath?: string }) {
   return (
-    <MemoryRouter initialEntries={[initialPath]}>
-      <LazyMotion features={domAnimation}>
-        {children}
-      </LazyMotion>
-    </MemoryRouter>
+    <MemoryRouter initialEntries={[initialPath]}>{children}</MemoryRouter>
   );
 }
 
@@ -57,45 +52,7 @@ describe('PageTransition', () => {
     expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
-  it('wraps children in a motion div', () => {
-    render(
-      <Wrapper>
-        <PageTransition>
-          <span>Test content</span>
-        </PageTransition>
-      </Wrapper>,
-    );
-    const content = screen.getByText('Test content');
-    // The content should be wrapped in a div (the m.div from PageTransition)
-    expect(content.parentElement).toBeInstanceOf(HTMLDivElement);
-  });
-
-  it('does not toggle a parent-rendering animating state during transitions', async () => {
-    // Regression guard for the black-article-area bug — re-introducing
-    // useState + onAnimationStart/Complete + willChange in this file
-    // jams AnimatePresence under mode="wait". See PageTransition.tsx for
-    // the why.
-    const fs = await import('node:fs/promises');
-    const path = await import('node:path');
-    const url = await import('node:url');
-    const here = path.dirname(url.fileURLToPath(import.meta.url));
-    const src = await fs.readFile(path.join(here, 'PageTransition.tsx'), 'utf-8');
-    // Strip line comments so the regression matchers don't catch the
-    // explanatory comments above the m.div (which name the banned symbols
-    // intentionally as a warning to future editors).
-    const code = src.replace(/\/\/.*$/gm, '');
-    expect(code).not.toMatch(/useState\b/);
-    expect(code).not.toMatch(/onAnimationStart\s*=/);
-    expect(code).not.toMatch(/onAnimationComplete\s*=/);
-    expect(code).not.toMatch(/willChange/);
-  });
-
   it('renders new content after navigation', () => {
-    // Under mode="wait" the exiting layer must finish before the new one
-    // mounts. In jsdom animations resolve synchronously, so a rerender
-    // immediately yields the new content — this test guards against a
-    // regression where the new content never appears at all (e.g. a stuck
-    // exit, or AnimatePresence dropping the entering child).
     const { rerender } = render(
       <Wrapper initialPath="/">
         <PageTransition>
@@ -126,71 +83,27 @@ describe('PageTransition', () => {
     expect(screen.getByText('Page view')).toBeInTheDocument();
   });
 
-  it('enters at opacity:1 so the new layer is never invisible (black page guard)', async () => {
-    // Regression test for the black-page-on-click bug. With initial.opacity:0
-    // → animate.opacity:1 under mode="wait", the entering m.div could get
-    // stuck at opacity:0 when interrupted (Suspense fallback swapping inside
-    // the entering layer for a lazy route chunk, or parent re-renders from
-    // setAnimating racing the enter tween). The user saw a fully black page
-    // after clicking an article in the sidebar; only a browser reload —
-    // which fires AnimatePresence with initial={false} and skips the enter
-    // animation entirely — restored the article. The fix is to enter at
-    // opacity:1 so the new layer is visible the moment it mounts; the slide
-    // (x axis) alone carries the visual transition. Exit still fades out.
+  it('is a no-op pass-through — no AnimatePresence / motion machinery', async () => {
+    // Regression guard for two consecutive black-article-area bugs caused
+    // by framer-motion-based route transitions in this component:
+    //   - mode="sync" left an exit layer at position:absolute that blocked
+    //     clicks (#660).
+    //   - mode="wait" left the exit layer stuck at opacity:0 indefinitely
+    //     so the new layer never mounted (#669, this fix).
+    // The animation isn't worth the bug surface. Re-introduce only with a
+    // behavioral test that asserts the exit layer actually unmounts in jsdom.
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
     const url = await import('node:url');
     const here = path.dirname(url.fileURLToPath(import.meta.url));
     const src = await fs.readFile(path.join(here, 'PageTransition.tsx'), 'utf-8');
-    // initial must not start at opacity:0 — that's the failure mode.
-    expect(src).not.toMatch(/initial=\{[^}]*opacity:\s*0/);
-    // animate must still settle at opacity:1.
-    expect(src).toMatch(/animate=\{[^}]*opacity:\s*1/);
-    // exit may still fade out (and must, to keep the leave transition).
-    expect(src).toMatch(/exit=\{[^}]*opacity:\s*0/);
-  });
-
-  it('uses AnimatePresence mode="wait" so exiting and entering layers never overlap', async () => {
-    // Regression test for the Pages-list click-stuck bug. With mode="sync"
-    // the exiting page sat absolutely positioned over the new one for ~220 ms.
-    // If the same key (location.pathname) reappeared mid-exit (rapid
-    // back/forward), framer-motion could cancel the exit but leave the
-    // inline exit styles (position: absolute; pointer-events: none) applied
-    // to a child that then rendered the current route's content — making
-    // every visible article unclickable.
-    //
-    // The fix is mode="wait": the previous layer must finish exiting before
-    // the next mounts, so the two layers never overlap and the race is
-    // impossible. Read the source directly so the test fails loudly if the
-    // mode is reverted by a future refactor.
-    const fs = await import('node:fs/promises');
-    const path = await import('node:path');
-    const url = await import('node:url');
-    const here = path.dirname(url.fileURLToPath(import.meta.url));
-    const src = await fs.readFile(path.join(here, 'PageTransition.tsx'), 'utf-8');
-    expect(src).toMatch(/<AnimatePresence[^>]*mode=["']wait["']/);
-    // The old workaround must not creep back in: with mode="wait" there is
-    // no overlap, so position:absolute / pointer-events:none on exit would
-    // only mask the wrong fix.
-    expect(src).not.toMatch(/exit=\{[^}]*pointerEvents:\s*['"]none['"]/);
-    expect(src).not.toMatch(/exit=\{[^}]*position:\s*['"]absolute['"]/);
-  });
-
-  it('updates prevDepthRef via a commit-phase effect, not inside useMemo', async () => {
-    // Mutating a ref inside useMemo is unsafe in React 19 + StrictMode:
-    // memos may re-run with the same deps, double-mutating the ref and
-    // corrupting the previous-depth tracking that drives slide direction.
-    // The ref update must live in useEffect so it runs exactly once per
-    // commit. Regression test in source form.
-    const fs = await import('node:fs/promises');
-    const path = await import('node:path');
-    const url = await import('node:url');
-    const here = path.dirname(url.fileURLToPath(import.meta.url));
-    const src = await fs.readFile(path.join(here, 'PageTransition.tsx'), 'utf-8');
-    // prevDepthRef.current = ... must appear inside a useEffect, never inside useMemo.
-    const memoBlock = src.match(/useMemo<[^>]*>\(\(\)\s*=>\s*\{[\s\S]*?\}\s*,\s*\[location\.pathname\]\)/);
-    expect(memoBlock).toBeTruthy();
-    expect(memoBlock![0]).not.toMatch(/prevDepthRef\.current\s*=/);
-    expect(src).toMatch(/useEffect\(\(\)\s*=>\s*\{\s*prevDepthRef\.current\s*=/);
+    // Strip block + line comments so explanatory text doesn't trip the
+    // matchers (the JSDoc above PageTransition intentionally names the
+    // banned symbols as a warning to future editors).
+    const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+    expect(code).not.toMatch(/AnimatePresence/);
+    expect(code).not.toMatch(/from\s+['"]framer-motion['"]/);
+    expect(code).not.toMatch(/\bm\.div\b/);
+    expect(code).not.toMatch(/useState\b/);
   });
 });

--- a/frontend/src/shared/components/layout/PageTransition.tsx
+++ b/frontend/src/shared/components/layout/PageTransition.tsx
@@ -1,101 +1,45 @@
-import { type ReactNode, useRef, useMemo, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
-import { AnimatePresence, m } from 'framer-motion';
-import { useReducedMotion } from 'framer-motion';
+import type { ReactNode } from 'react';
 
 /**
- * Route-depth ordering used to infer navigation direction:
+ * Route-depth ordering preserved for tests + any future use. Not currently
+ * consumed by this component because the AnimatePresence-based slide+fade
+ * was removed (see below).
+ *
  *   /          -> 0  (Pages list)
  *   /pages/new -> 1  (New page)
  *   /pages/:id -> 1  (Page view)
  *   /ai        -> 0  (AI assistant)
  *   /settings  -> 0  (Settings)
- *
- * Forward = depth increases (list -> detail).
- * Backward = depth decreases (detail -> list).
- * Same depth = fade only (no slide).
  */
 function routeDepth(pathname: string): number {
   if (pathname === '/' || pathname === '/ai' || pathname === '/settings' || pathname === '/login') {
     return 0;
   }
-  // /pages/new or /pages/:id
   if (pathname.startsWith('/pages/')) {
     return 1;
   }
   return 0;
 }
 
-const DURATION = 0.22; // 220ms - fast but perceivable
-
 interface PageTransitionProps {
   children: ReactNode;
 }
 
 /**
- * Wraps route content with AnimatePresence to provide smooth enter/exit
- * transitions when navigating between pages.
- *
- * - Forward navigation (e.g. list -> detail): slides left
- * - Backward navigation (e.g. detail -> list): slides right
- * - Same-level navigation: fade only
- * - Respects prefers-reduced-motion: falls back to simple opacity fade
+ * Pass-through wrapper. Previously ran a slide+fade via AnimatePresence
+ * (mode="sync" in #389, mode="wait" in #660). Both modes produced
+ * reproducible black-page bugs under framer-motion 12 + React 19:
+ *   - mode="sync": stuck exit layer with position:absolute blocked clicks
+ *     on the live page (#660).
+ *   - mode="wait": exit completed but the layer never unmounted, so the
+ *     new layer never mounted — fully black article area on sidebar click.
+ *     Multiple attempted fixes (#668, #669) didn't resolve it.
+ * The route transition is a nice-to-have, not load-bearing. Removing the
+ * machinery eliminates the bug surface. Re-introduce only with a fully
+ * reproduced, behavioral test that asserts the exit layer unmounts.
  */
 export function PageTransition({ children }: PageTransitionProps) {
-  const location = useLocation();
-  const reducedMotion = useReducedMotion();
-  const prevDepthRef = useRef(routeDepth(location.pathname));
-
-  // Compute direction synchronously during render so animation reads
-  // the correct value on the same frame the location changes.
-  // Note: prevDepthRef is updated in a commit-phase effect below to avoid
-  // mutating a ref inside useMemo (which can re-run in React 19 + StrictMode
-  // and corrupt the direction calculation).
-  const direction = useMemo<'forward' | 'backward' | 'neutral'>(() => {
-    const currentDepth = routeDepth(location.pathname);
-    const prevDepth = prevDepthRef.current;
-
-    if (currentDepth > prevDepth) return 'forward';
-    if (currentDepth < prevDepth) return 'backward';
-    return 'neutral';
-  }, [location.pathname]);
-
-  useEffect(() => {
-    prevDepthRef.current = routeDepth(location.pathname);
-  }, [location.pathname]);
-
-  // Slide offset based on direction (GPU-composited via translateX)
-  const slideX = reducedMotion
-    ? 0
-    : direction === 'forward'
-      ? 40
-      : direction === 'backward'
-        ? -40
-        : 0;
-
-  return (
-    <div className="flex flex-1 flex-col" style={{ position: 'relative' }}>
-      <AnimatePresence mode="wait" initial={false}>
-        <m.div
-          key={location.pathname}
-          // No onAnimationStart/Complete handlers and no reactive `style` prop:
-          // re-rendering this component during the exit tween jammed
-          // AnimatePresence under mode="wait" (exited layer never unmounted →
-          // black article area on sidebar click).
-          initial={{ opacity: 1, x: slideX }}
-          animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: -slideX }}
-          transition={{
-            duration: reducedMotion ? 0.1 : DURATION,
-            ease: [0.25, 0.1, 0.25, 1], // cubic-bezier for smooth deceleration
-          }}
-          className="flex w-full flex-1 flex-col"
-        >
-          {children}
-        </m.div>
-      </AnimatePresence>
-    </div>
-  );
+  return <div className="flex flex-1 flex-col">{children}</div>;
 }
 
 // eslint-disable-next-line react-refresh/only-export-components


### PR DESCRIPTION
## Why this PR

Verified end-to-end with Playwright on the freshly rebuilt `:dev` image: PR #669's removal of `setAnimating` did **not** fix the black-article-area bug. Same DOM evidence after the fix as before:

```
{
  count: 1,
  grandparentInlineStyle: "opacity: 0; transform: none;",
  parentClass: "mx-auto flex w-full flex-1 flex-col max-w-7xl"
}
```

Single `article-page` in the DOM, grandparent stuck at `opacity: 0` indefinitely, parent still wrapped in the `/` route's `max-w-7xl` container. The exit tween completes and the layer **never unmounts**, so the new layer never mounts. Screenshot confirms a fully black article area — matches the user's original report.

## Speculation budget exhausted

Three consecutive attempts to repair this under `framer-motion@12 + React@19 + mode="wait"`, each based on a plausible but unverified hypothesis:

| PR | Hypothesis | Result |
|----|-----------|--------|
| #660 | Switch `mode="sync"` → `mode="wait"` to eliminate overlap | Fixed the click-stuck bug but introduced this new one |
| #668 | `initial.opacity:0` could pin enter tween → set `opacity:1` | Bug unchanged. Reviewer flagged it as speculative |
| #669 | `setAnimating` state churn jams AnimatePresence | Bug unchanged. Verified in browser, not bisected |

Each attempt eliminated a candidate failure surface; none of them were the cause. The exact mechanism remains unidentified.

## Fix

Drop the animation entirely. `PageTransition` becomes a pure pass-through:

```tsx
export function PageTransition({ children }: PageTransitionProps) {
  return <div className="flex flex-1 flex-col">{children}</div>;
}
```

Route changes are now instantaneous. No slide, no fade. `routeDepth()` export is preserved for any future re-introduction.

## Tradeoff

Lose the 220ms slide/fade between routes. Worth it: two consecutive black-page bugs over six weeks demonstrate the animation isn't worth the bug surface in this codebase. If the visual is missed, re-introduce only behind a behavioral test that asserts (in jsdom) that the exit layer actually unmounts after navigation — the source-grep guards we've been relying on can't catch this class of bug.

## Regression test

New source-grep guard fails if `AnimatePresence`, `m.div`, `framer-motion` import, or `useState` come back to `PageTransition.tsx`. Existing tests for `routeDepth`, child rendering, and navigation stay.

## Test plan

- [x] `npx vitest run src/shared/components/layout` — 175/175 pass
- [ ] **Manual via Playwright after `:dev` rebuilds**: click article from `/` → article renders fully, no black area, no stuck `opacity:0` layer in DOM

Will not merge until the manual Playwright check is green. The previous two PRs both passed unit tests and still shipped the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)