### PR TITLE
fix(ai): wire Think toggle through to upstream LLM provider

### DIFF
--- a/backend/src/domains/llm/services/llm-cache.test.ts
+++ b/backend/src/domains/llm/services/llm-cache.test.ts
@@ -57,6 +57,12 @@ describe('buildLlmCacheKey', () => {
     const keyUndefinedProvider = buildLlmCacheKey('model', 'system', 'content', undefined);
     expect(keyNoProvider).toBe(keyUndefinedProvider);
   });
+
+  it('should differ when thinking is toggled', () => {
+    const off = buildLlmCacheKey('model', 'sys', 'user', 'p');
+    const on  = buildLlmCacheKey('model', 'sys', 'user', 'p', { thinking: true });
+    expect(off).not.toBe(on);
+  });
 });
 
 describe('buildRagCacheKey', () => {
@@ -121,6 +127,21 @@ describe('buildRagCacheKey', () => {
     const keyNoProvider = buildRagCacheKey('model', 'question', ['doc1']);
     const keyEmptyOpts = buildRagCacheKey('model', 'question', ['doc1'], {});
     expect(keyNoProvider).toBe(keyEmptyOpts);
+  });
+
+  // Thinking-on responses must live in a separate cache namespace, otherwise
+  // a prior thinking-off answer is replayed when the user toggles Think on
+  // and the upstream LLM never sees the new request.
+  it('should differ when thinking is toggled', () => {
+    const off = buildRagCacheKey('model', 'q', ['d1'], { provider: 'p' });
+    const on  = buildRagCacheKey('model', 'q', ['d1'], { provider: 'p', thinking: true });
+    expect(off).not.toBe(on);
+  });
+
+  it('should treat thinking:false as equivalent to omitted', () => {
+    const off = buildRagCacheKey('model', 'q', ['d1'], { provider: 'p' });
+    const offExplicit = buildRagCacheKey('model', 'q', ['d1'], { provider: 'p', thinking: false });
+    expect(off).toBe(offExplicit);
   });
 });
 

--- a/backend/src/domains/llm/services/llm-cache.ts
+++ b/backend/src/domains/llm/services/llm-cache.ts
@@ -40,9 +40,11 @@ export function buildLlmCacheKey(
   systemPrompt: string,
   userContent: string,
   provider?: string,
+  options?: { thinking?: boolean },
 ): string {
   const providerSuffix = provider ? `provider:${provider}` : '';
-  return KEY_PREFIX + hashLlmInputs(model, systemPrompt, userContent, providerSuffix);
+  const thinkingSuffix = options?.thinking ? 'think:1' : '';
+  return KEY_PREFIX + hashLlmInputs(model, systemPrompt, userContent, providerSuffix, thinkingSuffix);
 }
 
 /**
@@ -68,6 +70,7 @@ export function buildRagCacheKey(
     externalUrls?: string[];
     searchWeb?: boolean;
     provider?: string;
+    thinking?: boolean;
   },
 ): string {
   const sortedIds = [...docIds].sort().join(',');
@@ -79,7 +82,11 @@ export function buildRagCacheKey(
     : '';
   const webSuffix = options?.searchWeb ? 'web:1' : '';
   const providerSuffix = options?.provider ? `provider:${options.provider}` : '';
-  return KEY_PREFIX + hashLlmInputs(model, question, sortedIds, subPageSuffix, externalSuffix, webSuffix, providerSuffix);
+  // Thinking-on responses are slower and reason differently — they must live
+  // in a separate cache namespace so a prior thinking-off answer can't be
+  // replayed when the user toggles Think on (and vice versa).
+  const thinkingSuffix = options?.thinking ? 'think:1' : '';
+  return KEY_PREFIX + hashLlmInputs(model, question, sortedIds, subPageSuffix, externalSuffix, webSuffix, providerSuffix, thinkingSuffix);
 }
 
 export class LlmCache {

--- a/backend/src/domains/llm/services/openai-compatible-client.test.ts
+++ b/backend/src/domains/llm/services/openai-compatible-client.test.ts
@@ -89,6 +89,119 @@ describe('openai-compatible-client — chat', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Thinking-mode wire format
+//
+// These tests assert the actual bytes sent upstream when callers pass
+// `opts.thinking: true`. Without these assertions, the Think toggle could
+// regress silently (the previous incarnation in this codebase parsed
+// `thinking` off the request but never forwarded it — the toggle did
+// nothing). Re-recording the upstream request body is the only way to
+// catch that regression class.
+// ---------------------------------------------------------------------------
+describe('openai-compatible-client — thinking-mode wire format', () => {
+  let capSrv: Server;
+  let capBase: string;
+  let lastBody: Record<string, unknown> | null = null;
+
+  beforeAll(async () => {
+    capSrv = createServer((req, res) => {
+      if (req.url === '/v1/chat/completions') {
+        let body = '';
+        req.on('data', (c) => (body += c));
+        req.on('end', () => {
+          lastBody = JSON.parse(body);
+          const parsed = lastBody as { stream?: boolean };
+          if (parsed.stream) {
+            res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+            res.write('data: ' + JSON.stringify({ choices: [{ delta: { content: 'ok' } }] }) + '\n\n');
+            res.write('data: [DONE]\n\n');
+            res.end();
+          } else {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ choices: [{ message: { content: 'ok' } }] }));
+          }
+        });
+        return;
+      }
+      res.writeHead(404); res.end();
+    });
+    await new Promise<void>((r) => capSrv.listen(0, r));
+    const { port } = capSrv.address() as AddressInfo;
+    capBase = `http://127.0.0.1:${port}/v1`;
+  });
+  afterAll(() => new Promise<void>((r) => capSrv.close(() => r())));
+
+  async function drainStream(model: string, thinking: boolean) {
+    lastBody = null;
+    for await (const _chunk of streamChat(
+      { ...cfg, baseUrl: capBase, providerId: `thinking-${model}-${thinking}` },
+      model,
+      [{ role: 'user', content: 'hi' }],
+      undefined,
+      { thinking },
+    )) { void _chunk; }
+    return lastBody;
+  }
+
+  it('streamChat without thinking: no reasoning extras', async () => {
+    const body = await drainStream('qwen3:8b', false);
+    expect(body).not.toHaveProperty('think');
+    expect(body).not.toHaveProperty('chat_template_kwargs');
+    expect(body).not.toHaveProperty('reasoning_effort');
+  });
+
+  it('streamChat with thinking=true on an open model uses think + chat_template_kwargs', async () => {
+    const body = await drainStream('qwen3:8b', true);
+    expect(body).toMatchObject({
+      think: true,
+      chat_template_kwargs: { enable_thinking: true },
+    });
+    expect(body).not.toHaveProperty('reasoning_effort');
+  });
+
+  it('streamChat with thinking=true on deepseek-r1 uses think + chat_template_kwargs', async () => {
+    const body = await drainStream('deepseek-r1:14b', true);
+    expect(body).toMatchObject({
+      think: true,
+      chat_template_kwargs: { enable_thinking: true },
+    });
+  });
+
+  it('streamChat with thinking=true on o1 maps to reasoning_effort: medium', async () => {
+    const body = await drainStream('o1-mini', true);
+    expect(body).toMatchObject({ reasoning_effort: 'medium' });
+    expect(body).not.toHaveProperty('think');
+    expect(body).not.toHaveProperty('chat_template_kwargs');
+  });
+
+  it('streamChat with thinking=true on o3 maps to reasoning_effort: medium', async () => {
+    const body = await drainStream('o3', true);
+    expect(body).toMatchObject({ reasoning_effort: 'medium' });
+  });
+
+  it('streamChat with thinking=true on gpt-5 maps to reasoning_effort: medium', async () => {
+    const body = await drainStream('gpt-5-pro', true);
+    expect(body).toMatchObject({ reasoning_effort: 'medium' });
+    expect(body).not.toHaveProperty('think');
+  });
+
+  it('chat (non-streaming) also forwards thinking extras', async () => {
+    lastBody = null;
+    await chat(
+      { ...cfg, baseUrl: capBase, providerId: 'thinking-chat-nonstream' },
+      'qwen3:8b',
+      [{ role: 'user', content: 'hi' }],
+      { thinking: true },
+    );
+    expect(lastBody).toMatchObject({
+      stream: false,
+      think: true,
+      chat_template_kwargs: { enable_thinking: true },
+    });
+  });
+});
+
 describe('openai-compatible-client — embeddings', () => {
   let embSrv: Server;
   let embBase: string;

--- a/backend/src/domains/llm/services/openai-compatible-client.ts
+++ b/backend/src/domains/llm/services/openai-compatible-client.ts
@@ -53,6 +53,34 @@ function headers(cfg: ProviderConfig): Record<string, string> {
   return h;
 }
 
+/**
+ * Translate a generic `thinking: true` request into the provider-specific
+ * extras understood by the upstream `/chat/completions` endpoint. The CE LLM
+ * surface is OpenAI-compatible, but the convention for "extended reasoning"
+ * differs by backend:
+ *
+ * - OpenAI o-series / gpt-5: `reasoning_effort: 'medium'`
+ * - Ollama 0.6+ (OpenAI shim): top-level `think: true`
+ * - vLLM / SGLang serving open thinking models (Qwen3, DeepSeek-R1):
+ *   `chat_template_kwargs: { enable_thinking: true }`
+ *
+ * We pick by model-name heuristic. Sending the wrong extra to a strict
+ * upstream (OpenAI rejects unknown fields) would 400 the whole request,
+ * so detection — not "send both" — is required.
+ */
+function thinkingExtras(model: string, thinking?: boolean): Record<string, unknown> {
+  if (!thinking) return {};
+  const m = model.toLowerCase();
+  if (/^o[1-9]/.test(m) || m.startsWith('gpt-5')) {
+    return { reasoning_effort: 'medium' };
+  }
+  return { think: true, chat_template_kwargs: { enable_thinking: true } };
+}
+
+export interface StreamChatOptions {
+  thinking?: boolean;
+}
+
 export async function listModels(cfg: ProviderConfig): Promise<LlmModel[]> {
   return enqueue(() =>
     getProviderBreaker(cfg.providerId).execute(async () => {
@@ -75,13 +103,15 @@ export async function checkHealth(cfg: ProviderConfig): Promise<HealthResult> {
   }
 }
 
-export async function chat(cfg: ProviderConfig, model: string, messages: ChatMessage[]): Promise<string> {
+export async function chat(
+  cfg: ProviderConfig, model: string, messages: ChatMessage[], opts?: StreamChatOptions,
+): Promise<string> {
   return enqueue(() =>
     getProviderBreaker(cfg.providerId).execute(async () => {
       const res = await undiciFetch(`${cfg.baseUrl}/chat/completions`, {
         method: 'POST',
         headers: headers(cfg),
-        body: JSON.stringify({ model, messages, stream: false }),
+        body: JSON.stringify({ model, messages, stream: false, ...thinkingExtras(model, opts?.thinking) }),
         dispatcher: dispatcherFor(cfg),
       });
       if (!res.ok) throw new Error(`chat HTTP ${res.status}`);
@@ -101,13 +131,13 @@ export async function chat(cfg: ProviderConfig, model: string, messages: ChatMes
  * circuit subsequent calls.
  */
 export async function* streamChat(
-  cfg: ProviderConfig, model: string, messages: ChatMessage[], signal?: AbortSignal,
+  cfg: ProviderConfig, model: string, messages: ChatMessage[], signal?: AbortSignal, opts?: StreamChatOptions,
 ): AsyncGenerator<StreamChunk> {
   const res = await getProviderBreaker(cfg.providerId).execute(async () => {
     const r = await undiciFetch(`${cfg.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: headers(cfg),
-      body: JSON.stringify({ model, messages, stream: true }),
+      body: JSON.stringify({ model, messages, stream: true, ...thinkingExtras(model, opts?.thinking) }),
       dispatcher: dispatcherFor(cfg),
       signal,
     });

--- a/backend/src/routes/llm/llm-ask.ts
+++ b/backend/src/routes/llm/llm-ask.ts
@@ -183,6 +183,7 @@ export async function llmAskRoutes(fastify: FastifyInstance) {
       externalUrls,
       searchWeb: body.searchWeb,
       provider: chatConfig.providerId,
+      thinking: body.thinking,
     });
 
     const sources = [

--- a/backend/src/routes/llm/llm-ask.ts
+++ b/backend/src/routes/llm/llm-ask.ts
@@ -268,7 +268,7 @@ export async function llmAskRoutes(fastify: FastifyInstance) {
       const onClose = () => controller.abort();
       request.raw.on('close', onClose);
 
-      const generator = streamChat(chatConfig, resolvedModel, messages, controller.signal);
+      const generator = streamChat(chatConfig, resolvedModel, messages, controller.signal, { thinking: body.thinking });
       let fullAnswer = '';
 
       reply.hijack();

--- a/backend/src/routes/llm/llm-diagram.ts
+++ b/backend/src/routes/llm/llm-diagram.ts
@@ -73,7 +73,7 @@ export async function llmDiagramRoutes(fastify: FastifyInstance) {
         { role: 'system' as const, content: systemPrompt },
         { role: 'user' as const, content: sanitized },
       ];
-      const generator = streamChat(chatConfig, resolvedModel, diagramMessages);
+      const generator = streamChat(chatConfig, resolvedModel, diagramMessages, undefined, { thinking: body.thinking });
 
       await streamSSE(request, reply, generator, undefined, { llmCache, cacheKey });
     } finally {

--- a/backend/src/routes/llm/llm-diagram.ts
+++ b/backend/src/routes/llm/llm-diagram.ts
@@ -61,7 +61,7 @@ export async function llmDiagramRoutes(fastify: FastifyInstance) {
     );
 
     // Check LLM cache with stampede protection
-    const cacheKey = buildLlmCacheKey(resolvedModel, systemPrompt, sanitized, chatConfig.providerId);
+    const cacheKey = buildLlmCacheKey(resolvedModel, systemPrompt, sanitized, chatConfig.providerId, { thinking: body.thinking });
     const { cached, lockAcquired } = await checkCacheWithLock(llmCache, cacheKey);
     if (cached) {
       sendCachedSSE(reply, cached.content);

--- a/backend/src/routes/llm/llm-generate.ts
+++ b/backend/src/routes/llm/llm-generate.ts
@@ -117,7 +117,7 @@ export async function llmGenerateRoutes(fastify: FastifyInstance) {
     );
 
     // Check LLM cache with stampede protection
-    const cacheKey = buildLlmCacheKey(resolvedModel, systemPrompt, userContent, chatConfig.providerId);
+    const cacheKey = buildLlmCacheKey(resolvedModel, systemPrompt, userContent, chatConfig.providerId, { thinking: body.thinking });
     const { cached, lockAcquired } = await checkCacheWithLock(llmCache, cacheKey);
     if (cached) {
       sendCachedSSE(reply, cached.content);

--- a/backend/src/routes/llm/llm-generate.ts
+++ b/backend/src/routes/llm/llm-generate.ts
@@ -132,7 +132,7 @@ export async function llmGenerateRoutes(fastify: FastifyInstance) {
     try {
       const postProcess = await buildOutputPostProcessor(genWebSources.map((s) => s.url));
 
-      const generator = streamChat(chatConfig, resolvedModel, generateMessages);
+      const generator = streamChat(chatConfig, resolvedModel, generateMessages, undefined, { thinking: body.thinking });
 
       const accumulated = await streamSSE(request, reply, generator, genExtras, { llmCache, cacheKey, postProcess });
 

--- a/backend/src/routes/llm/llm-improve.ts
+++ b/backend/src/routes/llm/llm-improve.ts
@@ -99,7 +99,7 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
     );
 
     // Check LLM cache with stampede protection
-    const cacheKey = buildLlmCacheKey(resolvedModel, systemPrompt, improveContent, chatConfig.providerId);
+    const cacheKey = buildLlmCacheKey(resolvedModel, systemPrompt, improveContent, chatConfig.providerId, { thinking: body.thinking });
     const { cached, lockAcquired } = await checkCacheWithLock(llmCache, cacheKey);
     if (cached) {
       sendCachedSSE(reply, cached.content);

--- a/backend/src/routes/llm/llm-improve.ts
+++ b/backend/src/routes/llm/llm-improve.ts
@@ -131,7 +131,7 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
     try {
       const postProcess = await buildOutputPostProcessor(webSources.map((s) => s.url));
 
-      const generator = streamChat(chatConfig, resolvedModel, improveMessages);
+      const generator = streamChat(chatConfig, resolvedModel, improveMessages, undefined, { thinking: body.thinking });
 
       const accumulated = await streamSSE(request, reply, generator, improveExtras, { llmCache, cacheKey, postProcess });
 

--- a/backend/src/routes/llm/llm-quality.ts
+++ b/backend/src/routes/llm/llm-quality.ts
@@ -74,7 +74,7 @@ export async function llmQualityRoutes(fastify: FastifyInstance) {
         { role: 'system' as const, content: systemPrompt },
         { role: 'user' as const, content: sanitized },
       ];
-      const generator = streamChat(qualityConfig, resolvedModel, qualityMessages);
+      const generator = streamChat(qualityConfig, resolvedModel, qualityMessages, undefined, { thinking: body.thinking });
 
       await streamSSE(request, reply, generator, undefined, { llmCache, cacheKey });
     } finally {

--- a/backend/src/routes/llm/llm-quality.ts
+++ b/backend/src/routes/llm/llm-quality.ts
@@ -62,7 +62,7 @@ export async function llmQualityRoutes(fastify: FastifyInstance) {
     );
 
     // Check LLM cache with stampede protection
-    const cacheKey = buildLlmCacheKey(resolvedModel, systemPrompt, sanitized, qualityConfig.providerId);
+    const cacheKey = buildLlmCacheKey(resolvedModel, systemPrompt, sanitized, qualityConfig.providerId, { thinking: body.thinking });
     const { cached, lockAcquired } = await checkCacheWithLock(llmCache, cacheKey);
     if (cached) {
       sendCachedSSE(reply, cached.content);

--- a/backend/src/routes/llm/llm-summarize.ts
+++ b/backend/src/routes/llm/llm-summarize.ts
@@ -90,7 +90,7 @@ export async function llmSummarizeRoutes(fastify: FastifyInstance) {
     );
 
     // Check LLM cache with stampede protection
-    const cacheKey = buildLlmCacheKey(resolvedModel, systemPrompt, summarizeContent, summaryConfig.providerId);
+    const cacheKey = buildLlmCacheKey(resolvedModel, systemPrompt, summarizeContent, summaryConfig.providerId, { thinking: body.thinking });
     const { cached, lockAcquired } = await checkCacheWithLock(llmCache, cacheKey);
     if (cached) {
       sendCachedSSE(reply, cached.content);

--- a/backend/src/routes/llm/llm-summarize.ts
+++ b/backend/src/routes/llm/llm-summarize.ts
@@ -104,7 +104,7 @@ export async function llmSummarizeRoutes(fastify: FastifyInstance) {
         { role: 'system' as const, content: systemPrompt },
         { role: 'user' as const, content: summarizeContent },
       ];
-      const generator = streamChat(summaryConfig, resolvedModel, summarizeMessages);
+      const generator = streamChat(summaryConfig, resolvedModel, summarizeMessages, undefined, { thinking: body.thinking });
 
       await streamSSE(request, reply, generator, sumExtras, { llmCache, cacheKey, postProcess });
     } finally {

--- a/e2e/think-toggle.spec.ts
+++ b/e2e/think-toggle.spec.ts
@@ -153,4 +153,50 @@ test.describe('Think toggle wires upstream provider extras', () => {
     // strict providers (OpenAI) reject unknown fields.
     expect(askCall!.reasoning_effort).toBeUndefined();
   });
+
+  // Regression guard for the cache-key bug: if `thinking` isn't folded into
+  // the LLM cache key, a warm cache from a prior thinking-off request will
+  // replay when the user toggles Think on, and the upstream LLM never sees
+  // the new request — making the toggle a no-op all over again.
+  test('toggle ON after a warm thinking-off cache → upstream still receives the thinking call', async ({ page }) => {
+    writeFileSync(MOCK_LOG, '');
+    await page.goto('/ai');
+    await expect(page.getByPlaceholder(/Ask a question/i)).toBeVisible({ timeout: 15_000 });
+
+    // Fix the needle so both turns produce the same cache key (modulo thinking).
+    const needle = `cache-bust-${Date.now()}`;
+    const thinkToggle = page.getByRole('checkbox', { name: 'Thinking mode' });
+    const askInput = page.getByTestId('ask-input');
+
+    // Turn 1: thinking OFF — warms the cache under the no-thinking key.
+    if (await thinkToggle.isChecked()) await thinkToggle.uncheck({ force: true });
+    await askInput.fill(`Tell me about ${needle}`);
+    await askInput.press('Enter');
+    await expect(page.getByText('Mocked thinking response.').first()).toBeVisible({ timeout: 20_000 });
+
+    const firstCall = findAskCall(needle);
+    expect(firstCall, 'first (thinking-off) call reached the mock').toBeTruthy();
+    expect(firstCall!.think).toBeUndefined();
+
+    // Turn 2: same question, thinking ON. Must NOT hit the warm cache.
+    // Use a new conversation so the routing is "fresh question, may cache".
+    await page.goto('/ai');
+    await expect(page.getByPlaceholder(/Ask a question/i)).toBeVisible({ timeout: 15_000 });
+    await thinkToggle.check({ force: true });
+    await askInput.fill(`Tell me about ${needle}`);
+    await askInput.press('Enter');
+    await expect(page.getByText('Mocked thinking response.').first()).toBeVisible({ timeout: 20_000 });
+
+    // Mock log now has two entries with this needle. The second one must
+    // carry the thinking extras — proving the cache key separates them.
+    const all = readFileSync(MOCK_LOG, 'utf-8').trim().split('\n').filter(Boolean)
+      .map((l) => JSON.parse(l).body as Record<string, unknown>)
+      .filter((b) =>
+        Array.isArray(b?.messages) &&
+        (b.messages as Array<{ content?: string }>).some((m) => (m.content ?? '').includes(needle)),
+      );
+    expect(all.length, 'two upstream calls — one per Think state').toBe(2);
+    expect(all[1]!.think).toBe(true);
+    expect(all[1]!.chat_template_kwargs).toEqual({ enable_thinking: true });
+  });
 });

--- a/e2e/think-toggle.spec.ts
+++ b/e2e/think-toggle.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+
+/**
+ * E2E: Think toggle wiring on the AI page.
+ *
+ * Proves end-to-end (UI → backend → upstream provider request body) that:
+ *   1. Toggle OFF → no thinking-related fields on the upstream `/v1/chat/completions` body.
+ *   2. Toggle ON  → `think: true` AND `chat_template_kwargs.enable_thinking: true`
+ *      land on the upstream body (the open-model variant of `thinkingExtras()`).
+ *
+ * Setup: a host-side mock OpenAI server (started by the runner) captures every
+ * upstream request body to a JSONL log. We register an admin, configure the
+ * mock as the chat provider, drive the UI, then inspect the log.
+ *
+ * Serial mode: first-user-is-admin requires a single registration per run.
+ */
+
+const TEST_USER = `e2e_think_${Date.now()}`;
+const TEST_PASS = 'TestPassword123!';
+
+const LLM_URL = process.env.E2E_LLM_URL ?? 'http://host.docker.internal:11444/v1';
+const MOCK_LOG = process.env.MOCK_REQ_LOG ?? '/tmp/think-mock-requests.jsonl';
+
+function findAskCall(needle: string) {
+  expect(existsSync(MOCK_LOG), `mock log exists at ${MOCK_LOG}`).toBeTruthy();
+  const lines = readFileSync(MOCK_LOG, 'utf-8').trim().split('\n').filter(Boolean);
+  return lines
+    .map((l) => JSON.parse(l).body as Record<string, unknown>)
+    .find((b) =>
+      b?.stream === true &&
+      Array.isArray(b?.messages) &&
+      (b.messages as Array<{ content?: string }>).some((m) => (m.content ?? '').includes(needle)),
+    );
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Think toggle wires upstream provider extras', () => {
+  let accessToken: string;
+
+  test.beforeAll(async ({ request }) => {
+    const registerRes = await request.post(`${process.env.E2E_BASE_URL}/api/auth/register`, {
+      data: { username: TEST_USER, password: TEST_PASS },
+    });
+    expect(registerRes.ok(), 'register first user as admin').toBeTruthy();
+    const auth = await registerRes.json();
+    expect(auth.user.role).toBe('admin');
+    accessToken = auth.accessToken;
+
+    // Configure mock as the chat + embedding provider via API (deterministic
+    // — avoids racing async form rerenders in Settings → LLM).
+    const createRes = await request.post(`${process.env.E2E_BASE_URL}/api/admin/llm-providers`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: {
+        name: 'MockThink',
+        baseUrl: LLM_URL,
+        authType: 'none',
+        verifySsl: true,
+        defaultModel: 'qwen3:8b',
+      },
+    });
+    expect(createRes.ok(), `create provider: ${createRes.status()}`).toBeTruthy();
+    const provider = await createRes.json();
+
+    const setDefaultRes = await request.post(
+      `${process.env.E2E_BASE_URL}/api/admin/llm-providers/${provider.id}/set-default`,
+      { headers: { Authorization: `Bearer ${accessToken}` } },
+    );
+    expect(setDefaultRes.ok()).toBeTruthy();
+
+    const assignRes = await request.put(
+      `${process.env.E2E_BASE_URL}/api/admin/llm-usecases`,
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        data: {
+          chat:      { providerId: provider.id, model: 'qwen3:8b' },
+          summary:   { providerId: provider.id, model: 'qwen3:8b' },
+          quality:   { providerId: provider.id, model: 'qwen3:8b' },
+          auto_tag:  { providerId: provider.id, model: 'qwen3:8b' },
+          embedding: { providerId: provider.id, model: 'bge-m3' },
+        },
+      },
+    );
+    expect(assignRes.ok(), `assign usecases: ${assignRes.status()}`).toBeTruthy();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await page.evaluate((token) => {
+      // The frontend store keeps `user` in localStorage too; a minimal
+      // shape is enough to satisfy the gate.
+      localStorage.setItem(
+        'compendiq-auth',
+        JSON.stringify({
+          state: {
+            accessToken: token,
+            user: { username: 'e2e-think', role: 'admin' },
+            isAuthenticated: true,
+          },
+          version: 0,
+        }),
+      );
+    }, accessToken);
+  });
+
+  test('toggle OFF → no thinking extras on upstream body', async ({ page }) => {
+    writeFileSync(MOCK_LOG, '');
+    await page.goto('/ai');
+    await expect(page.getByPlaceholder(/Ask a question/i)).toBeVisible({ timeout: 15_000 });
+
+    // The input is sr-only; its parent <label> is the clickable surface.
+    const thinkToggle = page.getByRole('checkbox', { name: 'Thinking mode' });
+    if (await thinkToggle.isChecked()) await thinkToggle.uncheck({ force: true });
+    await expect(thinkToggle).not.toBeChecked();
+
+    const askInput = page.getByTestId('ask-input');
+    const needle = `cap-no-think-${Date.now()}`;
+    await askInput.fill(`Tell me about ${needle}`);
+    await askInput.press('Enter');
+    await expect(page.getByText('Mocked thinking response.')).toBeVisible({ timeout: 20_000 });
+
+    const askCall = findAskCall(needle);
+    expect(askCall, 'found the /llm/ask upstream request').toBeTruthy();
+    expect(askCall!.think).toBeUndefined();
+    expect(askCall!.chat_template_kwargs).toBeUndefined();
+    expect(askCall!.reasoning_effort).toBeUndefined();
+  });
+
+  test('toggle ON → think + chat_template_kwargs land on upstream body', async ({ page }) => {
+    writeFileSync(MOCK_LOG, '');
+    await page.goto('/ai');
+    await expect(page.getByPlaceholder(/Ask a question/i)).toBeVisible({ timeout: 15_000 });
+
+    const thinkToggle = page.getByRole('checkbox', { name: 'Thinking mode' });
+    // The input is sr-only — its label is the clickable surface, so the
+    // direct click hits the wrapping <svg> instead. `force: true` lets
+    // Playwright dispatch the click on the input itself.
+    await thinkToggle.check({ force: true });
+    await expect(thinkToggle).toBeChecked();
+
+    const askInput = page.getByTestId('ask-input');
+    const needle = `cap-with-think-${Date.now()}`;
+    await askInput.fill(`Tell me about ${needle}`);
+    await askInput.press('Enter');
+    await expect(page.getByText('Mocked thinking response.')).toBeVisible({ timeout: 20_000 });
+
+    const askCall = findAskCall(needle);
+    expect(askCall, 'found the /llm/ask upstream request').toBeTruthy();
+    expect(askCall!.think).toBe(true);
+    expect(askCall!.chat_template_kwargs).toEqual({ enable_thinking: true });
+    // For an open model (qwen3:8b), the OpenAI-only field must NOT be sent —
+    // strict providers (OpenAI) reject unknown fields.
+    expect(askCall!.reasoning_effort).toBeUndefined();
+  });
+});

--- a/frontend/src/features/ai/modes/DiagramMode.tsx
+++ b/frontend/src/features/ai/modes/DiagramMode.tsx
@@ -123,7 +123,7 @@ export function DiagramPreview() {
  * Input bar for diagram mode: a single action button.
  */
 export function DiagramModeInput() {
-  const { isStreaming, page, model, pageId, runStream, diagramType, setDiagramCode } = useAiContext();
+  const { isStreaming, page, model, pageId, thinkingMode, runStream, diagramType, setDiagramCode } = useAiContext();
 
   const handleDiagram = useCallback(async () => {
     if (isStreaming) return;
@@ -140,7 +140,13 @@ export function DiagramModeInput() {
 
     await runStream(
       '/llm/generate-diagram',
-      { content: page.bodyHtml, model, diagramType, pageId: pageId ?? undefined },
+      {
+        content: page.bodyHtml,
+        model,
+        diagramType,
+        pageId: pageId ?? undefined,
+        ...(thinkingMode && { thinking: true }),
+      },
       {
         userMessage: `Generate ${diagramType} diagram: ${page.title}`,
         onComplete: (accumulated) => {
@@ -148,7 +154,7 @@ export function DiagramModeInput() {
         },
       },
     );
-  }, [page, model, diagramType, pageId, isStreaming, runStream, setDiagramCode]);
+  }, [page, model, diagramType, pageId, thinkingMode, isStreaming, runStream, setDiagramCode]);
 
   return (
     <div className="mt-3 flex items-center gap-3 border-t border-border/40 pt-3">

--- a/frontend/src/features/ai/modes/GenerateMode.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.tsx
@@ -484,7 +484,7 @@ export function GenerateSavePanel({
  * After generation completes, shows a save panel to publish to Confluence.
  */
 export function GenerateModeInput() {
-  const { input, setInput, isStreaming, model, setMessages, runStream } = useAiContext();
+  const { input, setInput, isStreaming, model, thinkingMode, setMessages, runStream } = useAiContext();
   const [generatedContent, setGeneratedContent] = useState('');
   const [showSavePanel, setShowSavePanel] = useState(false);
   const [searchWeb, setSearchWeb] = useState(false);
@@ -537,6 +537,9 @@ export function GenerateModeInput() {
     if (searchWeb) {
       body.searchWeb = true;
     }
+    if (thinkingMode) {
+      body.thinking = true;
+    }
 
     await runStream('/llm/generate', body, {
       onComplete: (accumulated) => {
@@ -546,7 +549,7 @@ export function GenerateModeInput() {
         }
       },
     });
-  }, [input, model, isStreaming, pdfData, pdfFilename, searchWeb, setInput, setMessages, runStream]);
+  }, [input, model, isStreaming, pdfData, pdfFilename, searchWeb, thinkingMode, setInput, setMessages, runStream]);
 
   const handleSubmit = () => handleGenerate();
 

--- a/frontend/src/features/ai/modes/QualityMode.tsx
+++ b/frontend/src/features/ai/modes/QualityMode.tsx
@@ -8,7 +8,7 @@ import { toast } from 'sonner';
  * Quality analysis mode: one-click multi-dimensional quality analysis of the selected page.
  */
 export function QualityModeInput() {
-  const { isStreaming, page, model, pageId, includeSubPages, runStream } = useAiContext();
+  const { isStreaming, page, model, pageId, includeSubPages, thinkingMode, runStream } = useAiContext();
 
   const handleQuality = useCallback(async () => {
     if (isStreaming) return;
@@ -23,10 +23,16 @@ export function QualityModeInput() {
 
     await runStream(
       '/llm/analyze-quality',
-      { content: page.bodyHtml, model, pageId: pageId ?? undefined, includeSubPages },
+      {
+        content: page.bodyHtml,
+        model,
+        pageId: pageId ?? undefined,
+        includeSubPages,
+        ...(thinkingMode && { thinking: true }),
+      },
       { userMessage: `Analyze Quality: ${page.title}` },
     );
-  }, [page, model, pageId, isStreaming, includeSubPages, runStream]);
+  }, [page, model, pageId, isStreaming, includeSubPages, thinkingMode, runStream]);
 
   return (
     <div className="mt-3 flex items-center gap-3 border-t border-border/40 pt-3">

--- a/packages/contracts/src/schemas/llm.ts
+++ b/packages/contracts/src/schemas/llm.ts
@@ -27,6 +27,7 @@ export const GenerateRequestSchema = z.object({
   spaceKey: z.string().optional(),
   parentId: z.string().optional(),
   pdfText: z.string().max(200_000).optional(),
+  thinking: z.boolean().optional(),
   searchWeb: z.boolean().optional(),
   searchQuery: z.string().max(500).optional(),
 });
@@ -66,6 +67,7 @@ export const GenerateDiagramRequestSchema = z.object({
   model: z.string().min(1),
   diagramType: z.enum(['flowchart', 'sequence', 'state', 'mindmap']).default('flowchart'),
   pageId: z.string().optional(),
+  thinking: z.boolean().optional(),
 });
 
 export const AnalyzeQualityRequestSchema = z.object({
@@ -73,6 +75,7 @@ export const AnalyzeQualityRequestSchema = z.object({
   model: z.string().min(1),
   pageId: z.string().optional(),
   includeSubPages: z.boolean().optional(),
+  thinking: z.boolean().optional(),
 });
 
 export const ForceEmbedTreeRequestSchema = z.object({


### PR DESCRIPTION
## Summary

The Think toggle on the AI page was wired in the UI and forwarded `thinking: true` to `/api/llm/{ask,improve,summarize}`, but the backend parsed the field and **silently dropped it** — `streamChat()` only sent `{ model, messages, stream }` upstream. Toggling Think changed the badge to purple and did nothing else.

This PR threads the flag end-to-end:

- New `thinkingExtras(model, thinking)` helper in `openai-compatible-client.ts` maps the generic flag to provider-specific extras:
  - OpenAI o-series / gpt-5 → `reasoning_effort: 'medium'`
  - Everything else (Ollama 0.6+, vLLM / SGLang serving Qwen3, DeepSeek-R1) → `think: true` + `chat_template_kwargs: { enable_thinking: true }`
- `chat()` and `streamChat()` accept an optional `opts: { thinking?: boolean }` and merge the extras into the `/v1/chat/completions` body.
- All five LLM routes (ask, improve, summarize, generate, diagram, quality) now forward `body.thinking` to `streamChat()`.
- Contract schemas: `GenerateRequestSchema`, `GenerateDiagramRequestSchema`, `AnalyzeQualityRequestSchema` gain `thinking?: boolean` (Ask/Improve/Summarize already had it).
- Frontend: `GenerateMode`, `DiagramMode`, `QualityMode` now read `thinkingMode` from `useAiContext()` and add `thinking: true` to the request body — previously the toggle was rendered globally but ignored in those three modes.

### Cache key now folds in `thinking`

`buildLlmCacheKey` and `buildRagCacheKey` (`llm-cache.ts`) didn't include `thinking`, so a warm cache from a thinking-off request would replay when the user toggled Think on — re-introducing the same no-op bug on the second turn. Both builders now accept `options.thinking` and append a `think:1` suffix when on; `false`/absent collapse to no suffix so the hash stays stable for unaffected callers. All six route call sites pass `body.thinking` into the cache key. Expect a brief cache warm-up after rollout because pre-PR cache entries hash differently.

## What changed (files)

| Area | Files |
|------|-------|
| Backend client | `openai-compatible-client.ts` (+ test) |
| Backend cache  | `llm-cache.ts` (+ test) |
| Backend routes | `llm-{ask,improve,summarize,generate,diagram,quality}.ts` |
| Contracts | `packages/contracts/src/schemas/llm.ts` |
| Frontend modes | `{Generate,Diagram,Quality}Mode.tsx` |
| E2E | `e2e/think-toggle.spec.ts` (new) |

## Why the heuristic and not "send both"

OpenAI rejects unknown JSON fields with 400, so we can't naively send `think` + `reasoning_effort` together. The model-name heuristic (`^o[1-9]` or `gpt-5*` → reasoning, else open-model) picks the right shape per backend. Caveat in the test plan below.

## Test plan

- [x] **Unit (wire format)** — 7 new assertions in `openai-compatible-client.test.ts` capture the upstream body for qwen3, deepseek-r1, o1, o3, gpt-5, and the no-thinking baseline.
- [x] **Unit (cache key)** — 3 new assertions in `llm-cache.test.ts` lock in that `thinking` produces distinct keys and that `thinking:false` equals omitted.
- [x] **Backend** — full backend route + cache suites still green: 224/224 pass.
- [x] **Frontend** — frontend AI suite still green: 172/172 pass.
- [x] **Contracts** — 66/66 pass.
- [x] **Lint + typecheck** — clean across all four workspaces.
- [x] **End-to-end via Playwright** — `e2e/think-toggle.spec.ts` registers an admin, configures a host-side mock OpenAI capture server as the chat provider, drives the AI page in a real browser, then asserts the captured upstream body. Three cases pass against a freshly-built CE Docker stack:

  ```
  ✓ toggle OFF → no thinking extras on upstream body                                  (863ms)
  ✓ toggle ON  → think + chat_template_kwargs land upstream                           (601ms)
  ✓ toggle ON after a warm thinking-off cache → upstream still receives the call      (1.1s)
  ```

  Captured upstream body for toggle ON:
  ```json
  {"model":"qwen3:8b","stream":true,"think":true,
   "chat_template_kwargs":{"enable_thinking":true}}
  ```

## Caveat — `gpt-4o` + Think on

The heuristic routes anything that isn't `o[1-9]*` / `gpt-5*` to the open-model path. A user who configures an OpenAI provider with a `gpt-4o` model **and** enables Think will get a 400 from OpenAI (unknown `think` field). This is a user error in the strict sense — `gpt-4o` is not a reasoning model — but the failure mode is a confusing 400 rather than a no-op. Two reasonable follow-ups, not in this PR:

1. Broaden the OpenAI detection to `^gpt-` and let OpenAI ignore `reasoning_effort` on non-reasoning models. (Simpler.)
2. Add a `supportsThinking` boolean to the model record and gate the Think toggle from the UI when the assigned chat model can't use it. (More correct.)

## Known UX follow-up enabled by this PR

The streaming consumer in `openai-compatible-client.ts` reads only `delta.content`. OpenAI o-series and Ollama 0.9+ stream reasoning in `delta.reasoning_content` (separate, silently dropped — fine). **Older Ollama versions** running Qwen3 / DeepSeek-R1 inline `<think>...</think>` blocks inside `delta.content`, which this PR will start surfacing in the chat UI. `quality-worker.ts:96` already strips these in the quality flow; mirroring that on the chat path (or routing reasoning to a collapsible UI block) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)