### PR TITLE
fix(deps): force-hoist p-limit + ipaddr.js to root + CI hoisting guard

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -62,6 +62,21 @@ jobs:
           sbom: true
           provenance: mode=max
 
+      # Smoke-load the runtime image's prod node_modules. Guards against the
+      # class of bug where npm's hoister demotes a backend prod dep to
+      # `backend/node_modules/` — invisible to the runtime stage, which only
+      # copies the root tree. Builds succeed in that case; containers crash on
+      # boot. amd64-only steps suffice; arm64 (tags) shares the same module
+      # graph. Uses the first tag from metadata, which is always present.
+      - name: Smoke-test runtime module resolution
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        env:
+          IMAGE: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        run: |
+          docker pull "$IMAGE"
+          docker run --rm --entrypoint node "$IMAGE" --input-type=module -e \
+            "await import('p-limit'); await import('ipaddr.js'); console.log('runtime require smoke ok');"
+
   docker-frontend:
     name: Frontend Image
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -25,6 +25,35 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # The runtime Docker stage copies only the root node_modules. If npm's
+      # hoister demotes a backend prod dep to backend/node_modules (e.g.
+      # because a root devDep chain pins a conflicting major), the dep
+      # disappears at runtime and the container crash-loops on boot —
+      # invisible to `npm run build` and to `docker build` alike. Simulate
+      # the Docker prod-deps install in a tmpdir and assert the two
+      # historically-fragile packages stay at the root.
+      - name: Verify prod-deps hoist runtime-critical packages to root
+        run: |
+          set -euo pipefail
+          T=$(mktemp -d)
+          mkdir -p "$T/backend" "$T/packages/contracts" "$T/frontend"
+          cp package.json package-lock.json "$T/"
+          cp backend/package.json "$T/backend/"
+          cp packages/contracts/package.json "$T/packages/contracts/"
+          cp frontend/package.json "$T/frontend/"
+          (cd "$T" && npm ci --omit=dev -w backend -w @compendiq/contracts >/dev/null)
+          missing=()
+          for pkg in p-limit ipaddr.js; do
+            test -d "$T/node_modules/$pkg" || missing+=("$pkg")
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "::error::Prod deps not hoisted to root node_modules: ${missing[*]}"
+            echo "  These are listed in root package.json 'dependencies' so npm hoists them."
+            echo "  See the //deps-note in package.json for context."
+            exit 1
+          fi
+          echo "✓ p-limit + ipaddr.js hoisted to root node_modules"
+
       - name: Typecheck (contracts + backend + frontend)
         run: npm run typecheck
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.0",
   "private": true,
   "type": "module",
+  "//hoisting-note": "`p-limit` and `ipaddr.js` are ALSO declared in the root package.json `dependencies` block to force npm to hoist them to root node_modules. The runtime Docker stage only copies the root tree, so any version pinned here that ends up nested under backend/node_modules disappears at runtime. If you change the ranges below, update the root mirror in lockstep — the docker-build smoke step is the safety net but local repros are faster.",
   "scripts": {
     "dev": "tsx watch --env-file=../.env src/index.ts",
     "build": "tsc -p tsconfig.build.json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,10 @@
         "frontend",
         "packages/contracts"
       ],
+      "dependencies": {
+        "ipaddr.js": "^2.3.0",
+        "p-limit": "^7.3.0"
+      },
       "devDependencies": {
         "@lhci/cli": "^0.15.1",
         "@playwright/test": "^1.58.2",
@@ -92,28 +96,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "backend/node_modules/ipaddr.js": {
-      "version": "2.4.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "backend/node_modules/p-limit": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
-      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "backend/node_modules/undici-types": {
@@ -2402,15 +2384,6 @@
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
-      }
-    },
-    "node_modules/@fastify/proxy-addr/node_modules/ipaddr.js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
-      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@fastify/rate-limit": {
@@ -14494,12 +14467,12 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-alphabetical": {
@@ -17706,16 +17679,15 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
       "license": "MIT",
       "dependencies": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^1.2.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -17732,6 +17704,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -18597,6 +18585,15 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
     "knip": "knip",
     "prepare": "husky || true"
   },
+  "//deps-note": "These mirror two backend prod deps (kept in sync with backend/package.json) so npm hoists them to the root node_modules. Without this, conflicting majors from a root devDep chain (@lhci/cli → express/yargs) push backend's copy down to backend/node_modules, where the runtime Docker stage — which copies only the root tree and flattens backend/dist to /app/dist — can't reach them. The smoke step in .github/workflows/docker-build.yml guards against this regressing silently.",
+  "dependencies": {
+    "ipaddr.js": "^2.3.0",
+    "p-limit": "^7.3.0"
+  },
   "devDependencies": {
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.58.2",


### PR DESCRIPTION
## Why

PR #677's `2eaa9c9` (the `brace-expansion@5` override scope-fix) regenerated `package-lock.json`, which made npm reshuffle hoisting decisions. Two backend prod deps — `p-limit@7.3.0` and `ipaddr.js@2.4.0` — got demoted to `backend/node_modules/` because they conflict with `@lhci/cli`'s transitive chain (`yargs → p-locate → p-limit@2.x` and `express → proxy-addr → ipaddr.js@1.x`).

The Docker runtime stage (both `backend/Dockerfile` and `build/docker/Dockerfile.enterprise`) copies only the root `/app/node_modules` and flattens `backend/dist` to `/app/dist`. From `/app/dist/**/*.js`, Node's resolution walk only sees `/app/node_modules` — it never looks at `/app/backend/node_modules` (a sibling, not an ancestor).

Result on `dev` right now: any container built from `:dev` crash-loops with `ERR_MODULE_NOT_FOUND: p-limit` the moment it starts. CE Docker Build CI didn't catch it because it only verifies the image *builds*, not that it boots — the regression surfaced as a "Request failed" toast in the UI during local testing.

## The fix (three parts)

1. **Declare `p-limit` + `ipaddr.js` in root `dependencies`**, mirrored against `backend/package.json` with matching caret ranges. With root explicitly requiring them, npm picks those versions for hoisting; the lhci-chain's older majors stay nested.
2. **Document the coupling in both files** (`//deps-note` at root, `//hoisting-note` in `backend/package.json`) so a future maintainer touching either file sees the constraint immediately.
3. **Two new CI guards** so this can't silently regress again:
   - **`pr-check.yml`**: simulate the prod-deps install in a tmpdir and assert `p-limit` + `ipaddr.js` exist at root before merge. Fast (~5s, no Docker), runs on every PR.
   - **`docker-build.yml`**: after the backend image is pushed, `docker run` it with `node --input-type=module` and `await import` both packages. Catches Dockerfile drift that the PR-time check would miss.

## Addressing the review on the prior revision

| Finding | Action |
|---|---|
| Unannounced `@vitest/*` 4.1.6→4.1.7 bumps swept up by the lockfile regen | Lockfile is now surgical — reset to base, then `npm install ipaddr.js p-limit`. Only those two packages move; no incidental minor bumps. |
| No regression test for the hoisting | Added both a PR-time hoist check and a post-merge Docker boot smoke step. |
| Hidden coupling between root deps and `backend/package.json` | Comment mirrored in both files. |
| Typography change bundled with deps fix | Split into #679. This PR is deps-only now. |
| `dependencies` placement before `devDependencies` | Reordered to match convention. |

## Verification (local)

| Check | Result |
|---|---|
| Repro of `npm ci --omit=dev -w backend -w @compendiq/contracts` in clean tmpdir | `p-limit` + `ipaddr.js` hoist to root; **no** `backend/node_modules/` at all |
| `npm run lint` (backend + frontend) | clean |
| `npm run typecheck` (all workspaces) | clean |
| `npm audit` | 0 vulnerabilities (brace-expansion CVE still mitigated) |
| Locally rebuilt EE backend Docker image | boots `healthy`; `POST /api/pages/bulk/quality` returns `401` (route exists, auth fires) instead of the SCIM `404` it gave when the package was missing |

## Test plan

- [x] Lint, typecheck, audit clean
- [ ] PR Check: new hoisting verification step in `typecheck-lint` job goes green
- [ ] After merge: `Docker Build & Push` smoke step finds the modules in the built image
- [ ] After merge: `docker pull ghcr.io/compendiq/compendiq-ce-backend:dev` and confirm the container boots locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)