### PR TITLE
style(typography): unify headings on the body sans stack

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,8 +39,8 @@ html {
 }
 
 /* Premium typography rendering (Obsidian / Notion pattern). Uses the
-   brand body sans (Inter Variable), with system fallbacks if the font
-   failed to load. Headings opt into --font-display in the prose styles. */
+   brand body sans (IBM Plex Sans Variable), with system fallbacks if the
+   font failed to load. Headings share the same sans stack — see below. */
 body {
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
@@ -49,13 +49,12 @@ body {
   font-feature-settings: "liga" 1, "kern" 1;
 }
 
-/* Editorial serif for display copy (article titles, section headings,
-   marketing-style hero text). Newsreader's optical-size axis is auto, so
-   small headings stay legible while hero sizes get appropriate optical
-   adjustment. */
+/* Headings share the body's sans stack (IBM Plex Sans Variable) so the UI
+   reads as a single typographic system. font-optical-sizing stays on so
+   large-display sizes still pick up the variable font's display cut. */
 h1, h2, h3, h4, h5, h6,
 .prose :where(h1, h2, h3, h4, h5, h6) {
-  font-family: var(--font-display);
+  font-family: var(--font-sans);
   font-optical-sizing: auto;
 }
 


### PR DESCRIPTION
## Why

Split out of #678 per code review — typography is an opinionated UI change and shouldn't ride along behind an urgent dependency fix.

Drop the Newsreader serif from `h1-h6` / `.prose` headings; switch to `var(--font-sans)` (IBM Plex Sans Variable) so the UI reads as a single typographic family. `font-optical-sizing: auto` stays on so variable-font display cuts still kick in at large sizes.

The `--font-display` token stays defined for any future opt-in via Tailwind's `font-display` utility — this change is reversible without touching tokens.

## Scope

One file, two property values + two comment updates.

```diff
- font-family: var(--font-display);
+ font-family: var(--font-sans);
```

## Notes

- Designer eyes welcome — Newsreader was an intentional editorial choice ("Editorial serif for display copy"); this PR overrides that based on a user request to align headings with the body face. If anyone wants Newsreader back for a specific surface (article titles, marketing-style hero text), the token is still there to opt into.
- The CSS comment in `frontend/src/index.css` was updated to match the new state. The body-rendering comment also got a small fix — it called out "Inter Variable" when the actual stack is IBM Plex Sans Variable.

## Test plan

- [ ] Visual: heading face in the article view, settings pages, and onboarding wizard is IBM Plex Sans, not the serif.
- [ ] No layout shift — both fonts are variable, but optical-size + the slight metrics difference may nudge heading widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)