### PR TITLE
fix(editor): show drag handle on full block hover

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2022,10 +2022,13 @@ pre:hover .code-copy-btn {
   color: var(--color-primary);
 }
 
-/* Show the handle when it is positioned (visible) by the extension */
-.drag-handle[style*="display: block"],
-.drag-handle[style*="display:block"] {
-  opacity: 0.4;
+/* Show the handle whenever the extension positions it next to a hovered block.
+   The extension toggles `visibility: hidden` to hide, and clears it (no inline
+   visibility property) to show — so inverting that selector makes the handle
+   visible for any block under the cursor, not only when the pointer is on the
+   handle itself. */
+.drag-handle:not([style*="visibility: hidden"]):not([style*="visibility:hidden"]) {
+  opacity: 0.7;
 }
 
 /* ProseMirror drop cursor — the blue line shown during drag */

--- a/frontend/src/shared/components/article/Editor.test.tsx
+++ b/frontend/src/shared/components/article/Editor.test.tsx
@@ -220,6 +220,67 @@ describe('Editor', () => {
       const dragHandle = container.querySelector('.drag-handle');
       expect(dragHandle).toBeFalsy();
     });
+
+    // CSS guards. The original bug was a dead selector — `[style*="display:
+    // block"]` — that never matched because the upstream TipTap extension
+    // toggles `visibility`, not `display`. We want to catch any future
+    // change that silently re-introduces the same class of mistake.
+    describe('visibility-toggle CSS rule', () => {
+      it('targets the visibility-hidden inline style (file-content guard)', async () => {
+        const { readFileSync } = await import('node:fs');
+        const { resolve } = await import('node:path');
+        // Cheap, deterministic guard: read the rule out of index.css and
+        // assert the selector covers what the extension actually toggles.
+        // The old broken selector matched `display: block` (which the
+        // extension never sets); this guard ensures the rule still keys off
+        // `visibility: hidden` instead.
+        const cssPath = resolve(__dirname, '../../../index.css');
+        const css = readFileSync(cssPath, 'utf8');
+
+        // Must NOT have reverted to the previous dead-selector form.
+        expect(css).not.toMatch(/\.drag-handle\[style\*="display:\s*block"]/);
+
+        // Must invert the visibility-hidden state — both whitespace variants
+        // (browsers serialize as either `visibility: hidden` or, rarely,
+        // `visibility:hidden`).
+        expect(css).toMatch(/\.drag-handle:not\(\[style\*="visibility:\s*hidden"\]\):not\(\[style\*="visibility:hidden"\]\)/);
+      });
+
+      it('shows the handle when no visibility is set and hides it when visibility: hidden is set (behavioural)', () => {
+        // jsdom does not load `index.css`, so inject the rule we depend on.
+        // The selector copied here is what the file-content guard above
+        // pins down — keep these in sync if the selector changes.
+        const style = document.createElement('style');
+        style.textContent = `
+          .drag-handle { opacity: 0; }
+          .drag-handle:not([style*="visibility: hidden"]):not([style*="visibility:hidden"]) { opacity: 0.7; }
+        `;
+        document.head.appendChild(style);
+
+        const el = document.createElement('div');
+        el.className = 'drag-handle';
+        document.body.appendChild(el);
+
+        try {
+          // Extension's "shown" state — no inline visibility.
+          expect(getComputedStyle(el).opacity).toBe('0.7');
+
+          // Extension's "hidden" state — visibility cleared by setting it
+          // to hidden in the inline style.
+          el.style.visibility = 'hidden';
+          expect(getComputedStyle(el).opacity).toBe('0');
+
+          // Re-shown by clearing the visibility property — must reach 0.7
+          // again (this is the round-trip the user complaint produced when
+          // the cursor left and re-entered the block).
+          el.style.visibility = '';
+          expect(getComputedStyle(el).opacity).toBe('0.7');
+        } finally {
+          el.remove();
+          style.remove();
+        }
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Hovering over any block in the article editor now reveals the Notion-style grip handle, instead of only when the cursor sits on the invisible left-edge handle box.
- Root cause: the existing CSS gated visibility on `[style*="display: block"]`, but the TipTap drag-handle extension toggles `visibility`, not `display` — so the rule never matched and the handle stayed at `opacity: 0` unless directly hovered.
- Fix: invert the visibility toggle. When the extension clears the inline `visibility: hidden` (i.e. it has positioned the handle next to a hovered block), the handle is shown at `opacity: 0.7`. The existing `:hover` rule still bumps to `1` on direct hover.

Single-line CSS selector change in `frontend/src/index.css`. No JS, no behaviour change for the drag itself.

## Test plan
- [x] Built the frontend bundle, served via `vite preview`, logged in, opened an article in edit mode
- [x] Dispatched `mousemove` at the **centre** of an H1 (x=544, far from the left edge) — handle transitioned to `opacity: 0.7`, `visibility: visible`, positioned at `left: 20px; top: 24px` next to the block
- [x] Dispatched `mouseleave` on the editor — handle dropped to `opacity: 0`, `visibility: hidden`
- [x] Verified the new selector against all three states the extension produces (hidden / shown / re-shown) — opacities match the design
- [x] Screenshot confirms the grip is visible to the left of the heading while hovering its centre
- [ ] Manual smoke in your local stack to confirm the feel matches "Notion-style" expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)