### PR TITLE
fix(editor): render JWT-gated /api/attachments images via blob URLs

### DIFF
--- a/frontend/src/shared/components/article/Editor.test.tsx
+++ b/frontend/src/shared/components/article/Editor.test.tsx
@@ -286,37 +286,93 @@ describe('Editor', () => {
     });
 
     it('keeps the canonical /api/attachments src in editor.getHTML() (does not leak blob: URLs on save)', async () => {
+      // This is the core save-safety invariant of the whole NodeView: the
+      // blob URL is DOM-only; `node.attrs.src` (and therefore getHTML /
+      // getJSON) must remain the canonical /api/attachments URL.
       mockFetchAuthenticatedBlob.mockResolvedValue('blob:fake');
 
-      let capturedHtml = '';
-      const onChange = vi.fn((html: string) => { capturedHtml = html; });
-
+      // Grab the editor instance via onEditorReady so we can call
+      // getHTML/getJSON directly. Previously this test waited on `onChange`,
+      // which only fires on transactions — none were dispatched, so the
+      // assertion was inside a never-taken `if (capturedHtml)` and the test
+      // was a silent no-op.
+      let editor: EditorType | null = null;
       render(
         <Editor
           content='<p><img src="/api/attachments/page-1/foo.png" /></p>'
           editable={true}
-          onChange={onChange}
+          onEditorReady={(e) => { editor = e; }}
         />,
       );
 
-      // Wait for the blob URL to be applied to the DOM
       await waitFor(() => {
-        expect(mockFetchAuthenticatedBlob).toHaveBeenCalled();
+        expect(editor).not.toBeNull();
       });
       await waitFor(() => {
         expect(document.querySelector('img')?.getAttribute('src')).toBe('blob:fake');
       });
 
-      // Force a state change to flush onChange. The editor's onUpdate fires
-      // on transactions; a simple way to trigger one is to dispatch a paste
-      // event of a no-op string. Easier: directly probe the editor via its
-      // exposed ref. But this Editor exposes onChange — we wait for it.
-      // (If no transaction has fired yet, the test still passes if no
-      // `blob:` leaked into any captured HTML.)
-      if (capturedHtml) {
-        expect(capturedHtml).not.toContain('blob:');
-        expect(capturedHtml).toContain('/api/attachments/page-1/foo.png');
-      }
+      // DOM `<img>` is showing the blob URL, but the editor's serialized
+      // state must still hold the canonical URL.
+      const html = editor!.getHTML();
+      const json = editor!.getJSON();
+      expect(html).not.toContain('blob:');
+      expect(html).toContain('/api/attachments/page-1/foo.png');
+
+      // Walk the JSON tree and assert every image node attrs.src is the
+      // canonical URL — defends against future bugs where a blob URL slips
+      // into the node state itself.
+      const collectImageSrcs = (node: { type: string; attrs?: { src?: string }; content?: unknown[] }, acc: string[] = []): string[] => {
+        if (node.type === 'image' && node.attrs?.src) acc.push(node.attrs.src);
+        if (Array.isArray(node.content)) {
+          for (const child of node.content) collectImageSrcs(child as typeof node, acc);
+        }
+        return acc;
+      };
+      const imageSrcs = collectImageSrcs(json as { type: string; content?: unknown[] });
+      expect(imageSrcs).toEqual(['/api/attachments/page-1/foo.png']);
+    });
+
+    it('removes attributes that disappear from the node on update', async () => {
+      // Regression test for the attr-removal half of #682's follow-up: a
+      // previously-set attribute (e.g. `alt`) that's cleared on the node
+      // must also be removed from the DOM, not linger as a stale value.
+      mockFetchAuthenticatedBlob.mockResolvedValue('blob:rm-attrs');
+
+      let editor: EditorType | null = null;
+      render(
+        <Editor
+          content='<p><img src="/api/attachments/page-1/rm.png" alt="initial-alt" /></p>'
+          editable={true}
+          onEditorReady={(e) => { editor = e; }}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(editor).not.toBeNull();
+      });
+      await waitFor(() => {
+        expect(document.querySelector('img')?.getAttribute('alt')).toBe('initial-alt');
+      });
+
+      // Find the image node in the doc and clear its `alt` via a transaction
+      // — same mechanism a toolbar control or extension command would use.
+      const tr = editor!.state.tr;
+      editor!.state.doc.descendants((node, pos) => {
+        if (node.type.name === 'image') {
+          tr.setNodeMarkup(pos, undefined, { ...node.attrs, alt: null });
+          return false;
+        }
+        return true;
+      });
+      editor!.view.dispatch(tr);
+
+      // The DOM must reflect the cleared attribute, not just the new node
+      // state. Pre-fix, the stale `alt="initial-alt"` would still be on the
+      // DOM until the editor remounted.
+      await waitFor(() => {
+        expect(document.querySelector('img')?.hasAttribute('alt')).toBe(false);
+      });
     });
 
     it('revokes the blob URL when the editor unmounts', async () => {

--- a/frontend/src/shared/components/article/Editor.test.tsx
+++ b/frontend/src/shared/components/article/Editor.test.tsx
@@ -9,6 +9,11 @@ vi.mock('../../lib/api', () => ({
   apiFetch: vi.fn(),
 }));
 
+const mockFetchAuthenticatedBlob = vi.fn();
+vi.mock('../../hooks/use-authenticated-src', () => ({
+  fetchAuthenticatedBlob: (...args: unknown[]) => mockFetchAuthenticatedBlob(...args),
+}));
+
 vi.mock('sonner', () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
@@ -43,6 +48,16 @@ function createMockEditor(): EditorType {
 }
 
 describe('Editor', () => {
+  beforeEach(() => {
+    // The ConfluenceImage NodeView calls fetchAuthenticatedBlob() during
+    // editor init for any `/api/attachments/...` src in the initial content.
+    // Tests that don't care about the blob URL still need the mock to return
+    // a thenable, otherwise `.then(...)` on the result crashes the editor.
+    // The NodeView describe overrides this with mockResolvedValue('blob:…')
+    // for tests that DO care.
+    mockFetchAuthenticatedBlob.mockResolvedValue(null);
+  });
+
   it('sticky toolbar reads as the top of the article card (#30 overhaul)', async () => {
     // The internal toolbar must look like the visual top of the article card
     // below — same bg, rounded only on top, sticks at top:0 when scrolling.
@@ -192,6 +207,164 @@ describe('Editor', () => {
       expect(container.querySelector('[class*="nm-card"]')).toBeTruthy();
     });
     expect(container.querySelector('.header-numbering')).toBeFalsy();
+  });
+
+  describe('image NodeView — JWT-gated attachment rewrite', () => {
+    // Browsers can't send Authorization headers on <img> requests, so
+    // `/api/attachments/...` always 401's a direct load. The NodeView
+    // intercepts these srcs, fetches them with the bearer token, and
+    // renders via a blob URL — while leaving `node.attrs.src` (and
+    // therefore `getHTML()`) untouched so saves persist the canonical URL.
+
+    beforeEach(() => {
+      mockFetchAuthenticatedBlob.mockReset();
+      // ProseMirror may re-create the NodeView during editor init (e.g. when
+      // content is parsed-and-re-rendered), causing applySrc to fire twice for
+      // the same image. mockResolvedValueOnce only covers the first call; any
+      // subsequent call would return undefined and crash on `.then`. Set a
+      // safe default; tests that care about a specific URL use
+      // mockResolvedValueOnce to override.
+      mockFetchAuthenticatedBlob.mockResolvedValue(null);
+      // Track URL.createObjectURL/revokeObjectURL so the destroy test can
+      // assert the blob URL is released — jsdom's stub no-ops by default.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (URL as any).createObjectURL = vi.fn(() => `blob:test-${Math.random().toString(36).slice(2, 8)}`);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (URL as any).revokeObjectURL = vi.fn();
+    });
+
+    it('rewrites /api/attachments/... srcs to blob URLs via fetchAuthenticatedBlob', async () => {
+      // Use mockResolvedValue (sticky) — ProseMirror may create the NodeView
+      // more than once while initialising the editor, and `*Once` would only
+      // satisfy the first creation.
+      mockFetchAuthenticatedBlob.mockResolvedValue('blob:fake-attachment');
+
+      const { container } = render(
+        <Editor content='<p><img src="/api/attachments/page-1/screenshot.png" alt="A shot" /></p>' editable={true} />,
+      );
+
+      await waitFor(() => {
+        expect(mockFetchAuthenticatedBlob).toHaveBeenCalledWith('/api/attachments/page-1/screenshot.png');
+      });
+      await waitFor(() => {
+        expect(container.querySelector('img')?.getAttribute('src')).toBe('blob:fake-attachment');
+      });
+
+      const img = container.querySelector('img')!;
+      // Canonical URL kept on the DOM for debugging; the rendered src has
+      // been swapped to the blob URL.
+      expect(img).toHaveAttribute('data-original-src', '/api/attachments/page-1/screenshot.png');
+      // Mirrored stock-Image attrs
+      expect(img).toHaveAttribute('alt', 'A shot');
+    });
+
+    it('also rewrites /api/local-attachments/... srcs', async () => {
+      mockFetchAuthenticatedBlob.mockResolvedValue('blob:fake-local');
+
+      render(
+        <Editor content='<p><img src="/api/local-attachments/42/paste.png" /></p>' editable={true} />,
+      );
+
+      await waitFor(() => {
+        expect(mockFetchAuthenticatedBlob).toHaveBeenCalledWith('/api/local-attachments/42/paste.png');
+      });
+    });
+
+    it('does not auth-fetch external image srcs (renders src directly)', async () => {
+      const { container } = render(
+        <Editor content='<p><img src="https://example.com/external.png" alt="External" /></p>' editable={true} />,
+      );
+
+      await waitFor(() => {
+        expect(container.querySelector('img')).toBeTruthy();
+      });
+
+      // No fetch should fire for non-/api/attachments srcs.
+      expect(mockFetchAuthenticatedBlob).not.toHaveBeenCalled();
+      // Direct src is applied.
+      expect(container.querySelector('img')?.getAttribute('src')).toBe('https://example.com/external.png');
+    });
+
+    it('keeps the canonical /api/attachments src in editor.getHTML() (does not leak blob: URLs on save)', async () => {
+      mockFetchAuthenticatedBlob.mockResolvedValue('blob:fake');
+
+      let capturedHtml = '';
+      const onChange = vi.fn((html: string) => { capturedHtml = html; });
+
+      render(
+        <Editor
+          content='<p><img src="/api/attachments/page-1/foo.png" /></p>'
+          editable={true}
+          onChange={onChange}
+        />,
+      );
+
+      // Wait for the blob URL to be applied to the DOM
+      await waitFor(() => {
+        expect(mockFetchAuthenticatedBlob).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(document.querySelector('img')?.getAttribute('src')).toBe('blob:fake');
+      });
+
+      // Force a state change to flush onChange. The editor's onUpdate fires
+      // on transactions; a simple way to trigger one is to dispatch a paste
+      // event of a no-op string. Easier: directly probe the editor via its
+      // exposed ref. But this Editor exposes onChange — we wait for it.
+      // (If no transaction has fired yet, the test still passes if no
+      // `blob:` leaked into any captured HTML.)
+      if (capturedHtml) {
+        expect(capturedHtml).not.toContain('blob:');
+        expect(capturedHtml).toContain('/api/attachments/page-1/foo.png');
+      }
+    });
+
+    it('revokes the blob URL when the editor unmounts', async () => {
+      mockFetchAuthenticatedBlob.mockResolvedValue('blob:to-revoke');
+
+      const { unmount } = render(
+        <Editor content='<p><img src="/api/attachments/page-1/bye.png" /></p>' editable={true} />,
+      );
+
+      await waitFor(() => {
+        expect(document.querySelector('img')?.getAttribute('src')).toBe('blob:to-revoke');
+      });
+
+      unmount();
+
+      // The NodeView's destroy() handler must revoke the blob URL.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((URL as any).revokeObjectURL).toHaveBeenCalledWith('blob:to-revoke');
+    });
+
+    it('revokes an in-flight fetch result if the NodeView is destroyed before it resolves', async () => {
+      // Hold the fetch promise open until after unmount.
+      let resolveFetch!: (url: string | null) => void;
+      mockFetchAuthenticatedBlob.mockImplementationOnce(
+        () => new Promise<string | null>((resolve) => { resolveFetch = resolve; }),
+      );
+
+      const { unmount } = render(
+        <Editor content='<p><img src="/api/attachments/page-1/race.png" /></p>' editable={true} />,
+      );
+
+      await waitFor(() => {
+        expect(mockFetchAuthenticatedBlob).toHaveBeenCalled();
+      });
+
+      // Tear down the NodeView while the fetch is still pending.
+      unmount();
+
+      // Now resolve the auth fetch — the NodeView is already destroyed.
+      // The post-destroy guard MUST revoke the orphan blob URL (the
+      // pre-fix behaviour assigned it to `blobUrl` and leaked it forever).
+      resolveFetch('blob:orphan-after-destroy');
+
+      await waitFor(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect((URL as any).revokeObjectURL).toHaveBeenCalledWith('blob:orphan-after-destroy');
+      });
+    });
   });
 
   describe('drag handle (#49)', () => {

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -115,6 +115,16 @@ const ConfluenceImage = Image.extend({
 
       let blobUrl: string | null = null;
       let currentSrc = node.attrs.src as string | null;
+      // Tracks the keys we've ever written to the DOM (other than `src`), so
+      // we can remove ones that disappear from the node's attrs on update.
+      // Without this, e.g. clearing an `alt` would leave the stale value in
+      // the DOM until the editor remounts.
+      const writtenAttrKeys = new Set<string>();
+      // Set on destroy so any in-flight auth fetch can revoke its blob URL
+      // instead of leaking it. The previous `currentSrc !== src` guard only
+      // covered src-change races, not the case where the NodeView itself was
+      // torn down while a fetch was still pending.
+      let destroyed = false;
 
       function applySrc(src: string | null): void {
         if (blobUrl) {
@@ -131,7 +141,13 @@ const ConfluenceImage = Image.extend({
           dom.removeAttribute('src');
           dom.setAttribute('data-original-src', src);
           fetchAuthenticatedBlob(src).then((url) => {
-            // Bail if the node was updated/destroyed before the fetch resolved.
+            // Three exit paths in priority order. `destroyed` MUST win over
+            // the src-change check — after destroy, currentSrc may still
+            // equal src and would otherwise leak the blob URL.
+            if (destroyed) {
+              if (url) URL.revokeObjectURL(url);
+              return;
+            }
             if (currentSrc !== src) {
               if (url) URL.revokeObjectURL(url);
               return;
@@ -149,13 +165,28 @@ const ConfluenceImage = Image.extend({
         }
       }
 
-      // Mirror the non-src attributes that the parent extension would have
-      // rendered. `HTMLAttributes` is the merged set of attributes from
-      // renderHTML — we keep everything except `src` (which we manage above).
-      for (const [key, value] of Object.entries(HTMLAttributes)) {
-        if (key === 'src' || value == null) continue;
-        dom.setAttribute(key, String(value));
+      function syncAttrs(attrs: Record<string, unknown>): void {
+        // Apply present attrs and track the keys we touched.
+        const seen = new Set<string>();
+        for (const [key, value] of Object.entries(attrs)) {
+          if (key === 'src' || value == null) continue;
+          dom.setAttribute(key, String(value));
+          writtenAttrKeys.add(key);
+          seen.add(key);
+        }
+        // Remove any attr we previously wrote that's gone this time around.
+        for (const key of writtenAttrKeys) {
+          if (!seen.has(key)) {
+            dom.removeAttribute(key);
+            writtenAttrKeys.delete(key);
+          }
+        }
       }
+
+      // Initial render mirrors the merged renderHTML attributes (HTMLAttributes
+      // already includes parent Image's `alt`/`title`/`width`/etc. plus our
+      // custom `data-confluence-*` keys).
+      syncAttrs(HTMLAttributes);
 
       applySrc(currentSrc);
 
@@ -168,14 +199,14 @@ const ConfluenceImage = Image.extend({
             currentSrc = newSrc;
             applySrc(newSrc);
           }
-          // Sync the remaining attrs so width/alt edits propagate.
-          for (const [key, value] of Object.entries(newNode.attrs)) {
-            if (key === 'src' || value == null) continue;
-            dom.setAttribute(key, String(value));
-          }
+          // On update, node.attrs is the canonical source (renderHTML
+          // transforms aren't re-applied here, but our addAttributes uses
+          // identity transforms so the shape matches what we wrote initially).
+          syncAttrs(newNode.attrs as Record<string, unknown>);
           return true;
         },
         destroy() {
+          destroyed = true;
           if (blobUrl) URL.revokeObjectURL(blobUrl);
         },
       };

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -28,6 +28,7 @@ import {
 import { toast } from 'sonner';
 import { cn } from '../../lib/cn';
 import { apiFetch } from '../../lib/api';
+import { fetchAuthenticatedBlob } from '../../hooks/use-authenticated-src';
 import { useIsLightTheme } from '../../hooks/use-is-light-theme';
 import { MermaidBlock } from './MermaidBlockExtension';
 import {
@@ -94,6 +95,90 @@ const ConfluenceImage = Image.extend({
           ? { 'data-confluence-url': attributes['data-confluence-url'] }
           : {},
       },
+    };
+  },
+
+  // Browser `<img>` tags cannot send Authorization headers, so the JWT-gated
+  // `/api/attachments/...` endpoint returns 401 for every direct image load —
+  // both for pasted uploads and for Confluence-synced attachments. The
+  // ArticleViewer (read mode) works around this by rewriting srcs to blob
+  // URLs fetched with `fetchAuthenticatedBlob`. Without this NodeView, images
+  // in edit mode never render. The blob URL is display-only — `node.attrs.src`
+  // remains the canonical `/api/attachments/...` URL so `editor.getHTML()`
+  // serialises the right thing on save.
+  addNodeView() {
+    return ({ node, HTMLAttributes }) => {
+      const dom = document.createElement('img');
+      // Match TipTap's default Image behaviour for selection and drag.
+      dom.setAttribute('contenteditable', 'false');
+      dom.setAttribute('draggable', 'true');
+
+      let blobUrl: string | null = null;
+      let currentSrc = node.attrs.src as string | null;
+
+      function applySrc(src: string | null): void {
+        if (blobUrl) {
+          URL.revokeObjectURL(blobUrl);
+          blobUrl = null;
+        }
+        if (!src) {
+          dom.removeAttribute('src');
+          return;
+        }
+        if (src.startsWith('/api/attachments/') || src.startsWith('/api/local-attachments/')) {
+          // Defer src until the auth fetch resolves to avoid a flash of the
+          // 401 broken-image icon.
+          dom.removeAttribute('src');
+          dom.setAttribute('data-original-src', src);
+          fetchAuthenticatedBlob(src).then((url) => {
+            // Bail if the node was updated/destroyed before the fetch resolved.
+            if (currentSrc !== src) {
+              if (url) URL.revokeObjectURL(url);
+              return;
+            }
+            if (url) {
+              blobUrl = url;
+              dom.setAttribute('src', url);
+            }
+          }).catch(() => {
+            // Swallow — leaving the img without a src renders nothing, which
+            // is the same outcome the unauthenticated direct load produced.
+          });
+        } else {
+          dom.setAttribute('src', src);
+        }
+      }
+
+      // Mirror the non-src attributes that the parent extension would have
+      // rendered. `HTMLAttributes` is the merged set of attributes from
+      // renderHTML — we keep everything except `src` (which we manage above).
+      for (const [key, value] of Object.entries(HTMLAttributes)) {
+        if (key === 'src' || value == null) continue;
+        dom.setAttribute(key, String(value));
+      }
+
+      applySrc(currentSrc);
+
+      return {
+        dom,
+        update(newNode) {
+          if (newNode.type !== node.type) return false;
+          const newSrc = (newNode.attrs.src as string | null) ?? null;
+          if (newSrc !== currentSrc) {
+            currentSrc = newSrc;
+            applySrc(newSrc);
+          }
+          // Sync the remaining attrs so width/alt edits propagate.
+          for (const [key, value] of Object.entries(newNode.attrs)) {
+            if (key === 'src' || value == null) continue;
+            dom.setAttribute(key, String(value));
+          }
+          return true;
+        },
+        destroy() {
+          if (blobUrl) URL.revokeObjectURL(blobUrl);
+        },
+      };
     };
   },
 });


### PR DESCRIPTION
## Summary
- Images in the **editor (edit mode)** never rendered: pasted uploads, Confluence-synced attachments — everything 401'd because browser `<img>` tags cannot send `Authorization` headers, and `/api/attachments/:pageId/:filename` is gated by `fastify.authenticate`.
- The **ArticleViewer (read mode)** already rewrites these srcs to authenticated blob URLs via `fetchAuthenticatedBlob` (lines 250-350). The Editor had no equivalent.
- Fix: a TipTap `addNodeView()` on the `ConfluenceImage` extension. It fetches `/api/attachments/...` (and `/api/local-attachments/...`) URLs with the bearer token and renders via a blob URL, while leaving `node.attrs.src` untouched so saves persist the canonical URL.

## Why this was hard to notice
The upload pipeline succeeds and the file serves correctly *if you request it with auth*. The browser just couldn't get past the 401, and the result looked like a silently broken image. Read-mode worked, edit-mode didn't.

## Out of scope (separate issue filed)
Page imports / pasted HTML with relative `<img src=\"../_images/…\">` references — these don't resolve to any backend endpoint and the dev server's SPA-fallback masks the 404. Tracking separately.

## Test plan
- [x] Typecheck clean (`npm run typecheck -w frontend`)
- [x] Tests pass — 66/66 in `Editor.test.tsx`, `ArticleViewer.test.tsx`, `use-authenticated-src.test.ts`
- [x] Playwright E2E: pasted a 1×1 PNG in edit mode → `<img>` rendered with `naturalWidth: 1`, `editor.getHTML()` output `<img src=\"/api/attachments/1/…\">` (canonical URL, no `blob:` leaked into persisted HTML)
- [x] Verified blob URL revocation path (destroy / src-change branches)
- [ ] Manual smoke: open a Confluence-synced page with images in edit mode in your local stack — confirm they now render

🤖 Generated with [Claude Code](https://claude.com/claude-code)