### PR TITLE
release: v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-21
+
+### Fixed
+
+- **Drag handle now reveals on full-block hover, not only the left edge (#681).** The `.drag-handle` rule in `frontend/src/index.css` keyed off `[style*="display: block"]`, but `@tiptap/extension-drag-handle-react` toggles `visibility`, not `display` — so the selector was dead and the handle stayed at `opacity: 0` unless the cursor happened to land directly on the (invisible) handle box at the left edge of a block. New selector inverts the visibility toggle (`:not([style*="visibility: hidden"])`) so the handle is rendered at `opacity: 0.7` whenever the extension positions it next to a hovered block, restoring the Notion-style behaviour. The existing `:hover` rule still bumps to `opacity: 1` on direct hover. Two new tests in `Editor.test.tsx` pin the regression class: a file-content guard reading `index.css` and a behavioural test that injects the rule and asserts the shown → hidden → shown round-trip via `getComputedStyle`. (#681)
+- **JWT-gated `/api/attachments` images now render in edit mode (#682).** Browser `<img>` tags cannot send `Authorization` headers, so direct loads against `/api/attachments/:pageId/:filename` always returned 401 — pasted uploads and Confluence-synced attachments alike never rendered in the editor (even though the upload itself succeeded and the file served correctly with a JWT). `ArticleViewer` (read mode) already worked around this by rewriting srcs to authenticated blob URLs via `fetchAuthenticatedBlob`; the Editor had no equivalent. A new TipTap `addNodeView()` on the `ConfluenceImage` extension intercepts `/api/attachments/...` and `/api/local-attachments/...` srcs, fetches them with the bearer token, and renders via a blob URL. `node.attrs.src` is never mutated so `editor.getHTML()` (and therefore saves) keeps the canonical `/api/attachments/...` URL — verified end-to-end. Cleanup is symmetric: blob URLs are revoked on src change, on node update, on NodeView destroy, *and* if a fetch resolves after the NodeView has already been torn down (closing a memory-leak race that would otherwise orphan one blob URL per destroyed-while-fetching image). Update path also removes attributes that disappeared from the new node so e.g. clearing `alt` propagates to the DOM. Seven new NodeView tests cover the rewrite paths, the external-src pass-through, the canonical-src-in-`getHTML()` invariant, blob revocation on unmount, the destroy-before-resolve race, and the stale-attribute removal. (#682)
+
+### Known issues
+
+- Imported HTML with relative `<img src="../_images/...">` references (e.g. pasted from Sphinx-style external docs) still renders as broken images — these paths have no backend mapping and the JWT rewriter in #682 only targets `/api/attachments/...` URLs. Tracked in #683.
+
 ## [0.5.0] - 2026-05-20
 
 ### Added

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "//hoisting-note": "`p-limit` and `ipaddr.js` are ALSO declared in the root package.json `dependencies` block to force npm to hoist them to root node_modules. The runtime Docker stage only copies the root tree, so any version pinned here that ends up nested under backend/node_modules disappears at runtime. If you change the ranges below, update the root mirror in lockstep — the docker-build smoke step is the safety net but local repros are faster.",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2022,10 +2022,13 @@ pre:hover .code-copy-btn {
   color: var(--color-primary);
 }
 
-/* Show the handle when it is positioned (visible) by the extension */
-.drag-handle[style*="display: block"],
-.drag-handle[style*="display:block"] {
-  opacity: 0.4;
+/* Show the handle whenever the extension positions it next to a hovered block.
+   The extension toggles `visibility: hidden` to hide, and clears it (no inline
+   visibility property) to show — so inverting that selector makes the handle
+   visible for any block under the cursor, not only when the pointer is on the
+   handle itself. */
+.drag-handle:not([style*="visibility: hidden"]):not([style*="visibility:hidden"]) {
+  opacity: 0.7;
 }
 
 /* ProseMirror drop cursor — the blue line shown during drag */

--- a/frontend/src/shared/components/article/Editor.test.tsx
+++ b/frontend/src/shared/components/article/Editor.test.tsx
@@ -220,6 +220,67 @@ describe('Editor', () => {
       const dragHandle = container.querySelector('.drag-handle');
       expect(dragHandle).toBeFalsy();
     });
+
+    // CSS guards. The original bug was a dead selector — `[style*="display:
+    // block"]` — that never matched because the upstream TipTap extension
+    // toggles `visibility`, not `display`. We want to catch any future
+    // change that silently re-introduces the same class of mistake.
+    describe('visibility-toggle CSS rule', () => {
+      it('targets the visibility-hidden inline style (file-content guard)', async () => {
+        const { readFileSync } = await import('node:fs');
+        const { resolve } = await import('node:path');
+        // Cheap, deterministic guard: read the rule out of index.css and
+        // assert the selector covers what the extension actually toggles.
+        // The old broken selector matched `display: block` (which the
+        // extension never sets); this guard ensures the rule still keys off
+        // `visibility: hidden` instead.
+        const cssPath = resolve(__dirname, '../../../index.css');
+        const css = readFileSync(cssPath, 'utf8');
+
+        // Must NOT have reverted to the previous dead-selector form.
+        expect(css).not.toMatch(/\.drag-handle\[style\*="display:\s*block"]/);
+
+        // Must invert the visibility-hidden state — both whitespace variants
+        // (browsers serialize as either `visibility: hidden` or, rarely,
+        // `visibility:hidden`).
+        expect(css).toMatch(/\.drag-handle:not\(\[style\*="visibility:\s*hidden"\]\):not\(\[style\*="visibility:hidden"\]\)/);
+      });
+
+      it('shows the handle when no visibility is set and hides it when visibility: hidden is set (behavioural)', () => {
+        // jsdom does not load `index.css`, so inject the rule we depend on.
+        // The selector copied here is what the file-content guard above
+        // pins down — keep these in sync if the selector changes.
+        const style = document.createElement('style');
+        style.textContent = `
+          .drag-handle { opacity: 0; }
+          .drag-handle:not([style*="visibility: hidden"]):not([style*="visibility:hidden"]) { opacity: 0.7; }
+        `;
+        document.head.appendChild(style);
+
+        const el = document.createElement('div');
+        el.className = 'drag-handle';
+        document.body.appendChild(el);
+
+        try {
+          // Extension's "shown" state — no inline visibility.
+          expect(getComputedStyle(el).opacity).toBe('0.7');
+
+          // Extension's "hidden" state — visibility cleared by setting it
+          // to hidden in the inline style.
+          el.style.visibility = 'hidden';
+          expect(getComputedStyle(el).opacity).toBe('0');
+
+          // Re-shown by clearing the visibility property — must reach 0.7
+          // again (this is the round-trip the user complaint produced when
+          // the cursor left and re-entered the block).
+          el.style.visibility = '';
+          expect(getComputedStyle(el).opacity).toBe('0.7');
+        } finally {
+          el.remove();
+          style.remove();
+        }
+      });
+    });
   });
 });
 

--- a/frontend/src/shared/components/article/Editor.test.tsx
+++ b/frontend/src/shared/components/article/Editor.test.tsx
@@ -9,6 +9,11 @@ vi.mock('../../lib/api', () => ({
   apiFetch: vi.fn(),
 }));
 
+const mockFetchAuthenticatedBlob = vi.fn();
+vi.mock('../../hooks/use-authenticated-src', () => ({
+  fetchAuthenticatedBlob: (...args: unknown[]) => mockFetchAuthenticatedBlob(...args),
+}));
+
 vi.mock('sonner', () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
@@ -43,6 +48,16 @@ function createMockEditor(): EditorType {
 }
 
 describe('Editor', () => {
+  beforeEach(() => {
+    // The ConfluenceImage NodeView calls fetchAuthenticatedBlob() during
+    // editor init for any `/api/attachments/...` src in the initial content.
+    // Tests that don't care about the blob URL still need the mock to return
+    // a thenable, otherwise `.then(...)` on the result crashes the editor.
+    // The NodeView describe overrides this with mockResolvedValue('blob:…')
+    // for tests that DO care.
+    mockFetchAuthenticatedBlob.mockResolvedValue(null);
+  });
+
   it('sticky toolbar reads as the top of the article card (#30 overhaul)', async () => {
     // The internal toolbar must look like the visual top of the article card
     // below — same bg, rounded only on top, sticks at top:0 when scrolling.
@@ -192,6 +207,220 @@ describe('Editor', () => {
       expect(container.querySelector('[class*="nm-card"]')).toBeTruthy();
     });
     expect(container.querySelector('.header-numbering')).toBeFalsy();
+  });
+
+  describe('image NodeView — JWT-gated attachment rewrite', () => {
+    // Browsers can't send Authorization headers on <img> requests, so
+    // `/api/attachments/...` always 401's a direct load. The NodeView
+    // intercepts these srcs, fetches them with the bearer token, and
+    // renders via a blob URL — while leaving `node.attrs.src` (and
+    // therefore `getHTML()`) untouched so saves persist the canonical URL.
+
+    beforeEach(() => {
+      mockFetchAuthenticatedBlob.mockReset();
+      // ProseMirror may re-create the NodeView during editor init (e.g. when
+      // content is parsed-and-re-rendered), causing applySrc to fire twice for
+      // the same image. mockResolvedValueOnce only covers the first call; any
+      // subsequent call would return undefined and crash on `.then`. Set a
+      // safe default; tests that care about a specific URL use
+      // mockResolvedValueOnce to override.
+      mockFetchAuthenticatedBlob.mockResolvedValue(null);
+      // Track URL.createObjectURL/revokeObjectURL so the destroy test can
+      // assert the blob URL is released — jsdom's stub no-ops by default.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (URL as any).createObjectURL = vi.fn(() => `blob:test-${Math.random().toString(36).slice(2, 8)}`);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (URL as any).revokeObjectURL = vi.fn();
+    });
+
+    it('rewrites /api/attachments/... srcs to blob URLs via fetchAuthenticatedBlob', async () => {
+      // Use mockResolvedValue (sticky) — ProseMirror may create the NodeView
+      // more than once while initialising the editor, and `*Once` would only
+      // satisfy the first creation.
+      mockFetchAuthenticatedBlob.mockResolvedValue('blob:fake-attachment');
+
+      const { container } = render(
+        <Editor content='<p><img src="/api/attachments/page-1/screenshot.png" alt="A shot" /></p>' editable={true} />,
+      );
+
+      await waitFor(() => {
+        expect(mockFetchAuthenticatedBlob).toHaveBeenCalledWith('/api/attachments/page-1/screenshot.png');
+      });
+      await waitFor(() => {
+        expect(container.querySelector('img')?.getAttribute('src')).toBe('blob:fake-attachment');
+      });
+
+      const img = container.querySelector('img')!;
+      // Canonical URL kept on the DOM for debugging; the rendered src has
+      // been swapped to the blob URL.
+      expect(img).toHaveAttribute('data-original-src', '/api/attachments/page-1/screenshot.png');
+      // Mirrored stock-Image attrs
+      expect(img).toHaveAttribute('alt', 'A shot');
+    });
+
+    it('also rewrites /api/local-attachments/... srcs', async () => {
+      mockFetchAuthenticatedBlob.mockResolvedValue('blob:fake-local');
+
+      render(
+        <Editor content='<p><img src="/api/local-attachments/42/paste.png" /></p>' editable={true} />,
+      );
+
+      await waitFor(() => {
+        expect(mockFetchAuthenticatedBlob).toHaveBeenCalledWith('/api/local-attachments/42/paste.png');
+      });
+    });
+
+    it('does not auth-fetch external image srcs (renders src directly)', async () => {
+      const { container } = render(
+        <Editor content='<p><img src="https://example.com/external.png" alt="External" /></p>' editable={true} />,
+      );
+
+      await waitFor(() => {
+        expect(container.querySelector('img')).toBeTruthy();
+      });
+
+      // No fetch should fire for non-/api/attachments srcs.
+      expect(mockFetchAuthenticatedBlob).not.toHaveBeenCalled();
+      // Direct src is applied.
+      expect(container.querySelector('img')?.getAttribute('src')).toBe('https://example.com/external.png');
+    });
+
+    it('keeps the canonical /api/attachments src in editor.getHTML() (does not leak blob: URLs on save)', async () => {
+      // This is the core save-safety invariant of the whole NodeView: the
+      // blob URL is DOM-only; `node.attrs.src` (and therefore getHTML /
+      // getJSON) must remain the canonical /api/attachments URL.
+      mockFetchAuthenticatedBlob.mockResolvedValue('blob:fake');
+
+      // Grab the editor instance via onEditorReady so we can call
+      // getHTML/getJSON directly. Previously this test waited on `onChange`,
+      // which only fires on transactions — none were dispatched, so the
+      // assertion was inside a never-taken `if (capturedHtml)` and the test
+      // was a silent no-op.
+      let editor: EditorType | null = null;
+      render(
+        <Editor
+          content='<p><img src="/api/attachments/page-1/foo.png" /></p>'
+          editable={true}
+          onEditorReady={(e) => { editor = e; }}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(editor).not.toBeNull();
+      });
+      await waitFor(() => {
+        expect(document.querySelector('img')?.getAttribute('src')).toBe('blob:fake');
+      });
+
+      // DOM `<img>` is showing the blob URL, but the editor's serialized
+      // state must still hold the canonical URL.
+      const html = editor!.getHTML();
+      const json = editor!.getJSON();
+      expect(html).not.toContain('blob:');
+      expect(html).toContain('/api/attachments/page-1/foo.png');
+
+      // Walk the JSON tree and assert every image node attrs.src is the
+      // canonical URL — defends against future bugs where a blob URL slips
+      // into the node state itself.
+      const collectImageSrcs = (node: { type: string; attrs?: { src?: string }; content?: unknown[] }, acc: string[] = []): string[] => {
+        if (node.type === 'image' && node.attrs?.src) acc.push(node.attrs.src);
+        if (Array.isArray(node.content)) {
+          for (const child of node.content) collectImageSrcs(child as typeof node, acc);
+        }
+        return acc;
+      };
+      const imageSrcs = collectImageSrcs(json as { type: string; content?: unknown[] });
+      expect(imageSrcs).toEqual(['/api/attachments/page-1/foo.png']);
+    });
+
+    it('removes attributes that disappear from the node on update', async () => {
+      // Regression test for the attr-removal half of #682's follow-up: a
+      // previously-set attribute (e.g. `alt`) that's cleared on the node
+      // must also be removed from the DOM, not linger as a stale value.
+      mockFetchAuthenticatedBlob.mockResolvedValue('blob:rm-attrs');
+
+      let editor: EditorType | null = null;
+      render(
+        <Editor
+          content='<p><img src="/api/attachments/page-1/rm.png" alt="initial-alt" /></p>'
+          editable={true}
+          onEditorReady={(e) => { editor = e; }}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(editor).not.toBeNull();
+      });
+      await waitFor(() => {
+        expect(document.querySelector('img')?.getAttribute('alt')).toBe('initial-alt');
+      });
+
+      // Find the image node in the doc and clear its `alt` via a transaction
+      // — same mechanism a toolbar control or extension command would use.
+      const tr = editor!.state.tr;
+      editor!.state.doc.descendants((node, pos) => {
+        if (node.type.name === 'image') {
+          tr.setNodeMarkup(pos, undefined, { ...node.attrs, alt: null });
+          return false;
+        }
+        return true;
+      });
+      editor!.view.dispatch(tr);
+
+      // The DOM must reflect the cleared attribute, not just the new node
+      // state. Pre-fix, the stale `alt="initial-alt"` would still be on the
+      // DOM until the editor remounted.
+      await waitFor(() => {
+        expect(document.querySelector('img')?.hasAttribute('alt')).toBe(false);
+      });
+    });
+
+    it('revokes the blob URL when the editor unmounts', async () => {
+      mockFetchAuthenticatedBlob.mockResolvedValue('blob:to-revoke');
+
+      const { unmount } = render(
+        <Editor content='<p><img src="/api/attachments/page-1/bye.png" /></p>' editable={true} />,
+      );
+
+      await waitFor(() => {
+        expect(document.querySelector('img')?.getAttribute('src')).toBe('blob:to-revoke');
+      });
+
+      unmount();
+
+      // The NodeView's destroy() handler must revoke the blob URL.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((URL as any).revokeObjectURL).toHaveBeenCalledWith('blob:to-revoke');
+    });
+
+    it('revokes an in-flight fetch result if the NodeView is destroyed before it resolves', async () => {
+      // Hold the fetch promise open until after unmount.
+      let resolveFetch!: (url: string | null) => void;
+      mockFetchAuthenticatedBlob.mockImplementationOnce(
+        () => new Promise<string | null>((resolve) => { resolveFetch = resolve; }),
+      );
+
+      const { unmount } = render(
+        <Editor content='<p><img src="/api/attachments/page-1/race.png" /></p>' editable={true} />,
+      );
+
+      await waitFor(() => {
+        expect(mockFetchAuthenticatedBlob).toHaveBeenCalled();
+      });
+
+      // Tear down the NodeView while the fetch is still pending.
+      unmount();
+
+      // Now resolve the auth fetch — the NodeView is already destroyed.
+      // The post-destroy guard MUST revoke the orphan blob URL (the
+      // pre-fix behaviour assigned it to `blobUrl` and leaked it forever).
+      resolveFetch('blob:orphan-after-destroy');
+
+      await waitFor(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect((URL as any).revokeObjectURL).toHaveBeenCalledWith('blob:orphan-after-destroy');
+      });
+    });
   });
 
   describe('drag handle (#49)', () => {

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -28,6 +28,7 @@ import {
 import { toast } from 'sonner';
 import { cn } from '../../lib/cn';
 import { apiFetch } from '../../lib/api';
+import { fetchAuthenticatedBlob } from '../../hooks/use-authenticated-src';
 import { useIsLightTheme } from '../../hooks/use-is-light-theme';
 import { MermaidBlock } from './MermaidBlockExtension';
 import {
@@ -94,6 +95,121 @@ const ConfluenceImage = Image.extend({
           ? { 'data-confluence-url': attributes['data-confluence-url'] }
           : {},
       },
+    };
+  },
+
+  // Browser `<img>` tags cannot send Authorization headers, so the JWT-gated
+  // `/api/attachments/...` endpoint returns 401 for every direct image load —
+  // both for pasted uploads and for Confluence-synced attachments. The
+  // ArticleViewer (read mode) works around this by rewriting srcs to blob
+  // URLs fetched with `fetchAuthenticatedBlob`. Without this NodeView, images
+  // in edit mode never render. The blob URL is display-only — `node.attrs.src`
+  // remains the canonical `/api/attachments/...` URL so `editor.getHTML()`
+  // serialises the right thing on save.
+  addNodeView() {
+    return ({ node, HTMLAttributes }) => {
+      const dom = document.createElement('img');
+      // Match TipTap's default Image behaviour for selection and drag.
+      dom.setAttribute('contenteditable', 'false');
+      dom.setAttribute('draggable', 'true');
+
+      let blobUrl: string | null = null;
+      let currentSrc = node.attrs.src as string | null;
+      // Tracks the keys we've ever written to the DOM (other than `src`), so
+      // we can remove ones that disappear from the node's attrs on update.
+      // Without this, e.g. clearing an `alt` would leave the stale value in
+      // the DOM until the editor remounts.
+      const writtenAttrKeys = new Set<string>();
+      // Set on destroy so any in-flight auth fetch can revoke its blob URL
+      // instead of leaking it. The previous `currentSrc !== src` guard only
+      // covered src-change races, not the case where the NodeView itself was
+      // torn down while a fetch was still pending.
+      let destroyed = false;
+
+      function applySrc(src: string | null): void {
+        if (blobUrl) {
+          URL.revokeObjectURL(blobUrl);
+          blobUrl = null;
+        }
+        if (!src) {
+          dom.removeAttribute('src');
+          return;
+        }
+        if (src.startsWith('/api/attachments/') || src.startsWith('/api/local-attachments/')) {
+          // Defer src until the auth fetch resolves to avoid a flash of the
+          // 401 broken-image icon.
+          dom.removeAttribute('src');
+          dom.setAttribute('data-original-src', src);
+          fetchAuthenticatedBlob(src).then((url) => {
+            // Three exit paths in priority order. `destroyed` MUST win over
+            // the src-change check — after destroy, currentSrc may still
+            // equal src and would otherwise leak the blob URL.
+            if (destroyed) {
+              if (url) URL.revokeObjectURL(url);
+              return;
+            }
+            if (currentSrc !== src) {
+              if (url) URL.revokeObjectURL(url);
+              return;
+            }
+            if (url) {
+              blobUrl = url;
+              dom.setAttribute('src', url);
+            }
+          }).catch(() => {
+            // Swallow — leaving the img without a src renders nothing, which
+            // is the same outcome the unauthenticated direct load produced.
+          });
+        } else {
+          dom.setAttribute('src', src);
+        }
+      }
+
+      function syncAttrs(attrs: Record<string, unknown>): void {
+        // Apply present attrs and track the keys we touched.
+        const seen = new Set<string>();
+        for (const [key, value] of Object.entries(attrs)) {
+          if (key === 'src' || value == null) continue;
+          dom.setAttribute(key, String(value));
+          writtenAttrKeys.add(key);
+          seen.add(key);
+        }
+        // Remove any attr we previously wrote that's gone this time around.
+        for (const key of writtenAttrKeys) {
+          if (!seen.has(key)) {
+            dom.removeAttribute(key);
+            writtenAttrKeys.delete(key);
+          }
+        }
+      }
+
+      // Initial render mirrors the merged renderHTML attributes (HTMLAttributes
+      // already includes parent Image's `alt`/`title`/`width`/etc. plus our
+      // custom `data-confluence-*` keys).
+      syncAttrs(HTMLAttributes);
+
+      applySrc(currentSrc);
+
+      return {
+        dom,
+        update(newNode) {
+          if (newNode.type !== node.type) return false;
+          const newSrc = (newNode.attrs.src as string | null) ?? null;
+          if (newSrc !== currentSrc) {
+            currentSrc = newSrc;
+            applySrc(newSrc);
+          }
+          // On update, node.attrs is the canonical source (renderHTML
+          // transforms aren't re-applied here, but our addAttributes uses
+          // identity transforms so the shape matches what we wrote initially).
+          syncAttrs(newNode.attrs as Record<string, unknown>);
+          return true;
+        },
+        destroy() {
+          destroyed = true;
+          if (blobUrl) URL.revokeObjectURL(blobUrl);
+        },
+      };
     };
   },
 });

--- a/mcp-docs/package.json
+++ b/mcp-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq-mcp-docs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compendiq",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compendiq",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "workspaces": [
         "backend",
         "frontend",
@@ -29,7 +29,7 @@
       }
     },
     "backend": {
-      "version": "0.4.0",
+      "version": "0.5.1",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@fastify/compress": "^8.3.1",
@@ -104,7 +104,7 @@
       "license": "MIT"
     },
     "frontend": {
-      "version": "0.4.0",
+      "version": "0.5.1",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@dnd-kit/react": "^0.3.2",
@@ -21734,7 +21734,7 @@
     },
     "packages/contracts": {
       "name": "@compendiq/contracts",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "dependencies": {
         "zod": "^4.3.6"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "Compendiq - AI-powered knowledge base management with Confluence integration and Ollama LLM backend",
   "workspaces": [

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compendiq/contracts",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.5.1

Patch release. Two editor fixes shipped from `dev`.

### Fixes
- **#681** — `fix(editor): show drag handle on full block hover`. Dead-selector regression in the Notion-style drag handle (CSS keyed off `display`, library toggles `visibility`). Behaviour and CSS guards restored.
- **#682** — `fix(editor): render JWT-gated /api/attachments images via blob URLs`. Browser `<img>` tags can't carry auth headers, so attachment images 401'd in edit mode. New `addNodeView()` on `ConfluenceImage` rewrites via `fetchAuthenticatedBlob`; canonical URL preserved in `node.attrs.src` so saves remain correct. Symmetric blob-URL cleanup including the destroy-before-resolve race.

### Bumps
All five `package.json` files: 0.5.0 → 0.5.1 (root, backend, frontend, packages/contracts, mcp-docs). `CHANGELOG.md` stamped with `[0.5.1] - 2026-05-21`. `package-lock.json` regenerated to match.

### Known issue carried forward
- **#683** — Imported HTML with relative `<img src=\"../_images/...\">` references still doesn't resolve. Distinct root cause (no backend mapping, not an auth issue); intentionally out of scope for this patch.

### Test plan
- [x] All workspace tests pass on `release/v0.5.1` (73 frontend tests in the editor-touching suites)
- [x] Typecheck clean
- [x] Manual smoke against the running EE stack (`docker-compose.ee.yml`, frontend container rebuilt against this branch)
- [x] Playwright end-to-end on both fixes (drag handle visible mid-block, pasted images render with blob URLs, `getHTML()` keeps canonical srcs)

After merge: tag `v0.5.1` on `main` and rebuild the published frontend image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)