### PR TITLE
release: v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-21
+
+### Added
+
+- **Upload-on-paste for HTML pastes containing `<img>` tags (#686, closes #683).** When the user pastes rich HTML into the editor and the `<img>` srcs don't already point at our backend, each src is now rewritten to an internal `/api/attachments/...` URL automatically — data: URIs route through the existing `POST /api/pages/:id/images` upload endpoint; absolute `http(s)://` URLs go through a new `POST /api/pages/:id/images/import` route that fetches server-side. The new import route is SSRF-guarded (blocks private/loopback/link-local IPs *and* re-validates every redirect hop, closing a Location-header bypass), magic-byte-validated (the body must match the declared Content-Type — no HTML/JS masquerading as `image/png`), and streams the body with a mid-flight 10 MB cap that aborts even when the upstream lies about `Content-Length`. Relative paths (`../_images/...` from imported Sphinx docs) and other unfetchable srcs are tagged with `data-import-failed` and rendered through a new CSS placeholder ("⚠ Couldn't import image: {alt}") instead of the browser's native broken-image icon. Frontend imports run through a 5-concurrent semaphore so a 50-image paste doesn't trip the backend's global rate limit. 12 new backend tests + 6 new frontend tests cover the decision tree, SSRF redirect block, lying-Content-Length abort, magic-byte mismatch, RBAC for Confluence-spaced pages, and the mixed-paste "Imported X of Y images" toast. (#683, #686)
+
+### Fixed
+
+- **Backend `@fastify/compress` empty-body regression on `/api/health` (#685).** Deployed EE backend (Node 24.15-alpine, `@fastify/compress` 8.3.1) was returning an empty body with `content-encoding: zstd` and `content-length: 0` to browsers for the 1042-byte `/api/health` JSON, even though larger responses (e.g. `/api/pages/:id` at 1614 bytes) compressed correctly. Reproduced deterministically against the deployed container but not against the same plugin in isolation on Node 26 — likely an interaction with the container's Node 24 zstd encoder or the EE build pipeline that we don't yet fully understand. Workaround: register `compress` with `{ threshold: 4096 }` so payloads in the bug-prone size range pass through uncompressed. User-visible symptom (now fixed): Settings → Diagnostics no longer falls back to "Edition: Community (CE)" / "Backend commit: …" on EE deployments. Two new regression tests in `app.test.ts` pin both halves — sub-4 KB responses must be uncompressed, larger responses must still be compressed (so the threshold doesn't disable compression entirely). (#685)
+- **Test infrastructure: jsdom `Range.prototype.getClientRects` polyfill.** ProseMirror's `scrollToSelection` (which runs after every paste transaction) calls `getClientRects()`; jsdom doesn't implement it, the resulting `TypeError` lands as a Vitest "Unhandled Error", and CI's `vitest run` exits 1 even with all assertions passing. Stubbed in `test-setup.ts` with an empty `DOMRectList`-shaped value. Several other paste-related tests in the suite implicitly benefit. (Companion to #686.)
+
 ## [0.5.1] - 2026-05-21
 
 ### Fixed

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "//hoisting-note": "`p-limit` and `ipaddr.js` are ALSO declared in the root package.json `dependencies` block to force npm to hoist them to root node_modules. The runtime Docker stage only copies the root tree, so any version pinned here that ends up nested under backend/node_modules disappears at runtime. If you change the ranges below, update the root mirror in lockstep — the docker-build smoke step is the safety net but local repros are faster.",

--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -162,6 +162,69 @@ describe('buildApp — CORS multi-origin support', () => {
   });
 });
 
+describe('buildApp — compression threshold', () => {
+  // Regression guard for the production-only @fastify/compress bug observed in
+  // the EE backend container: a ~1KB JSON response (/api/health, 1042 bytes)
+  // was compressed to an empty body when the client sent
+  // `Accept-Encoding: gzip, br, zstd`, leaving the Diagnostics page unable
+  // to read backend metadata. The fix raises the floor to 4096 so payloads
+  // in the bug-prone size range pass through uncompressed.
+
+  it('does not compress responses below the 4096-byte threshold', async () => {
+    const { buildApp } = await import('./app.js');
+    const app = await buildApp();
+
+    // Synthetic route returning ~1KB JSON — the same size range as the live
+    // /api/health response that triggered the bug in production.
+    app.get('/__test__/small-payload', async (_req, reply) => {
+      const payload = { data: 'x'.repeat(1000), size: 'about-1KB' };
+      return reply.status(200).send(payload);
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/__test__/small-payload',
+      headers: { 'accept-encoding': 'gzip, br, zstd' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    // Below threshold → no content-encoding, body intact.
+    expect(response.headers['content-encoding']).toBeUndefined();
+    expect(response.rawPayload.length).toBeGreaterThan(900);
+    expect(() => JSON.parse(response.rawPayload.toString('utf8'))).not.toThrow();
+
+    await app.close();
+  });
+
+  it('does compress responses above the 4096-byte threshold', async () => {
+    const { buildApp } = await import('./app.js');
+    const app = await buildApp();
+
+    // Synthetic route returning ~5KB JSON — well above the threshold, so
+    // compression should kick in to confirm the plugin is wired up and the
+    // raised threshold isn't equivalent to disabling compression entirely.
+    app.get('/__test__/large-payload', async (_req, reply) => {
+      const payload = { data: 'x'.repeat(5000), size: 'about-5KB' };
+      return reply.status(200).send(payload);
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/__test__/large-payload',
+      headers: { 'accept-encoding': 'gzip, br, zstd' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    // Above threshold → some content-encoding must be set, and the body
+    // must be non-empty (the bug we are guarding against: empty body
+    // alongside an encoding header).
+    expect(response.headers['content-encoding']).toMatch(/^(gzip|br|zstd|deflate)$/);
+    expect(response.rawPayload.length).toBeGreaterThan(0);
+
+    await app.close();
+  });
+});
+
 describe('buildApp — error handler information leakage', () => {
   const originalNodeEnv = process.env.NODE_ENV;
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -130,7 +130,18 @@ export async function buildApp() {
 
   await app.register(sensible);
   await app.register(cookie);
-  await app.register(compress);
+  // Compression threshold raised from the @fastify/compress default of 1024
+  // bytes. The shipped EE backend (Node 24.15-alpine, @fastify/compress 8.3.1)
+  // produced empty zstd-encoded bodies for `/api/health` (1042 bytes JSON)
+  // while correctly compressing `/api/pages/:id` (1614 bytes) — deterministic
+  // and reproducible in production, not reproducible against the same plugin
+  // in isolation on Node 26. The smoking gun: response headers carry
+  // `content-encoding: zstd; content-length: 0` and the body is empty. Real
+  // bandwidth wins only start past a few KB anyway (the gzip/br/zstd header
+  // overhead eats most of the savings on sub-2KB payloads), so raising the
+  // floor is a low-cost protective measure even after a fresh image rebuild
+  // hypothetically restores the upstream behaviour.
+  await app.register(compress, { threshold: 4096 });
   await app.register(multipart, {
     limits: {
       fileSize: 20 * 1024 * 1024, // 20 MB

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -5,6 +5,7 @@ import { RedisCache } from '../../core/services/redis-cache.js';
 import { getClientForUser } from '../../domains/confluence/services/sync-service.js';
 import { htmlToConfluence, confluenceToHtml } from '../../core/services/content-converter.js';
 import { cleanPageAttachments, writeAttachmentCache } from '../../domains/confluence/services/attachment-handler.js';
+import { assertNonSsrfUrl, SsrfError } from '../../core/utils/ssrf-guard.js';
 import { logAuditEvent } from '../../core/services/audit-service.js';
 import {
   startBulkJob,
@@ -194,6 +195,171 @@ const ALLOWED_IMAGE_MIMES = new Set([
   'image/gif',
   'image/webp',
 ]);
+
+const ImportImageSchema = z.object({
+  url: z.string().url().max(2048),
+});
+
+/** Magic-byte signatures for each allowed import MIME. The leading bytes must
+ *  match the declared `Content-Type` from the upstream — otherwise a malicious
+ *  server could serve arbitrary bytes labelled as `image/png` and we'd store
+ *  them. The signatures here only need to cover the formats `ALLOWED_IMAGE_MIMES`
+ *  permits; SVG and other text-based image formats are intentionally absent
+ *  (sniffing them by leading bytes is unreliable). */
+const MAGIC_BYTE_SIGNATURES: Record<string, Array<readonly number[]>> = {
+  'image/png': [[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]],
+  'image/jpeg': [[0xff, 0xd8, 0xff]],
+  'image/jpg': [[0xff, 0xd8, 0xff]],
+  'image/gif': [
+    [0x47, 0x49, 0x46, 0x38, 0x37, 0x61], // GIF87a
+    [0x47, 0x49, 0x46, 0x38, 0x39, 0x61], // GIF89a
+  ],
+  'image/webp': [
+    // RIFF....WEBP — first 4 bytes are "RIFF", bytes 8-11 are "WEBP".
+    // We check the "RIFF" prefix here; the full "WEBP" check is done by
+    // `bufferMatchesMime` because it spans a non-prefix range.
+    [0x52, 0x49, 0x46, 0x46],
+  ],
+};
+
+function bufferMatchesMime(buf: Buffer, mime: string): boolean {
+  const sigs = MAGIC_BYTE_SIGNATURES[mime];
+  if (!sigs) return false;
+  for (const sig of sigs) {
+    if (buf.length < sig.length) continue;
+    let ok = true;
+    for (let i = 0; i < sig.length; i++) {
+      if (buf[i] !== sig[i]) { ok = false; break; }
+    }
+    if (!ok) continue;
+    // WEBP needs an extra check for the "WEBP" magic at bytes 8-11. (Bytes
+    // 4-7 are the little-endian file size — also untrusted, so we don't
+    // assert against it.)
+    if (mime === 'image/webp') {
+      if (buf.length < 12) continue;
+      if (buf[8] !== 0x57 || buf[9] !== 0x45 || buf[10] !== 0x42 || buf[11] !== 0x50) continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+/** Filename for an imported image — sanitised path basename, or a fallback. */
+function pickImportFilename(sourceUrl: string, contentType: string): string {
+  const extByType: Record<string, string> = {
+    'image/png': 'png',
+    'image/jpeg': 'jpg',
+    'image/jpg': 'jpg',
+    'image/gif': 'gif',
+    'image/webp': 'webp',
+  };
+  const fallbackExt = extByType[contentType] ?? 'png';
+  try {
+    const parsed = new URL(sourceUrl);
+    const last = parsed.pathname.split('/').filter(Boolean).pop() ?? '';
+    // Allow only ASCII word chars, dots, and hyphens — same constraint as
+    // `ImageUploadSchema`. Strip anything else.
+    const sanitised = last.replace(/[^\w.-]/g, '').replace(/^\.+/, '').slice(0, 200);
+    if (sanitised && /\.[a-z0-9]{2,5}$/i.test(sanitised)) {
+      return sanitised;
+    }
+  } catch {
+    // Unparseable URL — fall through to a generated name.
+  }
+  const hex = Math.floor(Math.random() * 0xffff).toString(16).padStart(4, '0');
+  return `imported-${Date.now()}-${hex}.${fallbackExt}`;
+}
+
+/** Maximum bytes accepted from any single upstream import. */
+const MAX_IMPORT_BYTES = 10 * 1024 * 1024;
+/** Hard cap on redirect hops. Every Location header is re-validated against
+ *  the SSRF guard before refetching. */
+const MAX_IMPORT_REDIRECTS = 5;
+/** Per-attempt fetch timeout. The full import budget is up to (timeout × hops). */
+const FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Server-side `fetch` with manual redirect chain validation. Each `Location`
+ * header is validated through `assertNonSsrfUrl` before the next request
+ * fires — so an upstream that returns `302 Location: http://192.168.1.1/`
+ * (or any other private/internal target) is blocked, not transparently
+ * followed.
+ *
+ * Returns the final non-redirect response, or throws if the chain exceeds
+ * `MAX_IMPORT_REDIRECTS` or any hop fails the SSRF check.
+ */
+async function safeFetchWithSsrfGuardedRedirects(initialUrl: string): Promise<Response> {
+  let currentUrl = initialUrl;
+  for (let hop = 0; hop <= MAX_IMPORT_REDIRECTS; hop++) {
+    // Validate the URL we are about to hit. The initial URL was already
+    // validated by the caller; we re-validate redirects (hop > 0).
+    if (hop > 0) {
+      await assertNonSsrfUrl(currentUrl);
+    }
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    let response: Response;
+    try {
+      response = await fetch(currentUrl, {
+        method: 'GET',
+        signal: controller.signal,
+        redirect: 'manual',
+        headers: { 'user-agent': 'Compendiq-ImageImporter/1.0' },
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+    // Manual-redirect mode surfaces 3xx responses with the Location header.
+    // Any 3xx-with-Location → re-validate and re-fetch. 3xx-without-Location
+    // is treated as a regular response (caller will handle non-2xx).
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (location) {
+        // Resolve relative redirects against the current URL.
+        currentUrl = new URL(location, currentUrl).toString();
+        continue;
+      }
+    }
+    return response;
+  }
+  throw new Error(`Too many redirects (exceeded ${MAX_IMPORT_REDIRECTS} hops)`);
+}
+
+/**
+ * Read a response body chunk-by-chunk, aborting if the accumulated size
+ * exceeds `MAX_IMPORT_BYTES`. Defends against upstreams that lie about
+ * Content-Length (or omit it) and stream arbitrary amounts of data.
+ *
+ * Returns `{ ok: true, buffer }` on success or `{ ok: false, reason }`
+ * when the size cap fires.
+ */
+async function readBodyWithSizeCap(
+  response: Response,
+): Promise<{ ok: true; buffer: Buffer } | { ok: false; reason: 'too-large' | 'read-failed' }> {
+  if (!response.body) {
+    // Older fetch implementations expose null `.body` for empty responses.
+    return { ok: true, buffer: Buffer.alloc(0) };
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_IMPORT_BYTES) {
+        // Best-effort cancel — frees the upstream socket.
+        try { await reader.cancel(); } catch { /* upstream already gone */ }
+        return { ok: false, reason: 'too-large' };
+      }
+      chunks.push(value);
+    }
+  } catch {
+    return { ok: false, reason: 'read-failed' };
+  }
+  return { ok: true, buffer: Buffer.concat(chunks) };
+}
 
 export async function pagesCrudRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -2266,6 +2432,220 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     } catch (err) {
       logger.error({ err, userId, pageId: id, filename }, 'Failed to save pasted image');
       throw fastify.httpErrors.internalServerError('Failed to save image');
+    }
+  });
+
+  // POST /api/pages/:id/images/import — server-side fetch an external image
+  // URL and store it as a page attachment, returning the internal URL.
+  //
+  // Companion to the upload-on-paste flow (#683): when a user pastes HTML
+  // containing `<img src="https://...">`, the frontend can't fetch the bytes
+  // itself (CORS, no auth). This route is server-side and SSRF-guarded.
+  //
+  // Scope:
+  //  - Accepts `http(s)://` URLs only (enforced by `assertNonSsrfUrl`).
+  //  - Blocks private/loopback/link-local IPs and DNS rebinding.
+  //  - Re-validates every redirect hop (no SSRF-via-Location bypass).
+  //  - Streams the body with a mid-flight size cap (defends against lying
+  //    Content-Length) at 10 MB.
+  //  - Validates `Content-Type: image/*` AND matches it against the body's
+  //    magic bytes (no serving HTML/JS masquerading as image/png).
+  //  - Stores via the same `writeAttachmentCache` path as the inline upload.
+  fastify.post('/pages/:id/images/import', async (request, reply) => {
+    const { id } = IdParamSchema.parse(request.params);
+    const userId = request.userId;
+
+    const parseResult = ImportImageSchema.safeParse(request.body);
+    if (!parseResult.success) {
+      return reply.status(400).send({
+        statusCode: 400,
+        error: 'Bad Request',
+        message: parseResult.error.issues[0]?.message ?? 'Invalid request body',
+      });
+    }
+    const { url: sourceUrl } = parseResult.data;
+
+    // SSRF guard. `assertNonSsrfUrl` enforces protocol = http(s),
+    // blocks private/loopback/link-local IPs, blocks RFC 1918 / IPv6
+    // private ranges, and resolves DNS to mitigate rebinding. The
+    // redirect-following helper re-validates every subsequent hop.
+    try {
+      await assertNonSsrfUrl(sourceUrl);
+    } catch (err) {
+      if (err instanceof SsrfError) {
+        logger.warn({ userId, pageId: id, sourceUrl, reason: err.message }, 'Image import blocked by SSRF guard');
+        return reply.status(400).send({
+          statusCode: 400,
+          error: 'Bad Request',
+          message: 'Source URL is not reachable or not allowed',
+        });
+      }
+      throw err;
+    }
+
+    // Verify the page exists and the user has access. Mirrors the inline
+    // upload route's logic exactly so the two stay aligned.
+    const isNumericId = /^\d+$/.test(id);
+    const pageResult = await query<{
+      id: number; source: string; confluence_id: string | null;
+      created_by_user_id: string | null; space_key: string | null;
+    }>(
+      `SELECT p.id, p.source, p.confluence_id, p.created_by_user_id, p.space_key
+       FROM pages p
+       WHERE ${isNumericId ? 'p.id = $1' : 'p.confluence_id = $1'}
+         AND p.deleted_at IS NULL`,
+      [isNumericId ? Number(id) : id],
+    );
+    if (pageResult.rows.length === 0) {
+      return reply.status(404).send({
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'Page not found',
+      });
+    }
+    const page = pageResult.rows[0]!;
+    if (page.source === 'standalone') {
+      if (page.created_by_user_id !== userId) {
+        return reply.status(403).send({
+          statusCode: 403,
+          error: 'Forbidden',
+          message: 'Not authorized to import images to this page',
+        });
+      }
+    } else if (page.space_key) {
+      const accessibleSpaces = await getUserAccessibleSpaces(userId);
+      if (!accessibleSpaces.includes(page.space_key)) {
+        return reply.status(403).send({
+          statusCode: 403,
+          error: 'Forbidden',
+          message: 'Not authorized to import images to this page',
+        });
+      }
+    } else {
+      return reply.status(403).send({
+        statusCode: 403,
+        error: 'Forbidden',
+        message: 'Access denied',
+      });
+    }
+
+    let response: Response;
+    try {
+      response = await safeFetchWithSsrfGuardedRedirects(sourceUrl);
+    } catch (err) {
+      if (err instanceof SsrfError) {
+        logger.warn({ userId, pageId: id, sourceUrl, reason: err.message }, 'Image import redirect blocked by SSRF guard');
+        return reply.status(400).send({
+          statusCode: 400,
+          error: 'Bad Request',
+          message: 'Source URL redirects to a disallowed destination',
+        });
+      }
+      logger.warn({ err, userId, pageId: id, sourceUrl }, 'Image import fetch failed');
+      return reply.status(502).send({
+        statusCode: 502,
+        error: 'Bad Gateway',
+        message: 'Failed to fetch source URL',
+      });
+    }
+
+    if (!response.ok) {
+      return reply.status(502).send({
+        statusCode: 502,
+        error: 'Bad Gateway',
+        message: `Source responded with HTTP ${response.status}`,
+      });
+    }
+
+    // Content-Type must be in the allowlist. We do NOT trust this completely
+    // — the magic-byte check below is the real validator — but it's a cheap
+    // first gate that avoids streaming non-image responses.
+    const contentType = (response.headers.get('content-type') ?? '').split(';')[0]!.trim().toLowerCase();
+    if (!contentType.startsWith('image/')) {
+      return reply.status(415).send({
+        statusCode: 415,
+        error: 'Unsupported Media Type',
+        message: `Source must be an image (got Content-Type: ${contentType || 'unknown'})`,
+      });
+    }
+    if (!ALLOWED_IMAGE_MIMES.has(contentType)) {
+      return reply.status(415).send({
+        statusCode: 415,
+        error: 'Unsupported Media Type',
+        message: `Image type not supported: ${contentType}. Allowed: png, jpg, gif, webp`,
+      });
+    }
+
+    // Defends against upstreams that lie about Content-Length: read the body
+    // chunk-by-chunk and abort once we cross the cap, rather than buffering
+    // everything before checking.
+    const declaredLength = Number(response.headers.get('content-length') ?? 0);
+    if (declaredLength > MAX_IMPORT_BYTES) {
+      return reply.status(413).send({
+        statusCode: 413,
+        error: 'Payload Too Large',
+        message: `Source image exceeds maximum size of ${MAX_IMPORT_BYTES / (1024 * 1024)} MB`,
+      });
+    }
+    const readResult = await readBodyWithSizeCap(response);
+    if (!readResult.ok) {
+      if (readResult.reason === 'too-large') {
+        return reply.status(413).send({
+          statusCode: 413,
+          error: 'Payload Too Large',
+          message: `Source image exceeds maximum size of ${MAX_IMPORT_BYTES / (1024 * 1024)} MB`,
+        });
+      }
+      logger.warn({ userId, pageId: id, sourceUrl }, 'Image import body read failed');
+      return reply.status(502).send({
+        statusCode: 502,
+        error: 'Bad Gateway',
+        message: 'Failed to read source image body',
+      });
+    }
+    const imageBuffer = readResult.buffer;
+    if (imageBuffer.length === 0) {
+      return reply.status(502).send({
+        statusCode: 502,
+        error: 'Bad Gateway',
+        message: 'Source returned an empty body',
+      });
+    }
+
+    // Magic-byte check: the bytes must match what the upstream said the
+    // Content-Type is. Defends against upstreams returning arbitrary bytes
+    // labelled as image/png (the most common "store-and-serve" abuse path).
+    if (!bufferMatchesMime(imageBuffer, contentType)) {
+      logger.warn(
+        { userId, pageId: id, sourceUrl, declaredContentType: contentType },
+        'Image import rejected: body does not match declared Content-Type',
+      );
+      return reply.status(415).send({
+        statusCode: 415,
+        error: 'Unsupported Media Type',
+        message: `Source body does not match declared Content-Type (${contentType})`,
+      });
+    }
+
+    // Derive a filename from the URL's path, falling back to a generated
+    // name if the URL doesn't yield a usable one. Sanitise to the same
+    // character class the inline-upload Zod schema enforces.
+    const filename = pickImportFilename(sourceUrl, contentType);
+
+    // Determine the attachment directory key — same logic as the inline
+    // upload route.
+    const attachmentPageId = page.source === 'standalone'
+      ? String(page.id)
+      : (page.confluence_id ?? String(page.id));
+
+    try {
+      await writeAttachmentCache(userId, attachmentPageId, filename, imageBuffer);
+      const internalUrl = `/api/attachments/${encodeURIComponent(attachmentPageId)}/${encodeURIComponent(filename)}`;
+      logger.info({ userId, pageId: id, attachmentPageId, filename, size: imageBuffer.length, sourceUrl }, 'Image imported from URL');
+      return { url: internalUrl };
+    } catch (err) {
+      logger.error({ err, userId, pageId: id, filename }, 'Failed to save imported image');
+      throw fastify.httpErrors.internalServerError('Failed to save imported image');
     }
   });
 }

--- a/backend/src/routes/knowledge/pages-image-import.test.ts
+++ b/backend/src/routes/knowledge/pages-image-import.test.ts
@@ -1,0 +1,501 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+import { pagesCrudRoutes } from './pages-crud.js';
+
+// Mocks mirror the setup in pages-image-upload.test.ts so the two routes
+// share their test plumbing.
+const mockWriteAttachmentCache = vi.fn();
+vi.mock('../../domains/confluence/services/attachment-handler.js', () => ({
+  cleanPageAttachments: vi.fn(),
+  writeAttachmentCache: (...args: unknown[]) => mockWriteAttachmentCache(...args),
+}));
+
+vi.mock('../../core/services/rbac-service.js', () => ({
+  getUserAccessibleSpaces: vi.fn().mockResolvedValue(['DEV', 'OPS']),
+  invalidateRbacCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockQuery = vi.fn();
+vi.mock('../../core/db/postgres.js', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+  getPool: vi.fn().mockReturnValue({
+    connect: vi.fn().mockResolvedValue({ query: vi.fn(), release: vi.fn() }),
+  }),
+}));
+
+vi.mock('../../domains/confluence/services/sync-service.js', () => ({
+  getClientForUser: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('../../core/services/content-converter.js', () => ({
+  htmlToConfluence: vi.fn(), confluenceToHtml: vi.fn(),
+}));
+vi.mock('../../core/services/audit-service.js', () => ({ logAuditEvent: vi.fn() }));
+vi.mock('../../domains/llm/services/embedding-service.js', () => ({
+  processDirtyPages: vi.fn(), isProcessingUser: vi.fn().mockReturnValue(false),
+}));
+vi.mock('../../core/utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../../core/services/redis-cache.js', () => {
+  class MockRedisCache {
+    get = vi.fn().mockResolvedValue(null);
+    set = vi.fn().mockResolvedValue(undefined);
+    invalidate = vi.fn().mockResolvedValue(undefined);
+  }
+  return { RedisCache: MockRedisCache, getRedisClient: vi.fn().mockReturnValue(null) };
+});
+
+// SSRF guard: allow `https://cdn.example.com`-style URLs and reject the
+// rest, so we can exercise both code paths deterministically.
+const mockAssertNonSsrfUrl = vi.fn();
+vi.mock('../../core/utils/ssrf-guard.js', async () => {
+  const actual = await vi.importActual<typeof import('../../core/utils/ssrf-guard.js')>(
+    '../../core/utils/ssrf-guard.js',
+  );
+  return {
+    ...actual,
+    assertNonSsrfUrl: (url: string) => mockAssertNonSsrfUrl(url),
+  };
+});
+
+// Tiny valid PNG (8-byte signature plus a minimal IHDR) — used as the
+// upstream response body. Just needs `content-type: image/png` and a
+// non-empty body; the route doesn't currently magic-byte-check imports
+// (the SSRF + content-type gates carry the trust, plus the storage layer
+// is the same as for paste uploads where we already do PNG sniffing).
+const TINY_PNG = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41,
+  0x54, 0x78, 0x9c, 0x63, 0xfa, 0xcf, 0x00, 0x00,
+  0x00, 0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc, 0x33,
+  0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44,
+  0xae, 0x42, 0x60, 0x82,
+]);
+
+function mockUpstream(
+  options: {
+    ok?: boolean;
+    status?: number;
+    contentType?: string;
+    contentLength?: number;
+    body?: Buffer;
+  } = {},
+): Response {
+  const body = options.body ?? TINY_PNG;
+  const headers = new Headers();
+  headers.set('content-type', options.contentType ?? 'image/png');
+  if (options.contentLength !== undefined) {
+    headers.set('content-length', String(options.contentLength));
+  } else {
+    headers.set('content-length', String(body.length));
+  }
+  return new Response(body, {
+    status: options.status ?? 200,
+    headers,
+  });
+}
+
+describe('POST /api/pages/:id/images/import', () => {
+  let app: ReturnType<typeof Fastify>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let originalFetch: any;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+    app.decorate('authenticate', async (request: { userId: string }) => {
+      request.userId = 'test-user';
+    });
+    app.decorateRequest('userId', '');
+    app.decorate('redis', null);
+    await app.register(pagesCrudRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockWriteAttachmentCache.mockReset();
+    mockWriteAttachmentCache.mockResolvedValue(undefined);
+    mockAssertNonSsrfUrl.mockReset();
+    mockAssertNonSsrfUrl.mockResolvedValue(undefined); // allow by default
+    if (!originalFetch) originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn();
+    mockQuery.mockResolvedValue({ rows: [] });
+  });
+
+  it('imports a valid PNG and returns the internal /api/attachments URL', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 42, source: 'standalone', confluence_id: null, created_by_user_id: 'test-user', space_key: null }],
+    });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockUpstream());
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'https://cdn.example.com/hero.png' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.payload);
+    expect(body.url).toMatch(/^\/api\/attachments\/42\/hero\.png$/);
+    expect(mockAssertNonSsrfUrl).toHaveBeenCalledWith('https://cdn.example.com/hero.png');
+    expect(mockWriteAttachmentCache).toHaveBeenCalledWith('test-user', '42', 'hero.png', expect.any(Buffer));
+  });
+
+  it('rejects URLs blocked by SSRF guard with 400 (does not leak the reason)', async () => {
+    mockAssertNonSsrfUrl.mockRejectedValueOnce(
+      Object.assign(new Error('SSRF blocked: cannot connect to internal/private network'), { name: 'SsrfError' }),
+    );
+    // Real SsrfError instances are produced by the guard; the route catches
+    // `instanceof SsrfError`. We import the real class so the instanceof
+    // check fires in the route.
+    const { SsrfError } = await vi.importActual<typeof import('../../core/utils/ssrf-guard.js')>(
+      '../../core/utils/ssrf-guard.js',
+    );
+    mockAssertNonSsrfUrl.mockReset();
+    mockAssertNonSsrfUrl.mockRejectedValueOnce(new SsrfError('blocked'));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'http://127.0.0.1/admin' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload).message).toMatch(/not reachable or not allowed/i);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(mockWriteAttachmentCache).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-image content-types with 415', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 42, source: 'standalone', confluence_id: null, created_by_user_id: 'test-user', space_key: null }],
+    });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockUpstream({ contentType: 'text/html', body: Buffer.from('<html>nope</html>') }),
+    );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'https://example.com/index.html' },
+    });
+
+    expect(response.statusCode).toBe(415);
+    expect(JSON.parse(response.payload).message).toMatch(/must be an image/i);
+    expect(mockWriteAttachmentCache).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported image MIME types (e.g. SVG, BMP) with 415', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 42, source: 'standalone', confluence_id: null, created_by_user_id: 'test-user', space_key: null }],
+    });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockUpstream({ contentType: 'image/svg+xml', body: Buffer.from('<svg/>') }),
+    );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'https://example.com/diagram.svg' },
+    });
+
+    expect(response.statusCode).toBe(415);
+    expect(JSON.parse(response.payload).message).toMatch(/not supported.*svg/i);
+  });
+
+  it('rejects oversized responses up front via the declared Content-Length', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 42, source: 'standalone', confluence_id: null, created_by_user_id: 'test-user', space_key: null }],
+    });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockUpstream({ contentLength: 50 * 1024 * 1024 }), // 50 MB declared
+    );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'https://cdn.example.com/huge.png' },
+    });
+
+    expect(response.statusCode).toBe(413);
+    expect(JSON.parse(response.payload).message).toMatch(/exceeds maximum size/i);
+  });
+
+  it('returns 502 when the upstream responds non-2xx', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 42, source: 'standalone', confluence_id: null, created_by_user_id: 'test-user', space_key: null }],
+    });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockUpstream({ status: 404, body: Buffer.alloc(0) }),
+    );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'https://cdn.example.com/missing.png' },
+    });
+
+    expect(response.statusCode).toBe(502);
+    expect(JSON.parse(response.payload).message).toMatch(/HTTP 404/);
+  });
+
+  it('returns 502 when the upstream returns an empty body', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 42, source: 'standalone', confluence_id: null, created_by_user_id: 'test-user', space_key: null }],
+    });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockUpstream({ body: Buffer.alloc(0), contentLength: 0 }),
+    );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'https://cdn.example.com/empty.png' },
+    });
+
+    expect(response.statusCode).toBe(502);
+    expect(JSON.parse(response.payload).message).toMatch(/empty body/i);
+  });
+
+  it('returns 502 when fetch throws (timeout, DNS, connection refused, …)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 42, source: 'standalone', confluence_id: null, created_by_user_id: 'test-user', space_key: null }],
+    });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new TypeError('fetch failed'));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'https://cdn.example.com/down.png' },
+    });
+
+    expect(response.statusCode).toBe(502);
+    expect(JSON.parse(response.payload).message).toMatch(/failed to fetch/i);
+  });
+
+  it('returns 404 when the page does not exist', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/999/images/import',
+      payload: { url: 'https://cdn.example.com/x.png' },
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('returns 403 when the user does not own a standalone page', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 42, source: 'standalone', confluence_id: null, created_by_user_id: 'other-user', space_key: null }],
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'https://cdn.example.com/x.png' },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(mockWriteAttachmentCache).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed URLs with 400', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'not-a-real-url' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(mockAssertNonSsrfUrl).not.toHaveBeenCalled(); // Zod rejects before we call the guard
+  });
+
+  it('generates a filename when the URL has no usable basename', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 42, source: 'standalone', confluence_id: null, created_by_user_id: 'test-user', space_key: null }],
+    });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockUpstream());
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'https://cdn.example.com/' }, // empty path
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.payload);
+    expect(body.url).toMatch(/^\/api\/attachments\/42\/imported-\d+-[0-9a-f]+\.png$/);
+  });
+
+  it('re-validates redirect Location headers against SSRF guard (chain bypass fix)', async () => {
+    // Regression test for the SSRF-via-redirect bypass found in code review:
+    // before the fix, fetch(url, {redirect: 'follow'}) would silently follow
+    // a 302 → http://192.168.1.1 even though the SSRF guard would have
+    // blocked that URL if submitted directly. The route now uses manual
+    // redirect mode and re-validates each hop.
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 42, source: 'standalone', confluence_id: null, created_by_user_id: 'test-user', space_key: null }],
+    });
+    const { SsrfError } = await vi.importActual<typeof import('../../core/utils/ssrf-guard.js')>(
+      '../../core/utils/ssrf-guard.js',
+    );
+
+    // First call (the initial URL) passes the guard…
+    mockAssertNonSsrfUrl.mockResolvedValueOnce(undefined);
+    // …upstream returns 302 → private IP.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(null, { status: 302, headers: { location: 'http://192.168.1.1/admin' } }),
+    );
+    // …the second guard call (for the Location target) rejects.
+    mockAssertNonSsrfUrl.mockRejectedValueOnce(new SsrfError('SSRF blocked: cannot connect to internal/private network'));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'https://cdn.example.com/redir.png' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload).message).toMatch(/redirects to a disallowed/i);
+    // Critical: fetch was called for the FIRST URL but NOT for the private IP.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith('https://cdn.example.com/redir.png', expect.anything());
+    expect(mockWriteAttachmentCache).not.toHaveBeenCalled();
+  });
+
+  it('follows safe redirect chains (re-validates and re-fetches the final URL)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 42, source: 'standalone', confluence_id: null, created_by_user_id: 'test-user', space_key: null }],
+    });
+
+    // Both hops pass SSRF — the chain is public-to-public.
+    mockAssertNonSsrfUrl.mockResolvedValueOnce(undefined);
+    mockAssertNonSsrfUrl.mockResolvedValueOnce(undefined);
+
+    (globalThis.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(new Response(null, { status: 302, headers: { location: 'https://final.example.com/hero.png' } }))
+      .mockResolvedValueOnce(mockUpstream());
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'https://short.example.com/r' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(mockAssertNonSsrfUrl).toHaveBeenCalledTimes(2);
+    expect(mockAssertNonSsrfUrl.mock.calls[1]![0]).toBe('https://final.example.com/hero.png');
+  });
+
+  it('aborts when the body exceeds the size cap mid-stream (lying Content-Length)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 42, source: 'standalone', confluence_id: null, created_by_user_id: 'test-user', space_key: null }],
+    });
+
+    // Build a ReadableStream that emits chunks summing past 10 MB, while
+    // claiming Content-Length: 100 in the header. Defends against
+    // upstreams that lie about size to bypass the up-front content-length
+    // check.
+    const CHUNK_BYTES = 1024 * 1024; // 1 MB chunks
+    const CHUNK_COUNT = 15;          // → ~15 MB total
+    const stream = new ReadableStream({
+      async start(controller) {
+        for (let i = 0; i < CHUNK_COUNT; i++) {
+          controller.enqueue(new Uint8Array(CHUNK_BYTES));
+          // Yield so the consumer can interleave reads with the cap check.
+          await new Promise((r) => setTimeout(r, 0));
+        }
+        controller.close();
+      },
+    });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(stream, {
+        status: 200,
+        headers: { 'content-type': 'image/png', 'content-length': '100' },
+      }),
+    );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'https://cdn.example.com/lying.png' },
+    });
+
+    expect(response.statusCode).toBe(413);
+    expect(JSON.parse(response.payload).message).toMatch(/exceeds maximum size/i);
+    expect(mockWriteAttachmentCache).not.toHaveBeenCalled();
+  });
+
+  it('rejects bodies whose magic bytes do not match the declared Content-Type', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 42, source: 'standalone', confluence_id: null, created_by_user_id: 'test-user', space_key: null }],
+    });
+
+    // Upstream returns `Content-Type: image/png` but the body is plain HTML
+    // bytes (no PNG signature). The route must reject this — otherwise an
+    // attacker can stash anything in our attachment store under a PNG MIME.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(Buffer.from('<!doctype html><script>alert(1)</script>'), {
+        status: 200,
+        headers: { 'content-type': 'image/png', 'content-length': '40' },
+      }),
+    );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/42/images/import',
+      payload: { url: 'https://attacker.example.com/fake.png' },
+    });
+
+    expect(response.statusCode).toBe(415);
+    expect(JSON.parse(response.payload).message).toMatch(/does not match declared/i);
+    expect(mockWriteAttachmentCache).not.toHaveBeenCalled();
+  });
+
+  it('allows Confluence-spaced pages when the user has access to the space (RBAC)', async () => {
+    // Coverage for the non-standalone branch — `getUserAccessibleSpaces`
+    // returns `['DEV', 'OPS']` per the mock at the top of the file.
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 100, source: 'confluence', confluence_id: 'CONFL-100', created_by_user_id: null, space_key: 'DEV' }],
+    });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockUpstream());
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/CONFL-100/images/import',
+      payload: { url: 'https://cdn.example.com/space-shot.png' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(mockWriteAttachmentCache).toHaveBeenCalledWith(
+      'test-user', 'CONFL-100', 'space-shot.png', expect.any(Buffer),
+    );
+  });
+
+  it('denies Confluence-spaced pages when the user does not have access', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 200, source: 'confluence', confluence_id: 'CONFL-200', created_by_user_id: null, space_key: 'SECRET' }],
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/CONFL-200/images/import',
+      payload: { url: 'https://cdn.example.com/x.png' },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2295,6 +2295,42 @@ pre:hover .code-copy-btn {
   cursor: help;
 }
 
+/* Unimportable image placeholder (#683).
+   Set on `<img>` by the HTML-paste handler when the src can't be
+   auto-imported — relative paths (`../_images/...`), fetch failures,
+   or unsupported types. Replaces the browser's native broken-image
+   icon with an explicit "couldn't import" affordance + the original
+   src as the hover title so the user can recover manually if needed. */
+.prose img[data-import-failed],
+.tiptap img[data-import-failed] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 88px;
+  min-width: 140px;
+  border: 1px dashed var(--color-warning);
+  background: oklch(from var(--color-warning) l c h / 0.08);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
+  color: var(--color-muted-foreground);
+  font-size: 0.8125rem;
+  /* The `content` property + `attr(alt)` makes the alt text (or the original
+     src as fallback) render in place of the broken image — same trick the
+     existing `image-load-error` placeholder uses. */
+  text-align: center;
+}
+.prose img[data-import-failed]::before,
+.tiptap img[data-import-failed]::before {
+  content: "⚠ Couldn't import image: " attr(alt);
+  white-space: normal;
+}
+.prose img[data-import-failed][alt=""]::before,
+.tiptap img[data-import-failed][alt=""]::before,
+.prose img[data-import-failed]:not([alt])::before,
+.tiptap img[data-import-failed]:not([alt])::before {
+  content: "⚠ Couldn't import image";
+}
+
 .tiptap .panel-info,
 .tiptap .panel-warning,
 .tiptap .panel-note,

--- a/frontend/src/shared/components/article/Editor.test.tsx
+++ b/frontend/src/shared/components/article/Editor.test.tsx
@@ -15,7 +15,16 @@ vi.mock('../../hooks/use-authenticated-src', () => ({
 }));
 
 vi.mock('sonner', () => ({
-  toast: { error: vi.fn(), success: vi.fn() },
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    // `loading` returns a toast id that `dismiss` / `success` / etc. can
+    // target. The HTML paste handler chains `toast.loading(...) → toast.x(...
+    // , { id })`, so the id needs to be a stable value across the mock.
+    loading: vi.fn(() => 'toast-id-1'),
+    dismiss: vi.fn(),
+  },
 }));
 
 import { Editor, EditorToolbar } from './Editor';
@@ -419,6 +428,213 @@ describe('Editor', () => {
       await waitFor(() => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expect((URL as any).revokeObjectURL).toHaveBeenCalledWith('blob:orphan-after-destroy');
+      });
+    });
+  });
+
+  describe('HTML paste — import non-internal <img> srcs (#683)', () => {
+    // When the user pastes HTML containing `<img>` tags whose srcs are not
+    // already pointing at our backend, the editor rewrites each src to an
+    // internal `/api/attachments/...` URL by routing through the inline
+    // upload endpoint (data: URIs) or the new `/import` endpoint (http(s)).
+    // Unfetchable srcs (relative paths, file:, …) get a `data-import-failed`
+    // attribute the CSS placeholder targets.
+
+    // We need apiFetch as a *mock function*, not just a vi.fn() the import
+    // refers to. The top-level mock at the file head wires `apiFetch: vi.fn()`
+    // — pull the same reference here so each test can mock per-call.
+    let mockApiFetch: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      const apiModule = await import('../../lib/api');
+      mockApiFetch = apiModule.apiFetch as ReturnType<typeof vi.fn>;
+      mockApiFetch.mockReset();
+      // Sticky default so the NodeView's auth fetch (which fires for any
+      // /api/attachments src inserted into the editor) doesn't crash on
+      // `.then(undefined)`.
+      mockFetchAuthenticatedBlob.mockResolvedValue('blob:fake');
+    });
+
+    // jsdom does not implement `DataTransfer` / `ClipboardEvent` with full
+    // clipboardData support, so we hand-build the minimal surface our paste
+    // handler reads: `clipboardData.items` (empty array — no inline image)
+    // and `clipboardData.getData('text/html')`.
+    function dispatchHtmlPaste(html: string): boolean {
+      const pm = document.querySelector('.ProseMirror') as HTMLElement | null;
+      if (!pm) throw new Error('ProseMirror element not mounted');
+      const evt = new Event('paste', { bubbles: true, cancelable: true }) as Event & {
+        clipboardData: { items: unknown[]; getData: (type: string) => string };
+      };
+      Object.defineProperty(evt, 'clipboardData', {
+        value: {
+          items: [],
+          getData: (type: string) => (type === 'text/html' ? html : ''),
+        },
+        writable: false,
+      });
+      pm.focus();
+      return pm.dispatchEvent(evt);
+    }
+
+    it('rewrites a single http(s) <img> src via /pages/:id/images/import', async () => {
+      mockApiFetch.mockResolvedValueOnce({ url: '/api/attachments/42/imported.png' });
+
+      render(<Editor content="<p>seed</p>" editable={true} pageId="42" />);
+      await waitFor(() => {
+        expect(document.querySelector('.ProseMirror')).toBeTruthy();
+      });
+
+      dispatchHtmlPaste('<p><img src="https://cdn.example.com/hero.png" alt="hero"></p>');
+
+      await waitFor(() => {
+        expect(mockApiFetch).toHaveBeenCalledWith(
+          '/pages/42/images/import',
+          expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ url: 'https://cdn.example.com/hero.png' }),
+          }),
+        );
+      });
+      await waitFor(() => {
+        const img = document.querySelector('.ProseMirror img');
+        expect(img?.getAttribute('data-original-src')).toBe('/api/attachments/42/imported.png');
+      });
+    });
+
+    it('rewrites a data: URI <img> via /pages/:id/images (existing upload endpoint)', async () => {
+      mockApiFetch.mockResolvedValueOnce({ url: '/api/attachments/42/imported-data.png' });
+
+      render(<Editor content="<p>seed</p>" editable={true} pageId="42" />);
+      await waitFor(() => {
+        expect(document.querySelector('.ProseMirror')).toBeTruthy();
+      });
+
+      dispatchHtmlPaste(
+        '<p><img src="data:image/png;base64,iVBORw0K" alt="data-img"></p>',
+      );
+
+      await waitFor(() => {
+        expect(mockApiFetch).toHaveBeenCalledWith(
+          '/pages/42/images',
+          expect.objectContaining({
+            method: 'POST',
+            // Body is a JSON string with dataUri + a generated filename.
+            body: expect.stringContaining('"dataUri":"data:image/png;base64,iVBORw0K"'),
+          }),
+        );
+      });
+      await waitFor(() => {
+        const img = document.querySelector('.ProseMirror img');
+        expect(img?.getAttribute('data-original-src')).toBe('/api/attachments/42/imported-data.png');
+      });
+    });
+
+    it('marks unfetchable srcs (relative paths, file:, …) with data-import-failed', async () => {
+      render(<Editor content="<p>seed</p>" editable={true} pageId="42" />);
+      await waitFor(() => {
+        expect(document.querySelector('.ProseMirror')).toBeTruthy();
+      });
+
+      dispatchHtmlPaste(
+        '<p><img src="../_images/qs-projects.png" alt="Projects"></p>',
+      );
+
+      await waitFor(() => {
+        const img = document.querySelector('.ProseMirror img');
+        expect(img?.getAttribute('data-import-failed')).toBe('true');
+      });
+      // No upload calls — relative paths are not auto-importable.
+      expect(mockApiFetch).not.toHaveBeenCalled();
+    });
+
+    it('marks failed http(s) imports with data-import-failed', async () => {
+      // /import returns null (apiFetch throws on non-2xx; our helper catches
+      // and returns null, which the rewriter treats as failure).
+      mockApiFetch.mockRejectedValueOnce(new Error('502 Bad Gateway'));
+
+      render(<Editor content="<p>seed</p>" editable={true} pageId="42" />);
+      await waitFor(() => {
+        expect(document.querySelector('.ProseMirror')).toBeTruthy();
+      });
+
+      dispatchHtmlPaste(
+        '<p><img src="https://nope.example.com/missing.png"></p>',
+      );
+
+      await waitFor(() => {
+        const img = document.querySelector('.ProseMirror img');
+        expect(img?.getAttribute('data-import-failed')).toBe('true');
+      });
+    });
+
+    it('leaves already-internal /api/attachments srcs untouched and does not call /import', async () => {
+      render(<Editor content="<p>seed</p>" editable={true} pageId="42" />);
+      await waitFor(() => {
+        expect(document.querySelector('.ProseMirror')).toBeTruthy();
+      });
+
+      dispatchHtmlPaste(
+        '<p><img src="/api/attachments/42/existing.png"></p>',
+      );
+
+      // Give the paste handler a tick to settle.
+      await new Promise((r) => setTimeout(r, 100));
+      // Sanity: the paste-handler import calls (which would hit `/pages/.../
+      // images` or `/pages/.../images/import`) must not have fired. The
+      // NodeView's auth-blob fetcher still runs against fetchAuthenticatedBlob,
+      // not apiFetch — so apiFetch should stay clean here.
+      expect(mockApiFetch).not.toHaveBeenCalledWith(
+        expect.stringContaining('/images/import'),
+        expect.anything(),
+      );
+      expect(mockApiFetch).not.toHaveBeenCalledWith(
+        '/pages/42/images',
+        expect.anything(),
+      );
+    });
+
+    it('falls back to default paste behaviour when no pageId is set', async () => {
+      render(<Editor content="<p>seed</p>" editable={true} /* no pageId */ />);
+      await waitFor(() => {
+        expect(document.querySelector('.ProseMirror')).toBeTruthy();
+      });
+
+      dispatchHtmlPaste('<p><img src="https://cdn.example.com/x.png"></p>');
+
+      // Our handler returns false (no preventDefault from us) so TipTap's
+      // own paste pipeline runs — TipTap may still preventDefault to take
+      // ownership of the insertion. The thing we actually want to test is
+      // that no upload was attempted: without a pageId we have nowhere to
+      // store the bytes.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(mockApiFetch).not.toHaveBeenCalled();
+    });
+
+    it('reports mixed outcomes via the toast (warning when some imports fail)', async () => {
+      // Two http(s) <img>s: first import succeeds, second fails. The toast
+      // helper should land on `toast.warning` with the X-of-Y message.
+      mockApiFetch
+        .mockResolvedValueOnce({ url: '/api/attachments/42/ok.png' })
+        .mockRejectedValueOnce(new Error('502 Bad Gateway'));
+
+      const sonner = await import('sonner');
+      const warningSpy = sonner.toast.warning as ReturnType<typeof vi.fn>;
+      warningSpy.mockClear();
+
+      render(<Editor content="<p>seed</p>" editable={true} pageId="42" />);
+      await waitFor(() => {
+        expect(document.querySelector('.ProseMirror')).toBeTruthy();
+      });
+
+      dispatchHtmlPaste(
+        '<p><img src="https://a.example.com/ok.png"><img src="https://b.example.com/bad.png"></p>',
+      );
+
+      await waitFor(() => {
+        expect(warningSpy).toHaveBeenCalledWith(
+          'Imported 1 of 2 images',
+          expect.objectContaining({ id: 'toast-id-1' }),
+        );
       });
     });
   });

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -95,6 +95,18 @@ const ConfluenceImage = Image.extend({
           ? { 'data-confluence-url': attributes['data-confluence-url'] }
           : {},
       },
+      // Set by the HTML-paste handler (#683) when an inline `<img src=…>` in
+      // pasted HTML can't be auto-imported (relative path, fetch failure,
+      // unsupported type). The CSS placeholder targets this attribute to
+      // render the broken-image affordance instead of letting the browser
+      // show its native 404 icon.
+      'data-import-failed': {
+        default: null,
+        parseHTML: (element) => element.getAttribute('data-import-failed'),
+        renderHTML: (attributes) => attributes['data-import-failed']
+          ? { 'data-import-failed': attributes['data-import-failed'] }
+          : {},
+      },
     };
   },
 
@@ -1044,6 +1056,164 @@ async function uploadPastedImage(file: File, pageId: string): Promise<string | n
   }
 }
 
+/**
+ * True when `src` points at one of our own backend attachment routes. We never
+ * try to re-import these — they're already where we want them.
+ */
+function isInternalAttachmentSrc(src: string): boolean {
+  return src.startsWith('/api/attachments/') || src.startsWith('/api/local-attachments/');
+}
+
+/**
+ * Tiny FIFO semaphore — caps how many import requests we keep in flight at
+ * once. Pasting HTML with dozens of images would otherwise fire every upload
+ * in parallel and risk tripping the backend's global rate limit (300/min).
+ */
+function makeConcurrencyLimiter(max: number): <T>(fn: () => Promise<T>) => Promise<T> {
+  const queue: Array<() => void> = [];
+  let inFlight = 0;
+  const tryDequeue = () => {
+    if (inFlight >= max) return;
+    const next = queue.shift();
+    if (next) { inFlight++; next(); }
+  };
+  // `<T,>` rather than `<T>` so the .tsx parser doesn't mistake the type
+  // parameter for a JSX tag.
+  return async <T,>(fn: () => Promise<T>): Promise<T> => {
+    if (inFlight >= max) {
+      await new Promise<void>((resolve) => queue.push(resolve));
+    } else {
+      inFlight++;
+    }
+    try {
+      return await fn();
+    } finally {
+      inFlight--;
+      tryDequeue();
+    }
+  };
+}
+
+/**
+ * Upload an image referenced by a `data:image/...;base64,...` URI via the
+ * existing per-page upload endpoint. Returns the internal `/api/attachments/…`
+ * URL on success, or `null` on failure (logs a console warning so failures
+ * are triagable from user reports).
+ */
+async function importDataUriImage(dataUri: string, pageId: string): Promise<string | null> {
+  // Pull the MIME so we can pick a sensible extension; the schema on the
+  // server requires `^[\w.-]+$` for the filename, so we generate a fresh
+  // one here rather than trusting whatever the source HTML implied.
+  const mimeMatch = /^data:(image\/([a-z+.-]+));base64,/.exec(dataUri);
+  if (!mimeMatch) return null;
+  const ext = MIME_TO_EXT[mimeMatch[1]!] ?? mimeMatch[2]!;
+  const hex = Math.floor(Math.random() * 0xffff).toString(16).padStart(4, '0');
+  const filename = `imported-${Date.now()}-${hex}.${ext}`;
+  try {
+    const result = await apiFetch<{ url: string }>(
+      `/pages/${encodeURIComponent(pageId)}/images`,
+      { method: 'POST', body: JSON.stringify({ dataUri, filename }) },
+    );
+    return result.url;
+  } catch (err) {
+    console.warn('[paste-import] data: URI import failed', { mime: mimeMatch[1], err });
+    return null;
+  }
+}
+
+/**
+ * Server-side fetch + import for an absolute `http(s)://` source URL via the
+ * `/import` endpoint. The backend SSRF-guards the URL and stores it via the
+ * same attachment infrastructure pasted uploads use.
+ */
+async function importHttpImage(sourceUrl: string, pageId: string): Promise<string | null> {
+  try {
+    const result = await apiFetch<{ url: string }>(
+      `/pages/${encodeURIComponent(pageId)}/images/import`,
+      { method: 'POST', body: JSON.stringify({ url: sourceUrl }) },
+    );
+    return result.url;
+  } catch (err) {
+    console.warn('[paste-import] http(s) import failed', { sourceUrl, err });
+    return null;
+  }
+}
+
+/** Max upload requests in flight at once during a single paste. Five is
+ *  a conservative middle ground — well under the backend's 300/min global
+ *  rate limit even when several users paste simultaneously. */
+const PASTE_IMPORT_CONCURRENCY = 5;
+
+/**
+ * Walk pasted HTML and replace any non-internal `<img>` srcs with our own
+ * attachment URLs (#683). Mutates a clone of the input; returns the rewritten
+ * HTML plus a summary of imports for the user-facing toast.
+ *
+ * Decision tree per src:
+ *   - already-internal (`/api/attachments/...`)  → leave alone, count as "imported"
+ *   - `data:image/...`                           → upload via /api/pages/:id/images
+ *   - `http(s)://...`                            → import via /api/pages/:id/images/import
+ *   - anything else (relative, file:, …)         → leave src, set `data-import-failed`
+ *
+ * Failed imports get `data-import-failed="true"` so the editor's CSS
+ * placeholder renders a "couldn't import" affordance instead of a native
+ * broken-image icon.
+ *
+ * Imports are run through a small concurrency limiter so pasting a 50-image
+ * document doesn't fire 50 simultaneous backend fetches.
+ */
+async function rewriteHtmlImageSrcs(
+  html: string,
+  pageId: string,
+): Promise<{ html: string; imported: number; failed: number; total: number }> {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const imgs = Array.from(doc.querySelectorAll('img'));
+  let imported = 0;
+  let failed = 0;
+  const limit = makeConcurrencyLimiter(PASTE_IMPORT_CONCURRENCY);
+
+  const pending = imgs.map((img) => limit(async () => {
+    const src = img.getAttribute('src') ?? '';
+    if (!src) {
+      img.setAttribute('data-import-failed', 'true');
+      failed += 1;
+      return;
+    }
+    if (isInternalAttachmentSrc(src)) {
+      // Already pointing at our backend — nothing to import, count as a
+      // success for the toast's "Imported N of M" math.
+      imported += 1;
+      return;
+    }
+    let newSrc: string | null = null;
+    if (src.startsWith('data:image/')) {
+      newSrc = await importDataUriImage(src, pageId);
+    } else if (/^https?:\/\//i.test(src)) {
+      newSrc = await importHttpImage(src, pageId);
+    } else {
+      // Relative path (`../_images/...`), `file:`, blob:, etc. — no auto-fix.
+      img.setAttribute('data-import-failed', 'true');
+      failed += 1;
+      return;
+    }
+    if (newSrc) {
+      img.setAttribute('src', newSrc);
+      // Strip any pre-existing `data-import-failed` from a previous round.
+      img.removeAttribute('data-import-failed');
+      imported += 1;
+    } else {
+      img.setAttribute('data-import-failed', 'true');
+      failed += 1;
+    }
+  }));
+
+  await Promise.allSettled(pending);
+  // `body.innerHTML` is what we want for clipboard HTML — DOMParser wraps the
+  // input in `<html><body>`, and the editor's `insertContent` expects bare
+  // fragment HTML.
+  return { html: doc.body.innerHTML, imported, failed, total: imgs.length };
+}
+
 const AUTO_SAVE_DELAY = 2000;
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -1195,11 +1365,55 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
       handlePaste(_view, event) {
         const items = Array.from(event.clipboardData?.items ?? []);
         const imageItem = items.find((i) => i.type.startsWith('image/'));
-        if (!imageItem) return false;
+        if (imageItem) {
+          // Single-image paste (Cmd+C on an image in a browser/file viewer) —
+          // existing fast path that uploads the file directly.
+          event.preventDefault();
+          const file = imageItem.getAsFile();
+          if (!file) return false;
+          return handleImageFiles([file]);
+        }
+
+        // Rich HTML paste (#683). If the clipboard carries `text/html` that
+        // contains `<img>` tags with non-internal srcs (relative paths from
+        // imported Sphinx docs, absolute URLs from a wiki, data: URIs), walk
+        // the HTML and rewrite each src to an internal attachment URL we
+        // actually serve. We hold off on inserting the original HTML so the
+        // user never sees the broken-image flash.
+        const htmlPayload = event.clipboardData?.getData('text/html');
+        if (!htmlPayload || !/<img\b/i.test(htmlPayload)) return false;
+
+        const currentPageId = pageIdRef.current;
+        if (!currentPageId) {
+          // No pageId means we can't upload anything — fall back to TipTap's
+          // default paste so the user at least sees the text content.
+          return false;
+        }
+
         event.preventDefault();
-        const file = imageItem.getAsFile();
-        if (!file) return false;
-        return handleImageFiles([file]);
+        const editorInstance = editorRef.current;
+        if (!editorInstance) return true;
+
+        const importToastId = toast.loading('Importing pasted images…');
+        rewriteHtmlImageSrcs(htmlPayload, currentPageId)
+          .then(({ html, imported, failed, total }) => {
+            editorInstance.chain().focus().insertContent(html).run();
+            if (total === 0) {
+              toast.dismiss(importToastId);
+              return;
+            }
+            if (failed === 0) {
+              toast.success(`Imported ${imported} image${imported === 1 ? '' : 's'}`, { id: importToastId });
+            } else if (imported === 0) {
+              toast.error(`Couldn't import ${failed} image${failed === 1 ? '' : 's'}`, { id: importToastId });
+            } else {
+              toast.warning(`Imported ${imported} of ${total} images`, { id: importToastId });
+            }
+          })
+          .catch(() => {
+            toast.error("Couldn't import pasted images", { id: importToastId });
+          });
+        return true;
       },
       handleDrop(_view, event, _slice, moved) {
         // Only handle external drops (not internal drag-and-drop of existing content)

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -66,6 +66,29 @@ if (typeof window !== 'undefined' && typeof window.localStorage?.setItem !== 'fu
   });
 }
 
+// Stub `getClientRects` for jsdom. ProseMirror's `scrollToSelection`
+// (which fires after every paste/transaction) calls this on the current
+// selection's DOM node and crashes the test run with a `TypeError:
+// target.getClientRects is not a function` otherwise. The crash propagates
+// as a Vitest "Unhandled Error" which makes CI's `vitest run` exit 1 even
+// when every test assertion passed. An empty DOMRectList-shaped value is
+// enough — ProseMirror only iterates it.
+function emptyDOMRectList(): DOMRectList {
+  const list: { length: number; item: (i: number) => DOMRect | null; [Symbol.iterator]: () => Iterator<DOMRect> } = {
+    length: 0,
+    item: () => null,
+    [Symbol.iterator]: () => ({ next: () => ({ done: true, value: undefined as unknown as DOMRect }) }),
+  };
+  return list as unknown as DOMRectList;
+}
+if (typeof Range !== 'undefined' && !Range.prototype.getClientRects) {
+  Range.prototype.getClientRects = () => emptyDOMRectList();
+}
+if (typeof Range !== 'undefined' && !Range.prototype.getBoundingClientRect) {
+  Range.prototype.getBoundingClientRect = () =>
+    ({ x: 0, y: 0, width: 0, height: 0, top: 0, right: 0, bottom: 0, left: 0, toJSON: () => ({}) }) as DOMRect;
+}
+
 // Mock matchMedia for jsdom (used by useCanHover, prefers-reduced-motion checks, and media query listeners)
 // Default: hover-capable device, no reduced motion
 if (!window.matchMedia) {

--- a/mcp-docs/package.json
+++ b/mcp-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq-mcp-docs",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compendiq",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compendiq",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "workspaces": [
         "backend",
         "frontend",
@@ -29,7 +29,7 @@
       }
     },
     "backend": {
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@fastify/compress": "^8.3.1",
@@ -104,7 +104,7 @@
       "license": "MIT"
     },
     "frontend": {
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@dnd-kit/react": "^0.3.2",
@@ -21734,7 +21734,7 @@
     },
     "packages/contracts": {
       "name": "@compendiq/contracts",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "zod": "^4.3.6"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "description": "Compendiq - AI-powered knowledge base management with Confluence integration and Ollama LLM backend",
   "workspaces": [

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compendiq/contracts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.5.2

Patch release. Two fixes and one feature shipped from `dev`.

### Added
- **#686** — `feat(editor): import non-internal <img> srcs on HTML paste (closes #683)`. New backend `POST /api/pages/:id/images/import` route (SSRF-guarded with redirect re-validation, magic-byte validated, streaming size cap), frontend `handlePaste` rewrites data: / http(s) / relative srcs accordingly, CSS placeholder for unfetchable refs.

### Fixed
- **#685** — `fix(backend): raise @fastify/compress threshold to 4096`. Fixes the empty-body regression on `/api/health` in the EE backend container that was causing Settings → Diagnostics to fall back to "Edition: Community (CE)" / "Backend commit: …".
- **Test infra polyfill**: jsdom `Range.prototype.getClientRects` stub in `test-setup.ts` so CI's `vitest run` doesn't exit 1 on ProseMirror's `scrollToSelection`-induced `TypeError`.

### Bumps
All five `package.json` files: 0.5.1 → 0.5.2 (root, backend, frontend, packages/contracts, mcp-docs). `CHANGELOG.md` stamped with `[0.5.2] - 2026-05-21`. `package-lock.json` regenerated.

### Test plan
- [x] All workspace tests pass on `release/v0.5.2`
- [x] Typecheck clean
- [x] Manual smoke against the EE stack (frontend + backend containers rebuilt against this branch; Diagnostics shows correct values; image import works for http(s) and relative paths)

After merge: tag `v0.5.2` and rebuild the published frontend + EE backend images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)