### PR TITLE
fix(oidc): derive redirect URI placeholder from window.location.origin

### DIFF
--- a/frontend/src/features/admin/OidcSettingsPage.tsx
+++ b/frontend/src/features/admin/OidcSettingsPage.tsx
@@ -330,7 +330,7 @@ function ProviderTab({ disabled }: { disabled?: boolean }) {
             type="url"
             value={redirectUri}
             onChange={(e) => setRedirectUri(e.target.value)}
-            placeholder="http://localhost:3000/api/auth/oidc/callback"
+            placeholder={`${window.location.origin}/api/auth/oidc/callback`}
             className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary disabled:opacity-60 disabled:cursor-not-allowed"
             data-testid="oidc-redirect-uri"
             disabled={disabled}


### PR DESCRIPTION
## Summary
- OIDC settings page hardcoded the redirect URI placeholder to `http://localhost:3000/api/auth/oidc/callback`, which is misleading for deployments behind a reverse proxy (e.g. Traefik on a real hostname + HTTPS).
- Derive the placeholder from `window.location.origin` so the suggested callback URL matches the public origin the admin is actually using to reach the settings page.

## Test plan
- [x] `npm run typecheck -w frontend` — clean
- [x] `npx vitest run src/features/admin/OidcSettingsPage.test.tsx` — 11/11 pass
- [ ] Manual: load settings page on `https://<public-host>/...` and confirm the placeholder reflects the public origin instead of `localhost:3000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)