### PR TITLE
feat(license): hide trial banner from non-admin users

### DIFF
--- a/frontend/src/shared/components/banners/TrialBanner.test.tsx
+++ b/frontend/src/shared/components/banners/TrialBanner.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { TrialBanner } from './TrialBanner';
+import { useAuthStore } from '../../../stores/auth-store';
 
 interface MockLicense {
   tier: string;
@@ -19,13 +20,24 @@ function mockLicenseFetch(value: MockLicense | null, status = 200) {
   );
 }
 
+function signInAs(role: 'admin' | 'user') {
+  useAuthStore.getState().setAuth('test-token', {
+    id: '1',
+    username: role,
+    role,
+  });
+}
+
 describe('TrialBanner', () => {
   beforeEach(() => {
-    // Default: no fetch mock — individual tests configure as needed.
+    // Default: signed in as admin so the banner is allowed to render.
+    // Individual tests override via signInAs() when they need a non-admin.
+    signInAs('admin');
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    useAuthStore.getState().clearAuth();
   });
 
   it('renders nothing when /api/license/info 404s (CE deployment)', async () => {
@@ -148,5 +160,31 @@ describe('TrialBanner', () => {
     // Allow the promise rejection to propagate
     await new Promise((r) => setTimeout(r, 0));
     expect(screen.queryByTestId('trial-banner')).toBeNull();
+  });
+
+  it('renders nothing for a non-admin user, even on an active trial', async () => {
+    signInAs('user');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    mockLicenseFetch({
+      tier: 'business',
+      type: 'trial',
+      expiresAt: '2026-05-09T23:59:59Z',
+      daysRemaining: 4,
+      isValid: true,
+    });
+    render(<TrialBanner />);
+    // Allow any pending microtasks to settle so a stray fetch would be observed.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByTestId('trial-banner')).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing when no user is signed in', async () => {
+    useAuthStore.getState().clearAuth();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    render(<TrialBanner />);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByTestId('trial-banner')).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/shared/components/banners/TrialBanner.tsx
+++ b/frontend/src/shared/components/banners/TrialBanner.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Clock, AlertTriangle } from 'lucide-react';
 import { cn } from '../../lib/cn';
+import { useAuthStore } from '../../../stores/auth-store';
 
 /**
  * Response shape from `GET /api/license/info` (EE-only endpoint).
@@ -23,15 +24,21 @@ interface LicenseInfoResponse {
  *   daysRemaining  1..7 → warning banner ("Trial — only N day(s) left")
  *   daysRemaining  <= 0 → destructive banner ("Trial expired N days ago")
  *
+ * Visible to admins only — non-admin users see a clean UI and don't need to
+ * act on (or worry about) trial expiry. The fetch is also gated so regular
+ * users don't poke the license endpoint on every mount.
+ *
  * Self-fetching, single shot on mount. Trial state changes day-to-day at
  * coarse granularity, so a 24h-stale banner is fine — and avoids the
  * polling overhead of `<ServiceStatus />`. Page reload picks up changes
  * issued via /api/admin/license.
  */
 export function TrialBanner() {
+  const isAdmin = useAuthStore((s) => s.user?.role === 'admin');
   const [info, setInfo] = useState<LicenseInfoResponse | null>(null);
 
   useEffect(() => {
+    if (!isAdmin) return;
     let cancelled = false;
     fetch('/api/license/info')
       .then((res) => (res.ok ? res.json() : null))
@@ -44,8 +51,9 @@ export function TrialBanner() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [isAdmin]);
 
+  if (!isAdmin) return null;
   if (!info || info.type !== 'trial' || info.daysRemaining === null) return null;
 
   const days = info.daysRemaining;


### PR DESCRIPTION
## Summary
- Trial countdown / expiry copy is only actionable by admins — they're the ones who own the license key under Settings → License. Showing it to regular users is noise they can't resolve, and it leaks license posture (trial / days remaining / expired) to every signed-in user.
- Gate `TrialBanner` visibility on `useAuthStore().user.role === 'admin'`. Also skip the `/api/license/info` fetch for non-admins so we don't hit the endpoint on every regular-user page load.

## Behavior
| User | Trial active | Behavior |
| --- | --- | --- |
| Admin | yes | Banner renders (info / warning / destructive as before) |
| Admin | no / paid / community | Banner hidden (unchanged) |
| Regular user | any | Banner hidden, no fetch |
| Unauthenticated | any | Banner hidden, no fetch |

## Test plan
- [x] `npx vitest run src/shared/components/banners/TrialBanner.test.tsx` — 12/12 pass (10 existing + 2 new gating cases)
- [x] `npm run typecheck -w frontend` — clean
- [ ] Manual: sign in as a non-admin while a trial license is active and confirm no banner renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)