### PR TITLE
refactor(knowledge): extract pasted-image uploader into a confluence service

### DIFF
--- a/backend/src/domains/confluence/services/pasted-image-uploader.test.ts
+++ b/backend/src/domains/confluence/services/pasted-image-uploader.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+
+// The module resolves its attachment root from process.env.ATTACHMENTS_DIR at
+// load time, so we point it at a throwaway temp dir BEFORE importing the module
+// under test (hence the dynamic import in beforeAll).
+let tmpRoot: string;
+let uploadLocalImagesToConfluence: typeof import('./pasted-image-uploader.js')['uploadLocalImagesToConfluence'];
+
+// A tiny but valid 1x1 transparent PNG.
+const PNG_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+function makeLog() {
+  // Stubbing the logger — not the subject under test.
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+}
+
+// Write a file into the local attachment cache the way the editor would, i.e.
+// at {ATTACHMENTS_DIR}/{pageId}/{filename}.
+async function seedAttachment(pageId: string, filename: string, bytes: Buffer = PNG_BYTES) {
+  // Test-only paths built from hardcoded literals under a mkdtemp root — no user input.
+  // nosemgrep
+  const dir = path.join(tmpRoot, pageId);
+  await mkdir(dir, { recursive: true });
+  // nosemgrep
+  await writeFile(path.join(dir, filename), bytes);
+}
+
+beforeAll(async () => {
+  tmpRoot = await mkdtemp(path.join(tmpdir(), 'pasted-img-'));
+  process.env.ATTACHMENTS_DIR = tmpRoot;
+  ({ uploadLocalImagesToConfluence } = await import('./pasted-image-uploader.js'));
+});
+
+afterAll(async () => {
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe('uploadLocalImagesToConfluence', () => {
+  it('returns the html unchanged when there are no local pasted images', async () => {
+    const client = { updateAttachment: vi.fn() } as never as Parameters<typeof uploadLocalImagesToConfluence>[2];
+    const html = '<p>hello <img src="https://cdn.example.com/remote.png"></p>';
+
+    const result = await uploadLocalImagesToConfluence(html, '9999', client, makeLog());
+
+    expect(result).toBe(html);
+    expect((client as { updateAttachment: ReturnType<typeof vi.fn> }).updateAttachment).not.toHaveBeenCalled();
+  });
+
+  it('uploads a pasted image to Confluence and annotates the tag', async () => {
+    await seedAttachment('local-1', 'pasted.png');
+    const updateAttachment = vi.fn().mockResolvedValue(undefined);
+    const client = { updateAttachment } as never as Parameters<typeof uploadLocalImagesToConfluence>[2];
+    const html = '<p><img src="/api/attachments/local-1/pasted.png"></p>';
+
+    const result = await uploadLocalImagesToConfluence(html, '9999', client, makeLog());
+
+    // Uploads under the *target* Confluence page id (arg 2), reading the file
+    // from the *source* page id parsed out of the src attribute.
+    expect(updateAttachment).toHaveBeenCalledWith('9999', 'pasted.png', PNG_BYTES, 'image/png');
+    expect(result).toContain('data-confluence-filename="pasted.png"');
+    expect(result).toContain('data-confluence-image-source="attachment"');
+  });
+
+  it('derives the mime type from the file extension', async () => {
+    await seedAttachment('local-1', 'photo.jpg');
+    const updateAttachment = vi.fn().mockResolvedValue(undefined);
+    const client = { updateAttachment } as never as Parameters<typeof uploadLocalImagesToConfluence>[2];
+    const html = '<p><img src="/api/attachments/local-1/photo.jpg"></p>';
+
+    await uploadLocalImagesToConfluence(html, '9999', client, makeLog());
+
+    expect(updateAttachment).toHaveBeenCalledWith('9999', 'photo.jpg', expect.any(Buffer), 'image/jpeg');
+  });
+
+  it('skips images already marked with a confluence filename', async () => {
+    const updateAttachment = vi.fn();
+    const client = { updateAttachment } as never as Parameters<typeof uploadLocalImagesToConfluence>[2];
+    const html =
+      '<p><img src="/api/attachments/local-1/synced.png" data-confluence-filename="synced.png"></p>';
+
+    const result = await uploadLocalImagesToConfluence(html, '9999', client, makeLog());
+
+    expect(updateAttachment).not.toHaveBeenCalled();
+    expect(result).toBe(html);
+  });
+
+  it('skips and warns when the local file is missing', async () => {
+    const updateAttachment = vi.fn();
+    const client = { updateAttachment } as never as Parameters<typeof uploadLocalImagesToConfluence>[2];
+    const log = makeLog();
+    const html = '<p><img src="/api/attachments/local-1/missing.png"></p>';
+
+    const result = await uploadLocalImagesToConfluence(html, '9999', client, log);
+
+    expect(updateAttachment).not.toHaveBeenCalled();
+    expect((log as unknown as { warn: ReturnType<typeof vi.fn> }).warn).toHaveBeenCalled();
+    expect(result).toBe(html);
+  });
+
+  it('logs and continues (no annotation) when the Confluence upload fails', async () => {
+    await seedAttachment('local-1', 'boom.png');
+    const updateAttachment = vi.fn().mockRejectedValue(new Error('confluence exploded'));
+    const client = { updateAttachment } as never as Parameters<typeof uploadLocalImagesToConfluence>[2];
+    const log = makeLog();
+    const html = '<p><img src="/api/attachments/local-1/boom.png"></p>';
+
+    const result = await uploadLocalImagesToConfluence(html, '9999', client, log);
+
+    expect((log as unknown as { error: ReturnType<typeof vi.fn> }).error).toHaveBeenCalled();
+    expect(result).not.toContain('data-confluence-filename');
+  });
+});

--- a/backend/src/domains/confluence/services/pasted-image-uploader.ts
+++ b/backend/src/domains/confluence/services/pasted-image-uploader.ts
@@ -1,0 +1,78 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+import type { ConfluenceClient } from './confluence-client.js';
+import type { FastifyBaseLogger } from 'fastify';
+
+const ATTACHMENTS_BASE = process.env.ATTACHMENTS_DIR ?? 'data/attachments';
+
+const MIME_BY_EXT: Record<string, string> = {
+  '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif', '.webp': 'image/webp', '.svg': 'image/svg+xml',
+};
+
+/**
+ * Scan editor HTML for locally-pasted images (those with /api/attachments/ src
+ * but missing data-confluence-filename). Upload each to Confluence as a page
+ * attachment, then add data-confluence-filename so htmlToConfluence() generates
+ * a valid ri:attachment reference.
+ */
+export async function uploadLocalImagesToConfluence(
+  html: string,
+  confluencePageId: string,
+  client: ConfluenceClient,
+  log: FastifyBaseLogger,
+): Promise<string> {
+  // Quick check — skip DOM parsing if no pasted images
+  if (!html.includes('/api/attachments/')) return html;
+
+  const { JSDOM } = await import('jsdom');
+  const dom = new JSDOM(`<body>${html}</body>`, { contentType: 'text/html' });
+  const doc = dom.window.document;
+
+  const localImages = doc.querySelectorAll('img[src^="/api/attachments/"]');
+  let changed = false;
+
+  for (const img of localImages) {
+    // Skip images that already have a Confluence filename (synced from Confluence)
+    if (img.getAttribute('data-confluence-filename')) continue;
+    if (img.getAttribute('data-confluence-image-source')) continue;
+
+    const src = img.getAttribute('src') ?? '';
+    // src = /api/attachments/{pageId}/{filename}
+    const parts = src.split('/');
+    const filename = decodeURIComponent(parts[parts.length - 1] ?? '');
+    const pageId = parts[parts.length - 2] ?? '';
+    if (!filename || !pageId) continue;
+
+    // Read the file from local attachment cache.
+    // Both `pageId` and `filename` are parsed out of the `src` attribute of
+    // an <img> tag produced by our own editor and are passed through
+    // `path.basename()` to strip any `..` / path separators before
+    // concatenation with the trusted `ATTACHMENTS_BASE` root.
+    // nosemgrep
+    const filePath = path.join(ATTACHMENTS_BASE, path.basename(pageId), path.basename(filename));
+    let fileData: Buffer;
+    try {
+      fileData = await readFile(filePath);
+    } catch {
+      log.warn({ filePath, filename }, 'Local pasted image not found, skipping upload');
+      continue;
+    }
+
+    const ext = path.extname(filename).toLowerCase();
+    const mimeType = MIME_BY_EXT[ext] ?? 'application/octet-stream';
+
+    try {
+      await client.updateAttachment(confluencePageId, filename, fileData, mimeType);
+      // Mark as a Confluence attachment so htmlToConfluence() uses the right filename
+      img.setAttribute('data-confluence-filename', filename);
+      img.setAttribute('data-confluence-image-source', 'attachment');
+      changed = true;
+      log.info({ confluencePageId, filename }, 'Uploaded pasted image to Confluence');
+    } catch (err) {
+      log.error({ err, confluencePageId, filename }, 'Failed to upload pasted image to Confluence');
+    }
+  }
+
+  return changed ? doc.body.innerHTML : html;
+}

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -25,88 +25,11 @@ import { PageListQuerySchema, PageTreeQuerySchema, CreatePageSchema, UpdatePageS
 import { z } from 'zod';
 import { logger } from '../../core/utils/logger.js';
 import pLimit from 'p-limit';
-import { readFile } from 'fs/promises';
-import path from 'path';
-import type { ConfluenceClient } from '../../domains/confluence/services/confluence-client.js';
-import type { FastifyBaseLogger } from 'fastify';
+import { uploadLocalImagesToConfluence } from '../../domains/confluence/services/pasted-image-uploader.js';
 
 /** Escape ILIKE metacharacters so user input like "100%" doesn't match all rows. */
 function escapeIlikeTerm(term: string): string {
   return term.replace(/[%_\\]/g, '\\$&');
-}
-
-const ATTACHMENTS_BASE = process.env.ATTACHMENTS_DIR ?? 'data/attachments';
-
-const MIME_BY_EXT: Record<string, string> = {
-  '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
-  '.gif': 'image/gif', '.webp': 'image/webp', '.svg': 'image/svg+xml',
-};
-
-/**
- * Scan editor HTML for locally-pasted images (those with /api/attachments/ src
- * but missing data-confluence-filename). Upload each to Confluence as a page
- * attachment, then add data-confluence-filename so htmlToConfluence() generates
- * a valid ri:attachment reference.
- */
-async function uploadLocalImagesToConfluence(
-  html: string,
-  confluencePageId: string,
-  client: ConfluenceClient,
-  log: FastifyBaseLogger,
-): Promise<string> {
-  // Quick check — skip DOM parsing if no pasted images
-  if (!html.includes('/api/attachments/')) return html;
-
-  const { JSDOM } = await import('jsdom');
-  const dom = new JSDOM(`<body>${html}</body>`, { contentType: 'text/html' });
-  const doc = dom.window.document;
-
-  const localImages = doc.querySelectorAll('img[src^="/api/attachments/"]');
-  let changed = false;
-
-  for (const img of localImages) {
-    // Skip images that already have a Confluence filename (synced from Confluence)
-    if (img.getAttribute('data-confluence-filename')) continue;
-    if (img.getAttribute('data-confluence-image-source')) continue;
-
-    const src = img.getAttribute('src') ?? '';
-    // src = /api/attachments/{pageId}/{filename}
-    const parts = src.split('/');
-    const filename = decodeURIComponent(parts[parts.length - 1] ?? '');
-    const pageId = parts[parts.length - 2] ?? '';
-    if (!filename || !pageId) continue;
-
-    // Read the file from local attachment cache.
-    // Both `pageId` and `filename` are parsed out of the `src` attribute of
-    // an <img> tag produced by our own editor and are passed through
-    // `path.basename()` to strip any `..` / path separators before
-    // concatenation with the trusted `ATTACHMENTS_BASE` root.
-    // nosemgrep
-    const filePath = path.join(ATTACHMENTS_BASE, path.basename(pageId), path.basename(filename));
-    let fileData: Buffer;
-    try {
-      fileData = await readFile(filePath);
-    } catch {
-      log.warn({ filePath, filename }, 'Local pasted image not found, skipping upload');
-      continue;
-    }
-
-    const ext = path.extname(filename).toLowerCase();
-    const mimeType = MIME_BY_EXT[ext] ?? 'application/octet-stream';
-
-    try {
-      await client.updateAttachment(confluencePageId, filename, fileData, mimeType);
-      // Mark as a Confluence attachment so htmlToConfluence() uses the right filename
-      img.setAttribute('data-confluence-filename', filename);
-      img.setAttribute('data-confluence-image-source', 'attachment');
-      changed = true;
-      log.info({ confluencePageId, filename }, 'Uploaded pasted image to Confluence');
-    } catch (err) {
-      log.error({ err, confluencePageId, filename }, 'Failed to upload pasted image to Confluence');
-    }
-  }
-
-  return changed ? doc.body.innerHTML : html;
 }
 
 /**


### PR DESCRIPTION
## What

Extracts `uploadLocalImagesToConfluence` (plus its MIME-type map and the attachment-root constant) out of the 2651-line `routes/knowledge/pages-crud.ts` into a dedicated `domains/confluence/services/pasted-image-uploader.ts`.

Pure code move — **no behavior change**. The single call site in the `PUT /api/pages/:id` handler is unchanged.

## Why

`pages-crud.ts` had grown to 2651 lines mixing routing, bulk ops, drafts, and inline image-upload orchestration. Moving the pasted-image logic into the `confluence` domain (next to `attachment-handler.ts`) shrinks the route file by ~79 lines, respects the ESLint domain boundaries, and — most usefully — lets the logic be unit-tested directly, which it never was.

## Tests

Adds `pasted-image-uploader.test.ts` (real fs temp dir + real JSDOM; stubs only the Confluence client HTTP boundary and the logger):
- no-op fast path when there are no `/api/attachments/` images
- uploads a pasted image and annotates the tag
- derives mime type from file extension
- skips images already marked with a confluence filename
- skips + warns when the local file is missing
- logs + continues (no annotation) when the Confluence upload fails

Existing `pages-image-upload` / `pages-image-import` integration tests remain the regression net.

## Verification

- New unit tests: **6/6 pass**
- Full `routes/knowledge` suite: **533 pass / 45 db-skipped / 0 fail**
- `eslint --max-warnings=0`: clean
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)