### PR TITLE
feat(confluence): skip redundant restriction fetches via audit-log change detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,7 @@ BACKEND_PORT=3051
 
 # --- Sync Scheduler ---
 # SYNC_INTERVAL_MIN=15               # How often the background sync scheduler polls for due syncs, in minutes (default: 15)
+# RESTRICTION_CONFIRM_WINDOW_HOURS=168  # (EE + RAG permission enforcement) Re-confirm each page's Confluence restrictions at least this often; the audit log is consulted to skip unchanged pages within the window. Fails safe to a full re-fetch. (default: 168 = 7 days)
 
 # --- Confluence API Rate Limiting ---
 # Configurable via admin_settings table (key: confluence_rate_limit_rpm). Env var is the startup default.

--- a/backend/src/core/db/migrations/075_pages_restrictions_synced_at.sql
+++ b/backend/src/core/db/migrations/075_pages_restrictions_synced_at.sql
@@ -1,0 +1,16 @@
+-- Migration 075: per-page restriction-sync high-water mark
+-- (Compendiq/compendiq-ce restriction-change detection)
+--
+-- Records when a page's Confluence read-restrictions were last mirrored into
+-- access_control_entries. Used by the audit-log-driven restriction-change
+-- detection optimization (EE + RAG_PERMISSION_ENFORCEMENT) to decide whether a
+-- page's restriction fetch can be skipped on a given sync run:
+--
+--   skip iff the audit log shows no `Permissions` change for the page within the
+--   confirm window AND restrictions_synced_at falls within that same window.
+--
+-- NULL = never mirrored (the page is always fetched). The optimization fails
+-- safe to a full fetch whenever this is NULL or older than the audit-covered
+-- window, so the column carries no correctness risk on its own.
+
+ALTER TABLE pages ADD COLUMN IF NOT EXISTS restrictions_synced_at TIMESTAMPTZ NULL;

--- a/backend/src/domains/confluence/services/confluence-client-audit.test.ts
+++ b/backend/src/domains/confluence/services/confluence-client-audit.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock undici request (low-level HTTP) — same boundary the other client tests mock.
+vi.mock('undici', () => ({ request: vi.fn() }));
+vi.mock('../../../core/utils/ssrf-guard.js', () => ({
+  validateUrl: vi.fn(),
+  addAllowedBaseUrl: vi.fn(),
+  resolveConfluenceUrl: vi.fn((url: string) => url),
+}));
+vi.mock('../../../core/utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../../../core/utils/tls-config.js', () => ({
+  confluenceDispatcher: {},
+  buildConnectOptions: vi.fn().mockReturnValue(undefined),
+  isVerifySslEnabled: vi.fn().mockReturnValue(true),
+}));
+vi.mock('./confluence-rate-limiter.js', () => ({ acquireToken: vi.fn().mockResolvedValue(undefined) }));
+
+import { request } from 'undici';
+import { ConfluenceClient, AuditUnavailableError } from './confluence-client.js';
+
+const mockRequest = vi.mocked(request);
+
+function jsonResponse(statusCode: number, payload: unknown) {
+  return { statusCode, headers: {}, body: { text: async () => JSON.stringify(payload) } } as never;
+}
+
+describe('ConfluenceClient audit access', () => {
+  const client = new ConfluenceClient('https://confluence.example.com', 'pat');
+
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('getAuditRetention', () => {
+    it('fetches /rest/api/audit/retention and returns the parsed period', async () => {
+      mockRequest.mockResolvedValue(jsonResponse(200, { number: 3, units: 'YEARS' }));
+
+      const retention = await client.getAuditRetention();
+
+      expect(retention).toEqual({ number: 3, units: 'YEARS' });
+      expect(String(mockRequest.mock.calls[0]![0])).toContain('/rest/api/audit/retention');
+    });
+  });
+
+  describe('getAuditRecords', () => {
+    it('queries from startDate (epoch ms) and returns normalized records', async () => {
+      mockRequest.mockResolvedValue(
+        jsonResponse(200, {
+          results: [
+            {
+              creationDate: 1700000000000,
+              category: 'Permissions',
+              summary: 'Page restrictions updated',
+              affectedObject: { id: '12345', type: 'page', name: 'Secret' },
+            },
+          ],
+          start: 0,
+          limit: 1000,
+          size: 1,
+        }),
+      );
+
+      const records = await client.getAuditRecords({ startDate: 1699990000000 });
+
+      const url = String(mockRequest.mock.calls[0]![0]);
+      expect(url).toContain('/rest/api/audit?');
+      expect(url).toContain('startDate=1699990000000');
+      expect(records).toHaveLength(1);
+      expect(records[0]!.category).toBe('Permissions');
+      expect(records[0]!.affectedObject).toEqual({ id: '12345', type: 'page', name: 'Secret' });
+    });
+
+    it('normalizes affectedObject.objectType to .type', async () => {
+      mockRequest.mockResolvedValue(
+        jsonResponse(200, {
+          results: [{ creationDate: 1, category: 'Permissions', affectedObject: { id: '7', objectType: 'page', name: 'P' } }],
+          start: 0,
+          limit: 1000,
+          size: 1,
+        }),
+      );
+
+      const records = await client.getAuditRecords({ startDate: 0 });
+
+      expect(records[0]!.affectedObject?.type).toBe('page');
+    });
+
+    it('paginates across multiple pages', async () => {
+      mockRequest
+        .mockResolvedValueOnce(
+          jsonResponse(200, {
+            results: [{ creationDate: 1, category: 'Permissions', affectedObject: { id: 'a', type: 'page', name: 'A' } }],
+            start: 0,
+            limit: 1,
+            size: 1,
+            _links: { next: '/rest/api/audit?start=1&limit=1' },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse(200, {
+            results: [{ creationDate: 2, category: 'Permissions', affectedObject: { id: 'b', type: 'page', name: 'B' } }],
+            start: 1,
+            limit: 1,
+            size: 1,
+          }),
+        );
+
+      const records = await client.getAuditRecords({ startDate: 0, limit: 1 });
+
+      expect(records.map((r) => r.affectedObject?.id)).toEqual(['a', 'b']);
+      expect(mockRequest).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws AuditUnavailableError on 403 (no admin permission)', async () => {
+      mockRequest.mockResolvedValue({ statusCode: 403, headers: {}, body: { text: async () => 'Forbidden' } } as never);
+      await expect(client.getAuditRecords({ startDate: 0 })).rejects.toThrow(AuditUnavailableError);
+    });
+
+    it('throws AuditUnavailableError on 404 (audit unavailable)', async () => {
+      mockRequest.mockResolvedValue({ statusCode: 404, headers: {}, body: { text: async () => 'Not found' } } as never);
+      await expect(client.getAuditRecords({ startDate: 0 })).rejects.toThrow(AuditUnavailableError);
+    });
+  });
+});

--- a/backend/src/domains/confluence/services/confluence-client.ts
+++ b/backend/src/domains/confluence/services/confluence-client.ts
@@ -62,6 +62,31 @@ interface PaginatedResponse<T> {
   _links?: { next?: string };
 }
 
+/** Raw audit record shape as returned by GET /rest/api/audit (only the fields we use). */
+interface RawAuditRecord {
+  creationDate?: number;
+  category?: string;
+  summary?: string;
+  affectedObject?: { id?: string | number; type?: string; objectType?: string; name?: string };
+}
+
+/**
+ * Normalised Confluence audit record. `affectedObject.type` is resolved from the
+ * raw `type` or `objectType` field (the field name varies across DC 9.x builds).
+ */
+export interface ConfluenceAuditRecord {
+  creationDate: number;
+  category?: string;
+  summary?: string;
+  affectedObject?: { id: string; type?: string; name?: string };
+}
+
+/** Audit-log retention period from GET /rest/api/audit/retention. */
+export interface AuditRetention {
+  number: number;
+  units: string;
+}
+
 interface RetryOptions {
   /** Maximum number of attempts (including the first). Default: 3 */
   maxAttempts?: number;
@@ -191,6 +216,71 @@ export class ConfluenceClient {
     }
 
     return spaces;
+  }
+
+  /**
+   * Fetch the configured audit-log retention period.
+   * Requires the Confluence administrator permission.
+   */
+  async getAuditRetention(): Promise<AuditRetention> {
+    return this.fetch<AuditRetention>('/rest/api/audit/retention');
+  }
+
+  /**
+   * Fetch audit-log records from `startDate` (epoch ms) up to now (or `endDate`),
+   * following pagination to completion and normalising each record. Requires the
+   * Confluence administrator permission; a 403/404 is surfaced as
+   * `AuditUnavailableError` so callers can fall back rather than treat it as a
+   * hard failure.
+   */
+  async getAuditRecords(opts: {
+    startDate: number;
+    endDate?: number;
+    start?: number;
+    limit?: number;
+  }): Promise<ConfluenceAuditRecord[]> {
+    const limit = opts.limit ?? 1000;
+    let start = opts.start ?? 0;
+    const records: ConfluenceAuditRecord[] = [];
+
+    while (true) {
+      const params = new URLSearchParams({
+        startDate: String(opts.startDate),
+        start: String(start),
+        limit: String(limit),
+      });
+      if (opts.endDate !== undefined) params.set('endDate', String(opts.endDate));
+
+      let response: PaginatedResponse<RawAuditRecord>;
+      try {
+        response = await this.fetch<PaginatedResponse<RawAuditRecord>>(`/rest/api/audit?${params.toString()}`);
+      } catch (err) {
+        if (err instanceof ConfluenceError && (err.statusCode === 403 || err.statusCode === 404)) {
+          throw new AuditUnavailableError(
+            `Confluence audit log not accessible (HTTP ${err.statusCode}); requires the Confluence administrator permission`,
+            err.statusCode,
+          );
+        }
+        throw err;
+      }
+
+      for (const raw of response.results ?? []) {
+        const ao = raw.affectedObject;
+        records.push({
+          creationDate: raw.creationDate ?? 0,
+          category: raw.category,
+          summary: raw.summary,
+          affectedObject: ao
+            ? { id: String(ao.id ?? ''), type: ao.type ?? ao.objectType, name: ao.name }
+            : undefined,
+        });
+      }
+
+      if ((response.size ?? 0) < limit || !response._links?.next) break;
+      start += limit;
+    }
+
+    return records;
   }
 
   async getPages(spaceKey: string, start = 0, limit = 50): Promise<PaginatedResponse<ConfluencePage>> {
@@ -898,6 +988,21 @@ export class ConfluenceError extends Error {
   ) {
     super(message);
     this.name = 'ConfluenceError';
+  }
+}
+
+/**
+ * Raised when the audit-log API is not accessible (HTTP 403/404 — typically the
+ * sync token lacks the Confluence administrator permission). Callers treat this
+ * as "optimization unavailable" and fall back to the full restriction sync.
+ */
+export class AuditUnavailableError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+  ) {
+    super(message);
+    this.name = 'AuditUnavailableError';
   }
 }
 

--- a/backend/src/domains/confluence/services/restriction-change-tracker.test.ts
+++ b/backend/src/domains/confluence/services/restriction-change-tracker.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getRestrictionChangeSet, RETENTION_SAFETY_MARGIN_MS } from './restriction-change-tracker.js';
+import { AuditUnavailableError } from './confluence-client.js';
+
+const NOW = 1_700_000_000_000;
+const HOUR = 3_600_000;
+
+function makeClient(over?: Partial<{ getAuditRetention: ReturnType<typeof vi.fn>; getAuditRecords: ReturnType<typeof vi.fn> }>) {
+  return {
+    getAuditRetention: vi.fn().mockResolvedValue({ number: 3, units: 'YEARS' }),
+    getAuditRecords: vi.fn().mockResolvedValue([]),
+    ...over,
+  };
+}
+
+describe('getRestrictionChangeSet', () => {
+  it('returns incremental with only Permissions/page event ids', async () => {
+    const client = makeClient({
+      getAuditRecords: vi.fn().mockResolvedValue([
+        { creationDate: NOW - 1000, category: 'Permissions', affectedObject: { id: '111', type: 'page', name: 'A' } },
+        { creationDate: NOW - 2000, category: 'Permissions', affectedObject: { id: '222', type: 'page', name: 'B' } },
+        { creationDate: NOW - 3000, category: 'Audit', affectedObject: { id: '999', type: 'page', name: 'X' } },
+        { creationDate: NOW - 4000, category: 'Permissions', affectedObject: { id: '333', type: 'space', name: 'S' } },
+      ]),
+    });
+
+    const result = await getRestrictionChangeSet(client, NOW, { confirmWindowHours: 168 });
+
+    expect(result.mode).toBe('incremental');
+    if (result.mode === 'incremental') {
+      expect([...result.changedPageIds].sort()).toEqual(['111', '222']);
+      expect(result.auditQueryAt).toBe(NOW);
+      expect(result.windowStartMs).toBe(NOW - 168 * HOUR);
+    }
+  });
+
+  it('falls back to full when the audit API is unavailable (403)', async () => {
+    const client = makeClient({ getAuditRecords: vi.fn().mockRejectedValue(new AuditUnavailableError('no admin', 403)) });
+    expect(await getRestrictionChangeSet(client, NOW, { confirmWindowHours: 168 })).toEqual({ mode: 'full' });
+  });
+
+  it('falls back to full on any audit query error', async () => {
+    const client = makeClient({ getAuditRecords: vi.fn().mockRejectedValue(new Error('5xx / timeout')) });
+    expect(await getRestrictionChangeSet(client, NOW)).toEqual({ mode: 'full' });
+  });
+
+  it('falls back to full when the retention probe fails (cannot establish a safe window)', async () => {
+    const client = makeClient({ getAuditRetention: vi.fn().mockRejectedValue(new Error('retention probe failed')) });
+    expect(await getRestrictionChangeSet(client, NOW)).toEqual({ mode: 'full' });
+  });
+
+  it('falls back to full when retention units are not understood', async () => {
+    const client = makeClient({ getAuditRetention: vi.fn().mockResolvedValue({ number: 5, units: 'FORTNIGHTS' }) });
+    expect(await getRestrictionChangeSet(client, NOW)).toEqual({ mode: 'full' });
+  });
+
+  it('falls back to full when a Permissions/page event has no parseable id', async () => {
+    const client = makeClient({
+      getAuditRecords: vi.fn().mockResolvedValue([
+        { creationDate: NOW, category: 'Permissions', affectedObject: { id: '', type: 'page' } },
+      ]),
+    });
+    expect(await getRestrictionChangeSet(client, NOW)).toEqual({ mode: 'full' });
+  });
+
+  it('narrows the window to the retention horizon (plus safety margin) when retention < confirm window', async () => {
+    const client = makeClient({ getAuditRetention: vi.fn().mockResolvedValue({ number: 1, units: 'DAYS' }) });
+
+    const result = await getRestrictionChangeSet(client, NOW, { confirmWindowHours: 168 });
+
+    expect(result.mode).toBe('incremental');
+    if (result.mode === 'incremental') {
+      const expectedStart = NOW - 24 * HOUR + RETENTION_SAFETY_MARGIN_MS;
+      expect(result.windowStartMs).toBe(expectedStart);
+      expect(client.getAuditRecords).toHaveBeenCalledWith({ startDate: expectedStart });
+    }
+  });
+
+  it('uses the confirm window when retention is much longer', async () => {
+    const client = makeClient({ getAuditRetention: vi.fn().mockResolvedValue({ number: 3, units: 'YEARS' }) });
+
+    const result = await getRestrictionChangeSet(client, NOW, { confirmWindowHours: 168 });
+
+    if (result.mode === 'incremental') {
+      expect(result.windowStartMs).toBe(NOW - 168 * HOUR);
+    }
+  });
+});

--- a/backend/src/domains/confluence/services/restriction-change-tracker.ts
+++ b/backend/src/domains/confluence/services/restriction-change-tracker.ts
@@ -1,0 +1,111 @@
+import type { AuditRetention, ConfluenceClient } from './confluence-client.js';
+import { logger } from '../../../core/utils/logger.js';
+
+/** Default "confirm window": re-confirm every page's restrictions at least this often. */
+const DEFAULT_CONFIRM_WINDOW_HOURS = 168; // 7 days
+
+/**
+ * Margin subtracted from the retention horizon so we never rely on audit records
+ * sitting right at the purge boundary (which may vanish mid-query).
+ */
+export const RETENTION_SAFETY_MARGIN_MS = 3_600_000; // 1 hour
+
+const HOUR_MS = 3_600_000;
+
+/**
+ * The outcome of asking "which pages' restrictions changed since we last looked?".
+ *
+ * - `full`: we could not establish a trustworthy audit window, so the caller must
+ *   re-fetch restrictions for every page (today's behavior — always correct).
+ * - `incremental`: the audit log covers `(windowStartMs, auditQueryAt]` with no
+ *   gaps; only pages in `changedPageIds` (or those not synced within the window)
+ *   need a re-fetch.
+ */
+export type RestrictionChangeSet =
+  | { mode: 'full' }
+  | { mode: 'incremental'; changedPageIds: Set<string>; windowStartMs: number; auditQueryAt: number };
+
+type AuditCapableClient = Pick<ConfluenceClient, 'getAuditRecords' | 'getAuditRetention'>;
+
+/**
+ * Determine which pages had restriction changes since the confirm window opened,
+ * using the Confluence Audit Log. Fails safe to `{ mode: 'full' }` on ANY
+ * uncertainty (no audit access, retention probe failure, unknown retention units,
+ * query error, or an unparseable permission event) — a page's ACEs are never
+ * staler than they are today.
+ */
+export async function getRestrictionChangeSet(
+  client: AuditCapableClient,
+  nowMs: number,
+  opts?: { confirmWindowHours?: number },
+): Promise<RestrictionChangeSet> {
+  const windowHours = opts?.confirmWindowHours ?? confirmWindowHoursFromEnv();
+  const auditQueryAt = nowMs;
+  const desiredStart = nowMs - windowHours * HOUR_MS;
+
+  try {
+    let retentionMs: number | null;
+    try {
+      retentionMs = retentionToMs(await client.getAuditRetention());
+    } catch (err) {
+      logFallback('audit retention probe failed', err);
+      return { mode: 'full' };
+    }
+    if (retentionMs === null) {
+      logFallback('audit retention units not understood', undefined);
+      return { mode: 'full' };
+    }
+
+    // Never trust a window that reaches past what the audit log still retains.
+    const safeRetentionStart = nowMs - retentionMs + RETENTION_SAFETY_MARGIN_MS;
+    const windowStartMs = Math.max(desiredStart, safeRetentionStart);
+
+    const records = await client.getAuditRecords({ startDate: windowStartMs });
+
+    const changedPageIds = new Set<string>();
+    for (const rec of records) {
+      if (rec.category !== 'Permissions') continue;
+      if (rec.affectedObject?.type !== 'page') continue;
+      const id = rec.affectedObject.id;
+      if (!id) {
+        // A page-permission event we can't pin to an id — don't risk missing it.
+        logFallback('audit Permissions event missing a page id', undefined);
+        return { mode: 'full' };
+      }
+      changedPageIds.add(id);
+    }
+
+    return { mode: 'incremental', changedPageIds, windowStartMs, auditQueryAt };
+  } catch (err) {
+    logFallback('audit records query failed', err);
+    return { mode: 'full' };
+  }
+}
+
+function confirmWindowHoursFromEnv(): number {
+  const raw = process.env.RESTRICTION_CONFIRM_WINDOW_HOURS;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_CONFIRM_WINDOW_HOURS;
+}
+
+/** Convert a Confluence audit retention period into milliseconds; null if not understood. */
+function retentionToMs(retention: AuditRetention): number | null {
+  const n = retention.number;
+  if (!Number.isFinite(n) || n <= 0) return null;
+  switch (String(retention.units).toUpperCase()) {
+    case 'MINUTES': return n * 60_000;
+    case 'HOURS': return n * HOUR_MS;
+    case 'DAYS': return n * 24 * HOUR_MS;
+    case 'WEEKS': return n * 7 * 24 * HOUR_MS;
+    case 'MONTHS': return n * 30 * 24 * HOUR_MS;
+    case 'YEARS': return n * 365 * 24 * HOUR_MS;
+    default: return null;
+  }
+}
+
+function logFallback(reason: string, err: unknown): void {
+  logger.warn(
+    { reason, error: err instanceof Error ? err.message : err ? String(err) : undefined },
+    'Restriction change-detection falling back to full restriction sync',
+  );
+}

--- a/backend/src/domains/confluence/services/sync-service.integration.test.ts
+++ b/backend/src/domains/confluence/services/sync-service.integration.test.ts
@@ -528,6 +528,116 @@ describe.skipIf(!dbAvailable)('sync-service per-page restriction branch (EE #112
     // v0.3 no-op behaviour.
   });
 
+  // ── Audit-log-driven restriction-change detection (skip rule) ───────────
+  // syncPageRestrictions takes an optional change-set. In 'incremental' mode a
+  // page is skipped (no Confluence fetch) iff it was mirrored within the
+  // audit-covered window AND is not in the changed set — but its ACE synced_at
+  // is still bumped so the global stale-ACE sweep keeps the rows.
+  const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+  const incremental = (changed: string[]) => ({
+    mode: 'incremental' as const,
+    changedPageIds: new Set<string>(changed),
+    windowStartMs: Date.now() - WEEK_MS,
+    auditQueryAt: Date.now(),
+  });
+
+  it('audit-skip: skips the Confluence fetch but bumps ACE synced_at when audit shows no change', async () => {
+    const userA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    await insertUser(userA, 'alice');
+    await ensureSpace('DOCS');
+    const pageDbId = await insertPage('c-600', 'DOCS');
+    // Mirrored an hour ago (well within the week-long window) ...
+    await query(`UPDATE pages SET restrictions_synced_at = $1, inherit_perms = FALSE WHERE id = $2`, [
+      new Date(Date.now() - 60 * 60 * 1000),
+      pageDbId,
+    ]);
+    // ... carrying a Confluence ACE from that prior run with a stale synced_at.
+    await query(
+      `INSERT INTO access_control_entries (resource_type, resource_id, principal_type, principal_id, permission, source, synced_at)
+       VALUES ('page', $1, 'user', $2, 'read', 'confluence', $3)`,
+      [pageDbId, userA, new Date('2020-01-01T00:00:00Z')],
+    );
+
+    const client = makeMockClient();
+    const startedAt = new Date();
+    await __internal.syncPageRestrictions(client as never, fakePage('c-600'), startedAt, new Map(), incremental([]));
+
+    expect(client.restrictionCalls).toHaveLength(0);
+    expect(client.ancestorCalls).toHaveLength(0);
+    const aces = await getAces(pageDbId);
+    expect(aces).toHaveLength(1);
+    expect(aces[0]!.synced_at!.getTime()).toBe(startedAt.getTime());
+  });
+
+  it('audit-skip: FETCHES when the page id is in the changed set', async () => {
+    const userA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    await insertUser(userA, 'alice');
+    await ensureSpace('DOCS');
+    const pageDbId = await insertPage('c-601', 'DOCS');
+    await query(`UPDATE pages SET restrictions_synced_at = $1, inherit_perms = FALSE WHERE id = $2`, [
+      new Date(Date.now() - 60 * 60 * 1000),
+      pageDbId,
+    ]);
+
+    const client = makeMockClient();
+    client.restrictionsByPage.set('c-601', [readRestriction([{ userKey: 'keyalice', username: 'alice' }])]);
+    await __internal.syncPageRestrictions(client as never, fakePage('c-601'), new Date(), new Map(), incremental(['c-601']));
+
+    expect(client.restrictionCalls).toEqual(['c-601']);
+    expect(await getAces(pageDbId)).toHaveLength(1);
+  });
+
+  it('audit-skip: FETCHES a never-mirrored page (restrictions_synced_at NULL) in incremental mode', async () => {
+    const userA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    await insertUser(userA, 'alice');
+    await ensureSpace('DOCS');
+    const pageDbId = await insertPage('c-602', 'DOCS'); // restrictions_synced_at stays NULL
+
+    const client = makeMockClient();
+    client.restrictionsByPage.set('c-602', [readRestriction([{ userKey: 'keyalice', username: 'alice' }])]);
+    await __internal.syncPageRestrictions(client as never, fakePage('c-602'), new Date(), new Map(), incremental([]));
+
+    expect(client.restrictionCalls).toEqual(['c-602']);
+    expect(await getAces(pageDbId)).toHaveLength(1);
+  });
+
+  it('audit-skip: FETCHES when restrictions_synced_at predates the audit window', async () => {
+    const userA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    await insertUser(userA, 'alice');
+    await ensureSpace('DOCS');
+    const pageDbId = await insertPage('c-603', 'DOCS');
+    await query(`UPDATE pages SET restrictions_synced_at = $1, inherit_perms = FALSE WHERE id = $2`, [
+      new Date('2020-01-01T00:00:00Z'),
+      pageDbId,
+    ]);
+
+    const client = makeMockClient();
+    client.restrictionsByPage.set('c-603', [readRestriction([{ userKey: 'keyalice', username: 'alice' }])]);
+    await __internal.syncPageRestrictions(client as never, fakePage('c-603'), new Date(), new Map(), incremental([]));
+
+    expect(client.restrictionCalls).toEqual(['c-603']);
+  });
+
+  it('audit-skip: full mode always fetches and stamps restrictions_synced_at', async () => {
+    const userA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    await insertUser(userA, 'alice');
+    await ensureSpace('DOCS');
+    const pageDbId = await insertPage('c-604', 'DOCS');
+    await query(`UPDATE pages SET restrictions_synced_at = $1 WHERE id = $2`, [new Date(Date.now() - 60 * 60 * 1000), pageDbId]);
+
+    const client = makeMockClient();
+    client.restrictionsByPage.set('c-604', [readRestriction([{ userKey: 'keyalice', username: 'alice' }])]);
+    const startedAt = new Date();
+    await __internal.syncPageRestrictions(client as never, fakePage('c-604'), startedAt, new Map(), { mode: 'full' as const });
+
+    expect(client.restrictionCalls).toEqual(['c-604']);
+    const row = await query<{ restrictions_synced_at: Date | null }>(
+      `SELECT restrictions_synced_at FROM pages WHERE id = $1`,
+      [pageDbId],
+    );
+    expect(row.rows[0]!.restrictions_synced_at!.getTime()).toBe(startedAt.getTime());
+  });
+
   it('ancestor cache collapses repeated restriction fetches across siblings', async () => {
     const userA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
     await insertUser(userA, 'alice');

--- a/backend/src/domains/confluence/services/sync-service.ts
+++ b/backend/src/domains/confluence/services/sync-service.ts
@@ -7,6 +7,7 @@ import {
   ConfluenceRestriction,
   ConfluenceError,
 } from './confluence-client.js';
+import { getRestrictionChangeSet, type RestrictionChangeSet } from './restriction-change-tracker.js';
 import { confluenceToHtml, htmlToText } from '../../../core/services/content-converter.js';
 import { syncDrawioAttachments, syncImageAttachments, cleanPageAttachments, getMissingAttachments } from './attachment-handler.js';
 import { saveVersionSnapshot } from '../../../core/services/version-snapshot.js';
@@ -137,6 +138,17 @@ export async function syncUser(userId: string): Promise<void> {
   const syncRunStartedAt = new Date();
   const ancestorCache = new Map<string, ConfluenceRestriction[]>();
 
+  // Audit-log-driven restriction-change detection (perf). When RAG permission
+  // enforcement is on, ask the Confluence audit log which pages' restrictions
+  // changed so `syncPageRestrictions` can skip the per-page fetch for the rest.
+  // Fails safe to a full re-fetch on any uncertainty (no admin access on the
+  // sync token, retention gap, audit error). Inert in CE / un-flagged EE.
+  const restrictionChangeSet: RestrictionChangeSet = isFeatureEnabled(
+    ENTERPRISE_FEATURES.RAG_PERMISSION_ENFORCEMENT,
+  )
+    ? await getRestrictionChangeSet(client, Date.now())
+    : { mode: 'full' };
+
   // Sync run id (Compendiq/compendiq-ee#118). Stamped onto every
   // `pending_sync_versions` row inserted during this run so the conflict-
   // resolution UI / retention sweep can group rows by run ("the 12
@@ -159,6 +171,7 @@ export async function syncUser(userId: string): Promise<void> {
         syncRunStartedAt,
         ancestorCache,
         syncRunId,
+        restrictionChangeSet,
       );
     }
 
@@ -226,6 +239,7 @@ async function syncSpace(
   syncRunStartedAt: Date,
   ancestorCache: Map<string, ConfluenceRestriction[]>,
   syncRunId: string,
+  changeSet: RestrictionChangeSet = { mode: 'full' },
 ): Promise<void> {
   const spaceStartedAt = Date.now();
   const counts: SyncSpaceCounts = { pagesCreated: 0, pagesUpdated: 0, pagesDeleted: 0 };
@@ -272,7 +286,7 @@ async function syncSpace(
     });
 
     const page = pages[i]!;
-    await syncPage(client, userId, spaceKey, page, syncRunStartedAt, ancestorCache, counts, syncRunId);
+    await syncPage(client, userId, spaceKey, page, syncRunStartedAt, ancestorCache, counts, syncRunId, changeSet);
   }
 
   // During incremental sync, also check for pages with missing attachments
@@ -321,6 +335,7 @@ async function syncPage(
   ancestorCache: Map<string, ConfluenceRestriction[]>,
   counts: SyncSpaceCounts,
   syncRunId: string,
+  changeSet: RestrictionChangeSet = { mode: 'full' },
 ): Promise<void> {
   // Fetch full page content
   const page = await client.getPage(pageSummary.id);
@@ -392,7 +407,7 @@ async function syncPage(
       // from the plan is not wired (see §1.4 TODO below). `syncPageRestrictions`
       // is a no-op when the feature flag is disabled, so CE builds pay zero
       // extra cost here.
-      await syncPageRestrictions(client, page, syncRunStartedAt, ancestorCache);
+      await syncPageRestrictions(client, page, syncRunStartedAt, ancestorCache, changeSet);
       return;
     }
 
@@ -455,7 +470,7 @@ async function syncPage(
     // Version-unchanged branch: still re-evaluate restrictions. See note at
     // the earlier early-return above. Safe/cheap because `syncPageRestrictions`
     // short-circuits on the feature flag.
-    await syncPageRestrictions(client, page, syncRunStartedAt, ancestorCache);
+    await syncPageRestrictions(client, page, syncRunStartedAt, ancestorCache, changeSet);
     return;
   }
 
@@ -524,7 +539,7 @@ async function syncPage(
   // the page upsert so `pages.id` is guaranteed to exist (the ACE foreign
   // key on `resource_id` points at that SERIAL). No-op when the
   // `RAG_PERMISSION_ENFORCEMENT` feature flag is off.
-  await syncPageRestrictions(client, page, syncRunStartedAt, ancestorCache);
+  await syncPageRestrictions(client, page, syncRunStartedAt, ancestorCache, changeSet);
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -891,6 +906,7 @@ async function syncPageRestrictions(
   page: ConfluencePage,
   syncRunStartedAt: Date,
   ancestorCache: Map<string, ConfluenceRestriction[]>,
+  changeSet: RestrictionChangeSet = { mode: 'full' },
 ): Promise<void> {
   if (!isFeatureEnabled(ENTERPRISE_FEATURES.RAG_PERMISSION_ENFORCEMENT)) {
     return;
@@ -900,8 +916,8 @@ async function syncPageRestrictions(
   // UPDATE paths in `syncPage` run before this call so the row is
   // guaranteed to exist. A missing row means the INSERT silently failed
   // upstream — log and bail rather than plough on with a bogus resource_id.
-  const pageRow = await query<{ id: number }>(
-    `SELECT id FROM pages WHERE confluence_id = $1`,
+  const pageRow = await query<{ id: number; restrictions_synced_at: Date | null }>(
+    `SELECT id, restrictions_synced_at FROM pages WHERE confluence_id = $1`,
     [page.id],
   );
   if (pageRow.rows.length === 0) {
@@ -912,6 +928,27 @@ async function syncPageRestrictions(
     return;
   }
   const pageDbId = pageRow.rows[0]!.id;
+  const restrictionsSyncedAt = pageRow.rows[0]!.restrictions_synced_at;
+
+  // Audit-log-driven skip (perf): when the audit window confirms no restriction
+  // change for this page since we last mirrored it (within the covered window),
+  // skip the rate-limited Confluence fetch. Still bump this page's Confluence ACE
+  // synced_at to the current run so the global stale-ACE sweep keeps the rows —
+  // the optimization is sweep-neutral. Any uncertainty falls through to a fetch.
+  if (
+    changeSet.mode === 'incremental' &&
+    restrictionsSyncedAt !== null &&
+    restrictionsSyncedAt.getTime() >= changeSet.windowStartMs &&
+    !changeSet.changedPageIds.has(page.id)
+  ) {
+    await query(
+      `UPDATE access_control_entries
+          SET synced_at = $1
+        WHERE resource_type = 'page' AND resource_id = $2 AND source = 'confluence'`,
+      [syncRunStartedAt, pageDbId],
+    );
+    return;
+  }
 
   let effective: Awaited<ReturnType<typeof computeEffectivePageReadRestrictions>>;
   try {
@@ -937,7 +974,7 @@ async function syncPageRestrictions(
     // restriction. Flip `inherit_perms` back to TRUE — `userCanAccessPage`
     // will fall through to the space-level role check. No ACE writes; the
     // end-of-run sweep cleans up any leftover rows from a prior sync.
-    await query(`UPDATE pages SET inherit_perms = TRUE WHERE id = $1`, [pageDbId]);
+    await query(`UPDATE pages SET inherit_perms = TRUE, restrictions_synced_at = $2 WHERE id = $1`, [pageDbId, syncRunStartedAt]);
     return;
   }
 
@@ -1010,8 +1047,8 @@ async function syncPageRestrictions(
       );
     }
     await dbClient.query(
-      `UPDATE pages SET inherit_perms = FALSE WHERE id = $1`,
-      [pageDbId],
+      `UPDATE pages SET inherit_perms = FALSE, restrictions_synced_at = $2 WHERE id = $1`,
+      [pageDbId, syncRunStartedAt],
     );
     await dbClient.query('COMMIT');
   } catch (err) {

--- a/docs/superpowers/specs/2026-05-28-restriction-change-detection-design.md
+++ b/docs/superpowers/specs/2026-05-28-restriction-change-detection-design.md
@@ -1,0 +1,167 @@
+# Audit-log-driven restriction-change detection
+
+**Date:** 2026-05-28
+**Status:** Approved design (revised after spec self-review — see "Why per-page, not a global cursor")
+**Area:** `backend` · `confluence` domain · sync pipeline (EE + `RAG_PERMISSION_ENFORCEMENT` only)
+
+## Problem
+
+When `RAG_PERMISSION_ENFORCEMENT` is enabled (EE), every sync run mirrors each
+page's Confluence read-restrictions into `access_control_entries` (ACEs) so RAG
+answers never leak restricted content. The mirror requires a
+`getPageRestrictions(pageId)` HTTP call **per page, every run** — even for pages
+whose restrictions never changed.
+
+Confluence restrictions change *independently* of content version, so we cannot
+use `version.number` / `history.lastUpdated` to decide whether a re-fetch is
+needed (verified against DC 9.x: no restriction-modified timestamp exists on the
+content object or the `/restriction` endpoints). The result is O(pages)
+restriction calls per sync on large spaces, bounded only by the 60 RPM rate
+limiter and the per-run `ancestorCache`.
+
+## Goal
+
+Re-fetch restrictions only for pages whose restrictions **actually changed**,
+detected via the Confluence **Audit Log API**.
+
+### Non-negotiable correctness guarantee
+
+A pure performance layer that **degrades to today's exact behavior on any
+uncertainty.** A page's ACEs are *never* staler than today. There is **no**
+ACL-staleness / information-disclosure trade-off — every "not sure" path fetches.
+
+## Non-goals
+
+- No inbound webhooks (would need an inbound endpoint + Confluence-side admin
+  config). Audit-log polling is pull-based.
+- No change to CE or un-flagged EE behavior. Gated behind
+  `RAG_PERMISSION_ENFORCEMENT`, like the restriction sync it optimizes.
+
+## Verified API facts (Confluence Data Center 9.x)
+
+- `GET /rest/api/audit` records: `category` (e.g. `"Permissions"`), `creationDate`
+  (epoch ms), `summary`, `affectedObject { id, type, name }`, `changedValues[]`,
+  `associatedObjects[]`. Page-restriction events carry the page as `affectedObject`
+  with a **numeric content id** in `affectedObject.id` and `type === "page"`.
+  (Caveat: some builds use `objectType` instead of `type` — read whichever exists.)
+- Query: `startDate`/`endDate` (epoch ms), `searchString`, `start`/`limit`
+  (max 1000). Envelope `{ results, start, limit, size, _links.next }`.
+- `GET /rest/api/audit/retention` → `{ number, units }`.
+- Requires **Confluence Administrator**. Without it: `403` (authenticated) /
+  `404` (otherwise). Records past the retention window are purged.
+
+## Why per-page high-water marks, not a global cursor
+
+`syncUser(userId)` only visits pages in that user's accessible spaces. A single
+global "last processed audit time" cursor is **unsafe**: user A's run would
+advance the cursor past a change-event for page P that A can't see; when user B
+later syncs P, the event is behind the cursor and P is wrongly treated as
+unchanged → **stale ACE**. So freshness is tracked **per page**, and each page's
+own `restrictions_synced_at` is its high-water mark. Advancing one page's mark
+never affects another's.
+
+## State model
+
+- **`pages.restrictions_synced_at TIMESTAMPTZ NULL`** — when this page's ACEs
+  were last mirrored from Confluence. `NULL` = never mirrored. Set to the run's
+  `auditQueryAt` whenever we fetch+mirror. **Not** updated on skip.
+- **Confirm window `W`** — `RESTRICTION_CONFIRM_WINDOW_HOURS` (default `168` = 7
+  days). A page whose mark is older than `now - W` is force-fetched regardless of
+  audit, which (a) bounds the audit query to `W` and (b) guarantees every page is
+  re-confirmed at least once per `W` even if the audit log ever missed an event.
+- No persistent global cursor.
+
+## Components (all CE, `confluence` domain)
+
+### 1. `confluence-client.ts` — audit access
+- `getAuditRecords({ startDate, endDate?, start?, limit? }): Promise<ConfluenceAuditRecord[]>`
+  — fully paginates (`_links.next` / `start`+`limit`).
+- `getAuditRetention(): Promise<AuditRetention>`.
+- New exported types `ConfluenceAuditRecord`, `AuditRetention`.
+- `403`/`404` → throw typed `AuditUnavailableError`.
+- Reads `affectedObject.type ?? affectedObject.objectType`.
+
+### 2. `restriction-change-tracker.ts` — the decision brain (new service)
+```
+getRestrictionChangeSet(client, nowMs): Promise<ChangeSet>
+type ChangeSet =
+  | { mode: 'full' }                                    // fetch everything (fail-safe)
+  | { mode: 'incremental'; changedPageIds: Set<string>; windowStartMs: number; auditQueryAt: number }
+```
+Logic:
+1. `auditQueryAt = nowMs`. Desired `windowStartMs = nowMs - W`.
+2. `getAuditRetention()`; `effectiveStart = max(windowStartMs, nowMs - retentionMs)`.
+   (If retention `< W`, the window narrows; pages older than `effectiveStart` are
+   force-fetched by the skip rule, so correctness holds.)
+3. `getAuditRecords({ startDate: effectiveStart })`, paginated; keep records with
+   `category === 'Permissions'` **and** `affectedObject.type === 'page'`; collect
+   `affectedObject.id`.
+4. Any matching record without a parseable page id → `{ mode: 'full' }` (conservative).
+5. Else → `{ mode: 'incremental', changedPageIds, windowStartMs: effectiveStart, auditQueryAt }`.
+6. Any thrown error (`AuditUnavailableError`, 5xx, timeout) → `{ mode: 'full' }`
+   + one throttled warning.
+
+### 3. Migration `075_pages_restrictions_synced_at.sql`
+- `ALTER TABLE pages ADD COLUMN restrictions_synced_at TIMESTAMPTZ NULL;`
+
+### 4. `sync-service.ts` wiring
+- In `syncUser`, only when `RAG_PERMISSION_ENFORCEMENT` is on: compute the
+  change-set once (`const changeSet = await getRestrictionChangeSet(client, Date.now())`),
+  thread it + its `windowStartMs`/`auditQueryAt` into `syncPageRestrictions(...)`.
+
+## The skip rule (crux — fail-safe by construction)
+
+Inside `syncPageRestrictions`, skip the `getPageRestrictions` fetch **iff all of:**
+1. `changeSet.mode === 'incremental'`, **and**
+2. `page.restrictions_synced_at` is non-null **and** `>= changeSet.windowStartMs`
+   (within the audit-covered confirm window), **and**
+3. `page.id ∉ changeSet.changedPageIds`.
+
+Otherwise: full fetch + ACE mirror exactly as today, then stamp
+`restrictions_synced_at = changeSet.auditQueryAt` (or `NOW()` in full mode).
+
+New pages (`NULL`), pages older than the window, and any uncertainty → fetch.
+
+### Why it's correct
+A skipped page P has `restrictions_synced_at = m ≥ windowStartMs`, and the audit
+window `(windowStartMs, now]` is fully covered with **no** change event for P.
+Therefore no restriction change occurred to P since `m` → P's ACEs are current.
+Skipping is safe. Anything that breaks an assumption (no audit coverage, mark too
+old, change present, never mirrored) falls through to a fetch.
+
+## Fail-safe matrix (all → full fetch; correctness == today)
+
+| Condition | Behavior |
+|---|---|
+| First mirror of a page (`NULL` mark) | fetch that page |
+| Mark older than confirm window `W` | fetch that page (+ re-stamp) |
+| Audit `403`/`404` (no admin permission) | full mode + warn once |
+| Audit `5xx` / timeout | full mode this run, retry next |
+| Retention `< W` | window narrows; older pages fetched |
+| Unparseable `Permissions` event | full mode |
+| Partial run failure | marks only advance for pages actually fetched |
+
+## Testing
+
+- **Unit — `restriction-change-tracker`** (mock client): `403`→full; 5xx→full;
+  retention-narrows-window; pagination across pages; `category`/`type` filtering;
+  unparseable record→full; happy path returns correct `changedPageIds` +
+  `windowStartMs`.
+- **Unit — `confluence-client` audit methods** (mock fetch): epoch-ms params;
+  `_links.next` pagination; `403`→`AuditUnavailableError`; `type` vs `objectType`.
+- **Integration — `sync-service`** (real Postgres): incremental skips an unchanged,
+  in-window page (assert `getPageRestrictions` **not** called); fetches a changed
+  page; fetches a `NULL`-mark page; fetches an out-of-window page; full mode fetches
+  all; `restrictions_synced_at` stamped only on fetched pages.
+
+## Expected benefit
+
+EE+RAG steady-state syncs: restriction fetches drop from O(pages) to
+O(changed pages + pages older than `W`) per run, with **identical** ACL accuracy.
+
+## Risks / mitigations
+
+- `"Permissions"` includes non-page events → filtered by `affectedObject.type ===
+  'page'`; a stray false positive only causes one extra (safe) fetch.
+- Field-name variance (`type`/`objectType`) → read both.
+- Audit log not enabled / admin perm absent → full mode (no regression vs. today).

--- a/docs/superpowers/specs/2026-05-28-restriction-change-detection-design.md
+++ b/docs/superpowers/specs/2026-05-28-restriction-change-detection-design.md
@@ -129,6 +129,22 @@ Therefore no restriction change occurred to P since `m` → P's ACEs are current
 Skipping is safe. Anything that breaks an assumption (no audit coverage, mark too
 old, change present, never mirrored) falls through to a fetch.
 
+### Interaction with the global stale-ACE sweep
+
+`syncUser` runs a **global** `sweepStaleConfluenceAces(syncRunStartedAt)` after the
+page loop, deleting every `source='confluence'` page ACE whose `synced_at` is
+older than the run start. Naively skipping a page would leave its ACEs with a
+stale `synced_at`, and the sweep would wrongly **delete** them — turning a
+restricted page public (an inverse disclosure bug).
+
+So the skip path **still bumps** the page's Confluence ACE `synced_at` to
+`syncRunStartedAt` (a cheap local `UPDATE`); it only avoids the rate-limited
+Confluence HTTP fetch + ancestor walk + principal resolution. The set of pages
+with a fresh `synced_at` after a run is therefore identical to today, leaving the
+sweep's behavior unchanged. The optimization is **sweep-neutral**.
+
+Config: `RESTRICTION_CONFIRM_WINDOW_HOURS` (default `168` = 7 days) sets `W`.
+
 ## Fail-safe matrix (all → full fetch; correctness == today)
 
 | Condition | Behavior |


### PR DESCRIPTION
## What

EE deployments with `RAG_PERMISSION_ENFORCEMENT` mirror each page's Confluence read restrictions into `access_control_entries` on every sync run, which required a `getPageRestrictions` HTTP call **per page, every run**. Confluence restrictions change independently of content version and DC exposes no restriction-modified timestamp, so there was no cheap way to know when a re-fetch was actually needed.

This adds **audit-log-driven change detection**: the sync consults `GET /rest/api/audit` once per run to learn which pages' restrictions changed, and skips the per-page restriction fetch for everything else.

## Safety (security-adjacent path)

A **pure performance layer that degrades to today's exact behavior on any uncertainty** — ACLs are never staler than today:
- No audit admin permission (403/404), retention gap, audit error, first sync, or unparseable event → **full re-fetch**.
- The skip path still bumps each page's ACE `synced_at`, so the **global stale-ACE sweep is unaffected** (sweep-neutral). Only the rate-limited HTTP fetch + ancestor walk are avoided.
- Per-page high-water marks (`pages.restrictions_synced_at`), **not** a global cursor — a global cursor would be unsafe under per-user sync scoping (one user's run could "consume" a change event for a page it cannot see).
- A bounded confirm window `W` (`RESTRICTION_CONFIRM_WINDOW_HOURS`, default 7 days) re-confirms every page at least once per `W` even absent an audit signal (defense-in-depth) and bounds the audit query size.

## Components

- `ConfluenceClient.getAuditRecords()` / `getAuditRetention()` + `AuditUnavailableError` (tolerates the DC `type`/`objectType` field-name variance)
- `restriction-change-tracker.getRestrictionChangeSet()` — the fail-safe decision brain
- migration `075_pages_restrictions_synced_at.sql`
- `sync-service` skip wiring (threaded `syncUser` → `syncSpace` → `syncPage` → `syncPageRestrictions`)

Gated behind `RAG_PERMISSION_ENFORCEMENT`; **CE and un-flagged EE are untouched**.

## Tests

- 6 `confluence-client` audit unit tests (pagination, epoch params, 403→AuditUnavailableError, type/objectType)
- 8 `restriction-change-tracker` unit tests (403→full, retention-gap→full, unparseable→full, filtering, window narrowing)
- 14 `sync-service` integration tests vs. real Postgres — **5 new** skip-rule cases + **9 existing** preserved

## Verification

`tsc --noEmit` clean · `eslint --max-warnings=0` clean · full `domains/confluence` suite **324 pass**

## Docs

Design + fail-safe invariants: `docs/superpowers/specs/2026-05-28-restriction-change-detection-design.md`. No architecture-diagram change needed — the sync→ACE mirroring flow is structurally unchanged; this only adds an internal skip path. Flagging per the diagram-source-of-truth rule in case a reviewer sees it differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)