### PR TITLE
feat(settings): polish LLM provider UX — dismissable modal, delete confirmation, pending states

### DIFF
--- a/frontend/src/features/settings/panels/ProviderEditModal.test.tsx
+++ b/frontend/src/features/settings/panels/ProviderEditModal.test.tsx
@@ -121,3 +121,43 @@ describe('ProviderEditModal — edit', () => {
     );
   });
 });
+
+describe('ProviderEditModal — dismissal & focus', () => {
+  beforeEach(() => {
+    useAuthStore.getState().setAuth('test-token', { id: '1', username: 'admin', role: 'admin' });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useAuthStore.getState().clearAuth();
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    const Wrapper = createWrapper();
+    render(<ProviderEditModal mode="create" open onClose={onClose} onSaved={() => {}} />, { wrapper: Wrapper });
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes when the backdrop is clicked', () => {
+    const onClose = vi.fn();
+    const Wrapper = createWrapper();
+    render(<ProviderEditModal mode="create" open onClose={onClose} onSaved={() => {}} />, { wrapper: Wrapper });
+    fireEvent.click(screen.getByTestId('provider-modal-backdrop'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not close when the dialog body is clicked', () => {
+    const onClose = vi.fn();
+    const Wrapper = createWrapper();
+    render(<ProviderEditModal mode="create" open onClose={onClose} onSaved={() => {}} />, { wrapper: Wrapper });
+    fireEvent.click(screen.getByRole('dialog'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('focuses the name field when opened', () => {
+    const Wrapper = createWrapper();
+    render(<ProviderEditModal mode="create" open onClose={() => {}} onSaved={() => {}} />, { wrapper: Wrapper });
+    expect(screen.getByLabelText(/name/i)).toHaveFocus();
+  });
+});

--- a/frontend/src/features/settings/panels/ProviderEditModal.tsx
+++ b/frontend/src/features/settings/panels/ProviderEditModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import type { LlmProvider, LlmProviderInput } from '@compendiq/contracts';
 import { apiFetch } from '../../../shared/lib/api';
@@ -20,6 +20,18 @@ export function ProviderEditModal({ mode, initial, open, onClose, onSaved }: Pro
   const [defaultModel, setDefaultModel] = useState(initial?.defaultModel ?? '');
   const [saving, setSaving] = useState(false);
   const canSave = name.trim().length > 0 && /^https?:\/\//.test(baseUrl);
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  // Close on Escape and move focus into the dialog when it opens.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    nameRef.current?.focus();
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
 
   if (!open) return null;
 
@@ -55,12 +67,25 @@ export function ProviderEditModal({ mode, initial, open, onClose, onSaved }: Pro
   }
 
   return (
-    <div role="dialog" className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="nm-card w-[480px] space-y-3 p-6">
-        <h2 className="text-lg font-semibold">{mode === 'create' ? 'Add provider' : 'Edit provider'}</h2>
+    <div
+      data-testid="provider-modal-backdrop"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="provider-modal-title"
+        className="nm-card w-[480px] space-y-3 p-6"
+      >
+        <h2 id="provider-modal-title" className="text-lg font-semibold">
+          {mode === 'create' ? 'Add provider' : 'Edit provider'}
+        </h2>
         <label className="block text-sm">
           Name
-          <input className="nm-input w-full" value={name} onChange={(e) => setName(e.target.value)} />
+          <input ref={nameRef} className="nm-input w-full" value={name} onChange={(e) => setName(e.target.value)} />
         </label>
         <label className="block text-sm">
           Base URL

--- a/frontend/src/features/settings/panels/ProviderListSection.test.tsx
+++ b/frontend/src/features/settings/panels/ProviderListSection.test.tsx
@@ -128,4 +128,48 @@ describe('ProviderListSection', () => {
       );
     });
   });
+
+  it('delete requires confirmation before calling the API', async () => {
+    const Wrapper = createWrapper();
+    const spy = mockFetchJson([
+      { match: (url, init) => url.endsWith('/admin/llm-providers') && (init.method ?? 'GET') === 'GET', body: [providerA, providerB] },
+      { match: (url, init) => url.includes(`/admin/llm-providers/${providerB.id}`) && init.method === 'DELETE', body: { ok: true } },
+    ]);
+    render(<ProviderListSection />, { wrapper: Wrapper });
+    await screen.findByText('OpenAI');
+
+    // providerB (index 1) is non-default → deletable.
+    fireEvent.click(screen.getAllByRole('button', { name: /^delete$/i })[1]);
+
+    // No DELETE fired yet — a confirmation step is required.
+    const deletedYet = spy.mock.calls.some(
+      ([url, init]) => String(url).includes(`/admin/llm-providers/${providerB.id}`) && (init as RequestInit)?.method === 'DELETE',
+    );
+    expect(deletedYet).toBe(false);
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm delete/i }));
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining(`/admin/llm-providers/${providerB.id}`),
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  it('cancelling the delete confirmation makes no API call', async () => {
+    const Wrapper = createWrapper();
+    const spy = mockFetchJson([
+      { match: (url, init) => url.endsWith('/admin/llm-providers') && (init.method ?? 'GET') === 'GET', body: [providerA, providerB] },
+    ]);
+    render(<ProviderListSection />, { wrapper: Wrapper });
+    await screen.findByText('OpenAI');
+
+    fireEvent.click(screen.getAllByRole('button', { name: /^delete$/i })[1]);
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    // Back to the Delete button, and no DELETE was ever issued.
+    expect(screen.getAllByRole('button', { name: /^delete$/i }).length).toBeGreaterThan(0);
+    const deleted = spy.mock.calls.some(([, init]) => (init as RequestInit)?.method === 'DELETE');
+    expect(deleted).toBe(false);
+  });
 });

--- a/frontend/src/features/settings/panels/ProviderListSection.tsx
+++ b/frontend/src/features/settings/panels/ProviderListSection.tsx
@@ -13,6 +13,7 @@ export function ProviderListSection() {
   });
   const [editing, setEditing] = useState<LlmProvider | null>(null);
   const [adding, setAdding] = useState(false);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
   const setDefault = useMutation({
     mutationFn: (id: string) =>
@@ -32,6 +33,7 @@ export function ProviderListSection() {
       toast.success('Provider deleted');
     },
     onError: (e: Error) => toast.error(e.message),
+    onSettled: () => setConfirmDeleteId(null),
   });
 
   const test = useMutation({
@@ -70,15 +72,36 @@ export function ProviderListSection() {
               </div>
               <div className="text-muted-foreground text-xs">{p.baseUrl}</div>
             </div>
-            <div className="flex gap-2 text-xs">
+            <div className="flex items-center gap-2 text-xs">
               <button onClick={() => setEditing(p)}>Edit</button>
-              <button onClick={() => setDefault.mutate(p.id)} disabled={p.isDefault}>
-                Set default
+              <button
+                onClick={() => setDefault.mutate(p.id)}
+                disabled={p.isDefault || (setDefault.isPending && setDefault.variables === p.id)}
+              >
+                {setDefault.isPending && setDefault.variables === p.id ? 'Setting…' : 'Set default'}
               </button>
-              <button onClick={() => test.mutate(p.id)}>Test</button>
-              <button onClick={() => del.mutate(p.id)} disabled={p.isDefault}>
-                Delete
+              <button
+                onClick={() => test.mutate(p.id)}
+                disabled={test.isPending && test.variables === p.id}
+              >
+                {test.isPending && test.variables === p.id ? 'Testing…' : 'Test'}
               </button>
+              {confirmDeleteId === p.id ? (
+                <>
+                  <button
+                    className="text-error"
+                    onClick={() => del.mutate(p.id)}
+                    disabled={del.isPending && del.variables === p.id}
+                  >
+                    {del.isPending && del.variables === p.id ? 'Deleting…' : 'Confirm delete'}
+                  </button>
+                  <button onClick={() => setConfirmDeleteId(null)}>Cancel</button>
+                </>
+              ) : (
+                <button onClick={() => setConfirmDeleteId(p.id)} disabled={p.isDefault}>
+                  Delete
+                </button>
+              )}
             </div>
           </li>
         ))}


### PR DESCRIPTION
## What

Targeted UX polish for **Settings → LLM providers**, a flow admins use regularly:

- **Dismissable modal** (`ProviderEditModal`): closes on **Escape** and on **backdrop click** (but not when clicking inside the dialog body), moves focus to the Name field on open, and is marked up as a proper `role="dialog"` + `aria-modal` + `aria-labelledby` card. Previously neither Escape nor click-outside worked — you had to find the Cancel button.
- **Delete confirmation** (`ProviderListSection`): deleting a provider now takes two steps (**Confirm delete** / **Cancel**) instead of firing on a single click. Provider config (base URL, API key, default-model assignments) is easy to lose by a stray click; this prevents accidental, irreversible deletion.
- **Pending feedback**: **Set default**, **Test**, and **Delete** show a per-row pending label (`Setting…` / `Testing…` / `Deleting…`) and disable while their request is in flight, so a button never just silently "goes gray".

## Tests

6 new (all existing provider tests preserved):
- modal: closes on Escape, closes on backdrop click, does **not** close on body click, focuses Name on open
- list: delete requires confirmation before any API call; cancelling the confirmation issues no DELETE

## Verification

`tsc --noEmit` clean · `eslint --max-warnings=0` clean · provider test files **16 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)