### PR TITLE
feat(settings): per-row progress indicator when setting a space home page

### DIFF
--- a/frontend/src/features/settings/SpaceHomePicker.test.tsx
+++ b/frontend/src/features/settings/SpaceHomePicker.test.tsx
@@ -137,6 +137,46 @@ describe('SpaceHomePicker (#379)', () => {
     });
   });
 
+  it('marks the chosen result row busy while the set-home request is in flight', async () => {
+    let releaseSetHome!: () => void;
+    const setHomePending = new Promise<Response>((resolve) => {
+      releaseSetHome = () =>
+        resolve(
+          new Response(JSON.stringify({ spaceKey: 'DEV', customHomePageId: 999 }), {
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+    });
+    const json = (body: unknown) =>
+      new Response(JSON.stringify(body), { headers: { 'Content-Type': 'application/json' } });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+      const u = String(url);
+      if (u.includes('/permissions/check')) return json({ allowed: true });
+      if (u.includes('/search')) return json({ items: [{ id: 999, title: 'Welcome page', excerpt: '', source: 'confluence', spaceKey: 'DEV', score: 1 }], total: 1 });
+      if (u.includes('/spaces/DEV/home') && init?.method === 'PUT') return setHomePending;
+      return json({});
+    });
+
+    render(
+      <SpaceHomePicker spaceKey="DEV" resolvedHomePageId={null} customHomePageId={null} />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(await screen.findByTestId('space-home-picker-trigger-DEV'));
+    fireEvent.change(await screen.findByTestId('space-home-picker-search-DEV'), { target: { value: 'wel' } });
+    fireEvent.click(await screen.findByTestId('space-home-picker-result-999'));
+
+    // While the PUT is pending, the clicked row advertises a busy state.
+    await waitFor(() =>
+      expect(screen.getByTestId('space-home-picker-result-999')).toHaveAttribute('aria-busy', 'true'),
+    );
+
+    // Once it resolves, the picker closes (the row is gone).
+    releaseSetHome();
+    await waitFor(() => expect(screen.queryByTestId('space-home-picker-result-999')).toBeNull());
+  });
+
   it('PUTs homePageId: null when "Use Confluence default" is clicked', async () => {
     const calls = mockFetch((call) => {
       if (call.url.includes('/permissions/check')) return { allowed: true };

--- a/frontend/src/features/settings/SpaceHomePicker.tsx
+++ b/frontend/src/features/settings/SpaceHomePicker.tsx
@@ -42,6 +42,8 @@ export function SpaceHomePicker({
   const [query, setQuery] = useState('');
 
   const setHome = useSetSpaceHome();
+  // Which result row is currently being set as home (for a per-row spinner).
+  const [settingPageId, setSettingPageId] = useState<number | null>(null);
 
   // Show the resolved current home (page title + breadcrumb-ish hint).
   // The search hook is enabled at q.length >= 2 so the page lookup here
@@ -53,6 +55,7 @@ export function SpaceHomePicker({
   const search = useSearch({ q: query.trim(), spaceKey });
 
   const setOverride = (homePageId: number | null) => {
+    if (homePageId !== null) setSettingPageId(homePageId);
     setHome.mutate(
       { spaceKey, homePageId },
       {
@@ -68,6 +71,7 @@ export function SpaceHomePicker({
         onError: (err) => {
           toast.error(err.message || 'Could not update the space home page.');
         },
+        onSettled: () => setSettingPageId(null),
       },
     );
   };
@@ -188,6 +192,7 @@ export function SpaceHomePicker({
                         type="button"
                         role="option"
                         aria-selected={isCurrent}
+                        aria-busy={settingPageId === p.id}
                         disabled={setHome.isPending}
                         onClick={() => setOverride(p.id)}
                         className={cn(
@@ -198,7 +203,11 @@ export function SpaceHomePicker({
                         data-testid={`space-home-picker-result-${p.id}`}
                       >
                         <span className="flex-1 truncate">{p.title}</span>
-                        {isCurrent && <Check size={12} className="shrink-0 text-action" />}
+                        {settingPageId === p.id ? (
+                          <Loader2 size={12} className="shrink-0 animate-spin text-action" />
+                        ) : isCurrent ? (
+                          <Check size={12} className="shrink-0 text-action" />
+                        ) : null}
                       </button>
                     </li>
                   );


### PR DESCRIPTION
## What

In `SpaceHomePicker`, choosing a search result to set as the space home page disabled the whole result list while the request was in flight but gave **no positive feedback on the row you clicked** — it just greyed out, leaving you unsure whether it registered.

Now the clicked row shows a spinner and `aria-busy` while its set-home `PUT` is pending, falling back to the existing current-home check mark once settled.

## Why just this (and not the other UX candidates)

While building this I verified the other flagged UX items against the code and found them already handled or intentional:
- **LabelManager** already has a two-step delete confirmation **and** a success toast with the affected-page count (`Removed "X" from N pages`).
- The `react-hooks/exhaustive-deps` disables in **GraphPage** and **SpacesTab** are addressed separately (follow-up PR) — GraphPage's in particular is intentional (adding `searchParams` to the deps would infinite-loop the URL sync).

## Test

New: the clicked result row is `aria-busy` while the PUT is pending (deferred mock), then clears on resolve. All existing SpaceHomePicker tests preserved (**8 pass**). `tsc --noEmit` + `eslint --max-warnings=0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)