### PR TITLE
feat(db): unique index on (oidc_issuer, oidc_sub) — OIDC identity integrity

### DIFF
--- a/backend/src/core/db/migrations/076_oidc_identity_unique.sql
+++ b/backend/src/core/db/migrations/076_oidc_identity_unique.sql
@@ -1,0 +1,20 @@
+-- Migration 076: one Compendiq account per OIDC identity
+--
+-- The EE OIDC SSO provisioning path (provisionOidcUser) looks users up by
+-- (oidc_sub, oidc_issuer) and inserts on miss, with no DB-level uniqueness
+-- guard. Two concurrent first-logins for the same IdP subject could therefore
+-- both pass the lookup and both insert, creating duplicate accounts for one
+-- identity (with divergent role/group state). This partial unique index makes
+-- "one IdP subject = one user" authoritative; the EE provisioning path now
+-- catches the resulting 23505 and converges on the winning row.
+--
+-- Partial (WHERE oidc_sub IS NOT NULL) so local / non-OIDC users — whose
+-- oidc_sub and oidc_issuer are NULL — are entirely unaffected and may coexist.
+--
+-- NOTE: if a deployment already contains duplicate (oidc_issuer, oidc_sub) rows
+-- from the pre-fix behaviour, this index creation will fail; resolve the
+-- duplicates (merge/disable the extra accounts) before applying.
+
+CREATE UNIQUE INDEX IF NOT EXISTS users_oidc_identity_uniq
+  ON users (oidc_issuer, oidc_sub)
+  WHERE oidc_sub IS NOT NULL;


### PR DESCRIPTION
## What

Adds migration `076_oidc_identity_unique.sql` — a **partial unique index** on `users (oidc_issuer, oidc_sub) WHERE oidc_sub IS NOT NULL`.

## Why

The EE OIDC SSO provisioning path (`provisionOidcUser`) looked users up by `(oidc_sub, oidc_issuer)` and inserted on miss with **no DB uniqueness guard**, so two concurrent first-logins for one IdP subject could both insert → duplicate accounts for a single identity, with divergent role/group state. This index makes "one IdP subject = one user" authoritative.

Partial (`WHERE oidc_sub IS NOT NULL`) so local/non-OIDC users (NULL oidc_sub/issuer) are unaffected and coexist freely.

## Companion change

The EE provisioning path is updated in `Compendiq/compendiq-ee#187` to catch the `23505` this index raises and converge on the winning row. That EE change is safe with or without this index; this migration makes it fully effective.

## Upgrade note

If a deployment already contains duplicate `(oidc_issuer, oidc_sub)` rows from the prior behaviour, index creation fails until the duplicates are resolved — surfaced loudly rather than silently kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)