### PR TITLE
feat(llm): invoke the PII scanner on generated summaries (EE #119 wiring)

### DIFF
--- a/backend/src/domains/knowledge/services/summary-worker.test.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.test.ts
@@ -10,6 +10,7 @@ import {
   startSummaryWorker,
   stopSummaryWorker,
 } from './summary-worker.js';
+import { setPiiScanHook, _resetPiiScanHookForTests } from '../../../core/services/pii-scan-hook.js';
 
 const dbAvailable = await isDbAvailable();
 
@@ -235,6 +236,53 @@ describe.skipIf(!dbAvailable)('Summary Worker', () => {
       expect(result.rows[0].summary_html).toContain('test');
       expect(result.rows[0].summary_model).toBe('test-model');
       expect(result.rows[0].summary_content_hash).toHaveLength(64);
+    });
+
+    describe('PII guard (EE #119)', () => {
+      afterEach(() => {
+        _resetPiiScanHookForTests();
+      });
+
+      it('withholds the summary when the PII scanner blocks it', async () => {
+        setPiiScanHook(async () => ({
+          spans: [{ start: 0, end: 5, category: 'EMAIL', confidence: 0.99, source: 'regex' }],
+          action: 'blocked',
+        }));
+        await query(
+          `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status)
+           VALUES ('pii-block', $1, 'PII Page', $2, 'pending')`,
+          [testSpaceKey, 'C'.repeat(200)],
+        );
+
+        await runSummaryBatch('test-model');
+
+        const row = await query<{ summary_status: string; summary_text: string | null }>(
+          "SELECT summary_status, summary_text FROM pages WHERE confluence_id = 'pii-block'",
+        );
+        expect(row.rows[0].summary_status).toBe('skipped');
+        expect(row.rows[0].summary_text).toBeNull();
+      });
+
+      it('persists the redacted summary when the PII scanner redacts', async () => {
+        setPiiScanHook(async () => ({
+          spans: [{ start: 0, end: 5, category: 'EMAIL', confidence: 0.99, source: 'regex' }],
+          action: 'redacted',
+          redactedText: 'Redacted [REDACTED:EMAIL] summary.',
+        }));
+        await query(
+          `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status)
+           VALUES ('pii-redact', $1, 'PII Page', $2, 'pending')`,
+          [testSpaceKey, 'D'.repeat(200)],
+        );
+
+        await runSummaryBatch('test-model');
+
+        const row = await query<{ summary_status: string; summary_html: string }>(
+          "SELECT summary_status, summary_html FROM pages WHERE confluence_id = 'pii-redact'",
+        );
+        expect(row.rows[0].summary_status).toBe('summarized');
+        expect(row.rows[0].summary_html).toContain('REDACTED');
+      });
     });
 
     it('should detect content changes via timestamp and re-summarize', async () => {

--- a/backend/src/domains/knowledge/services/summary-worker.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.ts
@@ -30,6 +30,7 @@
 import crypto from 'node:crypto';
 import { query } from '../../../core/db/postgres.js';
 import { emitWebhookEvent } from '../../../core/services/webhook-emit-hook.js';
+import { scanForPii } from '../../../core/services/pii-scan-hook.js';
 import { getSystemPrompt } from '../../llm/services/prompts.js';
 import { resolveUsecase } from '../../llm/services/llm-provider-resolver.js';
 import {
@@ -263,8 +264,34 @@ async function summarizePage(
       throw new Error('LLM returned empty summary');
     }
 
+    // PII guard (EE #119): scan the generated summary before persisting it.
+    // No-op in CE / when no policy is active. On 'blocked' the summary is
+    // withheld (terminal 'skipped' + content hash so it isn't retried until the
+    // source content changes); on 'redacted' the redacted variant is persisted.
+    const piiResult = await scanForPii(markdownSummary, 'summary');
+    if (piiResult?.action === 'blocked') {
+      await query(
+        `UPDATE pages
+         SET summary_status = 'skipped',
+             summary_error = $1,
+             summary_content_hash = $2,
+             summary_retry_count = 0
+         WHERE id = $3`,
+        ['Summary withheld: detected PII (policy: block)', contentHash, id],
+      );
+      logger.warn(
+        { pageId: id, title, piiSpans: piiResult.spans.length },
+        'Summary blocked — PII detected in generated summary',
+      );
+      return;
+    }
+    const summaryMarkdown =
+      piiResult?.action === 'redacted' && piiResult.redactedText
+        ? piiResult.redactedText
+        : markdownSummary;
+
     // Convert Markdown → HTML
-    const summaryHtml = await markdownToHtml(markdownSummary);
+    const summaryHtml = await markdownToHtml(summaryMarkdown);
     const summaryText = stripHtml(summaryHtml);
 
     // Store result


### PR DESCRIPTION
## What

The EE PII detection/redaction pipeline (`scanForPii` hook) was **never called** from any CE inference path — so an admin enabling "block publication / redact" got no runtime effect. This wires the **summary worker** (the one buffered, non-streaming generator that persists AI text) to call `scanForPii(summary, "summary")` before storing:

- **`blocked`** → summary withheld (`summary_status=skipped` + content hash, so it is not retried until the source content changes)
- **`redacted`** → the redacted variant is persisted
- **`flag-only` / CE (no hook)** → unchanged

## Scope (why only the summary worker)

While wiring this I confirmed the route shapes:
- **`generate` / `improve` / `ask`** stream output to the client via `streamChat`+SSE and persist only when the user later **saves/publishes** — so blocking at generation is architecturally impossible; their enforcement belongs at the **publish path** (a separate, larger change).
- **`auto-tag` / `pages-tags`** emit tags constrained to a fixed `ALLOWED_TAGS` allowlist — no free text, so no PII scan is warranted.

So the summary worker is the only generation-time scan point that is both clean and valuable; it makes the pipeline genuinely invoked. The streaming-content publish-path enforcement and the EE scanner fail-closed-on-error refinement are tracked as follow-ups.

## Tests
`summary-worker` suite **19 pass** vs real Postgres, incl. 2 new cases (withhold-on-block, persist-redacted). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)