### PR TITLE
feat(frontend): add SSO login button to CE login page

### DIFF
--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -95,6 +95,27 @@ vi.mock('./domains/llm/services/llm-provider-bootstrap.js', () => ({
   bootstrapLlmProviders: bootstrapLlmProvidersSpy,
 }));
 
+describe('buildApp — community OIDC config fallback', () => {
+  it('serves a disabled OIDC config so the shared CE login page hides the SSO button', async () => {
+    const { buildApp } = await import('./app.js');
+    const app = await buildApp();
+
+    try {
+      const response = await app.inject({ method: 'GET', url: '/api/auth/oidc/config' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        enabled: false,
+        issuer: null,
+        name: null,
+        enterpriseRequired: true,
+      });
+    } finally {
+      await app.close();
+    }
+  });
+});
+
 describe('buildApp — CORS multi-origin support', () => {
   const originalFrontendUrl = process.env.FRONTEND_URL;
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -90,6 +90,7 @@ import { initLlmQueueClusterCoordination } from './domains/llm/services/llm-queu
 import { setLlmAuditHook } from './domains/llm/services/llm-audit-hook.js';
 import { defaultLlmAuditWriter } from './domains/llm/services/llm-audit-default-writer.js';
 import { ENTERPRISE_FEATURES } from './core/enterprise/features.js';
+import type { OidcConfig } from '@compendiq/contracts';
 
 export async function buildApp() {
   // v0.4 epic §3.4 — replace the previous blanket `trustProxy: true` with a
@@ -387,6 +388,20 @@ export async function buildApp() {
       tier: 'community',
       valid: true,
       features: [],
+    }));
+  }
+
+  // Community-mode OIDC config fallback.
+  // The EE plugin serves a richer GET /api/auth/oidc/config when OIDC_SSO is
+  // licensed (see the conditional registration below); in community mode we
+  // return a static "disabled" payload so the shared CE login page can hide
+  // the SSO button instead of 404-ing on every load.
+  if (enterprise.version === 'community') {
+    app.get('/api/auth/oidc/config', async (): Promise<OidcConfig> => ({
+      enabled: false,
+      issuer: null,
+      name: null,
+      enterpriseRequired: true,
     }));
   }
 

--- a/frontend/src/features/settings/LoginPage.test.tsx
+++ b/frontend/src/features/settings/LoginPage.test.tsx
@@ -75,20 +75,41 @@ describe('LoginPage', () => {
     expect(screen.queryByTestId('sso-login-btn')).not.toBeInTheDocument();
   });
 
-  it('shows an error toast when redirected back with an OIDC error param', async () => {
+  it('shows a mapped error toast when redirected back with a known OIDC error code', async () => {
     const { toast } = await import('sonner');
     const { apiFetch } = await import('../../shared/lib/api');
     vi.mocked(apiFetch).mockResolvedValueOnce({
       enabled: false,
       issuer: null,
       name: null,
-      enterpriseRequired: false,
+      enterpriseRequired: true,
     } as never);
 
     renderLoginPage('/login?error=access_denied');
 
     await waitFor(() => {
-      expect(vi.mocked(toast.error)).toHaveBeenCalledWith('SSO login failed: access_denied');
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith('SSO sign-in was cancelled or denied.');
     });
+  });
+
+  it('shows a generic toast (never the raw param) for an unknown OIDC error code', async () => {
+    const { toast } = await import('sonner');
+    const { apiFetch } = await import('../../shared/lib/api');
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      enabled: false,
+      issuer: null,
+      name: null,
+      enterpriseRequired: true,
+    } as never);
+
+    renderLoginPage('/login?error=<script>alert(1)</script>');
+
+    await waitFor(() => {
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+        'SSO sign-in failed. Please try again or use local login.',
+      );
+    });
+    const echoedRaw = vi.mocked(toast.error).mock.calls.some((c) => String(c[0]).includes('<script>'));
+    expect(echoedRaw).toBe(false);
   });
 });

--- a/frontend/src/features/settings/LoginPage.test.tsx
+++ b/frontend/src/features/settings/LoginPage.test.tsx
@@ -10,7 +10,7 @@ function renderLoginPage(initialEntry = '/login') {
     <LazyMotion features={domAnimation}>
       <MemoryRouter initialEntries={[initialEntry]}>
         <LoginPage />
-      </MemoryRouter>
+      </MemoryRouter>,
     </LazyMotion>,
   );
 }
@@ -18,6 +18,10 @@ function renderLoginPage(initialEntry = '/login') {
 describe('LoginPage', () => {
   beforeEach(() => {
     useAuthStore.getState().clearAuth();
+    vi.resetAllMocks();
+    vi.mock('../../shared/lib/api', () => ({
+      apiFetch: vi.fn(),
+    }));
   });
 
   afterEach(() => {
@@ -32,7 +36,36 @@ describe('LoginPage', () => {
     expect(screen.getByPlaceholderText('Enter password')).toBeInTheDocument();
   });
 
-  it('does not show SSO button (enterprise feature)', () => {
+  it('renders SSO button when OIDC is enabled', async () => {
+    const { apiFetch } = await import('../../shared/lib/api');
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      enabled: true,
+      issuer: 'https://idp.example.com',
+      name: 'OrgSSO',
+      enterpriseRequired: false,
+    } as never);
+
+    renderLoginPage();
+    expect(await screen.findByRole('button', { name: 'Sign in with OrgSSO' })).toBeInTheDocument();
+  });
+
+  it('does not render SSO button when OIDC is disabled', async () => {
+    const { apiFetch } = await import('../../shared/lib/api');
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      enabled: false,
+      issuer: null,
+      name: null,
+      enterpriseRequired: false,
+    } as never);
+
+    renderLoginPage();
+    expect(screen.queryByTestId('sso-login-btn')).not.toBeInTheDocument();
+  });
+
+  it('does not render SSO button when OIDC config fetch fails', async () => {
+    const { apiFetch } = await import('../../shared/lib/api');
+    vi.mocked(apiFetch).mockRejectedValueOnce(new Error('Network error'));
+
     renderLoginPage();
     expect(screen.queryByTestId('sso-login-btn')).not.toBeInTheDocument();
   });

--- a/frontend/src/features/settings/LoginPage.test.tsx
+++ b/frontend/src/features/settings/LoginPage.test.tsx
@@ -1,16 +1,24 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { LazyMotion, domAnimation } from 'framer-motion';
 import { LoginPage } from './LoginPage';
 import { useAuthStore } from '../../stores/auth-store';
+
+vi.mock('../../shared/lib/api', () => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
 
 function renderLoginPage(initialEntry = '/login') {
   return render(
     <LazyMotion features={domAnimation}>
       <MemoryRouter initialEntries={[initialEntry]}>
         <LoginPage />
-      </MemoryRouter>,
+      </MemoryRouter>
     </LazyMotion>,
   );
 }
@@ -19,9 +27,6 @@ describe('LoginPage', () => {
   beforeEach(() => {
     useAuthStore.getState().clearAuth();
     vi.resetAllMocks();
-    vi.mock('../../shared/lib/api', () => ({
-      apiFetch: vi.fn(),
-    }));
   });
 
   afterEach(() => {
@@ -68,5 +73,22 @@ describe('LoginPage', () => {
 
     renderLoginPage();
     expect(screen.queryByTestId('sso-login-btn')).not.toBeInTheDocument();
+  });
+
+  it('shows an error toast when redirected back with an OIDC error param', async () => {
+    const { toast } = await import('sonner');
+    const { apiFetch } = await import('../../shared/lib/api');
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      enabled: false,
+      issuer: null,
+      name: null,
+      enterpriseRequired: false,
+    } as never);
+
+    renderLoginPage('/login?error=access_denied');
+
+    await waitFor(() => {
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith('SSO login failed: access_denied');
+    });
   });
 });

--- a/frontend/src/features/settings/LoginPage.tsx
+++ b/frontend/src/features/settings/LoginPage.tsx
@@ -1,16 +1,49 @@
-import { useState, type FormEvent } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState, useEffect, type FormEvent } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { useAuthStore } from '../../stores/auth-store';
 import { apiFetch } from '../../shared/lib/api';
 
+interface OidcConfig {
+  enabled: boolean;
+  issuer: string | null;
+  name: string | null;
+  enterpriseRequired: boolean;
+}
+
 export function LoginPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const setAuth = useAuthStore((s) => s.setAuth);
   const [isRegister, setIsRegister] = useState(false);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const [oidcConfig, setOidcConfig] = useState<OidcConfig | null>(null);
+  const [oidcLoading, setOidcLoading] = useState(true);
+
+  useEffect(() => {
+    const searchError = searchParams.get('error');
+    if (searchError) {
+      toast.error(`SSO login failed: ${searchError}`);
+      navigate('/login', { replace: true });
+      return;
+    }
+  }, [searchParams, navigate]);
+
+  useEffect(() => {
+    async function fetchOidcConfig() {
+      try {
+        const config = await apiFetch<OidcConfig>('/auth/oidc/config');
+        setOidcConfig(config);
+      } catch {
+        // If config fetch fails, don't show SSO button
+      } finally {
+        setOidcLoading(false);
+      }
+    }
+    fetchOidcConfig();
+  }, []);
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -82,6 +115,25 @@ export function LoginPage() {
           >
             {loading ? 'Loading...' : isRegister ? 'Create Account' : 'Sign In'}
           </button>
+
+          {oidcConfig && oidcConfig.enabled && !oidcConfig.enterpriseRequired && (
+            <button
+              type="button"
+              onClick={() => {
+                const params = new URLSearchParams(window.location.search);
+                if (params.toString()) {
+                  params.delete('error');
+                  window.location.href = `/login?${params.toString()}`;
+                }
+                window.location.href = '/api/auth/oidc/authorize';
+              }}
+              disabled={oidcLoading}
+              data-testid="sso-login-btn"
+              className="w-full rounded-lg border border-border/40 bg-card/30 px-4 py-2.5 text-sm font-medium text-muted-foreground hover:bg-card/60"
+            >
+              {oidcLoading ? 'Loading...' : `Sign in with ${oidcConfig.name || 'SSO'}`}
+            </button>
+          )}
         </form>
 
         <p className="mt-6 text-center text-sm text-muted-foreground">

--- a/frontend/src/features/settings/LoginPage.tsx
+++ b/frontend/src/features/settings/LoginPage.tsx
@@ -1,15 +1,24 @@
 import { useState, useEffect, type FormEvent } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
+import { OidcConfigSchema, type OidcConfig } from '@compendiq/contracts';
 import { useAuthStore } from '../../stores/auth-store';
 import { apiFetch } from '../../shared/lib/api';
 
-interface OidcConfig {
-  enabled: boolean;
-  issuer: string | null;
-  name: string | null;
-  enterpriseRequired: boolean;
-}
+/**
+ * Friendly copy for the OIDC/OAuth2 error codes an IdP may append to the
+ * post-redirect URL (?error=...). We map known codes and fall back to a
+ * generic message rather than echoing the raw param, which is
+ * attacker-controllable.
+ */
+const OIDC_ERROR_MESSAGES: Record<string, string> = {
+  access_denied: 'SSO sign-in was cancelled or denied.',
+  login_required: 'SSO sign-in could not be completed. Please try again.',
+  interaction_required: 'SSO sign-in could not be completed. Please try again.',
+  consent_required: 'Additional consent is required to sign in via SSO.',
+  server_error: 'The SSO provider reported an error. Please try again later.',
+  temporarily_unavailable: 'SSO is temporarily unavailable. Please try again later.',
+};
 
 export function LoginPage() {
   const navigate = useNavigate();
@@ -24,7 +33,9 @@ export function LoginPage() {
   useEffect(() => {
     const searchError = searchParams.get('error');
     if (searchError) {
-      toast.error(`SSO login failed: ${searchError}`);
+      toast.error(
+        OIDC_ERROR_MESSAGES[searchError] ?? 'SSO sign-in failed. Please try again or use local login.',
+      );
       // Clear the error param so a refresh doesn't re-trigger the toast.
       navigate('/login', { replace: true });
     }
@@ -33,10 +44,10 @@ export function LoginPage() {
   useEffect(() => {
     async function fetchOidcConfig() {
       try {
-        const config = await apiFetch<OidcConfig>('/auth/oidc/config');
+        const config = OidcConfigSchema.parse(await apiFetch('/auth/oidc/config'));
         setOidcConfig(config);
       } catch {
-        // If the config fetch fails (e.g. OIDC route absent in CE), leave the SSO button hidden.
+        // No/invalid config (e.g. the OIDC route is absent in CE) — leave the SSO button hidden.
       }
     }
     fetchOidcConfig();
@@ -120,7 +131,7 @@ export function LoginPage() {
                 window.location.href = '/api/auth/oidc/authorize';
               }}
               data-testid="sso-login-btn"
-              className="w-full rounded-lg border border-border/40 bg-card/30 px-4 py-2.5 text-sm font-medium text-muted-foreground hover:bg-card/60"
+              className="nm-button-ghost w-full py-2.5"
             >
               Sign in with {oidcConfig.name || 'SSO'}
             </button>

--- a/frontend/src/features/settings/LoginPage.tsx
+++ b/frontend/src/features/settings/LoginPage.tsx
@@ -20,14 +20,13 @@ export function LoginPage() {
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [oidcConfig, setOidcConfig] = useState<OidcConfig | null>(null);
-  const [oidcLoading, setOidcLoading] = useState(true);
 
   useEffect(() => {
     const searchError = searchParams.get('error');
     if (searchError) {
       toast.error(`SSO login failed: ${searchError}`);
+      // Clear the error param so a refresh doesn't re-trigger the toast.
       navigate('/login', { replace: true });
-      return;
     }
   }, [searchParams, navigate]);
 
@@ -37,9 +36,7 @@ export function LoginPage() {
         const config = await apiFetch<OidcConfig>('/auth/oidc/config');
         setOidcConfig(config);
       } catch {
-        // If config fetch fails, don't show SSO button
-      } finally {
-        setOidcLoading(false);
+        // If the config fetch fails (e.g. OIDC route absent in CE), leave the SSO button hidden.
       }
     }
     fetchOidcConfig();
@@ -120,18 +117,12 @@ export function LoginPage() {
             <button
               type="button"
               onClick={() => {
-                const params = new URLSearchParams(window.location.search);
-                if (params.toString()) {
-                  params.delete('error');
-                  window.location.href = `/login?${params.toString()}`;
-                }
                 window.location.href = '/api/auth/oidc/authorize';
               }}
-              disabled={oidcLoading}
               data-testid="sso-login-btn"
               className="w-full rounded-lg border border-border/40 bg-card/30 px-4 py-2.5 text-sm font-medium text-muted-foreground hover:bg-card/60"
             >
-              {oidcLoading ? 'Loading...' : `Sign in with ${oidcConfig.name || 'SSO'}`}
+              Sign in with {oidcConfig.name || 'SSO'}
             </button>
           )}
         </form>

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,4 +1,5 @@
 export * from './schemas/auth.js';
+export * from './schemas/oidc.js';
 export * from './schemas/settings.js';
 export * from './schemas/pages.js';
 export * from './schemas/spaces.js';

--- a/packages/contracts/src/schemas/oidc.ts
+++ b/packages/contracts/src/schemas/oidc.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+/**
+ * Shared schema for the public OIDC config endpoint
+ * (`GET /api/auth/oidc/config`).
+ *
+ * Served by the EE backend when the OIDC_SSO feature is licensed, and by a
+ * community-mode fallback in CE that always reports `enabled: false`. The
+ * shared CE login page consumes this to decide whether to render the SSO
+ * sign-in button.
+ */
+export const OidcConfigSchema = z.object({
+  /** Whether OIDC SSO is configured and available for interactive login. */
+  enabled: z.boolean(),
+  /** Issuer URL of the configured identity provider, or null when not configured. */
+  issuer: z.string().nullable(),
+  /** Display name for the SSO button (e.g. "OrgSSO"); null falls back to "SSO". */
+  name: z.string().nullable(),
+  /**
+   * True when SSO requires an enterprise license that the responding backend
+   * does not have. CE reports this so the login page keeps the button hidden
+   * even if some other signal were to flip `enabled`.
+   */
+  enterpriseRequired: z.boolean(),
+});
+
+export type OidcConfig = z.infer<typeof OidcConfigSchema>;


### PR DESCRIPTION
## Summary

Adds an SSO (OIDC) login button to the Community Edition login page, allowing users to authenticate via SSO alongside local credentials.

## Changes

- `LoginPage.tsx`: Add SSO button below local login form when OIDC is enabled
  - Fetches OIDC config from `/auth/oidc/config` to determine button visibility
  - Only shows button when OIDC is enabled and enterprise is not required
  - Handles OIDC error redirect parameter (e.g. user rejected consent)
  - Adds `data-testid` for testability
- `LoginPage.test.tsx`: Update tests to cover OIDC enabled/disabled/failure states