### PR TITLE
fix(contracts): make OidcConfigSchema tolerant of EE response drift

### DIFF
--- a/frontend/src/features/settings/LoginPage.test.tsx
+++ b/frontend/src/features/settings/LoginPage.test.tsx
@@ -112,4 +112,13 @@ describe('LoginPage', () => {
     const echoedRaw = vi.mocked(toast.error).mock.calls.some((c) => String(c[0]).includes('<script>'));
     expect(echoedRaw).toBe(false);
   });
+
+  it('renders the SSO button when EE omits optional config fields (fails open)', async () => {
+    const { apiFetch } = await import('../../shared/lib/api');
+    // EE returns only `enabled` + `name`; issuer and enterpriseRequired are absent.
+    vi.mocked(apiFetch).mockResolvedValueOnce({ enabled: true, name: 'OrgSSO' } as never);
+
+    renderLoginPage();
+    expect(await screen.findByRole('button', { name: 'Sign in with OrgSSO' })).toBeInTheDocument();
+  });
 });

--- a/packages/contracts/src/schemas/oidc.test.ts
+++ b/packages/contracts/src/schemas/oidc.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { OidcConfigSchema } from './oidc.js';
+
+describe('OidcConfigSchema', () => {
+  it('parses a full payload', () => {
+    const parsed = OidcConfigSchema.parse({
+      enabled: true,
+      issuer: 'https://idp.example.com',
+      name: 'OrgSSO',
+      enterpriseRequired: false,
+    });
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.name).toBe('OrgSSO');
+    expect(parsed.enterpriseRequired).toBe(false);
+  });
+
+  it('accepts null issuer/name (EE serializes unset fields as null)', () => {
+    const parsed = OidcConfigSchema.parse({
+      enabled: false,
+      issuer: null,
+      name: null,
+      enterpriseRequired: true,
+    });
+    expect(parsed.issuer).toBeNull();
+    expect(parsed.enterpriseRequired).toBe(true);
+  });
+
+  it('fails open: tolerates omitted optional fields so a minor EE shape drift still enables the button', () => {
+    // Only `enabled` is guaranteed; issuer/name/enterpriseRequired may be absent.
+    const parsed = OidcConfigSchema.parse({ enabled: true });
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.enterpriseRequired).toBe(false); // default — does not gate the button off
+    expect(parsed.issuer).toBeUndefined();
+    expect(parsed.name).toBeUndefined();
+  });
+
+  it('still requires enabled (the gating field) — fails closed if absent', () => {
+    expect(() => OidcConfigSchema.parse({ issuer: null, name: null })).toThrow();
+  });
+
+  it('rejects a wrong-typed enabled', () => {
+    expect(() => OidcConfigSchema.parse({ enabled: 'yes' })).toThrow();
+  });
+});

--- a/packages/contracts/src/schemas/oidc.ts
+++ b/packages/contracts/src/schemas/oidc.ts
@@ -8,20 +8,27 @@ import { z } from 'zod';
  * community-mode fallback in CE that always reports `enabled: false`. The
  * shared CE login page consumes this to decide whether to render the SSO
  * sign-in button.
+ *
+ * Resilience: only `enabled` is required. The remaining fields are optional
+ * so a minor shape drift from the EE endpoint (e.g. an omitted key) fails
+ * *open* — the login page still shows the button when `enabled` is true —
+ * rather than throwing in `.parse()` and silently hiding a working SSO
+ * button.
  */
 export const OidcConfigSchema = z.object({
   /** Whether OIDC SSO is configured and available for interactive login. */
   enabled: z.boolean(),
-  /** Issuer URL of the configured identity provider, or null when not configured. */
-  issuer: z.string().nullable(),
-  /** Display name for the SSO button (e.g. "OrgSSO"); null falls back to "SSO". */
-  name: z.string().nullable(),
+  /** Issuer URL of the configured identity provider; null/absent when not configured. */
+  issuer: z.string().nullish(),
+  /** Display name for the SSO button (e.g. "OrgSSO"); null/absent falls back to "SSO". */
+  name: z.string().nullish(),
   /**
    * True when SSO requires an enterprise license that the responding backend
    * does not have. CE reports this so the login page keeps the button hidden
-   * even if some other signal were to flip `enabled`.
+   * even if some other signal were to flip `enabled`. Defaults to false when
+   * absent (an EE backend that omits it is licensed, so SSO is allowed).
    */
-  enterpriseRequired: z.boolean(),
+  enterpriseRequired: z.boolean().default(false),
 });
 
 export type OidcConfig = z.infer<typeof OidcConfigSchema>;


### PR DESCRIPTION
## Summary

Follow-up to #701. The CE login page now validates `GET /api/auth/oidc/config` with `OidcConfigSchema.parse()`. The schema required all four fields, so if the EE endpoint's response drifts (omits a key, or serializes an unset field as `undefined` rather than `null`), `.parse()` throws → the SSO button is silently hidden for EE customers — a fail-**closed** regression vs. the previous unchecked TS cast.

This loosens the schema so it fails **open** on benign drift while still validating the one field that gates the button.

## Changes

- `OidcConfigSchema`:
  - `issuer` / `name` → `.nullish()` (accept `string | null | undefined`)
  - `enterpriseRequired` → `.default(false)` (omitted ⇒ SSO allowed)
  - `enabled` stays **required** — fail closed on the gating field
- Tests:
  - `packages/contracts/src/schemas/oidc.test.ts` (new): full payload, null fields, omitted-fields fail-open, missing/invalid `enabled` fail-closed
  - `LoginPage.test.tsx`: button still renders when EE returns only `{ enabled, name }`

## Verification

contracts build + typecheck clean, 71 contracts tests · frontend tsc/lint clean, 7/7 LoginPage tests · backend tsc clean, 12/12 app tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
