### PR TITLE
fix(oidc): warn on FRONTEND_URL/Redirect-URI mismatch + document public-origin requirement (#710)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ REDIS_URL=redis://:changeme-redis@localhost:6379
 NODE_ENV=development
 BACKEND_PORT=3051
 # FRONTEND_URL=http://localhost:5273    # Used for CORS origin (default: http://localhost:5273). Comma-separated for multiple origins: http://localhost:5273,https://app.example.com
+                                        # Behind a reverse proxy with SSO/OIDC (EE): MUST be the public origin (e.g. https://app.example.com).
+                                        # The post-login OIDC redirect to the SPA is built from this value — leaving it at the localhost default dead-ends login. See docs/ADMIN-GUIDE.md → OIDC / SSO.
 # LOG_LEVEL=info                        # Pino log level: 'fatal','error','warn','info','debug','trace' (default: info)
 
 # --- Session ---

--- a/docs/ADMIN-GUIDE.md
+++ b/docs/ADMIN-GUIDE.md
@@ -116,7 +116,7 @@ curl http://localhost:3051/api/health
 |----------|---------|-------------|
 | `NODE_ENV` | `development` | Set to `production` for production deployments |
 | `BACKEND_PORT` | `3051` | Backend server port |
-| `FRONTEND_URL` | `http://localhost:5273` | Used for CORS origin and OIDC redirects |
+| `FRONTEND_URL` | `http://localhost:5273` | CORS origin **and** the origin the post-login OIDC redirect is built from. Behind a reverse proxy with SSO, set this to your public origin (see [OIDC / SSO](#oidc--sso)). |
 | `FRONTEND_PORT` | `5273` | Host port mapped to the frontend container (Docker Compose only) |
 | `LOG_LEVEL` | `info` | Pino log level: `fatal`, `error`, `warn`, `info`, `debug`, `trace` |
 | `ACCESS_TOKEN_EXPIRY` | `1h` | JWT access token lifetime (jose duration format: `30m`, `1h`, `2h`) |
@@ -286,7 +286,20 @@ Settings configured via the admin UI are persisted in the `admin_settings` datab
 
 ### OIDC / SSO
 
-OIDC is configured entirely via the Admin UI (Settings > OIDC/SSO). No environment variables are required -- all OIDC configuration is stored in the database.
+OIDC provider settings (issuer, client ID/secret, group mappings) are configured entirely via the Admin UI (Settings > OIDC/SSO) and stored in the database.
+
+**`FRONTEND_URL` must be your public origin behind a reverse proxy.** OIDC login uses a two-hop callback:
+
+1. The IdP redirects the browser back to the **Redirect URI** you configure in Settings > OIDC/SSO — e.g. `https://compendiq.example.com/api/auth/oidc/callback`. This hits the backend.
+2. The backend exchanges the code and then redirects the browser to the SPA callback route (`/auth/oidc/callback?login_code=…`). It builds **that** redirect from the backend's `FRONTEND_URL` env var — **not** from the Redirect URI.
+
+These are two independent URLs. If `FRONTEND_URL` is left at its `http://localhost:8081` / `http://localhost:5273` default while the admin reaches the app through a public host, a correctly-configured Redirect URI still bounces the browser to `localhost` after the IdP round-trip, dead-ending login. Set:
+
+```
+FRONTEND_URL=https://compendiq.example.com
+```
+
+(matching the origin of your Redirect URI) and restart the backend. `FRONTEND_URL` also accepts a comma-separated list, which doubles as the CORS allowlist. The Settings > OIDC/SSO page warns inline when the Redirect URI origin diverges from the origin you loaded the app from, and surfaces the exact `FRONTEND_URL` value to set.
 
 ### IP Allowlist (Enterprise, v0.4+)
 

--- a/docs/ADMIN-GUIDE.md
+++ b/docs/ADMIN-GUIDE.md
@@ -299,7 +299,7 @@ These are two independent URLs. If `FRONTEND_URL` is left at its `http://localho
 FRONTEND_URL=https://compendiq.example.com
 ```
 
-(matching the origin of your Redirect URI) and restart the backend. `FRONTEND_URL` also accepts a comma-separated list, which doubles as the CORS allowlist. The Settings > OIDC/SSO page warns inline when the Redirect URI origin diverges from the origin you loaded the app from, and surfaces the exact `FRONTEND_URL` value to set.
+(matching the origin of your Redirect URI) and restart the backend. `FRONTEND_URL` also accepts a comma-separated list, which doubles as the CORS allowlist — so if you already configured multiple origins, **append** the public origin (`…,https://compendiq.example.com`) rather than overwriting the existing list. The Settings > OIDC/SSO page warns inline when the Redirect URI origin diverges from the origin you loaded the app from, and surfaces the exact `FRONTEND_URL` value to set.
 
 ### IP Allowlist (Enterprise, v0.4+)
 

--- a/frontend/src/features/admin/OidcSettingsPage.test.tsx
+++ b/frontend/src/features/admin/OidcSettingsPage.test.tsx
@@ -233,6 +233,38 @@ describe('OidcSettingsPage', () => {
     expect(screen.getByTestId('oidc-save-btn')).toBeDisabled();
   });
 
+  it('warns when the Redirect URI origin diverges from the app origin (#710)', async () => {
+    // jsdom serves the page from http://localhost:3000; the mock provider's
+    // Redirect URI origin is http://localhost:3051, so the two diverge.
+    mockFetch();
+    render(<OidcSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oidc-redirect-origin-warning')).toBeInTheDocument();
+    });
+    const warning = screen.getByTestId('oidc-redirect-origin-warning');
+    // Surfaces the exact FRONTEND_URL the admin must set.
+    expect(warning).toHaveTextContent('FRONTEND_URL=http://localhost:3051');
+  });
+
+  it('hides the Redirect URI warning when the origin matches the app origin', async () => {
+    mockFetch();
+    render(<OidcSettingsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oidc-redirect-uri')).toBeInTheDocument();
+    });
+
+    // Retype the Redirect URI to use jsdom's own origin (http://localhost:3000).
+    fireEvent.change(screen.getByTestId('oidc-redirect-uri'), {
+      target: { value: `${window.location.origin}/api/auth/oidc/callback` },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('oidc-redirect-origin-warning')).not.toBeInTheDocument();
+    });
+  });
+
   it('shows create mapping form when button clicked', async () => {
     mockFetch();
     render(<OidcSettingsPage />, { wrapper: createWrapper() });

--- a/frontend/src/features/admin/OidcSettingsPage.test.tsx
+++ b/frontend/src/features/admin/OidcSettingsPage.test.tsx
@@ -245,6 +245,9 @@ describe('OidcSettingsPage', () => {
     const warning = screen.getByTestId('oidc-redirect-origin-warning');
     // Surfaces the exact FRONTEND_URL the admin must set.
     expect(warning).toHaveTextContent('FRONTEND_URL=http://localhost:3051');
+    // Advises appending to (not overwriting) the comma-separated CORS allowlist.
+    expect(warning).toHaveTextContent('comma-separated CORS allowlist');
+    expect(warning).toHaveTextContent(',http://localhost:3051');
   });
 
   it('hides the Redirect URI warning when the origin matches the app origin', async () => {

--- a/frontend/src/features/admin/OidcSettingsPage.tsx
+++ b/frontend/src/features/admin/OidcSettingsPage.tsx
@@ -378,7 +378,14 @@ function ProviderTab({ disabled }: { disabled?: boolean }) {
                   <code className="rounded bg-foreground/10 px-1 py-0.5">
                     FRONTEND_URL={redirectCheck.redirectOrigin}
                   </code>{' '}
-                  and restart the backend.
+                  and restart the backend.{' '}
+                  <code className="rounded bg-foreground/10 px-1 py-0.5">FRONTEND_URL</code>{' '}
+                  doubles as the comma-separated CORS allowlist — if you already set
+                  multiple origins, append this one (
+                  <code className="rounded bg-foreground/10 px-1 py-0.5">
+                    …,{redirectCheck.redirectOrigin}
+                  </code>
+                  ) rather than overwriting the list.
                 </div>
               </div>
             </m.div>

--- a/frontend/src/features/admin/OidcSettingsPage.tsx
+++ b/frontend/src/features/admin/OidcSettingsPage.tsx
@@ -9,6 +9,7 @@ import {
 import type { LicenseInfoResponse } from '@compendiq/contracts';
 import { apiFetch } from '../../shared/lib/api';
 import { cn } from '../../shared/lib/cn';
+import { checkRedirectUriOrigin } from './oidc-redirect-uri';
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -182,6 +183,14 @@ function ProviderTab({ disabled }: { disabled?: boolean }) {
     );
   }
 
+  // Warn when the Redirect URI origin diverges from the origin the admin loaded
+  // the app from. The backend builds the post-login SPA redirect (hop 3) from
+  // its FRONTEND_URL env var, not from this Redirect URI — so a mismatch here
+  // is a strong signal that FRONTEND_URL is still the localhost default and
+  // login will dead-end behind a reverse proxy (issue #710).
+  const appOrigin = window.location.origin;
+  const redirectCheck = checkRedirectUriOrigin(redirectUri, appOrigin);
+
   return (
     <div className="space-y-6" data-testid="oidc-provider-form">
       {/* Status indicator */}
@@ -338,6 +347,42 @@ function ProviderTab({ disabled }: { disabled?: boolean }) {
           <p className="mt-1 text-xs text-muted-foreground">
             Must match the redirect URI registered with your identity provider.
           </p>
+          {redirectCheck.mismatch && (
+            <m.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: 'auto' }}
+              className="mt-2 flex items-start gap-2 rounded-md bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-400"
+              data-testid="oidc-redirect-origin-warning"
+            >
+              <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+              <div className="space-y-1">
+                <div className="font-medium">
+                  Redirect URI origin doesn&apos;t match this app&apos;s origin
+                </div>
+                <div className="text-muted-foreground">
+                  The Redirect URI uses{' '}
+                  <code className="rounded bg-foreground/10 px-1 py-0.5">
+                    {redirectCheck.redirectOrigin}
+                  </code>
+                  , but you loaded this app from{' '}
+                  <code className="rounded bg-foreground/10 px-1 py-0.5">{appOrigin}</code>.
+                  After login, the backend redirects the browser to the SPA using its{' '}
+                  <code className="rounded bg-foreground/10 px-1 py-0.5">FRONTEND_URL</code>{' '}
+                  env var — <strong>not</strong> this Redirect URI. If they diverge, login
+                  dead-ends on an unreachable host.
+                </div>
+                <div className="text-muted-foreground">
+                  Set the backend{' '}
+                  <code className="rounded bg-foreground/10 px-1 py-0.5">FRONTEND_URL</code>{' '}
+                  to your public origin:{' '}
+                  <code className="rounded bg-foreground/10 px-1 py-0.5">
+                    FRONTEND_URL={redirectCheck.redirectOrigin}
+                  </code>{' '}
+                  and restart the backend.
+                </div>
+              </div>
+            </m.div>
+          )}
         </div>
 
         <div>

--- a/frontend/src/features/admin/oidc-redirect-uri.test.ts
+++ b/frontend/src/features/admin/oidc-redirect-uri.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { originOf, checkRedirectUriOrigin } from './oidc-redirect-uri';
+
+describe('originOf', () => {
+  it('extracts the origin from a full URL', () => {
+    expect(originOf('https://compendiq.example.com/api/auth/oidc/callback')).toBe(
+      'https://compendiq.example.com',
+    );
+  });
+
+  it('includes a non-default port in the origin', () => {
+    expect(originOf('http://localhost:8081/api/auth/oidc/callback')).toBe(
+      'http://localhost:8081',
+    );
+  });
+
+  it('returns null for an empty or whitespace-only string', () => {
+    expect(originOf('')).toBeNull();
+    expect(originOf('   ')).toBeNull();
+  });
+
+  it('returns null for an unparseable URL', () => {
+    expect(originOf('not a url')).toBeNull();
+    expect(originOf('/api/auth/oidc/callback')).toBeNull();
+  });
+});
+
+describe('checkRedirectUriOrigin', () => {
+  const appOrigin = 'https://compendiq.example.com';
+
+  it('flags a mismatch when the Redirect URI origin diverges from the app origin', () => {
+    const result = checkRedirectUriOrigin(
+      'http://localhost:8081/api/auth/oidc/callback',
+      appOrigin,
+    );
+    expect(result.mismatch).toBe(true);
+    expect(result.redirectOrigin).toBe('http://localhost:8081');
+    expect(result.appOrigin).toBe(appOrigin);
+  });
+
+  it('does not flag a match when origins are identical', () => {
+    const result = checkRedirectUriOrigin(
+      'https://compendiq.example.com/api/auth/oidc/callback',
+      appOrigin,
+    );
+    expect(result.mismatch).toBe(false);
+    expect(result.redirectOrigin).toBe(appOrigin);
+  });
+
+  it('treats differing ports as a mismatch', () => {
+    const result = checkRedirectUriOrigin(
+      'https://compendiq.example.com:8443/api/auth/oidc/callback',
+      appOrigin,
+    );
+    expect(result.mismatch).toBe(true);
+  });
+
+  it('treats differing schemes as a mismatch', () => {
+    const result = checkRedirectUriOrigin(
+      'http://compendiq.example.com/api/auth/oidc/callback',
+      appOrigin,
+    );
+    expect(result.mismatch).toBe(true);
+  });
+
+  it('does not flag while the Redirect URI is empty', () => {
+    const result = checkRedirectUriOrigin('', appOrigin);
+    expect(result.mismatch).toBe(false);
+    expect(result.redirectOrigin).toBeNull();
+  });
+
+  it('does not flag while the Redirect URI is not yet a valid URL', () => {
+    const result = checkRedirectUriOrigin('https://comp', appOrigin);
+    // 'https://comp' parses to origin 'https://comp' which differs — but a
+    // partially-typed bare host without a dot is still a complete, parseable
+    // origin, so this is a genuine mismatch and we surface it.
+    expect(result.redirectOrigin).toBe('https://comp');
+    expect(result.mismatch).toBe(true);
+  });
+
+  it('does not flag a fragment-only or relative path that cannot be parsed', () => {
+    const result = checkRedirectUriOrigin('/api/auth/oidc/callback', appOrigin);
+    expect(result.redirectOrigin).toBeNull();
+    expect(result.mismatch).toBe(false);
+  });
+});

--- a/frontend/src/features/admin/oidc-redirect-uri.test.ts
+++ b/frontend/src/features/admin/oidc-redirect-uri.test.ts
@@ -23,6 +23,12 @@ describe('originOf', () => {
     expect(originOf('not a url')).toBeNull();
     expect(originOf('/api/auth/oidc/callback')).toBeNull();
   });
+
+  it('rejects non-http(s) schemes', () => {
+    expect(originOf('ftp://example.com/x')).toBeNull();
+    expect(originOf('file:///etc/passwd')).toBeNull();
+    expect(originOf('javascript:alert(1)')).toBeNull();
+  });
 });
 
 describe('checkRedirectUriOrigin', () => {

--- a/frontend/src/features/admin/oidc-redirect-uri.ts
+++ b/frontend/src/features/admin/oidc-redirect-uri.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure helpers for validating the OIDC Redirect URI against the origin the
+ * admin is actually using.
+ *
+ * Background (issue #710): OIDC login uses a two-hop callback. The configured
+ * Redirect URI governs hop 1 (IdP → backend). Hop 3 (backend → SPA) is built
+ * from the backend's `FRONTEND_URL` env var, which defaults to a localhost
+ * value. When those two origins diverge — typically behind a reverse proxy —
+ * a correctly-set Redirect URI still bounces the browser to `localhost`,
+ * dead-ending login. `FRONTEND_URL` is invisible in the admin UI, so the
+ * footgun is silent.
+ *
+ * These helpers let the settings page warn when the Redirect URI's origin does
+ * not match the origin the admin loaded the app from (`window.location.origin`),
+ * and surface the exact `FRONTEND_URL` value the backend must be set to.
+ */
+
+/** Extract the origin (`scheme://host[:port]`) from a URL string, or null if unparseable. */
+export function originOf(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return null;
+  }
+}
+
+export interface RedirectUriCheck {
+  /** True when the Redirect URI origin diverges from the app origin. */
+  mismatch: boolean;
+  /** Origin parsed from the Redirect URI, or null if it isn't a valid URL yet. */
+  redirectOrigin: string | null;
+  /** The origin the admin is currently using (typically window.location.origin). */
+  appOrigin: string;
+}
+
+/**
+ * Compare the Redirect URI's origin against the app origin.
+ *
+ * Returns `mismatch: false` while the Redirect URI is empty or not yet a valid
+ * URL (nothing to warn about until the admin has typed a complete origin), so
+ * the warning only fires on a genuine, confident divergence.
+ */
+export function checkRedirectUriOrigin(redirectUri: string, appOrigin: string): RedirectUriCheck {
+  const redirectOrigin = originOf(redirectUri);
+  return {
+    redirectOrigin,
+    appOrigin,
+    mismatch: redirectOrigin !== null && redirectOrigin !== appOrigin,
+  };
+}

--- a/frontend/src/features/admin/oidc-redirect-uri.ts
+++ b/frontend/src/features/admin/oidc-redirect-uri.ts
@@ -15,12 +15,18 @@
  * and surface the exact `FRONTEND_URL` value the backend must be set to.
  */
 
-/** Extract the origin (`scheme://host[:port]`) from a URL string, or null if unparseable. */
+/**
+ * Extract the origin (`scheme://host[:port]`) from an http(s) URL string, or
+ * null if it isn't a parseable http/https URL. Non-web schemes (`ftp:`,
+ * `file:`, `javascript:`, …) are rejected — a Redirect URI is always http(s).
+ */
 export function originOf(url: string): string | null {
   const trimmed = url.trim();
   if (!trimmed) return null;
   try {
-    return new URL(trimmed).origin;
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.origin;
   } catch {
     return null;
   }


### PR DESCRIPTION
Closes #710

## Problem

OIDC login uses a two-hop callback. The configured **Redirect URI** governs hop 1 (IdP → backend). Hop 3 (backend → SPA) is built from the backend's **`FRONTEND_URL`** env var, which defaults to a `localhost` value. When those origins diverge — typically behind a reverse proxy — a correctly-set Redirect URI still bounces the browser to `localhost` after the IdP round-trip, dead-ending login. `FRONTEND_URL` is invisible in the admin UI, so the footgun is silent.

## Scope (CE only)

The root fix — building the step-3 SPA redirect from the Redirect URI's origin (or honoring `X-Forwarded-*`) — lives in the **private `@compendiq/enterprise` OIDC callback handler**, which is **not in this CE repo**. This PR ships only the CE-owned mitigations:

- **`OidcSettingsPage`** — inline amber warning under the Redirect URI field when its origin diverges from `window.location.origin` (the origin the admin loaded the app from). It explains the two-hop behavior and surfaces the **exact `FRONTEND_URL` value** to set (previously invisible).
- **New pure helper** `frontend/src/features/admin/oidc-redirect-uri.ts` — `originOf()` + `checkRedirectUriOrigin()`. The mismatch check only fires once the Redirect URI is a complete, parseable origin (no nagging mid-type).
- **Docs** — `docs/ADMIN-GUIDE.md` → OIDC / SSO now documents the two-hop callback and the `FRONTEND_URL` public-origin requirement; the Server env table entry for `FRONTEND_URL` cross-links it. A note was added near `FRONTEND_URL` in `.env.example`.

No backend/runtime defaults changed (docker-compose untouched).

## Remaining EE-side follow-up

The actual redirect-construction fix must land in `@compendiq/enterprise`'s `/api/auth/oidc/callback` handler: build the step-3 SPA redirect from the Redirect URI's origin (swap `/api/auth/oidc/callback` → `/auth/oidc/callback`) instead of `FRONTEND_URL`, or honor `X-Forwarded-Proto`/`X-Forwarded-Host` (with an allowlist). Acceptance items 1–2 in the issue (login actually landing on the public host) depend on that EE change; this PR addresses items 3–4 (admin warning + docs) plus the inline `FRONTEND_URL` discoverability.

## Tests

- `frontend/src/features/admin/oidc-redirect-uri.test.ts` — pure-function unit tests (origin parsing, mismatch on scheme/host/port, empty/partial/relative inputs).
- `frontend/src/features/admin/OidcSettingsPage.test.tsx` — warning shows on origin mismatch (asserts the surfaced `FRONTEND_URL=...` value) and hides when the Redirect URI is retyped to the app origin.

```
$ npx vitest run oidc-redirect-uri.test.ts OidcSettingsPage.test.tsx
Test Files  2 passed (2)
     Tests  24 passed (24)
$ npm run typecheck -w frontend   # clean
$ npm run lint -w frontend        # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)