### PR TITLE
fix(ai): diff Improve like-for-like against original markdown (#704)

### DIFF
--- a/backend/src/routes/llm/improve-page-id.test.ts
+++ b/backend/src/routes/llm/improve-page-id.test.ts
@@ -68,9 +68,11 @@ vi.mock('../../domains/llm/services/embedding-service.js', () => ({
   computePageRelationships: vi.fn(),
 }));
 
+// Shared cache mock so individual tests can force a cache hit (#704).
+const mockGetCachedResponse = vi.fn().mockResolvedValue(null);
 vi.mock('../../domains/llm/services/llm-cache.js', () => {
   class MockLlmCache {
-    getCachedResponse = vi.fn().mockResolvedValue(null);
+    getCachedResponse = (...args: unknown[]) => mockGetCachedResponse(...args);
     setCachedResponse = vi.fn();
     acquireLock = vi.fn().mockResolvedValue(true);
     releaseLock = vi.fn().mockResolvedValue(undefined);
@@ -112,6 +114,14 @@ vi.mock('../../core/utils/sanitize-llm-input.js', () => ({
 
 import { llmImproveRoutes } from './llm-improve.js';
 
+/** Parse an SSE response body into the JSON payloads of each `data:` line. */
+function parseSseEvents(body: string): Array<Record<string, unknown>> {
+  return body
+    .split('\n')
+    .filter((line) => line.startsWith('data: '))
+    .map((line) => JSON.parse(line.slice(6)) as Record<string, unknown>);
+}
+
 describe('POST /api/llm/improve — page_id resolution (regression: issue #418)', () => {
   let app: ReturnType<typeof Fastify>;
 
@@ -138,6 +148,7 @@ describe('POST /api/llm/improve — page_id resolution (regression: issue #418)'
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetCachedResponse.mockResolvedValue(null);
     mockResolveUsecase.mockResolvedValue({
       config: {
         providerId: 'p1', baseUrl: 'http://x/v1', apiKey: null,
@@ -292,6 +303,79 @@ describe('POST /api/llm/improve — page_id resolution (regression: issue #418)'
       (args) => typeof args[0] === 'string' && (args[0] as string).includes("SET improved_content"),
     );
     expect(updateCall).toBeUndefined();
+  });
+
+  it('#704: echoes the original markdown (what the model was fed) in the final SSE event', async () => {
+    // htmlToMarkdown is mocked to echo its input, so the markdown baseline the
+    // backend feeds the model equals the request content. The final SSE event
+    // must carry that markdown so the frontend can diff like-for-like.
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes('INSERT INTO llm_improvements')) {
+        return Promise.resolve({ rows: [{ id: 'improvement-1' }] });
+      }
+      if (sql.includes('SELECT custom_prompts FROM user_settings')) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    async function* mockGenerator() {
+      yield { content: '# Heading\n\nImproved markdown body', done: true };
+    }
+    mockProviderStreamChat.mockReturnValue(mockGenerator());
+
+    const original = '# Heading\n\nOriginal markdown body';
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/improve',
+      payload: {
+        content: original,
+        type: 'grammar',
+        model: 'llama3',
+        pageId: 'conf-123',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    // The final SSE event (done + final) must include originalMarkdown.
+    const finalEvent = parseSseEvents(response.body).find((e) => e.final === true);
+    expect(finalEvent).toBeDefined();
+    expect(finalEvent!.originalMarkdown).toBe(original);
+  });
+
+  it('#704: cached responses also echo the original markdown', async () => {
+    // Force a cache hit: getCachedResponse returns content so the route takes
+    // the sendCachedSSE path, which must still emit originalMarkdown.
+    mockGetCachedResponse.mockResolvedValue({ content: 'cached improved markdown' });
+
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT custom_prompts FROM user_settings')) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const original = '# Heading\n\nOriginal markdown body';
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/improve',
+      payload: {
+        content: original,
+        type: 'grammar',
+        model: 'llama3',
+        pageId: 'conf-123',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toBe('text/event-stream');
+
+    const finalEvent = parseSseEvents(response.body).find((e) => e.final === true);
+    expect(finalEvent).toBeDefined();
+    expect(finalEvent!.originalMarkdown).toBe(original);
+    // The cached content must still stream through.
+    expect(response.body).toContain('cached improved markdown');
   });
 
   it('when no pageId provided, no INSERT is attempted at all', async () => {

--- a/backend/src/routes/llm/llm-improve.ts
+++ b/backend/src/routes/llm/llm-improve.ts
@@ -102,7 +102,10 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
     const cacheKey = buildLlmCacheKey(resolvedModel, systemPrompt, improveContent, chatConfig.providerId);
     const { cached, lockAcquired } = await checkCacheWithLock(llmCache, cacheKey);
     if (cached) {
-      sendCachedSSE(reply, cached.content);
+      // Echo back the markdown the model was given (#704) so the frontend can
+      // diff like-for-like (original markdown vs improved markdown) instead of
+      // comparing formatting-stripped bodyText against the markdown output.
+      sendCachedSSE(reply, cached.content, { originalMarkdown: markdown });
       return;
     }
 
@@ -117,11 +120,15 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
       improvementId = insertResult.rows[0]?.id;
     }
 
-    const improveExtras = webSources.length > 0 ? {
-      sources: webSources.map((s) => ({
+    // Always echo the markdown the model was given (#704) so the frontend can
+    // diff like-for-like (original markdown vs improved markdown). Web sources,
+    // when present, ride along in the same final SSE event.
+    const improveExtras: Record<string, unknown> = { originalMarkdown: markdown };
+    if (webSources.length > 0) {
+      improveExtras.sources = webSources.map((s) => ({
         pageTitle: s.title, spaceKey: 'Web', confluenceId: s.url, score: 1,
-      })),
-    } : undefined;
+      }));
+    }
 
     const improveMessages = [
       { role: 'system' as const, content: systemPrompt },

--- a/frontend/src/features/ai/AiContext.tsx
+++ b/frontend/src/features/ai/AiContext.tsx
@@ -469,7 +469,10 @@ export function AiProvider({ children }: { children: ReactNode }) {
         }
         // Improve route (#704): capture the original markdown baseline so the
         // diff compares like-for-like markdown instead of stripped bodyText.
-        if (chunk.originalMarkdown) {
+        // Use !== undefined (not truthiness) so an intentionally empty baseline
+        // (empty page → htmlToMarkdown('') === '') is preserved rather than
+        // falling back to the also-empty bodyText.
+        if (chunk.originalMarkdown !== undefined) {
           originalMarkdown = chunk.originalMarkdown;
         }
       }

--- a/frontend/src/features/ai/AiContext.tsx
+++ b/frontend/src/features/ai/AiContext.tsx
@@ -108,6 +108,9 @@ interface AiContextValue {
   setShowDiffView: (v: boolean) => void;
   improvedContent: string;
   setImprovedContent: (v: string) => void;
+  /** Markdown baseline (#704) the model was fed — diffed against `improvedContent`. */
+  originalMarkdown: string;
+  setOriginalMarkdown: (v: string) => void;
 
   // Diagram mode state
   diagramType: string;
@@ -119,16 +122,34 @@ interface AiContextValue {
 
   // Streaming helper
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  runStream: <T extends { content?: string; error?: string; done?: boolean; final?: boolean; conversationId?: string; sources?: Source[] }>(
+  runStream: <T extends StreamChunk>(
     endpoint: string,
     body: Record<string, unknown>,
     opts?: {
       onBeforeStream?: () => void;
       onContent?: (accumulated: string) => void;
-      onComplete?: (accumulated: string, sources?: Source[]) => void;
+      onComplete?: (accumulated: string, sources?: Source[], meta?: StreamMeta) => void;
       userMessage?: string;
     },
   ) => Promise<void>;
+}
+
+/** Shape of a single parsed SSE event from any `/llm/*` streaming route. */
+interface StreamChunk {
+  content?: string;
+  error?: string;
+  done?: boolean;
+  final?: boolean;
+  conversationId?: string;
+  sources?: Source[];
+  /** Improve route (#704): the original markdown the model was fed, echoed on the final event. */
+  originalMarkdown?: string;
+}
+
+/** Extra, non-content metadata surfaced to `onComplete` once a stream finishes. */
+export interface StreamMeta {
+  /** Improve route (#704): markdown baseline for like-for-like diffing. */
+  originalMarkdown?: string;
 }
 
 const AiCtx = createContext<AiContextValue | null>(null);
@@ -172,6 +193,7 @@ export function AiProvider({ children }: { children: ReactNode }) {
   const [improvementType, setImprovementType] = useState('grammar');
   const [showDiffView, setShowDiffView] = useState(false);
   const [improvedContent, setImprovedContent] = useState('');
+  const [originalMarkdown, setOriginalMarkdown] = useState('');
   const [diagramType, setDiagramType] = useState('flowchart');
   const [diagramCode, setDiagramCode] = useState('');
   const [isInsertingDiagram, setIsInsertingDiagram] = useState(false);
@@ -202,6 +224,7 @@ export function AiProvider({ children }: { children: ReactNode }) {
       setInput('');
       setShowDiffView(false);
       setImprovedContent('');
+      setOriginalMarkdown('');
       setDiagramCode('');
     }
   }, [pageId]);
@@ -377,13 +400,13 @@ export function AiProvider({ children }: { children: ReactNode }) {
    * Generic SSE streaming helper used by all mode handlers.
    * Manages abort controller, streaming state, thinking state, and message accumulation.
    */
-  const runStream = useCallback(async <T extends { content?: string; error?: string; done?: boolean; final?: boolean; conversationId?: string; sources?: Source[] }>(
+  const runStream = useCallback(async <T extends StreamChunk>(
     endpoint: string,
     body: Record<string, unknown>,
     opts?: {
       onBeforeStream?: () => void;
       onContent?: (accumulated: string) => void;
-      onComplete?: (accumulated: string, sources?: Source[]) => void;
+      onComplete?: (accumulated: string, sources?: Source[], meta?: StreamMeta) => void;
       userMessage?: string;
     },
   ) => {
@@ -404,6 +427,7 @@ export function AiProvider({ children }: { children: ReactNode }) {
 
     let accumulated = '';
     let finalSources: Source[] = [];
+    let originalMarkdown: string | undefined;
 
     // Add the placeholder assistant message with a stable ID
     const assistantMsgId = nextMessageId();
@@ -443,6 +467,11 @@ export function AiProvider({ children }: { children: ReactNode }) {
         if (chunk.final && chunk.sources) {
           finalSources = chunk.sources;
         }
+        // Improve route (#704): capture the original markdown baseline so the
+        // diff compares like-for-like markdown instead of stripped bodyText.
+        if (chunk.originalMarkdown) {
+          originalMarkdown = chunk.originalMarkdown;
+        }
       }
       // Attach sources to the last assistant message
       if (finalSources.length > 0) {
@@ -453,7 +482,11 @@ export function AiProvider({ children }: { children: ReactNode }) {
           return updated;
         });
       }
-      opts?.onComplete?.(accumulated, finalSources.length > 0 ? finalSources : undefined);
+      opts?.onComplete?.(
+        accumulated,
+        finalSources.length > 0 ? finalSources : undefined,
+        originalMarkdown !== undefined ? { originalMarkdown } : undefined,
+      );
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return;
       toast.error(err instanceof Error ? err.message : 'Request failed');
@@ -509,6 +542,8 @@ export function AiProvider({ children }: { children: ReactNode }) {
     setShowDiffView,
     improvedContent,
     setImprovedContent,
+    originalMarkdown,
+    setOriginalMarkdown,
     diagramType,
     setDiagramType,
     diagramCode,

--- a/frontend/src/features/ai/modes/ImproveMode.test.tsx
+++ b/frontend/src/features/ai/modes/ImproveMode.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LazyMotion, domAnimation } from 'framer-motion';
-import { ImproveTypeSelector, ImproveModeInput, IMPROVE_EMPTY_TITLE, improveEmptySubtitle } from './ImproveMode';
+import { ImproveTypeSelector, ImproveModeInput, ImproveDiffView, IMPROVE_EMPTY_TITLE, improveEmptySubtitle } from './ImproveMode';
 import { AiProvider } from '../AiContext';
 import { useAuthStore } from '../../../stores/auth-store';
 
@@ -191,6 +191,78 @@ describe('ImproveMode', () => {
     render(<ImproveModeInput />, { wrapper: createWrapper() });
     const textarea = screen.getByPlaceholderText(/Additional instructions/i) as HTMLTextAreaElement;
     expect(textarea.maxLength).toBe(10000);
+  });
+
+  // #704: the diff must compare the original *markdown* the model was fed
+  // (echoed by the backend on the final SSE event) against the improved
+  // markdown — not the formatting-stripped page.bodyText.
+  describe('#704 diff baseline is original markdown', () => {
+    const ORIGINAL_MD = '# Title\n\nThis sentence have a grammar error.\n\n- item one\n- item two';
+    const IMPROVED_MD = '# Title\n\nThis sentence has a grammar error.\n\n- item one\n- item two';
+
+    async function runImprove() {
+      // Stream the improved markdown, then a final event carrying the original
+      // markdown baseline (mirrors the backend's `improveExtras`).
+      async function* fakeStream() {
+        yield { content: IMPROVED_MD };
+        yield { originalMarkdown: ORIGINAL_MD, done: true, final: true };
+      }
+      streamSSEMock.mockReturnValue(fakeStream());
+
+      render(
+        <>
+          <ImproveModeInput />
+          <ImproveDiffView />
+        </>,
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /Improve Page/i });
+        expect(btn).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByRole('button', { name: /Improve Page/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('unified-diff')).toBeInTheDocument();
+      });
+    }
+
+    it('uses the echoed original markdown (with markup) as the diff baseline, not stripped bodyText', async () => {
+      await runImprove();
+
+      const diff = screen.getByTestId('unified-diff');
+      // The markdown markup (`#`, list `-`) must be present in the baseline and
+      // NOT flagged as additions. With a grammar-only edit, the only highlighted
+      // change is the wording — markup carries over unchanged.
+      const addedSpans = diff.querySelectorAll('.text-success');
+      const addedText = Array.from(addedSpans).map((s) => s.textContent).join('');
+
+      // No markup tokens should appear as additions (the old bug surfaced
+      // `#`, `**`, `-` as green additions).
+      expect(addedText).not.toContain('#');
+      expect(addedText).not.toContain('- item');
+      // The genuine grammar edit ("has") is still highlighted.
+      expect(addedText).toContain('has');
+
+      // The full diff text preserves the markdown structure (baseline kept its
+      // headers/lists rather than being whitespace-collapsed plain text).
+      expect(diff.textContent).toContain('# Title');
+      expect(diff.textContent).toContain('- item one');
+    });
+
+    it('marks only the changed word as removed, leaving markup untouched', async () => {
+      await runImprove();
+
+      const diff = screen.getByTestId('unified-diff');
+      const removedSpans = diff.querySelectorAll('.text-destructive');
+      const removedText = Array.from(removedSpans).map((s) => s.textContent).join('');
+
+      // The replaced word is removed; markup is not.
+      expect(removedText).toContain('have');
+      expect(removedText).not.toContain('#');
+      expect(removedText).not.toContain('- item');
+    });
   });
 
   it('disables textarea while streaming', async () => {

--- a/frontend/src/features/ai/modes/ImproveMode.tsx
+++ b/frontend/src/features/ai/modes/ImproveMode.tsx
@@ -52,7 +52,7 @@ export function ImproveTypeSelector() {
  * Diff view shown after an improve stream completes.
  */
 export function ImproveDiffView() {
-  const { page, pageId, navigate, queryClient, isStreaming, showDiffView, setShowDiffView, improvedContent } = useAiContext();
+  const { page, pageId, navigate, queryClient, isStreaming, showDiffView, setShowDiffView, improvedContent, originalMarkdown } = useAiContext();
   const [isApplying, setIsApplying] = useState(false);
 
   const handleAccept = useCallback(async () => {
@@ -82,7 +82,11 @@ export function ImproveDiffView() {
 
   return (
     <DiffView
-      original={page.bodyText || page.bodyHtml}
+      // #704: diff like-for-like — the original markdown the model was fed
+      // (echoed by /llm/improve) vs the improved markdown it returned, so only
+      // genuine wording/structure edits show. Falls back to the page body only
+      // if the backend didn't supply the baseline (e.g. an aborted stream).
+      original={originalMarkdown || page.bodyText || page.bodyHtml}
       improved={improvedContent}
       onAccept={handleAccept}
       onReject={() => setShowDiffView(false)}
@@ -97,7 +101,7 @@ export function ImproveDiffView() {
 export function ImproveModeInput() {
   const {
     isStreaming, page, isPageLoading, model, pageId, includeSubPages, thinkingMode, runStream,
-    improvementType, setShowDiffView, setImprovedContent,
+    improvementType, setShowDiffView, setImprovedContent, setOriginalMarkdown,
   } = useAiContext();
   const [instruction, setInstruction] = useState('');
   const [searchWeb, setSearchWeb] = useState(false);
@@ -125,6 +129,7 @@ export function ImproveModeInput() {
 
     setShowDiffView(false);
     setImprovedContent('');
+    setOriginalMarkdown('');
 
     const body: Record<string, unknown> = {
       content: page.bodyHtml, type: improvementType, model, pageId: pageId ?? undefined, includeSubPages,
@@ -142,13 +147,18 @@ export function ImproveModeInput() {
       body,
       {
         userMessage: `Improve (${improvementType}): ${page.title}`,
-        onComplete: (accumulated) => {
+        onComplete: (accumulated, _sources, meta) => {
           setImprovedContent(accumulated);
+          // #704: store the markdown baseline echoed by the backend so the diff
+          // compares like-for-like markdown, not stripped bodyText.
+          if (meta?.originalMarkdown !== undefined) {
+            setOriginalMarkdown(meta.originalMarkdown);
+          }
           setShowDiffView(true);
         },
       },
     );
-  }, [page, model, improvementType, pageId, isStreaming, includeSubPages, thinkingMode, instruction, searchWeb, runStream, setShowDiffView, setImprovedContent]);
+  }, [page, model, improvementType, pageId, isStreaming, includeSubPages, thinkingMode, instruction, searchWeb, runStream, setShowDiffView, setImprovedContent, setOriginalMarkdown]);
 
   return (
     <div className="mt-3 flex flex-col gap-3 border-t border-border/40 pt-3">


### PR DESCRIPTION
Closes #704

## Problem

The AI Improve change preview ran a word-level diff between the page's
formatting-stripped `bodyText` (no `#`/`**`/`-`/newlines) and the LLM's
**Markdown** output. Every Markdown token and structural newline showed up
as a green addition, and the Original column looked like it had lost all its
formatting. The diff was dominated by representation noise.

## Fix — diff like-for-like

Compare the original *as Markdown* against the improved Markdown, so only
genuine wording/structure edits appear.

**Backend** (`backend/src/routes/llm/llm-improve.ts`)
- `POST /api/llm/improve` now echoes the exact Markdown it fed the model —
  `htmlToMarkdown(page.bodyHtml)`, already computed in `assembleContextIfNeeded`
  and previously discarded — as `originalMarkdown` on the **final SSE event**.
- Emitted on **both** the streamed path (`improveExtras`) and the cached path
  (`sendCachedSSE` extras), so the diff baseline is present even on a cache hit.

**Frontend** (`AiContext.tsx`, `modes/ImproveMode.tsx`)
- `runStream` captures `originalMarkdown` from the final event and surfaces it
  to `onComplete` via a new `meta` argument (typed `StreamMeta`). The chunk/meta
  shapes are now named types (`StreamChunk`, `StreamMeta`).
- `ImproveMode` stores it in new context state (`originalMarkdown`) and
  `ImproveDiffView` passes it to `DiffView` as `original` instead of
  `page.bodyText`. Falls back to `page.bodyText || page.bodyHtml` only if the
  backend didn't supply the baseline (e.g. an aborted stream / older backend).

**Accept is unchanged** — it still posts `improvedMarkdown: improvedContent`,
and apply converts Markdown→HTML server-side (`llm-conversations.ts`).

## Design decisions

- Used the assembled `markdown` (what the model actually received, pre-web-context)
  as the baseline — this is exactly the issue's recommended Option 1 and keeps real
  formatting edits visible while removing the false ones. When `includeSubPages` is on,
  the baseline is the same assembled markdown the model saw, so the diff stays consistent.
- Reused the existing final-SSE-`extras` channel rather than adding a new meta event,
  matching how `sources` are already delivered.

## Tests

- **Backend** (`improve-page-id.test.ts`): asserts the final SSE event carries
  `originalMarkdown` on the streamed path and on the cached path (via a shared
  cache-mock that forces a hit).
- **Frontend** (`ImproveMode.test.tsx`): drives a grammar-only stream with an echoed
  `originalMarkdown` baseline and asserts the Markdown markup (`#`, list `-`) is NOT
  flagged as additions/removals while the genuine word change (`have`→`has`) is.

Verification (all green):
- `npm run typecheck -w backend` / `-w frontend`
- `npm run lint -w backend` / `-w frontend`
- backend `improve-page-id.test.ts` (6 passed), related SSE/improve suites (40 passed)
- frontend `ImproveMode.test.tsx` (11 passed), `DiffView` + `AiAssistantPage` (53 passed)

## Docs / diagrams

No diagram update needed: this adds one metadata field to an existing SSE event
in an existing flow — no change to domains, FKs, auth/sync/RAG flows, compose, or
ESLint boundaries. `docs/architecture/09-flow-rag-chat.md` documents the `/llm/ask`
SSE frames specifically, not `/llm/improve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)