### PR TITLE
feat(ai): optional Swiss spelling (ß→ss) post-processing rule (#705)

### DIFF
--- a/backend/src/core/services/ai-safety-service.test.ts
+++ b/backend/src/core/services/ai-safety-service.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, truncateAllTables, teardownTestDb, isDbAvailable } from '../../test-db-helper.js';
+import { query } from '../db/postgres.js';
+import { getAiOutputRules, upsertAiOutputRules } from './ai-safety-service.js';
+
+const dbAvailable = await isDbAvailable();
+
+// Real-Postgres coverage for the Swiss-spelling output rule (#705): persistence
+// into `admin_settings`, the default-off getter, and cache invalidation on
+// write. The 60s TTL cache is module-level, but `upsertAiOutputRules` nulls it
+// on every write, so a read-after-write reflects the new value immediately.
+describe.skipIf(!dbAvailable)('ai-safety-service — Swiss spelling output rule (#705)', () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables();
+    // Read once after truncate to refresh the module cache to the post-truncate
+    // (empty admin_settings) state, so each test starts from defaults.
+    await getAiOutputRules();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  it('defaults swissSpelling to false when no admin_settings row exists', async () => {
+    const rules = await getAiOutputRules();
+    expect(rules.swissSpelling).toBe(false);
+  });
+
+  it('persists swissSpelling=true and reflects it on the next read (cache invalidated on write)', async () => {
+    await upsertAiOutputRules({ swissSpelling: true });
+
+    const row = await query<{ setting_value: string }>(
+      `SELECT setting_value FROM admin_settings WHERE setting_key = 'ai_output_rule_swiss_spelling'`,
+    );
+    expect(row.rows[0]?.setting_value).toBe('true');
+
+    const rules = await getAiOutputRules();
+    expect(rules.swissSpelling).toBe(true);
+  });
+
+  it('persists swissSpelling=false explicitly', async () => {
+    await upsertAiOutputRules({ swissSpelling: true });
+    expect((await getAiOutputRules()).swissSpelling).toBe(true);
+
+    await upsertAiOutputRules({ swissSpelling: false });
+    expect((await getAiOutputRules()).swissSpelling).toBe(false);
+  });
+
+  it('leaves swissSpelling untouched when an unrelated output rule is updated', async () => {
+    await upsertAiOutputRules({ swissSpelling: true });
+    await upsertAiOutputRules({ referenceAction: 'strip' });
+
+    const rules = await getAiOutputRules();
+    expect(rules.swissSpelling).toBe(true);
+    expect(rules.referenceAction).toBe('strip');
+  });
+});

--- a/backend/src/core/services/ai-safety-service.ts
+++ b/backend/src/core/services/ai-safety-service.ts
@@ -13,6 +13,12 @@ export type ReferenceAction = 'flag' | 'strip' | 'off';
 interface AiOutputRules {
   stripReferences: boolean;
   referenceAction: ReferenceAction;
+  /**
+   * Issue #705 — Swiss spelling. When true, the output post-processor replaces
+   * `ß` → `ss` and capital `ẞ` (U+1E9E) → `SS` on the final AI output. Default
+   * off so German spelling is preserved unless an admin opts in.
+   */
+  swissSpelling: boolean;
 }
 
 // ─── Defaults ─────────────────────────────────────────────────────────────────
@@ -25,9 +31,18 @@ const DEFAULT_GUARDRAILS: AiGuardrails = {
   noFabricationEnabled: true,
 };
 
+/**
+ * Issue #705 — supplementary prompt hint appended when Swiss spelling is on.
+ * The deterministic `ß→ss` post-processor is the source of truth; this hint
+ * just reduces churn before that pass by nudging the model up front.
+ */
+export const SWISS_SPELLING_INSTRUCTION =
+  "Use Swiss orthography: never use the character 'ß' (eszett); always write 'ss' instead.";
+
 const DEFAULT_OUTPUT_RULES: AiOutputRules = {
   stripReferences: true,
   referenceAction: 'flag',
+  swissSpelling: false,
 };
 
 // ─── In-process TTL cache (critic fix #3) ─────────────────────────────────────
@@ -42,6 +57,7 @@ const AI_SAFETY_KEYS = [
   'ai_guardrail_no_fabrication_enabled',
   'ai_output_rule_strip_references',
   'ai_output_rule_reference_action',
+  'ai_output_rule_swiss_spelling',
 ] as const;
 
 async function getAiSettingsMap(): Promise<Record<string, string>> {
@@ -88,6 +104,9 @@ export async function getAiOutputRules(): Promise<AiOutputRules> {
       action === 'strip' || action === 'flag' || action === 'off'
         ? action
         : DEFAULT_OUTPUT_RULES.referenceAction,
+    // Default off (#705): only enabled when an admin explicitly opts in.
+    swissSpelling:
+      map['ai_output_rule_swiss_spelling'] === 'true',
   };
   outputRuleCache = { value, expiresAt: Date.now() + CACHE_TTL_MS };
   return value;
@@ -168,6 +187,14 @@ export async function upsertAiOutputRules(
          VALUES ('ai_output_rule_reference_action', $1, NOW())
          ON CONFLICT (setting_key) DO UPDATE SET setting_value = $1, updated_at = NOW()`,
         [updates.referenceAction],
+      );
+    }
+    if (updates.swissSpelling !== undefined) {
+      await client.query(
+        `INSERT INTO admin_settings (setting_key, setting_value, updated_at)
+         VALUES ('ai_output_rule_swiss_spelling', $1, NOW())
+         ON CONFLICT (setting_key) DO UPDATE SET setting_value = $1, updated_at = NOW()`,
+        [String(updates.swissSpelling)],
       );
     }
 

--- a/backend/src/core/utils/sanitize-llm-output.test.ts
+++ b/backend/src/core/utils/sanitize-llm-output.test.ts
@@ -182,3 +182,87 @@ describe('sanitizeLlmOutput', () => {
     expect(result.strippedSections).toEqual(['References']);
   });
 });
+
+// ── Swiss spelling (#705) ────────────────────────────────────────────────────
+
+describe('sanitizeLlmOutput — Swiss spelling (#705)', () => {
+  // Swiss spelling combined with reference detection disabled, so only the
+  // ß→ss transform is exercised in isolation.
+  const RULES_SWISS_ONLY: OutputRules = {
+    stripReferences: false,
+    referenceAction: 'flag',
+    swissSpelling: true,
+  };
+  const RULES_NO_SWISS: OutputRules = {
+    stripReferences: false,
+    referenceAction: 'flag',
+    swissSpelling: false,
+  };
+
+  it('replaces lowercase ß with ss', () => {
+    const result = sanitizeLlmOutput('Die Straße ist groß.', RULES_SWISS_ONLY);
+    expect(result.content).toBe('Die Strasse ist gross.');
+    expect(result.wasModified).toBe(true);
+  });
+
+  it('replaces capital ẞ (U+1E9E) with SS', () => {
+    const result = sanitizeLlmOutput('STRAẞE', RULES_SWISS_ONLY);
+    expect(result.content).toBe('STRASSE');
+    expect(result.wasModified).toBe(true);
+  });
+
+  it('replaces every occurrence, not just the first', () => {
+    const result = sanitizeLlmOutput('Maß, Fuß, Spaß', RULES_SWISS_ONLY);
+    expect(result.content).toBe('Mass, Fuss, Spass');
+    expect(result.content).not.toContain('ß');
+  });
+
+  it('leaves output with no eszett unchanged and unmodified', () => {
+    const content = 'Plain ASCII content with no special characters.';
+    const result = sanitizeLlmOutput(content, RULES_SWISS_ONLY);
+    expect(result.content).toBe(content);
+    expect(result.wasModified).toBe(false);
+  });
+
+  it('does not touch ß when swissSpelling is off (default behaviour)', () => {
+    const content = 'Die Straße ist groß.';
+    const result = sanitizeLlmOutput(content, RULES_NO_SWISS);
+    expect(result.content).toBe(content);
+    expect(result.wasModified).toBe(false);
+  });
+
+  it('also normalizes ß inside fenced code blocks (blanket replace)', () => {
+    const content = 'Run:\n```\nconst gruß = "groß";\n```';
+    const result = sanitizeLlmOutput(content, RULES_SWISS_ONLY);
+    expect(result.content).toBe('Run:\n```\nconst gruss = "gross";\n```');
+    expect(result.content).not.toContain('ß');
+  });
+
+  it('applies Swiss spelling AND strips references in the same pass', () => {
+    const content = '# Artikel\nGroße Straße.\n\n## References\n- https://fake.com';
+    const rules: OutputRules = { stripReferences: true, referenceAction: 'strip', swissSpelling: true };
+    const result = sanitizeLlmOutput(content, rules);
+    expect(result.wasModified).toBe(true);
+    expect(result.strippedSections).toEqual(['References']);
+    expect(result.content).toBe('# Artikel\nGrosse Strasse.');
+    expect(result.content).not.toContain('ß');
+  });
+
+  it('applies Swiss spelling to flagged content including the kept reference section', () => {
+    const content = '# Artikel\nGroße Straße.\n\n## References\n- https://fake.com';
+    const rules: OutputRules = { stripReferences: true, referenceAction: 'flag', swissSpelling: true };
+    const result = sanitizeLlmOutput(content, rules);
+    expect(result.wasModified).toBe(true);
+    expect(result.content).toContain('Grosse Strasse.');
+    expect(result.content).toContain('## References');
+    expect(result.content).not.toContain('ß');
+  });
+
+  it('reports wasModified=true even when only Swiss spelling changes content', () => {
+    // No reference section present, so the reference pass is a no-op; the
+    // modification flag must still reflect the ß→ss substitution.
+    const result = sanitizeLlmOutput('groß', RULES_SWISS_ONLY);
+    expect(result.wasModified).toBe(true);
+    expect(result.content).toBe('gross');
+  });
+});

--- a/backend/src/core/utils/sanitize-llm-output.ts
+++ b/backend/src/core/utils/sanitize-llm-output.ts
@@ -13,6 +13,13 @@ export interface OutputRules {
   stripReferences: boolean;
   referenceAction: ReferenceAction;
   verifiedSources?: string[];
+  /**
+   * Issue #705 — Swiss spelling. When true, every `ß` is replaced with `ss`
+   * and capital `ẞ` (U+1E9E) with `SS`. Switzerland abolished the eszett, so
+   * for Swiss teams every `ß` the model produces is wrong. This is a blanket
+   * replace (including fenced/inline code) — CH uses `ss` everywhere.
+   */
+  swissSpelling?: boolean;
 }
 
 // ─── Default disclaimer ───────────────────────────────────────────────────────
@@ -73,9 +80,43 @@ function allUrlsVerified(urls: string[], verifiedSources: string[]): boolean {
   return urls.every((url) => verified.has(url.toLowerCase()));
 }
 
+/**
+ * Issue #705 — enforce Swiss orthography by replacing the eszett.
+ *
+ * Swiss Standard German uses `ss` in every position where German Standard
+ * German uses `ß`, so a blanket replace is exactly correct (there are no
+ * positional exceptions). `ß` → `ss`, capital `ẞ` (U+1E9E) → `SS`.
+ */
+function applySwissSpelling(content: string): string {
+  return content.replace(/ß/g, 'ss').replace(/ẞ/g, 'SS');
+}
+
 // ─── Main sanitizer ───────────────────────────────────────────────────────────
 
 export function sanitizeLlmOutput(output: string, rules: OutputRules): OutputSanitizeResult {
+  // Run the reference-handling pass, then the Swiss-spelling pass. The two are
+  // independent rules — Swiss spelling must apply even when reference detection
+  // is disabled — so the result of the first feeds the second.
+  const referenceResult = sanitizeReferences(output, rules);
+
+  if (!rules.swissSpelling) {
+    return referenceResult;
+  }
+
+  const swissContent = applySwissSpelling(referenceResult.content);
+  return {
+    ...referenceResult,
+    content: swissContent,
+    wasModified: referenceResult.wasModified || swissContent !== referenceResult.content,
+  };
+}
+
+/**
+ * Reference-section handling (strip / flag / verified-source preservation).
+ * Returns the unmodified output when reference detection is disabled or no
+ * reference section is found.
+ */
+function sanitizeReferences(output: string, rules: OutputRules): OutputSanitizeResult {
   // Pass through if disabled
   if (!rules.stripReferences || rules.referenceAction === 'off') {
     return { content: output, wasModified: false, strippedSections: [], disclaimer: null };

--- a/backend/src/routes/foundation/admin.ts
+++ b/backend/src/routes/foundation/admin.ts
@@ -278,6 +278,7 @@ export async function adminRoutes(fastify: FastifyInstance) {
       aiGuardrailNoFabricationEnabled: guardrails.noFabricationEnabled,
       aiOutputRuleStripReferences: outputRules.stripReferences,
       aiOutputRuleReferenceAction: outputRules.referenceAction,
+      aiOutputRuleSwissSpelling: outputRules.swissSpelling,
       // Rate limits
       rateLimitGlobal: rateLimits.global.max,
       rateLimitAuth: rateLimits.auth.max,
@@ -438,7 +439,9 @@ export async function adminRoutes(fastify: FastifyInstance) {
     const hasAiGuardrailChanges =
       body.aiGuardrailNoFabrication !== undefined || body.aiGuardrailNoFabricationEnabled !== undefined;
     const hasAiOutputRuleChanges =
-      body.aiOutputRuleStripReferences !== undefined || body.aiOutputRuleReferenceAction !== undefined;
+      body.aiOutputRuleStripReferences !== undefined ||
+      body.aiOutputRuleReferenceAction !== undefined ||
+      body.aiOutputRuleSwissSpelling !== undefined;
 
     if (hasAiGuardrailChanges) {
       // Sanitize admin-supplied guardrail text to prevent prompt injection (critic fix #6)
@@ -461,6 +464,7 @@ export async function adminRoutes(fastify: FastifyInstance) {
         {
           stripReferences: body.aiOutputRuleStripReferences,
           referenceAction: body.aiOutputRuleReferenceAction,
+          swissSpelling: body.aiOutputRuleSwissSpelling,
         },
         request.userId,
       );

--- a/backend/src/routes/llm/_helpers.ts
+++ b/backend/src/routes/llm/_helpers.ts
@@ -232,11 +232,6 @@ export async function streamSSE(
 }
 
 /**
- * Build an output post-processor using the current admin AI output rules.
- * Returns undefined if output processing is disabled, so callers can pass it
- * directly to `streamSSE` options.
- */
-/**
  * Get admin-configured SearXNG max results (reads from admin_settings, defaults to 5).
  */
 export async function getSearxngMaxResults(): Promise<number> {
@@ -246,6 +241,11 @@ export async function getSearxngMaxResults(): Promise<number> {
   return parseInt(result.rows[0]?.setting_value ?? '5', 10);
 }
 
+/**
+ * Build an output post-processor using the current admin AI output rules.
+ * Returns undefined if output processing is disabled, so callers can pass it
+ * directly to `streamSSE` options.
+ */
 export async function buildOutputPostProcessor(
   verifiedSources?: string[],
 ): Promise<((content: string) => OutputSanitizeResult) | undefined> {

--- a/backend/src/routes/llm/_helpers.ts
+++ b/backend/src/routes/llm/_helpers.ts
@@ -8,7 +8,7 @@ import {
   LANGUAGE_PRESERVATION_INSTRUCTION,
 } from '../../domains/llm/services/prompts.js';
 import { LlmCache, type CachedLlmResponse } from '../../domains/llm/services/llm-cache.js';
-import { getAiGuardrails, getAiOutputRules } from '../../core/services/ai-safety-service.js';
+import { getAiGuardrails, getAiOutputRules, SWISS_SPELLING_INSTRUCTION } from '../../core/services/ai-safety-service.js';
 import { sanitizeLlmOutput, type OutputSanitizeResult } from '../../core/utils/sanitize-llm-output.js';
 import { assembleSubPageContext, getMultiPagePromptSuffix } from '../../domains/confluence/services/subpage-context.js';
 import { htmlToMarkdown } from '../../core/services/content-converter.js';
@@ -86,6 +86,13 @@ export async function resolveSystemPrompt(userId: string, key: SystemPromptKey):
   const guardrails = await getAiGuardrails();
   if (guardrails.noFabricationEnabled && guardrails.noFabricationInstruction) {
     prompt += ` ${guardrails.noFabricationInstruction}`;
+  }
+
+  // Issue #705 — supplementary Swiss-spelling hint. The deterministic post-
+  // processor still enforces ß→ss; this just reduces churn before that pass.
+  const outputRules = await getAiOutputRules();
+  if (outputRules.swissSpelling) {
+    prompt += ` ${SWISS_SPELLING_INSTRUCTION}`;
   }
 
   return prompt;
@@ -243,7 +250,12 @@ export async function buildOutputPostProcessor(
   verifiedSources?: string[],
 ): Promise<((content: string) => OutputSanitizeResult) | undefined> {
   const rules = await getAiOutputRules();
-  if (!rules.stripReferences || rules.referenceAction === 'off') return undefined;
+
+  // Reference detection and Swiss spelling (#705) are independent output rules.
+  // Skip the post-processor only when BOTH are inactive — otherwise Swiss
+  // spelling would never run while reference detection is off.
+  const referenceActive = rules.stripReferences && rules.referenceAction !== 'off';
+  if (!referenceActive && !rules.swissSpelling) return undefined;
 
   return (content: string) =>
     sanitizeLlmOutput(content, {

--- a/backend/src/routes/llm/sse-stream-limit-gate.test.ts
+++ b/backend/src/routes/llm/sse-stream-limit-gate.test.ts
@@ -122,9 +122,11 @@ vi.mock('../../core/services/ai-safety-service.js', () => ({
   getAiOutputRules: vi.fn().mockResolvedValue({
     stripReferences: false,
     referenceAction: 'off',
+    swissSpelling: false,
   }),
   upsertAiGuardrails: vi.fn(),
   upsertAiOutputRules: vi.fn(),
+  SWISS_SPELLING_INSTRUCTION: "Use Swiss orthography: never use the character 'ß' (eszett); always write 'ss' instead.",
 }));
 
 vi.mock('../../domains/confluence/services/subpage-context.js', () => ({

--- a/frontend/src/features/settings/AiSafetyTab.test.tsx
+++ b/frontend/src/features/settings/AiSafetyTab.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { AiSafetyTab } from './AiSafetyTab';
+
+// Mock auth store (apiFetch reads the access token from it)
+const authState = { user: { role: 'admin' }, accessToken: 'test-token', setAuth: vi.fn(), clearAuth: vi.fn() };
+vi.mock('../../stores/auth-store', () => ({
+  useAuthStore: Object.assign(
+    (selector: (state: typeof authState) => unknown) => selector(authState),
+    { getState: () => authState },
+  ),
+}));
+
+const defaultSettings = {
+  aiGuardrailNoFabricationEnabled: true,
+  aiGuardrailNoFabrication:
+    'IMPORTANT: Do not fabricate, invent, or hallucinate references, sources, URLs, citations, or bibliographic entries. If you do not have a verified source for a claim, say so explicitly. Never generate fake links or made-up author names. Only cite sources that were provided to you in the context.',
+  aiOutputRuleStripReferences: true,
+  aiOutputRuleReferenceAction: 'flag' as const,
+  aiOutputRuleSwissSpelling: false,
+};
+
+function mockFetchWith(settings: Record<string, unknown>) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+    if (url.includes('/admin/settings')) {
+      if ((input as Request)?.method === 'PUT') {
+        return new Response(JSON.stringify({ message: 'Updated' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify(settings), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    return new Response('Not found', { status: 404 });
+  });
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('AiSafetyTab — Swiss spelling toggle (#705)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the Swiss spelling toggle, unchecked by default', async () => {
+    mockFetchWith(defaultSettings);
+    render(<AiSafetyTab />, { wrapper: createWrapper() });
+
+    const toggle = await waitFor(() =>
+      screen.getByTestId('ai-output-rule-swiss-spelling-toggle').querySelector('input') as HTMLInputElement,
+    );
+    expect(toggle.checked).toBe(false);
+    expect(screen.getByText('Swiss spelling — never use ß')).toBeInTheDocument();
+  });
+
+  it('initializes the toggle as checked when the setting is on', async () => {
+    mockFetchWith({ ...defaultSettings, aiOutputRuleSwissSpelling: true });
+    render(<AiSafetyTab />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      const toggle = screen.getByTestId('ai-output-rule-swiss-spelling-toggle').querySelector('input') as HTMLInputElement;
+      expect(toggle.checked).toBe(true);
+    });
+  });
+
+  it('enables the save button after toggling Swiss spelling on', async () => {
+    mockFetchWith(defaultSettings);
+    render(<AiSafetyTab />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ai-safety-save-btn')).toBeDisabled();
+    });
+
+    const toggle = screen.getByTestId('ai-output-rule-swiss-spelling-toggle').querySelector('input') as HTMLInputElement;
+    fireEvent.click(toggle);
+
+    expect(screen.getByTestId('ai-safety-save-btn')).not.toBeDisabled();
+  });
+
+  it('sends aiOutputRuleSwissSpelling=true in the PUT payload on save', async () => {
+    const fetchSpy = mockFetchWith(defaultSettings);
+    render(<AiSafetyTab />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ai-output-rule-swiss-spelling-toggle')).toBeInTheDocument();
+    });
+
+    const toggle = screen.getByTestId('ai-output-rule-swiss-spelling-toggle').querySelector('input') as HTMLInputElement;
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByTestId('ai-safety-save-btn'));
+
+    await waitFor(() => {
+      const putCall = fetchSpy.mock.calls.find((c) => (c[1] as RequestInit | undefined)?.method === 'PUT');
+      expect(putCall).toBeDefined();
+      const body = JSON.parse((putCall![1] as RequestInit).body as string);
+      expect(body.aiOutputRuleSwissSpelling).toBe(true);
+    });
+  });
+});

--- a/frontend/src/features/settings/AiSafetyTab.test.tsx
+++ b/frontend/src/features/settings/AiSafetyTab.test.tsx
@@ -23,10 +23,12 @@ const defaultSettings = {
 };
 
 function mockFetchWith(settings: Record<string, unknown>) {
-  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
     if (url.includes('/admin/settings')) {
-      if ((input as Request)?.method === 'PUT') {
+      // apiFetch calls fetch(stringURL, optionsObject), so the method lives on
+      // the 2nd arg, not on `input`.
+      if ((init as RequestInit)?.method === 'PUT') {
         return new Response(JSON.stringify({ message: 'Updated' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
       return new Response(JSON.stringify(settings), { status: 200, headers: { 'Content-Type': 'application/json' } });

--- a/frontend/src/features/settings/AiSafetyTab.tsx
+++ b/frontend/src/features/settings/AiSafetyTab.tsx
@@ -9,6 +9,7 @@ interface AdminSettings {
   aiGuardrailNoFabricationEnabled?: boolean;
   aiOutputRuleStripReferences?: boolean;
   aiOutputRuleReferenceAction?: ReferenceAction;
+  aiOutputRuleSwissSpelling?: boolean;
   [key: string]: unknown;
 }
 
@@ -33,6 +34,7 @@ export function AiSafetyTab() {
   const [guardrailText, setGuardrailText] = useState(DEFAULT_GUARDRAIL_TEXT);
   const [stripReferences, setStripReferences] = useState(true);
   const [referenceAction, setReferenceAction] = useState<ReferenceAction>('flag');
+  const [swissSpelling, setSwissSpelling] = useState(false);
 
   // Initialize form from settings
   useEffect(() => {
@@ -41,6 +43,7 @@ export function AiSafetyTab() {
       setGuardrailText(settings.aiGuardrailNoFabrication ?? DEFAULT_GUARDRAIL_TEXT);
       setStripReferences(settings.aiOutputRuleStripReferences ?? true);
       setReferenceAction(settings.aiOutputRuleReferenceAction ?? 'flag');
+      setSwissSpelling(settings.aiOutputRuleSwissSpelling ?? false);
     }
   }, [settings]);
 
@@ -61,7 +64,8 @@ export function AiSafetyTab() {
     guardrailEnabled !== (settings?.aiGuardrailNoFabricationEnabled ?? true) ||
     guardrailText !== (settings?.aiGuardrailNoFabrication ?? DEFAULT_GUARDRAIL_TEXT) ||
     stripReferences !== (settings?.aiOutputRuleStripReferences ?? true) ||
-    referenceAction !== (settings?.aiOutputRuleReferenceAction ?? 'flag');
+    referenceAction !== (settings?.aiOutputRuleReferenceAction ?? 'flag') ||
+    swissSpelling !== (settings?.aiOutputRuleSwissSpelling ?? false);
 
   function handleSave() {
     mutation.mutate({
@@ -69,6 +73,7 @@ export function AiSafetyTab() {
       aiGuardrailNoFabrication: guardrailText,
       aiOutputRuleStripReferences: stripReferences,
       aiOutputRuleReferenceAction: referenceAction,
+      aiOutputRuleSwissSpelling: swissSpelling,
     });
   }
 
@@ -163,6 +168,26 @@ export function AiSafetyTab() {
             ))}
           </div>
         )}
+
+        {/* Swiss spelling — never use ß (#705) */}
+        <label
+          className="mt-6 flex items-start gap-2 border-t border-border/40 pt-4"
+          data-testid="ai-output-rule-swiss-spelling-toggle"
+        >
+          <input
+            type="checkbox"
+            checked={swissSpelling}
+            onChange={(e) => setSwissSpelling(e.target.checked)}
+            className="mt-1 rounded border-border/40"
+          />
+          <div>
+            <span className="text-sm font-medium">Swiss spelling — never use ß</span>
+            <p className="text-xs text-muted-foreground">
+              Replaces every ß with ss (and capital ẞ with SS) in AI Improve / Summarize / Generate
+              output. Switzerland writes ss everywhere. Off by default.
+            </p>
+          </div>
+        </label>
       </div>
 
       {/* Save button */}

--- a/packages/contracts/src/schemas/admin.ts
+++ b/packages/contracts/src/schemas/admin.ts
@@ -33,6 +33,13 @@ export const AdminSettingsSchema = z.object({
   aiGuardrailNoFabricationEnabled: z.boolean().optional(),
   aiOutputRuleStripReferences: z.boolean().optional(),
   aiOutputRuleReferenceAction: ReferenceActionSchema.optional(),
+  /**
+   * Issue #705 — Swiss spelling. When true, the output post-processor replaces
+   * every `ß` with `ss` and capital `ẞ` (U+1E9E) with `SS` on the final AI
+   * output (Improve / Summarize / Generate). Switzerland abolished the eszett,
+   * so for Swiss teams every `ß` the model emits is wrong. Default off.
+   */
+  aiOutputRuleSwissSpelling: z.boolean().optional(),
   // Rate limits (requests per minute)
   rateLimitGlobal: z.number().int().min(10).max(10000).optional(),
   rateLimitAuth: z.number().int().min(3).max(1000).optional(),
@@ -92,6 +99,8 @@ export const UpdateAdminSettingsSchema = z.object({
   aiGuardrailNoFabricationEnabled: z.boolean().optional(),
   aiOutputRuleStripReferences: z.boolean().optional(),
   aiOutputRuleReferenceAction: ReferenceActionSchema.optional(),
+  /** Issue #705 — Swiss spelling (ß→ss). Optional on update; omitted → unchanged. */
+  aiOutputRuleSwissSpelling: z.boolean().optional(),
   // Rate limits (requests per minute)
   rateLimitGlobal: z.number().int().min(10).max(10000).optional(),
   rateLimitAuth: z.number().int().min(3).max(1000).optional(),


### PR DESCRIPTION
Closes #705

## What

Adds an admin AI-Safety toggle **"Swiss spelling — never use ß"** (default **OFF**). When ON, the output post-processor replaces every `ß` → `ss` and capital `ẞ` (U+1E9E) → `SS` on the final accumulated AI output, so **AI Improve / Summarize / Generate** never emit the eszett. Switzerland abolished `ß` (Swiss keyboards lack the key), so for Swiss teams every `ß` the model produces is wrong and has to be hand-corrected.

The deterministic transform is the source of truth; a short Swiss-orthography hint is also appended to the system prompt to reduce churn before that pass.

## Changes

- **`backend/src/core/utils/sanitize-llm-output.ts`** — new `swissSpelling` rule. Refactored `sanitizeLlmOutput` so the reference-handling pass and the Swiss-spelling pass are **independent**: Swiss spelling now applies even when reference detection is off, and is layered on top of strip/flag results. `wasModified` is set correctly when only the eszett substitution changes content (so `streamSSE` forwards the cleaned `finalContent` to the frontend).
- **`backend/src/core/services/ai-safety-service.ts`** — `swissSpelling: boolean` on `AiOutputRules`, backed by the new `ai_output_rule_swiss_spelling` `admin_settings` key. Default **off** (opt-in `=== 'true'` semantics, unlike the default-on reference rule). Respects the existing 60s TTL cache and cache invalidation on write. Exports `SWISS_SPELLING_INSTRUCTION`.
- **`backend/src/routes/llm/_helpers.ts`** — `buildOutputPostProcessor` no longer short-circuits to `undefined` when only reference detection is off (it would have skipped Swiss spelling entirely); it now returns the processor when **either** rule is active. `resolveSystemPrompt` appends the Swiss hint when the toggle is on.
- **`packages/contracts/src/schemas/admin.ts`** — `aiOutputRuleSwissSpelling` added to both the read (`AdminSettingsSchema`) and update (`UpdateAdminSettingsSchema`) schemas.
- **`backend/src/routes/foundation/admin.ts`** — GET response field + PUT handler wiring through `upsertAiOutputRules`.
- **`frontend/src/features/settings/AiSafetyTab.tsx`** — toggle in the existing "AI Output Rules" section, next to the reference-detection rule.

## Decision: code-block handling

**Blanket replace, admin-wide scope** — including fenced/inline code regions. Swiss Standard German uses `ss` in **all** positions where German uses `ß` (no positional exceptions, unlike the German ß-vs-ss rule), and the issue notes CH uses `ss` everywhere, so a blanket substitution is exactly correct and avoids a fragile code-region parser. This is documented in the rule's doc comment.

## Test evidence

```
sanitize-llm-output.test.ts ........ 30 passed   (10 new: ß→ss, ẞ→SS, every-occurrence,
                                                  off=unchanged, code blocks, + combined with
                                                  reference strip/flag, wasModified flag)
ai-safety-service.test.ts (real PG) . 5 passed   (default-off, persistence, cache invalidation,
                                                  independence from other output rules)
AiSafetyTab.test.tsx (jsdom) ........ 4 passed   (renders unchecked, inits from setting, enables
                                                  save, sends aiOutputRuleSwissSpelling in PUT)
```

- `npm run typecheck -w backend` / `-w frontend` / `-w @compendiq/contracts` — pass
- `npm run lint -w backend` / `-w frontend` — pass (`--max-warnings=0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)