### PR TITLE
feat(editor): Notion-style selection bubble menu with inline AI improve (#708)

### DIFF
--- a/docs/architecture/11-content-pipeline.md
+++ b/docs/architecture/11-content-pipeline.md
@@ -93,6 +93,35 @@ Markdown is regenerated on demand because (a) LLM prompt sizes vary by
 model so partial/windowed serialisation is common, and (b) the conversion
 is cheap compared to the LLM call itself.
 
+## Client-side Markdown → HTML (inline selection improve, #708)
+
+`markdownToHtml()` normally runs on the **backend** when an `/ai`-page
+improvement is applied. The editor's **inline selection improve** (the
+Notion-style bubble menu) introduces a second, **client-side** path:
+`/llm/improve` streams Markdown for the selected fragment, and the editor
+converts it to HTML in the browser before `insertContentAt` replaces the
+captured range.
+
+- Conversion: `marked` (already a frontend dep) → DOMPurify, in
+  `frontend/src/shared/components/article/improve-markdown.ts`. A lone
+  wrapping `<p>` is unwrapped for in-place replacement so a mid-sentence
+  selection doesn't gain a block break; "Insert below" keeps the block HTML.
+- The request sends **only** the selected text as `content`, with `pageId` /
+  `includeSubPages` omitted — so the backend skips whole-page/sub-page
+  context assembly and writes **no** `llm_improvements` row (selection edits
+  are ephemeral previews, accepted via the normal editor draft/save flow).
+
+```mermaid
+flowchart LR
+    SEL["Editor selection<br/>(plain text)"]
+    IMP[("/llm/improve<br/>SSE → Markdown")]
+    MH["marked + DOMPurify<br/>(client)"]
+    ED["Editor (TipTap v3)<br/>insertContentAt"]
+    SEL -- "fragment only" --> IMP
+    IMP -- "Markdown stream" --> MH
+    MH -- "sanitized HTML" --> ED
+```
+
 ## Attachments
 
 Images, drawio diagrams, and PDFs are downloaded during sync to

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -54,6 +54,7 @@ import {
 import type { Editor as EditorType } from '@tiptap/react';
 import { VimExtension, type VimState } from './vim-extension';
 import { VimModeIndicator } from './VimModeIndicator';
+import { EditorBubbleMenu } from './EditorBubbleMenu';
 
 const ConfluenceImage = Image.extend({
   addAttributes() {
@@ -1126,6 +1127,7 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
         </div>
       )}
       {editable && editor && <SearchAndReplace editor={editor} />}
+      {editable && editor && <EditorBubbleMenu editor={editor} />}
       {editable && editor && (
         <DragHandle editor={editor} className="drag-handle">
           <GripVertical size={16} />

--- a/frontend/src/shared/components/article/EditorBubbleMenu.test.tsx
+++ b/frontend/src/shared/components/article/EditorBubbleMenu.test.tsx
@@ -193,3 +193,48 @@ describe('BubbleMenuContent — inline AI improve replace-range', () => {
     expect(body).not.toHaveProperty('pageId');
   });
 });
+
+describe('BubbleMenuContent — try-again replays the chosen action', () => {
+  beforeEach(() => streamSSE.mockReset());
+
+  it('replays the user-selected action, not the default "Improve writing"', async () => {
+    streamSSE.mockReturnValue(gen([{ content: 'Short.' }]));
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 12 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    // Run a NON-default action — "Make shorter" carries a distinctive instruction.
+    fireEvent.click(await screen.findByText('Make shorter'));
+    await waitFor(() => expect(screen.getByTestId('bubble-ai-preview')).toHaveTextContent('Short.'));
+
+    const [, firstBody] = streamSSE.mock.calls[0]!;
+    expect((firstBody as { instruction: string }).instruction).toContain('more concise');
+
+    // Try again must replay the SAME action's instruction (not the default).
+    streamSSE.mockReturnValue(gen([{ content: 'Shorter.' }]));
+    fireEvent.click(screen.getByTitle('Try again'));
+
+    await waitFor(() => expect(streamSSE).toHaveBeenCalledTimes(2));
+    const [, secondBody] = streamSSE.mock.calls[1]!;
+    expect((secondBody as { instruction: string }).instruction).toContain('more concise');
+  });
+});
+
+describe('BubbleMenuContent — empty result feedback', () => {
+  beforeEach(() => streamSSE.mockReset());
+
+  it('shows a "No changes returned" state instead of silently reverting', async () => {
+    // Stream completes but yields nothing.
+    streamSSE.mockReturnValue(gen([]));
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    fireEvent.click(await screen.findByText('Improve writing'));
+
+    const empty = await screen.findByTestId('bubble-ai-empty');
+    expect(empty).toHaveTextContent(/No changes returned/i);
+    // The quick-action menu must NOT be shown in the empty state.
+    expect(screen.queryByText('Fix spelling & grammar')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/components/article/EditorBubbleMenu.test.tsx
+++ b/frontend/src/shared/components/article/EditorBubbleMenu.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { useEditor, EditorContent } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import { Highlight } from '@tiptap/extension-highlight';
+import type { Editor as EditorType } from '@tiptap/react';
+import { useEffect } from 'react';
+
+// Mock the SSE transport so "Improve" actions don't hit the network.
+const streamSSE = vi.fn();
+vi.mock('../../lib/sse', () => ({
+  streamSSE: (...args: unknown[]) => streamSSE(...args),
+}));
+
+import { BubbleMenuContent, selectionShouldShow } from './EditorBubbleMenu';
+
+function gen(chunks: Array<Record<string, unknown>>) {
+  return (async function* () {
+    for (const c of chunks) yield c;
+  })();
+}
+
+// jsdom has no layout engine, so ProseMirror's scroll-into-view (triggered by
+// `.focus()` after insertContentAt) calls `getClientRects` on a DOM range and
+// throws. Stub it to a no-op so the editor commands run cleanly under jsdom.
+beforeAll(() => {
+  if (typeof Range !== 'undefined' && !Range.prototype.getClientRects) {
+    Range.prototype.getClientRects = () => ({ length: 0, item: () => null, [Symbol.iterator]: function* () {} }) as unknown as DOMRectList;
+    Range.prototype.getBoundingClientRect = () => ({ top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+  }
+});
+
+/**
+ * Test harness: mounts a real TipTap editor, exposes it via a ref callback, and
+ * renders the bubble-menu body directly (bypassing the Floating UI wrapper,
+ * which does not render in jsdom). Using a real editor means formatting commands
+ * and `insertContentAt` ranges are exercised against genuine ProseMirror state.
+ */
+function Harness({
+  content,
+  onReady,
+}: {
+  content: string;
+  onReady: (editor: EditorType) => void;
+}) {
+  const editor = useEditor({
+    extensions: [StarterKit, Highlight.configure({ multicolor: true })],
+    content,
+    immediatelyRender: false,
+  });
+
+  useEffect(() => {
+    if (editor) onReady(editor);
+  }, [editor, onReady]);
+
+  if (!editor) return null;
+  return (
+    <>
+      <EditorContent editor={editor} />
+      <BubbleMenuContent editor={editor} />
+    </>
+  );
+}
+
+async function mountEditor(content: string): Promise<EditorType> {
+  let editor: EditorType | null = null;
+  render(<Harness content={content} onReady={(e) => { editor = e; }} />);
+  await waitFor(() => expect(editor).not.toBeNull());
+  return editor!;
+}
+
+describe('selectionShouldShow', () => {
+  it('hides on an empty selection', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection(2); }); // collapsed
+    expect(selectionShouldShow(editor, false)).toBe(false);
+  });
+
+  it('shows on a non-empty text selection', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+    expect(selectionShouldShow(editor, false)).toBe(true);
+  });
+
+  it('hides inside a code block even with a selection', async () => {
+    const editor = await mountEditor('<pre><code>const x = 1;</code></pre>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+    expect(selectionShouldShow(editor, false)).toBe(false);
+  });
+
+  it('hides when the editor is not editable', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => {
+      editor.setEditable(false);
+      editor.commands.setTextSelection({ from: 1, to: 6 });
+    });
+    expect(selectionShouldShow(editor, false)).toBe(false);
+  });
+
+  it('stays shown while the AI popover is open, regardless of selection', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection(2); }); // collapsed
+    expect(selectionShouldShow(editor, true)).toBe(true);
+  });
+});
+
+describe('BubbleMenuContent — formatting commands', () => {
+  beforeEach(() => streamSSE.mockReset());
+
+  it('toggles bold on the current selection', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTitle('Bold (Ctrl+B)'));
+    expect(editor.getHTML()).toContain('<strong>Hello</strong>');
+  });
+
+  it('toggles italic on the current selection', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTitle('Italic (Ctrl+I)'));
+    expect(editor.getHTML()).toContain('<em>Hello</em>');
+  });
+
+  it('toggles inline code on the current selection', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTitle('Inline code (Ctrl+E)'));
+    expect(editor.getHTML()).toContain('<code>Hello</code>');
+  });
+
+  it('renders the AI Improve trigger', async () => {
+    await mountEditor('<p>Hello world</p>');
+    expect(screen.getByTestId('bubble-ai-trigger')).toBeInTheDocument();
+  });
+});
+
+describe('BubbleMenuContent — inline AI improve replace-range', () => {
+  beforeEach(() => streamSSE.mockReset());
+
+  it('replaces ONLY the captured selection range with the improved fragment', async () => {
+    streamSSE.mockReturnValue(gen([{ content: 'Howdy' }]));
+    const editor = await mountEditor('<p>Hello world</p>');
+    // Select "Hello" (positions 1..6 in a single paragraph).
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    // Open the AI popover (captures the range), run an action, accept Replace.
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    fireEvent.click(await screen.findByText('Improve writing'));
+
+    await waitFor(() => expect(screen.getByTestId('bubble-ai-preview')).toHaveTextContent('Howdy'));
+
+    fireEvent.click(screen.getByTitle('Replace selection'));
+
+    await waitFor(() => {
+      // Only "Hello" was replaced; " world" is preserved.
+      expect(editor.getHTML()).toContain('Howdy world');
+      expect(editor.getHTML()).not.toContain('Hello');
+    });
+  });
+
+  it('inserts the improved fragment below without removing the original', async () => {
+    streamSSE.mockReturnValue(gen([{ content: 'Extra detail' }]));
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 12 }); }); // whole text
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    fireEvent.click(await screen.findByText('Make longer'));
+    await waitFor(() => expect(screen.getByTestId('bubble-ai-preview')).toHaveTextContent('Extra detail'));
+
+    fireEvent.click(screen.getByTitle('Insert below selection'));
+
+    await waitFor(() => {
+      const html = editor.getHTML();
+      expect(html).toContain('Hello world'); // original kept
+      expect(html).toContain('Extra detail'); // inserted
+    });
+  });
+
+  it('sends only the selected text as content (no whole-page context)', async () => {
+    streamSSE.mockReturnValue(gen([{ content: 'x' }]));
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    fireEvent.click(await screen.findByText('Fix spelling & grammar'));
+
+    await waitFor(() => expect(streamSSE).toHaveBeenCalled());
+    const [, body] = streamSSE.mock.calls[0]!;
+    expect((body as { content: string }).content).toBe('Hello');
+    expect(body).not.toHaveProperty('pageId');
+  });
+});

--- a/frontend/src/shared/components/article/EditorBubbleMenu.tsx
+++ b/frontend/src/shared/components/article/EditorBubbleMenu.tsx
@@ -1,0 +1,445 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { BubbleMenu } from '@tiptap/react/menus';
+import { useEditorState } from '@tiptap/react';
+import * as Popover from '@radix-ui/react-popover';
+import type { Editor as EditorType } from '@tiptap/react';
+import {
+  Bold, Italic, Underline, Strikethrough, Code, Highlighter,
+  Sparkles, Loader2, Check, ArrowDownToLine, RotateCcw, X,
+} from 'lucide-react';
+import type { ImprovementType } from '@compendiq/contracts';
+import { cn } from '../../lib/cn';
+import { SanitizedHtml } from '../SanitizedHtml';
+import { useImproveStream } from './use-improve-stream';
+import { buildImproveHtml } from './improve-markdown';
+
+/**
+ * #708 — Notion-style selection bubble menu for the article editor (edit mode
+ * only). Shows core inline-formatting actions plus an "Improve" entry that
+ * streams an AI rewrite of ONLY the selected fragment into a popover preview.
+ * The document is never mutated until the user accepts (Replace / Insert).
+ */
+
+interface QuickAction {
+  key: string;
+  label: string;
+  type: ImprovementType;
+  /** Extra instruction passed to `/llm/improve` for tone/length variants. */
+  instruction?: string;
+}
+
+// Quick actions map onto the backend's five `ImprovementType` values. Tone /
+// length variants ride on the optional `instruction` field rather than new
+// backend types, keeping v1 within the existing `/llm/improve` contract.
+const QUICK_ACTIONS: readonly QuickAction[] = [
+  { key: 'improve', label: 'Improve writing', type: 'clarity' },
+  { key: 'grammar', label: 'Fix spelling & grammar', type: 'grammar' },
+  {
+    key: 'shorter', label: 'Make shorter', type: 'clarity',
+    instruction: 'Make the passage more concise while preserving all key information.',
+  },
+  {
+    key: 'longer', label: 'Make longer', type: 'completeness',
+    instruction: 'Expand the passage with more detail and helpful examples.',
+  },
+  {
+    key: 'professional', label: 'More professional tone', type: 'clarity',
+    instruction: 'Rewrite the passage in a more professional, formal tone.',
+  },
+];
+
+// Selection-specific prompt steering: the `improve_*` system prompts assume a
+// whole article, so we pass an instruction that scopes the model to the passage
+// and forbids extra commentary. (#708 — "improve the following passage; return
+// only the improved passage, same language".)
+const SELECTION_INSTRUCTION =
+  'You are improving a SHORT SELECTED PASSAGE from a larger document, not the whole document. ' +
+  'Return ONLY the improved passage with no preamble, headings, or explanation, and keep it in the same language.';
+
+function buildInstruction(action: QuickAction, freeForm?: string): string {
+  const parts = [SELECTION_INSTRUCTION];
+  if (action.instruction) parts.push(action.instruction);
+  if (freeForm?.trim()) parts.push(freeForm.trim());
+  return parts.join('\n\n');
+}
+
+/**
+ * Whether the selection bubble menu should be visible. Exported for unit
+ * testing the show/hide contract (the BubbleMenu plugin calls this on every
+ * selection change). When `aiOpen` is true the menu stays mounted regardless
+ * of editor focus/selection — that is the BubbleMenu focus pitfall fix: the AI
+ * input steals focus from the editor, which would otherwise hide the menu.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function selectionShouldShow(editor: EditorType, aiOpen: boolean): boolean {
+  if (aiOpen) return true;
+  if (!editor.isEditable) return false;
+  if (editor.state.selection.empty) return false;
+  // Skip code blocks — formatting marks don't apply and improving code inline
+  // isn't the intent here.
+  if (editor.isActive('codeBlock')) return false;
+  return true;
+}
+
+function MenuButton({
+  onClick, active, title, children,
+}: {
+  onClick: () => void;
+  active?: boolean;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onMouseDown={(e) => e.preventDefault()} // keep editor selection on click
+      onClick={onClick}
+      title={title}
+      aria-label={title}
+      aria-pressed={active}
+      className={cn(
+        'flex h-8 w-8 items-center justify-center rounded transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+        active
+          ? 'bg-primary/20 text-primary ring-1 ring-primary/30'
+          : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * The visible menu body. Split out from `EditorBubbleMenu` so it can be tested
+ * directly with an editor instance, independent of the TipTap BubbleMenu
+ * wrapper (which relies on Floating UI + a ProseMirror plugin that does not
+ * render in jsdom). `onAiOpenChange` lets the wrapper mirror AI-popover state
+ * into `shouldShow`.
+ */
+export function BubbleMenuContent({
+  editor,
+  onAiOpenChange,
+}: {
+  editor: EditorType;
+  onAiOpenChange?: (open: boolean) => void;
+}) {
+  const [aiOpen, setAiOpen] = useState(false);
+  // Range captured the moment "Improve" is clicked, so Replace/Insert act on
+  // the original selection even after focus moves or the selection collapses.
+  const rangeRef = useRef<{ from: number; to: number } | null>(null);
+  const [freeForm, setFreeForm] = useState('');
+  const stream = useImproveStream();
+
+  // Subscribe to active marks so the formatting buttons re-render their
+  // active/pressed state on selection and toggle changes (mirrors EditorToolbar).
+  const active = useEditorState({
+    editor,
+    selector: ({ editor: e }) => ({
+      bold: e.isActive('bold'),
+      italic: e.isActive('italic'),
+      underline: e.isActive('underline'),
+      strike: e.isActive('strike'),
+      code: e.isActive('code'),
+      highlight: e.isActive('highlight'),
+    }),
+  });
+
+  const setAi = useCallback((open: boolean) => {
+    setAiOpen(open);
+    onAiOpenChange?.(open);
+  }, [onAiOpenChange]);
+
+  const openAi = useCallback(() => {
+    const { from, to } = editor.state.selection;
+    if (from === to) return;
+    rangeRef.current = { from, to };
+    setFreeForm('');
+    stream.reset();
+    setAi(true);
+  }, [editor, stream, setAi]);
+
+  const closeAi = useCallback(() => {
+    stream.abort();
+    stream.reset();
+    setAi(false);
+    rangeRef.current = null;
+  }, [stream, setAi]);
+
+  // Cmd/Ctrl+J opens the AI popover on the current selection (#708 optional
+  // keyboard trigger).
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'j') {
+        if (!editor.isEditable || editor.state.selection.empty) return;
+        e.preventDefault();
+        openAi();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [editor, openAi]);
+
+  const runAction = useCallback(
+    (action: QuickAction) => {
+      const range = rangeRef.current;
+      if (!range) return;
+      const text = editor.state.doc.textBetween(range.from, range.to, '\n');
+      if (!text.trim()) return;
+      void stream.run(text, action.type, buildInstruction(action, freeForm));
+    },
+    [editor, stream, freeForm],
+  );
+
+  const replaceSelection = useCallback(() => {
+    const range = rangeRef.current;
+    if (!range || !stream.output) return;
+    const { inline } = buildImproveHtml(stream.output);
+    editor.chain().focus().insertContentAt({ from: range.from, to: range.to }, inline).run();
+    closeAi();
+  }, [editor, stream.output, closeAi]);
+
+  const insertBelow = useCallback(() => {
+    const range = rangeRef.current;
+    if (!range || !stream.output) return;
+    const { html } = buildImproveHtml(stream.output);
+    // Insert after the selection end so the original passage is preserved.
+    editor.chain().focus().insertContentAt(range.to, html).run();
+    closeAi();
+  }, [editor, stream.output, closeAi]);
+
+  const isStreaming = stream.status === 'streaming';
+  const hasResult = stream.output.length > 0;
+  const { html: previewHtml } = buildImproveHtml(stream.output);
+
+  return (
+    <div
+      data-testid="editor-bubble-menu"
+      className={cn(
+        'flex items-center gap-0.5 rounded-lg border border-border bg-card p-1 shadow-lg',
+        'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-95',
+      )}
+      role="toolbar"
+      aria-label="Selection formatting"
+    >
+      <MenuButton
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        active={active.bold}
+        title="Bold (Ctrl+B)"
+      >
+        <Bold size={15} />
+      </MenuButton>
+      <MenuButton
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        active={active.italic}
+        title="Italic (Ctrl+I)"
+      >
+        <Italic size={15} />
+      </MenuButton>
+      <MenuButton
+        onClick={() => editor.chain().focus().toggleUnderline().run()}
+        active={active.underline}
+        title="Underline (Ctrl+U)"
+      >
+        <Underline size={15} />
+      </MenuButton>
+      <MenuButton
+        onClick={() => editor.chain().focus().toggleStrike().run()}
+        active={active.strike}
+        title="Strikethrough (Ctrl+Shift+X)"
+      >
+        <Strikethrough size={15} />
+      </MenuButton>
+      <MenuButton
+        onClick={() => editor.chain().focus().toggleCode().run()}
+        active={active.code}
+        title="Inline code (Ctrl+E)"
+      >
+        <Code size={15} />
+      </MenuButton>
+      <MenuButton
+        onClick={() => editor.chain().focus().toggleHighlight().run()}
+        active={active.highlight}
+        title="Highlight (Ctrl+Shift+H)"
+      >
+        <Highlighter size={15} />
+      </MenuButton>
+
+      <div role="separator" aria-orientation="vertical" className="mx-0.5 h-5 w-px bg-border" />
+
+      <Popover.Root open={aiOpen} onOpenChange={(o) => (o ? openAi() : closeAi())}>
+        <Popover.Trigger asChild>
+          <button
+            type="button"
+            onMouseDown={(e) => e.preventDefault()}
+            title="Improve with AI"
+            aria-label="Improve with AI"
+            data-testid="bubble-ai-trigger"
+            className={cn(
+              'flex h-8 items-center gap-1 rounded px-2 text-sm font-medium transition-colors',
+              'text-primary hover:bg-primary/10',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+            )}
+          >
+            <Sparkles size={15} />
+            <span>Improve</span>
+          </button>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+            align="start"
+            side="bottom"
+            sideOffset={6}
+            data-testid="bubble-ai-popover"
+            // Keep focus inside; closing is explicit (Discard / Escape).
+            onOpenAutoFocus={(e) => { if (hasResult || isStreaming) e.preventDefault(); }}
+            className={cn(
+              'z-50 w-80 rounded-lg border border-border bg-card p-3 shadow-xl outline-none',
+              'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-95',
+            )}
+          >
+            {!hasResult && !isStreaming && stream.status !== 'error' && (
+              <div className="flex flex-col gap-2">
+                <input
+                  type="text"
+                  value={freeForm}
+                  autoFocus
+                  onChange={(e) => setFreeForm(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && freeForm.trim()) {
+                      e.preventDefault();
+                      runAction(QUICK_ACTIONS[0]!);
+                    }
+                  }}
+                  placeholder="Ask AI to edit the selection…"
+                  aria-label="Ask AI to edit the selection"
+                  className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                />
+                <div className="flex flex-col gap-0.5">
+                  {QUICK_ACTIONS.map((action) => (
+                    <button
+                      key={action.key}
+                      type="button"
+                      onClick={() => runAction(action)}
+                      className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                    >
+                      <Sparkles size={14} className="text-primary" />
+                      {action.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {(isStreaming || hasResult) && (
+              <div className="flex flex-col gap-2">
+                <div
+                  data-testid="bubble-ai-preview"
+                  aria-live="polite"
+                  className={cn(
+                    'prose prose-sm max-h-56 max-w-none overflow-y-auto rounded-md border border-border/60 bg-background p-2 text-sm',
+                    isStreaming && !hasResult && 'motion-safe:animate-pulse',
+                  )}
+                >
+                  {hasResult
+                    ? <SanitizedHtml html={previewHtml} />
+                    : <span className="text-muted-foreground">Improving selection…</span>}
+                </div>
+
+                <div className="flex flex-wrap items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={replaceSelection}
+                    disabled={!hasResult || isStreaming}
+                    title="Replace selection"
+                    className="flex items-center gap-1 rounded-md bg-primary/15 px-2 py-1 text-xs font-medium text-primary hover:bg-primary/25 disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    <Check size={13} /> Replace
+                  </button>
+                  <button
+                    type="button"
+                    onClick={insertBelow}
+                    disabled={!hasResult || isStreaming}
+                    title="Insert below selection"
+                    className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    <ArrowDownToLine size={13} /> Insert below
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => runAction(QUICK_ACTIONS[0]!)}
+                    disabled={isStreaming}
+                    title="Try again"
+                    className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    <RotateCcw size={13} /> Try again
+                  </button>
+                  <button
+                    type="button"
+                    onClick={closeAi}
+                    title="Discard"
+                    className="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    <X size={13} /> Discard
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {isStreaming && (
+              <div className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Loader2 size={13} className="motion-safe:animate-spin" />
+                Streaming…
+              </div>
+            )}
+
+            {stream.status === 'error' && (
+              <div className="flex flex-col gap-2">
+                <p className="text-sm text-destructive" role="alert">{stream.error}</p>
+                <div className="flex gap-1">
+                  <button
+                    type="button"
+                    onClick={() => runAction(QUICK_ACTIONS[0]!)}
+                    className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    <RotateCcw size={13} /> Try again
+                  </button>
+                  <button
+                    type="button"
+                    onClick={closeAi}
+                    className="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    <X size={13} /> Close
+                  </button>
+                </div>
+              </div>
+            )}
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
+    </div>
+  );
+}
+
+export function EditorBubbleMenu({ editor }: { editor: EditorType }) {
+  // Mirror the AI-popover open state in a ref so the stable `shouldShow`
+  // closure passed to the BubbleMenu plugin keeps the menu mounted while the
+  // AI input has focus.
+  const aiOpenRef = useRef(false);
+
+  const shouldShow = useCallback(
+    ({ editor: e }: { editor: EditorType }) => selectionShouldShow(e, aiOpenRef.current),
+    [],
+  );
+
+  return (
+    <BubbleMenu
+      editor={editor}
+      shouldShow={shouldShow}
+      options={{ placement: 'top' }}
+      updateDelay={100}
+    >
+      <BubbleMenuContent editor={editor} onAiOpenChange={(open) => { aiOpenRef.current = open; }} />
+    </BubbleMenu>
+  );
+}

--- a/frontend/src/shared/components/article/EditorBubbleMenu.tsx
+++ b/frontend/src/shared/components/article/EditorBubbleMenu.tsx
@@ -129,6 +129,9 @@ export function BubbleMenuContent({
   // the original selection even after focus moves or the selection collapses.
   const rangeRef = useRef<{ from: number; to: number } | null>(null);
   const [freeForm, setFreeForm] = useState('');
+  // The action + free-form text of the most recent run, captured so "Try again"
+  // replays the user's actual choice rather than a hardcoded default.
+  const lastRunRef = useRef<{ action: QuickAction; freeForm: string } | null>(null);
   const stream = useImproveStream();
 
   // Subscribe to active marks so the formatting buttons re-render their
@@ -164,6 +167,7 @@ export function BubbleMenuContent({
     stream.reset();
     setAi(false);
     rangeRef.current = null;
+    lastRunRef.current = null;
   }, [stream, setAi]);
 
   // Cmd/Ctrl+J opens the AI popover on the current selection (#708 optional
@@ -181,15 +185,24 @@ export function BubbleMenuContent({
   }, [editor, openAi]);
 
   const runAction = useCallback(
-    (action: QuickAction) => {
+    (action: QuickAction, freeFormText: string) => {
       const range = rangeRef.current;
       if (!range) return;
       const text = editor.state.doc.textBetween(range.from, range.to, '\n');
       if (!text.trim()) return;
-      void stream.run(text, action.type, buildInstruction(action, freeForm));
+      lastRunRef.current = { action, freeForm: freeFormText };
+      void stream.run(text, action.type, buildInstruction(action, freeFormText));
     },
-    [editor, stream, freeForm],
+    [editor, stream],
   );
+
+  // "Try again" replays the last action with its captured free-form text,
+  // falling back to the default quick action if nothing has run yet.
+  const retry = useCallback(() => {
+    const last = lastRunRef.current;
+    if (last) runAction(last.action, last.freeForm);
+    else runAction(QUICK_ACTIONS[0]!, freeForm);
+  }, [runAction, freeForm]);
 
   const replaceSelection = useCallback(() => {
     const range = rangeRef.current;
@@ -203,13 +216,22 @@ export function BubbleMenuContent({
     const range = rangeRef.current;
     if (!range || !stream.output) return;
     const { html } = buildImproveHtml(stream.output);
-    // Insert after the selection end so the original passage is preserved.
+    // Insert block HTML at the end of the selection so the original passage is
+    // preserved. Caveat: when the selection ends mid-block (e.g. mid-sentence),
+    // ProseMirror splits the containing block to place the new block-level
+    // node, so the remainder of the paragraph moves below the insertion. This
+    // matches Notion's "Insert below" (it always produces a new block) and is
+    // the expected outcome for a block-level insert; we keep it as-is rather
+    // than constraining selections to block boundaries.
     editor.chain().focus().insertContentAt(range.to, html).run();
     closeAi();
   }, [editor, stream.output, closeAi]);
 
   const isStreaming = stream.status === 'streaming';
   const hasResult = stream.output.length > 0;
+  // The stream finished but produced nothing — surface explicit feedback rather
+  // than silently dropping back to the quick-action menu.
+  const emptyResult = stream.status === 'done' && !hasResult;
   const { html: previewHtml } = buildImproveHtml(stream.output);
 
   return (
@@ -298,7 +320,7 @@ export function BubbleMenuContent({
               'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-95',
             )}
           >
-            {!hasResult && !isStreaming && stream.status !== 'error' && (
+            {!hasResult && !isStreaming && !emptyResult && stream.status !== 'error' && (
               <div className="flex flex-col gap-2">
                 <input
                   type="text"
@@ -308,7 +330,7 @@ export function BubbleMenuContent({
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' && freeForm.trim()) {
                       e.preventDefault();
-                      runAction(QUICK_ACTIONS[0]!);
+                      runAction(QUICK_ACTIONS[0]!, freeForm);
                     }
                   }}
                   placeholder="Ask AI to edit the selection…"
@@ -320,7 +342,7 @@ export function BubbleMenuContent({
                     <button
                       key={action.key}
                       type="button"
-                      onClick={() => runAction(action)}
+                      onClick={() => runAction(action, freeForm)}
                       className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                     >
                       <Sparkles size={14} className="text-primary" />
@@ -367,7 +389,7 @@ export function BubbleMenuContent({
                   </button>
                   <button
                     type="button"
-                    onClick={() => runAction(QUICK_ACTIONS[0]!)}
+                    onClick={retry}
                     disabled={isStreaming}
                     title="Try again"
                     className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
@@ -393,13 +415,39 @@ export function BubbleMenuContent({
               </div>
             )}
 
+            {emptyResult && (
+              <div className="flex flex-col gap-2" data-testid="bubble-ai-empty">
+                <p className="text-sm text-muted-foreground" role="status">
+                  No changes returned. Try again or adjust your request.
+                </p>
+                <div className="flex gap-1">
+                  <button
+                    type="button"
+                    onClick={retry}
+                    title="Try again"
+                    className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    <RotateCcw size={13} /> Try again
+                  </button>
+                  <button
+                    type="button"
+                    onClick={closeAi}
+                    title="Discard"
+                    className="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    <X size={13} /> Discard
+                  </button>
+                </div>
+              </div>
+            )}
+
             {stream.status === 'error' && (
               <div className="flex flex-col gap-2">
                 <p className="text-sm text-destructive" role="alert">{stream.error}</p>
                 <div className="flex gap-1">
                   <button
                     type="button"
-                    onClick={() => runAction(QUICK_ACTIONS[0]!)}
+                    onClick={retry}
                     className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                   >
                     <RotateCcw size={13} /> Try again

--- a/frontend/src/shared/components/article/improve-markdown.test.ts
+++ b/frontend/src/shared/components/article/improve-markdown.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { improveMarkdownToHtml, unwrapSingleParagraph, buildImproveHtml } from './improve-markdown';
+
+describe('improveMarkdownToHtml', () => {
+  it('converts inline markdown to HTML', () => {
+    const html = improveMarkdownToHtml('This is **bold** and *italic*.');
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('<em>italic</em>');
+  });
+
+  it('converts block markdown (lists) to HTML', () => {
+    const html = improveMarkdownToHtml('- one\n- two');
+    expect(html).toContain('<ul>');
+    expect(html).toContain('<li>one</li>');
+  });
+
+  it('strips dangerous tags via DOMPurify', () => {
+    const html = improveMarkdownToHtml('ok <script>alert(1)</script> done');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('ok');
+  });
+
+  it('strips inline event-handler attributes', () => {
+    const html = improveMarkdownToHtml('<img src="x" onerror="alert(1)">');
+    expect(html.toLowerCase()).not.toContain('onerror');
+  });
+});
+
+describe('unwrapSingleParagraph', () => {
+  it('unwraps a single paragraph so inline replacement stays in-block', () => {
+    expect(unwrapSingleParagraph('<p>hello world</p>')).toBe('hello world');
+  });
+
+  it('keeps inline marks when unwrapping', () => {
+    expect(unwrapSingleParagraph('<p>a <strong>b</strong> c</p>')).toBe('a <strong>b</strong> c');
+  });
+
+  it('does not unwrap when there are multiple blocks', () => {
+    const multi = '<p>one</p>\n<p>two</p>';
+    expect(unwrapSingleParagraph(multi)).toBe(multi);
+  });
+
+  it('does not unwrap non-paragraph blocks', () => {
+    expect(unwrapSingleParagraph('<ul><li>x</li></ul>')).toBe('<ul><li>x</li></ul>');
+  });
+});
+
+describe('buildImproveHtml', () => {
+  it('returns block html and an inline (unwrapped) variant for a single paragraph', () => {
+    const { html, inline } = buildImproveHtml('Fixed sentence.');
+    expect(html).toContain('<p>Fixed sentence.</p>');
+    expect(inline).toBe('Fixed sentence.');
+  });
+
+  it('inline falls back to block html for multi-block output', () => {
+    const { html, inline } = buildImproveHtml('- a\n- b');
+    expect(html).toContain('<ul>');
+    expect(inline).toBe(html.trim());
+  });
+});

--- a/frontend/src/shared/components/article/improve-markdown.ts
+++ b/frontend/src/shared/components/article/improve-markdown.ts
@@ -1,0 +1,50 @@
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+/**
+ * #708 — KEY DECISION: `/llm/improve` streams **Markdown**, but inline
+ * replacement in the TipTap editor needs **HTML**. We convert on the client
+ * with `marked` (already a frontend dependency, used the same way in
+ * `GenerateMode`) and sanitize with DOMPurify before handing the fragment to
+ * `insertContentAt`. This keeps the backend route untouched (no new
+ * "return HTML" mode) and reuses the project's single sanitization library.
+ *
+ * Two output shapes are produced from the same parse:
+ *  - `html`   — block-level HTML, suitable for "Insert below" where a fresh
+ *               paragraph/list is welcome.
+ *  - `inline` — the same content with a single wrapping `<p>` unwrapped, so a
+ *               selection inside a sentence is replaced in place without
+ *               injecting a block break. When the improved text is genuinely
+ *               multi-block (e.g. the model returns a list), `inline` falls
+ *               back to the block HTML.
+ */
+
+const FORBID_TAGS = ['script', 'style', 'iframe', 'object', 'embed', 'form'];
+const FORBID_ATTR = ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus'];
+
+/** Parse Markdown to a sanitized HTML string (synchronous). */
+export function improveMarkdownToHtml(markdown: string): string {
+  const parsed = marked.parse(markdown, { async: false });
+  const raw = typeof parsed === 'string' ? parsed : '';
+  return DOMPurify.sanitize(raw, { FORBID_TAGS, FORBID_ATTR }) as string;
+}
+
+/**
+ * Strip a single outer `<p>…</p>` wrapper when the HTML contains exactly one
+ * paragraph and no other block-level siblings. Used for in-place selection
+ * replacement so the editor keeps the surrounding block intact.
+ */
+export function unwrapSingleParagraph(html: string): string {
+  const trimmed = html.trim();
+  const match = /^<p>([\s\S]*)<\/p>$/.exec(trimmed);
+  if (!match) return trimmed;
+  // Bail out if there is a nested block break — only unwrap a lone paragraph.
+  if (/<p[\s>]/i.test(match[1]!)) return trimmed;
+  return match[1]!.trim();
+}
+
+/** Convenience: sanitized HTML in both block and inline shapes. */
+export function buildImproveHtml(markdown: string): { html: string; inline: string } {
+  const html = improveMarkdownToHtml(markdown);
+  return { html, inline: unwrapSingleParagraph(html) };
+}

--- a/frontend/src/shared/components/article/use-improve-stream.test.ts
+++ b/frontend/src/shared/components/article/use-improve-stream.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// Mock the SSE transport at the lib boundary — the hook's job is to accumulate
+// chunks and manage status, not to do real network I/O.
+const streamSSE = vi.fn();
+vi.mock('../../lib/sse', () => ({
+  streamSSE: (...args: unknown[]) => streamSSE(...args),
+}));
+
+import { useImproveStream } from './use-improve-stream';
+
+/** Build an async generator yielding the given chunks. */
+function gen(chunks: Array<Record<string, unknown>>) {
+  return (async function* () {
+    for (const c of chunks) yield c;
+  })();
+}
+
+describe('useImproveStream', () => {
+  beforeEach(() => {
+    streamSSE.mockReset();
+  });
+
+  it('accumulates streamed content and ends in done', async () => {
+    streamSSE.mockReturnValue(gen([{ content: 'Hello ' }, { content: 'world' }]));
+
+    const { result } = renderHook(() => useImproveStream());
+    await act(async () => {
+      await result.current.run('hi', 'grammar');
+    });
+
+    expect(result.current.output).toBe('Hello world');
+    expect(result.current.status).toBe('done');
+  });
+
+  it('sends only the selection content with pageId omitted', async () => {
+    streamSSE.mockReturnValue(gen([{ content: 'x' }]));
+
+    const { result } = renderHook(() => useImproveStream());
+    await act(async () => {
+      await result.current.run('the passage', 'clarity', 'be concise');
+    });
+
+    expect(streamSSE).toHaveBeenCalledTimes(1);
+    const [endpoint, body] = streamSSE.mock.calls[0]!;
+    expect(endpoint).toBe('/llm/improve');
+    expect(body).toMatchObject({ content: 'the passage', type: 'clarity', instruction: 'be concise' });
+    expect(body).not.toHaveProperty('pageId');
+    expect(body).not.toHaveProperty('includeSubPages');
+    // A non-empty model is required by the schema even though the route ignores it.
+    expect((body as { model: string }).model.length).toBeGreaterThan(0);
+  });
+
+  it('prefers finalContent (post-processed) over accumulated chunks', async () => {
+    streamSSE.mockReturnValue(gen([{ content: 'partial' }, { finalContent: 'clean final' }]));
+
+    const { result } = renderHook(() => useImproveStream());
+    await act(async () => {
+      await result.current.run('hi', 'grammar');
+    });
+
+    expect(result.current.output).toBe('clean final');
+  });
+
+  it('surfaces an error chunk as error status', async () => {
+    streamSSE.mockReturnValue(gen([{ error: 'model unavailable' }]));
+
+    const { result } = renderHook(() => useImproveStream());
+    await act(async () => {
+      await result.current.run('hi', 'grammar');
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toBe('model unavailable');
+  });
+
+  it('reset clears output and returns to idle', async () => {
+    streamSSE.mockReturnValue(gen([{ content: 'abc' }]));
+
+    const { result } = renderHook(() => useImproveStream());
+    await act(async () => {
+      await result.current.run('hi', 'grammar');
+    });
+    expect(result.current.output).toBe('abc');
+
+    act(() => result.current.reset());
+    await waitFor(() => {
+      expect(result.current.status).toBe('idle');
+      expect(result.current.output).toBe('');
+    });
+  });
+});

--- a/frontend/src/shared/components/article/use-improve-stream.ts
+++ b/frontend/src/shared/components/article/use-improve-stream.ts
@@ -1,0 +1,113 @@
+import { useCallback, useRef, useState } from 'react';
+import { streamSSE } from '../../lib/sse';
+import type { ImprovementType } from '@compendiq/contracts';
+
+/**
+ * #708 — Lightweight SSE consumer for the editor bubble menu's inline AI
+ * improve. Deliberately separate from `AiContext.runStream`, which is scoped
+ * to the `/ai` page (it owns conversation/message/thinking state and a single
+ * shared abort controller). The editor only needs to stream the improved
+ * fragment for the current selection into a popover preview — so this hook
+ * keeps just the accumulated text, a status, and its own abort controller.
+ *
+ * The request sends ONLY the selected fragment as `content`, with `pageId` /
+ * `includeSubPages` omitted, so the backend skips whole-page/sub-page context
+ * assembly and never writes an `llm_improvements` row (selection edits are
+ * ephemeral previews, not page-level improvements).
+ */
+
+export type ImproveStreamStatus = 'idle' | 'streaming' | 'done' | 'error';
+
+/** SSE chunk shapes emitted by `/llm/improve` (see `streamSSE` on the backend). */
+interface ImproveChunk {
+  content?: string;
+  finalContent?: string;
+  error?: string;
+  done?: boolean;
+}
+
+export interface UseImproveStreamResult {
+  status: ImproveStreamStatus;
+  /** Accumulated improved Markdown streamed so far. */
+  output: string;
+  error: string | null;
+  /** Start a stream for the given selection text + improvement type. */
+  run: (content: string, type: ImprovementType, instruction?: string) => Promise<void>;
+  /** Abort the in-flight stream (no-op if idle). */
+  abort: () => void;
+  /** Reset back to idle, clearing output/error. */
+  reset: () => void;
+}
+
+// The backend resolves the `chat` use-case itself and ignores the request's
+// `model` beyond logging; the schema only requires a non-empty string. We send
+// a sentinel so validation passes without the editor needing model state.
+const SELECTION_MODEL = 'selection';
+
+export function useImproveStream(): UseImproveStreamResult {
+  const [status, setStatus] = useState<ImproveStreamStatus>('idle');
+  const [output, setOutput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const abort = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
+  const reset = useCallback(() => {
+    abort();
+    setStatus('idle');
+    setOutput('');
+    setError(null);
+  }, [abort]);
+
+  const run = useCallback(async (content: string, type: ImprovementType, instruction?: string) => {
+    abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setStatus('streaming');
+    setOutput('');
+    setError(null);
+
+    let accumulated = '';
+    try {
+      for await (const chunk of streamSSE<ImproveChunk>(
+        '/llm/improve',
+        {
+          content,
+          type,
+          model: SELECTION_MODEL,
+          // pageId / includeSubPages intentionally omitted — selection-only.
+          ...(instruction ? { instruction } : {}),
+        },
+        controller.signal,
+      )) {
+        if (chunk.error) {
+          setError(chunk.error);
+          setStatus('error');
+          return;
+        }
+        // Post-processing may emit a cleaned full replacement.
+        if (chunk.finalContent !== undefined) {
+          accumulated = chunk.finalContent;
+          setOutput(accumulated);
+        } else if (chunk.content) {
+          accumulated += chunk.content;
+          setOutput(accumulated);
+        }
+      }
+      setStatus('done');
+    } catch (err) {
+      // Aborts are intentional (user discarded / retried) — stay silent.
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Improve request failed');
+      setStatus('error');
+    } finally {
+      if (abortRef.current === controller) abortRef.current = null;
+    }
+  }, [abort]);
+
+  return { status, output, error, run, abort, reset };
+}


### PR DESCRIPTION
Closes #708

## What this adds

A Notion-style **selection bubble menu** in the article TipTap editor (`Editor.tsx`), **edit mode only**. Selecting text shows a floating menu with:

- **Core inline formatting** — Bold / Italic / Underline / Strikethrough / Inline code / Highlight, reusing the existing chain commands (`toggleBold` … `toggleHighlight`). Active state subscribes via `useEditorState` like the main toolbar.
- **An "Improve" AI action scoped to the selection** that opens a Radix Popover (same pattern as `ColorPickerDropdown`) and **streams `POST /api/llm/improve` sending only the selected fragment** as `content`, with `pageId` / `includeSubPages` **omitted** (no whole-page context, no `llm_improvements` row).

The AI result **streams into a preview**; the document is **not mutated until the user accepts**:

- **Replace selection** — `insertContentAt({from,to}, html)` over the **range captured when Improve was opened**, so it survives focus moving to the AI input and any later selection collapse.
- **Insert below** · **Try again** · **Discard**.
- Quick actions: Improve writing · Fix spelling & grammar · Make shorter · Make longer · More professional tone, plus a free-form "Ask AI…" input. Tone/length variants ride on the optional `instruction` field, keeping v1 within the existing `/llm/improve` contract (5 `ImprovementType` values).
- A selection-specific instruction scopes the model to the passage ("return only the improved passage, same language") rather than the whole-article `improve_*` prompts.

**Never navigates to `/ai`.** Optional **Cmd/Ctrl+J** opens Improve on the current selection.

### BubbleMenu focus pitfall

When the AI input takes focus the editor blurs, which would normally hide the menu. `shouldShow` returns `true` while the AI popover is open (mirrored into a ref the stable `shouldShow` closure reads), keeping the menu/popover mounted.

## KEY DECISION — Markdown→HTML for inline replace

`/llm/improve` streams **Markdown**, but inline replacement needs **HTML**. I chose **client-side conversion**: `marked` + DOMPurify (`improve-markdown.ts`), both already frontend deps and used the same way in `GenerateMode` / `SanitizedHtml`. A lone wrapping `<p>` is unwrapped for **in-place replace** (so a mid-sentence selection doesn't gain a block break); **Insert below** keeps the block HTML. This needs **no backend change**. Documented in `docs/architecture/11-content-pipeline.md` (new client-side path + diagram).

## New files

- `EditorBubbleMenu.tsx` — bubble menu + AI popover (`BubbleMenuContent` split out for testability; `selectionShouldShow` exported).
- `use-improve-stream.ts` — lightweight editor-scoped SSE consumer (separate from the `/ai`-page `AiContext.runStream`).
- `improve-markdown.ts` — Markdown→HTML helper.

## Tests

`npx vitest run` on the article folder: **375 passed** (49 directly relevant across the 4 touched/added files). Covers `shouldShow` (empty/non-empty/code-block/non-editable/AI-open), the formatting commands against a **real TipTap editor**, the SSE hook (accumulate / finalContent / error / pageId-omitted), the Markdown→HTML helper, and the **replace/insert range** behavior (only the selected range changes). `typecheck` + `lint` clean; frontend `build` succeeds.

## Deferred / flagged for review

- Quick actions reuse the 5 backend `ImprovementType`s via `instruction`; dedicated tone/length backend types are out of scope for v1.
- Permission: relies on the route's existing `llm:improve` global permission guard; no separate frontend gate added.
- Read-mode "Ask AI about selection" is intentionally out of scope (editor exists only in edit mode).
- Could later switch the focus-pitfall handling to TipTap's programmatic `setMeta('show'/'hide')` if `shouldShow` proves brittle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)