### PR TITLE
docs: design + implementation plans for #718/#721/#722/#723/#724

### DIFF
--- a/docs/superpowers/plans/2026-06-09-issue-718-autotag-button.md
+++ b/docs/superpowers/plans/2026-06-09-issue-718-autotag-button.md
@@ -1,0 +1,271 @@
+# Unit A — #718: Restore the AI Auto-tag button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the AI Auto-tag button reappear in the article right pane (read mode, edit mode, collapsed rail) by removing the legacy `activeModel` gate that ADR-021 / migration 054 emptied.
+
+**Architecture:** Frontend-only. The backend `POST /pages/:id/auto-tag` already resolves the `auto_tag` use-case server-side, so the client needs no model. Drop the legacy `settings.llmProvider/ollamaModel/openaiModel`-derived gate; make `AutoTagger`'s `model` prop optional; gate visibility on a new-source "AI configured" signal (mirroring `AiContext`'s `usecase-default` query) that defaults to *visible*.
+
+**Tech Stack:** React 19, TanStack Query, Vitest + @testing-library/react (jsdom).
+
+**Branch:** `feature/issue-718-autotag-button` off `dev`.
+
+---
+
+### Task 1: Make `AutoTagger`'s `model` prop optional
+
+**Files:**
+- Modify: `frontend/src/features/pages/AutoTagger.tsx:14-19` (props), `:27-32` (mutation body)
+- Test: `frontend/src/features/pages/AutoTagger.test.tsx` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Create/extend `frontend/src/features/pages/AutoTagger.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AutoTagger } from './AutoTagger';
+
+const apiFetch = vi.fn();
+vi.mock('../../shared/lib/api', () => ({ apiFetch: (...a: unknown[]) => apiFetch(...a) }));
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), error: vi.fn(), success: vi.fn() } }));
+
+function renderWith(ui: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+describe('AutoTagger', () => {
+  beforeEach(() => apiFetch.mockReset());
+
+  it('omits model from the request body when no model prop is given', async () => {
+    apiFetch.mockResolvedValue({ suggestedTags: [], existingLabels: [] });
+    renderWith(<AutoTagger pageId="42" currentLabels={[]} />);
+    fireEvent.click(screen.getByText('Auto-tag'));
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+    const [, opts] = apiFetch.mock.calls[0];
+    expect(JSON.parse((opts as { body: string }).body)).toEqual({});
+  });
+
+  it('still sends model when provided', async () => {
+    apiFetch.mockResolvedValue({ suggestedTags: [], existingLabels: [] });
+    renderWith(<AutoTagger pageId="42" currentLabels={[]} model="bge-x" />);
+    fireEvent.click(screen.getByText('Auto-tag'));
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+    const [, opts] = apiFetch.mock.calls[0];
+    expect(JSON.parse((opts as { body: string }).body)).toEqual({ model: 'bge-x' });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/features/pages/AutoTagger.test.tsx`
+Expected: FAIL — `model` is currently required (type error) / body always `{ model: undefined }`.
+
+- [ ] **Step 3: Make the prop optional and conditionally include it**
+
+In `AutoTagger.tsx`, change the interface (`:14-19`):
+
+```tsx
+interface AutoTaggerProps {
+  pageId: string;
+  currentLabels: string[];
+  model?: string;
+  className?: string;
+}
+```
+
+And the mutation body (`:27-32`) so `model` is only sent when present:
+
+```tsx
+  const autoTagMutation = useMutation({
+    mutationFn: () =>
+      apiFetch<AutoTagResult>(`/pages/${pageId}/auto-tag`, {
+        method: 'POST',
+        body: JSON.stringify(model ? { model } : {}),
+      }),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/features/pages/AutoTagger.test.tsx`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/pages/AutoTagger.tsx frontend/src/features/pages/AutoTagger.test.tsx
+git commit -m "feat(autotag): make AutoTagger model prop optional (#718)"
+```
+
+---
+
+### Task 2: Replace the legacy `activeModel` gate in `ArticleRightPane`
+
+**Files:**
+- Modify: `frontend/src/shared/components/article/ArticleRightPane.tsx:207-210` (delete `activeModel`), `:511` / `:655` / `:678` (gates)
+- Reference pattern: `frontend/src/features/ai/AiContext.tsx:264-272` (the `usecase-default` query)
+
+- [ ] **Step 1: Write the failing test** — see Task 3 (the ArticleRightPane test drives this). Implement Task 2 and Task 3 together; the test in Task 3 is the failing test for this change.
+
+- [ ] **Step 2: Delete the legacy `activeModel` derivation**
+
+Remove `ArticleRightPane.tsx:207-210`:
+
+```tsx
+  // Derive the active LLM model from settings for auto-tagging
+  const activeModel = settings?.llmProvider === 'openai'
+    ? (settings.openaiModel ?? '')
+    : (settings?.ollamaModel ?? '');
+```
+
+- [ ] **Step 3: Add a new-source "AI configured for auto-tag" gate**
+
+Near the other queries (after `const { data: settings } = useSettings();`, ~`:197`), add a query mirroring `AiContext.tsx:264-272`. Import `useQuery` from `@tanstack/react-query` and `apiFetch` from the shared api lib if not already imported.
+
+```tsx
+  // #718: gate the Auto-tag button on the NEW provider source, not the removed
+  // legacy settings.llmProvider/ollamaModel/openaiModel fields (ADR-021 / migration
+  // 054). The backend resolves the auto_tag use-case itself; we only hide the button
+  // when we positively know no provider can serve auto-tag. Default to VISIBLE while
+  // the query is in flight so the button never flickers out on load.
+  const autoTagDefaultQuery = useQuery<{ model?: string | null }>({
+    queryKey: ['llm', 'usecase-default', 'auto_tag'],
+    queryFn: () => apiFetch('/llm/usecase-default?usecase=auto_tag'),
+    retry: false,
+    staleTime: 30_000,
+  });
+  const aiAutoTagAvailable =
+    autoTagDefaultQuery.isLoading || Boolean(autoTagDefaultQuery.data?.model);
+```
+
+- [ ] **Step 4: Update the three render gates**
+
+Collapsed rail (`:511`):
+
+```tsx
+                {aiAutoTagAvailable && id && (
+                  <AutoTagger
+                    pageId={id}
+                    currentLabels={page?.labels ?? []}
+                    className={`${railIconBtn} [&>span]:hidden`}
+                  />
+                )}
+```
+
+Edit mode (`:655-664`):
+
+```tsx
+      {page && id && aiAutoTagAvailable && editing && (
+        <div className="p-2 space-y-0.5" data-testid="article-actions-edit">
+          <AutoTagger
+            pageId={id}
+            currentLabels={page?.labels ?? []}
+            className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-sm text-muted-foreground transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background hover:bg-[var(--glass-pill-hover)] hover:text-foreground"
+          />
+        </div>
+      )}
+```
+
+Read mode (`:678-685`):
+
+```tsx
+          {id && aiAutoTagAvailable && (
+            <AutoTagger
+              pageId={id}
+              currentLabels={page?.labels ?? []}
+              className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-sm text-muted-foreground transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background hover:bg-[var(--glass-pill-hover)] hover:text-foreground"
+            />
+          )}
+```
+
+(The `model={activeModel}` prop is removed from all three.)
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no errors (and no remaining references to `activeModel`).
+
+---
+
+### Task 3: Update `ArticleRightPane.test.tsx` to the new provider model + regression guard
+
+**Files:**
+- Modify: `frontend/src/shared/components/article/ArticleRightPane.test.tsx:73-87` (mocks)
+
+- [ ] **Step 1: Update the settings mock and AutoTagger mock**
+
+The `use-settings` mock (`:73-77`) currently feeds legacy `ollamaModel`/`llmProvider`. Remove those fields (keep `confluenceUrl`):
+
+```tsx
+vi.mock('../../hooks/use-settings', () => ({
+  useSettings: () => ({
+    data: { confluenceUrl: 'https://confluence.example.com' },
+  }),
+}));
+```
+
+The component now issues a TanStack Query to `/llm/usecase-default?usecase=auto_tag`. Ensure the test renders within a `QueryClientProvider` and stub `apiFetch` so the query resolves with a model. If the test file does not already wrap in a QueryClientProvider, add a render helper:
+
+```tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+// mock the api module so the usecase-default query resolves "configured"
+vi.mock('../../shared/lib/api', () => ({
+  apiFetch: vi.fn(async (url: string) =>
+    url.includes('usecase-default') ? { provider: 'p1', model: 'bge-x' } : {},
+  ),
+}));
+```
+
+Adjust the existing render calls to wrap with a fresh `QueryClient` (retry:false) if not already done.
+
+The AutoTagger mock (`:83-87`) no longer receives `model`; drop `data-model`:
+
+```tsx
+vi.mock('../../../features/pages/AutoTagger', () => ({
+  AutoTagger: ({ pageId, currentLabels }: { pageId: string; currentLabels: string[] }) => (
+    <div data-testid="auto-tagger" data-page-id={pageId} data-labels={currentLabels.join(',')} />
+  ),
+}));
+```
+
+- [ ] **Step 2: Add a regression test asserting the button renders WITHOUT legacy fields**
+
+```tsx
+it('renders the Auto-tag button in read mode without any legacy settings fields (#718 regression)', async () => {
+  // settings mock has no ollamaModel/openaiModel/llmProvider; the button must still appear.
+  renderRightPane(); // existing helper that renders ArticleRightPane in read mode
+  expect(await screen.findByTestId('auto-tagger')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 3: Run the full ArticleRightPane suite**
+
+Run: `cd frontend && npx vitest run src/shared/components/article/ArticleRightPane.test.tsx`
+Expected: PASS, including the new regression test.
+
+- [ ] **Step 4: Lint + commit**
+
+```bash
+cd frontend && npx eslint src/shared/components/article/ArticleRightPane.tsx src/shared/components/article/ArticleRightPane.test.tsx
+git add frontend/src/shared/components/article/ArticleRightPane.tsx frontend/src/shared/components/article/ArticleRightPane.test.tsx
+git commit -m "fix(autotag): gate Auto-tag on new provider source, not legacy settings (#718)"
+```
+
+---
+
+### Task 4: Full verification
+
+- [ ] **Step 1:** `cd frontend && npx vitest run` — all frontend tests pass.
+- [ ] **Step 2:** `cd frontend && npx tsc --noEmit && npx eslint src` — clean.
+- [ ] **Step 3:** Confirm no remaining references: `git grep -n "activeModel" frontend/src` returns nothing.
+- [ ] **Step 4:** Open a PR titled `fix(autotag): restore AI Auto-tag button (#718)` targeting `dev`; body references #718 and lists the acceptance checkboxes.
+
+## Acceptance mapping (#718)
+- Button below AI Improve in read/edit/collapsed → Task 2 gates.
+- Click calls `/pages/:id/auto-tag` without legacy model → Task 1.
+- No dependence on `settings.llmProvider/openaiModel/ollamaModel` → Task 2 deletion + Task 3 mock.
+- Regression guard → Task 3 new test.

--- a/docs/superpowers/plans/2026-06-09-issue-721-space-unsync.md
+++ b/docs/superpowers/plans/2026-06-09-issue-721-space-unsync.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Let an admin remove/stop-syncing a Confluence space: a new endpoint purges the space's local pages (cascading embeddings/versions), attachments, the `spaces` row, and all `space_role_assignments`; the Spaces tab gets a Remove action, can save an empty selection, and reflects deselection for admins.
+**Goal:** Let an admin remove/stop-syncing a Confluence space: a new endpoint purges the space's local pages (a raw `DELETE FROM pages` whose FK cascade removes embeddings/versions), best-effort attachment files, the `spaces` row, and all `space_role_assignments`; it also reconciles orphaned `space_key` rows (space-scoped `oidc_group_role_mappings` deleted; `templates`/`knowledge_requests` detached). The Spaces tab gets a Remove action, can save an empty selection, and reflects deselection for admins.
 
-**Architecture:** Backend adds an exported `unsyncSpace(spaceKey)` purge in the confluence domain and a `DELETE /api/spaces/:key` route (admin-gated, read-only against Confluence). `GET /settings` stops sourcing the tab's `selectedSpaces` from the admin "all spaces" view and uses the user's explicit editor assignments instead. Frontend adds a per-space Remove button with a confirm dialog and relaxes the empty-selection guard on Save.
+**Architecture:** Backend adds an exported `unsyncSpace(spaceKey)` purge in the confluence domain and a `DELETE /api/spaces/:key` route (admin-gated, read-only against Confluence). The purge wraps all row deletes/updates in a single `BEGIN`/`COMMIT` transaction on one pooled client (`getPool().connect()`), ROLLBACK + re-throw on error; filesystem attachment cleanup is best-effort and runs **before/outside** the transaction. Deleting `pages` cascades to `page_embeddings`/`page_versions` via the `page_id` FK (migration 030) — it does **not** call `purgeDeletedPages`. `GET /settings` stops sourcing the tab's `selectedSpaces` from the admin "all spaces" view and uses the user's explicit editor assignments instead. Frontend adds a per-space Remove button with a confirm dialog and relaxes the empty-selection guard on Save.
 
 **Tech Stack:** Fastify 5, Postgres (real DB in tests via `backend/src/test-db-helper.ts`), React 19 + TanStack Query, Vitest.
 
@@ -31,7 +31,7 @@ describe('unsyncSpace', () => {
   beforeEach(async () => { await setupTestDb(); await truncateAllTables(); });
   afterAll(async () => { await teardownTestDb(); });
 
-  it('deletes the space, its pages (cascading versions/embeddings), and role assignments', async () => {
+  it('deletes the space, its pages (cascading versions/embeddings), and reconciles orphaned space_key rows', async () => {
     await query(`INSERT INTO spaces (space_key, name, source) VALUES ('ENG','Engineering','confluence')`);
     const p = await query<{ id: number }>(
       `INSERT INTO pages (confluence_id, space_key, title, version, source)
@@ -40,6 +40,14 @@ describe('unsyncSpace', () => {
     await query(`INSERT INTO page_versions (page_id, version_number, title) VALUES ($1, 1, 'Page')`, [pageId]);
     await query(`INSERT INTO space_role_assignments (space_key, principal_type, principal_id, role_id)
                  SELECT 'ENG','user', gen_random_uuid(), id FROM roles WHERE name='editor' LIMIT 1`);
+    await query(`INSERT INTO oidc_group_role_mappings (oidc_group, role_id, space_key)
+                 SELECT 'g','` /* role_id */ + `'... , 'ENG'`); // seed a space-scoped mapping
+    const tpl = await query<{ id: number }>(
+      `INSERT INTO templates (title, body_json, body_html, created_by, space_key)
+       VALUES ('T','{}','<p/>', gen_random_uuid(), 'ENG') RETURNING id`);
+    const kr = await query<{ id: number }>(
+      `INSERT INTO knowledge_requests (title, requested_by, space_key)
+       VALUES ('K', gen_random_uuid(), 'ENG') RETURNING id`);
 
     const result = await unsyncSpace('ENG');
 
@@ -48,11 +56,21 @@ describe('unsyncSpace', () => {
     expect((await query(`SELECT 1 FROM pages WHERE space_key='ENG'`)).rows).toHaveLength(0);
     expect((await query(`SELECT 1 FROM page_versions WHERE page_id=$1`, [pageId])).rows).toHaveLength(0);
     expect((await query(`SELECT 1 FROM space_role_assignments WHERE space_key='ENG'`)).rows).toHaveLength(0);
+    expect((await query(`SELECT 1 FROM oidc_group_role_mappings WHERE space_key='ENG'`)).rows).toHaveLength(0);
+    // templates / knowledge_requests are DETACHED (row kept, space_key NULLed), not deleted.
+    expect((await query(`SELECT space_key FROM templates WHERE id=$1`, [tpl.rows[0]!.id])).rows[0]!.space_key).toBeNull();
+    expect((await query(`SELECT space_key FROM knowledge_requests WHERE id=$1`, [kr.rows[0]!.id])).rows[0]!.space_key).toBeNull();
+  });
+
+  it('rolls back every row delete atomically when a statement fails mid-transaction', async () => {
+    // Seed every affected table for 'ENG'; force a failure inside the transaction
+    // (e.g. by violating a constraint) and assert ALL 'ENG' rows survive — the
+    // BEGIN/COMMIT wrapper must ROLLBACK and re-throw, leaving no partial purge.
   });
 });
 ```
 
-> Adjust the `pages` INSERT column list to the table's actual NOT NULL columns (read `backend/src/core/db/migrations` for the `pages` schema; add `body_html`/`body_text`/etc. defaults if required).
+> Adjust the `pages` INSERT column list to the table's actual NOT NULL columns (read `backend/src/core/db/migrations` for the `pages` schema; add `body_html`/`body_text`/etc. defaults if required). The `oidc_group_role_mappings` seed needs a real `role_id` (look one up from `roles`); also seed a second space (e.g. `OPS`) and assert its rows are untouched.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -61,16 +79,29 @@ Expected: FAIL — `unsyncSpace` is not exported.
 
 - [ ] **Step 3: Implement `unsyncSpace`**
 
-Add to `sync-service.ts` (ensure `cleanPageAttachments` and `logger` are imported; `cleanPageAttachments` is already imported in this module):
+Add to `sync-service.ts` (ensure `cleanPageAttachments`, `logger`, and `getPool` are imported; `cleanPageAttachments` is already imported in this module). The purge is a **raw `DELETE FROM pages`** relying on the FK cascade — **not** `purgeDeletedPages` (that is the soft-delete-reconciliation path). All row mutations run inside one transaction; the per-page attachment cleanup is best-effort and happens **before** the transaction opens so a file-cleanup failure can never abort the DB work.
 
 ```ts
 /**
  * #721: Remove a synced Confluence space and all of its local data. Read-only
- * against Confluence — only local rows/files are deleted. Deleting the `pages`
- * rows cascades to `page_embeddings` and `page_versions` (page_id FK, migration
- * 030). Attachment files/caches are cleaned per page first.
+ * against Confluence — only local rows/files are deleted.
+ *
+ * Filesystem attachment cleanup is best-effort and runs BEFORE the transaction;
+ * a file-cleanup failure is logged, never fatal. Deleting the `pages` rows
+ * cascades to `page_embeddings` and `page_versions` (page_id FK, migration 030).
+ *
+ * Orphaned `space_key` rows (no FK to `spaces`) are reconciled inside the same
+ * transaction:
+ *   - space_role_assignments — RBAC + sync selection (the old
+ *     `user_space_selections` table was migrated into this one and DROPPED in
+ *     migration 040). DELETE, scoped to the space.
+ *   - oidc_group_role_mappings — DELETE only rows whose space_key matches; global
+ *     (space_key IS NULL) rows are kept.
+ *   - templates / knowledge_requests — may hold user-authored content; NULL the
+ *     (nullable) space_key to DETACH rather than destroy work.
  */
 export async function unsyncSpace(spaceKey: string): Promise<{ pagesDeleted: number }> {
+  // Best-effort, non-transactional filesystem cleanup BEFORE the DB transaction.
   const pages = await query<{ id: number }>(
     'SELECT id FROM pages WHERE space_key = $1',
     [spaceKey],
@@ -82,11 +113,31 @@ export async function unsyncSpace(spaceKey: string): Promise<{ pagesDeleted: num
       logger.warn({ err, pageId: p.id, spaceKey }, 'unsyncSpace: attachment cleanup failed (continuing)');
     }
   }
-  const del = await query('DELETE FROM pages WHERE space_key = $1', [spaceKey]);
-  await query('DELETE FROM space_role_assignments WHERE space_key = $1', [spaceKey]);
-  await query('DELETE FROM spaces WHERE space_key = $1', [spaceKey]);
-  logger.info({ spaceKey, pagesDeleted: del.rowCount ?? 0 }, 'unsyncSpace: purged synced space');
-  return { pagesDeleted: del.rowCount ?? 0 };
+
+  const pool = getPool();
+  const conn = await pool.connect();
+  try {
+    await conn.query('BEGIN');
+    // Pages → cascades to page_embeddings + page_versions (migration 030).
+    const del = await conn.query('DELETE FROM pages WHERE space_key = $1', [spaceKey]);
+    // RBAC / sync-selection rows for the removed space.
+    await conn.query('DELETE FROM space_role_assignments WHERE space_key = $1', [spaceKey]);
+    // OIDC group→space mappings scoped to this space (NULL = global, kept).
+    await conn.query('DELETE FROM oidc_group_role_mappings WHERE space_key = $1', [spaceKey]);
+    // User-authored artifacts: detach (retain the row, NULL the space_key).
+    await conn.query('UPDATE templates SET space_key = NULL WHERE space_key = $1', [spaceKey]);
+    await conn.query('UPDATE knowledge_requests SET space_key = NULL WHERE space_key = $1', [spaceKey]);
+    // Finally the space row itself.
+    await conn.query('DELETE FROM spaces WHERE space_key = $1', [spaceKey]);
+    await conn.query('COMMIT');
+    logger.info({ spaceKey, pagesDeleted: del.rowCount ?? 0 }, 'unsyncSpace: purged synced space');
+    return { pagesDeleted: del.rowCount ?? 0 };
+  } catch (err) {
+    await conn.query('ROLLBACK').catch(() => { /* original error already surfacing */ });
+    throw err;
+  } finally {
+    conn.release();
+  }
 }
 ```
 
@@ -340,7 +391,7 @@ git commit -m "feat(spaces): Remove action + allow empty save in Spaces tab (#72
 **Files:**
 - Modify: `docs/architecture/08-flow-sync.md` (note the unsync/purge path + selection decoupling)
 
-- [ ] **Step 1:** Update `docs/architecture/08-flow-sync.md`: add the `DELETE /api/spaces/:key` → `unsyncSpace` purge path and that the Spaces tab selection now derives from explicit editor assignments.
+- [ ] **Step 1:** Update `docs/architecture/08-flow-sync.md`: add the `DELETE /api/spaces/:key` → `unsyncSpace` purge path (single transaction; raw `DELETE FROM pages` + FK cascade; orphan reconciliation of `oidc_group_role_mappings` / `templates` / `knowledge_requests`; best-effort attachment cleanup outside the transaction) and that the Spaces tab selection now derives from explicit editor assignments.
 - [ ] **Step 2:** `cd backend && npx vitest run src/domains/confluence/services/sync-service.unsync.test.ts src/routes/confluence/spaces.test.ts src/routes/foundation/settings.test.ts` — green.
 - [ ] **Step 3:** `cd backend && npm run lint && npm run typecheck` (or workspace equivalents) — clean.
 - [ ] **Step 4:** `cd frontend && npx vitest run && npx tsc --noEmit` — clean.
@@ -349,5 +400,5 @@ git commit -m "feat(spaces): Remove action + allow empty save in Spaces tab (#72
 ## Acceptance mapping (#721)
 - Admin can remove a space; stops syncing; pages gone locally; stays gone after refresh → Tasks 1+2 (+3 keeps it unchecked).
 - Works down to zero selected → Task 4 (relaxed Save guard).
-- Cleans pages/embeddings/attachments + all `space_role_assignments`; nothing in Confluence → Task 1 (cascade + cleanPageAttachments; no Confluence calls).
+- Cleans pages/embeddings/attachments (raw `DELETE FROM pages` + FK cascade + best-effort `cleanPageAttachments`), all `space_role_assignments`, and space-scoped `oidc_group_role_mappings`; detaches `templates`/`knowledge_requests`; all DB work atomic (single transaction); nothing in Confluence → Task 1.
 - Non-admin deselect still loses access, no orphaned data → Task 3 + Task 1 purge.

--- a/docs/superpowers/plans/2026-06-09-issue-721-space-unsync.md
+++ b/docs/superpowers/plans/2026-06-09-issue-721-space-unsync.md
@@ -1,0 +1,353 @@
+# Unit B — #721: Unsync / remove a synced Confluence space Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an admin remove/stop-syncing a Confluence space: a new endpoint purges the space's local pages (cascading embeddings/versions), attachments, the `spaces` row, and all `space_role_assignments`; the Spaces tab gets a Remove action, can save an empty selection, and reflects deselection for admins.
+
+**Architecture:** Backend adds an exported `unsyncSpace(spaceKey)` purge in the confluence domain and a `DELETE /api/spaces/:key` route (admin-gated, read-only against Confluence). `GET /settings` stops sourcing the tab's `selectedSpaces` from the admin "all spaces" view and uses the user's explicit editor assignments instead. Frontend adds a per-space Remove button with a confirm dialog and relaxes the empty-selection guard on Save.
+
+**Tech Stack:** Fastify 5, Postgres (real DB in tests via `backend/src/test-db-helper.ts`), React 19 + TanStack Query, Vitest.
+
+**Branch:** `feature/issue-721-space-unsync` off `dev`. Backend tests run with `fileParallelism:false` against an isolated test Postgres.
+
+---
+
+### Task 1: `unsyncSpace(spaceKey)` purge service
+
+**Files:**
+- Modify: `backend/src/domains/confluence/services/sync-service.ts` (add exported function near `purgeDeletedPages` at `:1385`)
+- Reuse: `cleanPageAttachments(_userId, pageId)` from `backend/src/domains/confluence/services/attachment-handler.ts:748`
+- Test: `backend/src/domains/confluence/services/sync-service.unsync.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, truncateAllTables, teardownTestDb } from '../../../test-db-helper.js';
+import { query } from '../../../core/db/postgres.js';
+import { unsyncSpace } from './sync-service.js';
+
+describe('unsyncSpace', () => {
+  beforeEach(async () => { await setupTestDb(); await truncateAllTables(); });
+  afterAll(async () => { await teardownTestDb(); });
+
+  it('deletes the space, its pages (cascading versions/embeddings), and role assignments', async () => {
+    await query(`INSERT INTO spaces (space_key, name, source) VALUES ('ENG','Engineering','confluence')`);
+    const p = await query<{ id: number }>(
+      `INSERT INTO pages (confluence_id, space_key, title, version, source)
+       VALUES ('c-1','ENG','Page','1','confluence') RETURNING id`);
+    const pageId = p.rows[0]!.id;
+    await query(`INSERT INTO page_versions (page_id, version_number, title) VALUES ($1, 1, 'Page')`, [pageId]);
+    await query(`INSERT INTO space_role_assignments (space_key, principal_type, principal_id, role_id)
+                 SELECT 'ENG','user', gen_random_uuid(), id FROM roles WHERE name='editor' LIMIT 1`);
+
+    const result = await unsyncSpace('ENG');
+
+    expect(result.pagesDeleted).toBe(1);
+    expect((await query(`SELECT 1 FROM spaces WHERE space_key='ENG'`)).rows).toHaveLength(0);
+    expect((await query(`SELECT 1 FROM pages WHERE space_key='ENG'`)).rows).toHaveLength(0);
+    expect((await query(`SELECT 1 FROM page_versions WHERE page_id=$1`, [pageId])).rows).toHaveLength(0);
+    expect((await query(`SELECT 1 FROM space_role_assignments WHERE space_key='ENG'`)).rows).toHaveLength(0);
+  });
+});
+```
+
+> Adjust the `pages` INSERT column list to the table's actual NOT NULL columns (read `backend/src/core/db/migrations` for the `pages` schema; add `body_html`/`body_text`/etc. defaults if required).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && npx vitest run src/domains/confluence/services/sync-service.unsync.test.ts`
+Expected: FAIL — `unsyncSpace` is not exported.
+
+- [ ] **Step 3: Implement `unsyncSpace`**
+
+Add to `sync-service.ts` (ensure `cleanPageAttachments` and `logger` are imported; `cleanPageAttachments` is already imported in this module):
+
+```ts
+/**
+ * #721: Remove a synced Confluence space and all of its local data. Read-only
+ * against Confluence — only local rows/files are deleted. Deleting the `pages`
+ * rows cascades to `page_embeddings` and `page_versions` (page_id FK, migration
+ * 030). Attachment files/caches are cleaned per page first.
+ */
+export async function unsyncSpace(spaceKey: string): Promise<{ pagesDeleted: number }> {
+  const pages = await query<{ id: number }>(
+    'SELECT id FROM pages WHERE space_key = $1',
+    [spaceKey],
+  );
+  for (const p of pages.rows) {
+    try {
+      await cleanPageAttachments('', String(p.id));
+    } catch (err) {
+      logger.warn({ err, pageId: p.id, spaceKey }, 'unsyncSpace: attachment cleanup failed (continuing)');
+    }
+  }
+  const del = await query('DELETE FROM pages WHERE space_key = $1', [spaceKey]);
+  await query('DELETE FROM space_role_assignments WHERE space_key = $1', [spaceKey]);
+  await query('DELETE FROM spaces WHERE space_key = $1', [spaceKey]);
+  logger.info({ spaceKey, pagesDeleted: del.rowCount ?? 0 }, 'unsyncSpace: purged synced space');
+  return { pagesDeleted: del.rowCount ?? 0 };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && npx vitest run src/domains/confluence/services/sync-service.unsync.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/domains/confluence/services/sync-service.ts backend/src/domains/confluence/services/sync-service.unsync.test.ts
+git commit -m "feat(spaces): add unsyncSpace purge service (#721)"
+```
+
+---
+
+### Task 2: `DELETE /api/spaces/:key` route (admin-gated)
+
+**Files:**
+- Modify: `backend/src/routes/confluence/spaces.ts` (add after the existing handlers; the file already registers `/spaces`, `/spaces/:key/home`, `/spaces/available`)
+- Test: `backend/src/routes/confluence/spaces.test.ts` (extend, or create)
+
+- [ ] **Step 1: Write the failing route test**
+
+Model on `backend/src/routes/knowledge/local-spaces.test.ts` (real DB + `app.inject`). Add:
+
+```ts
+it('DELETE /api/spaces/:key removes a synced space and its data (admin)', async () => {
+  await query(`INSERT INTO spaces (space_key, name, source) VALUES ('ENG','Engineering','confluence')`);
+  await query(`INSERT INTO pages (confluence_id, space_key, title, version, source)
+               VALUES ('c-1','ENG','Page','1','confluence')`);
+
+  const res = await app.inject({ method: 'DELETE', url: '/api/spaces/ENG' });
+
+  expect(res.statusCode).toBe(200);
+  expect(res.json()).toMatchObject({ key: 'ENG', deleted: true });
+  expect((await query(`SELECT 1 FROM spaces WHERE space_key='ENG'`)).rows).toHaveLength(0);
+  expect((await query(`SELECT 1 FROM pages WHERE space_key='ENG'`)).rows).toHaveLength(0);
+});
+
+it('DELETE /api/spaces/:key 404s for unknown space', async () => {
+  const res = await app.inject({ method: 'DELETE', url: '/api/spaces/NOPE' });
+  expect(res.statusCode).toBe(404);
+});
+```
+
+> Mirror the admin-auth setup used by other admin-gated route tests (e.g. `backend/src/routes/foundation/rbac.test.ts`): seed an admin user and stub `fastify.authenticate` to set `request.userId`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && npx vitest run src/routes/confluence/spaces.test.ts`
+Expected: FAIL — route returns 404/405 (not registered).
+
+- [ ] **Step 3: Implement the route**
+
+In `spaces.ts`, import `unsyncSpace` from the confluence domain service, the existing `query`, cache, `logAuditEvent`, and the admin guard used elsewhere in this file. Add:
+
+```ts
+  // DELETE /api/spaces/:key — stop syncing a Confluence space and purge its local
+  // data (#721). Admin-only. Read-only against Confluence.
+  fastify.delete('/spaces/:key', async (request) => {
+    const userId = request.userId;
+    await assertSystemAdmin(userId); // use the same admin check other admin routes use
+    const { key } = KeyParamSchema.parse(request.params);
+
+    const existing = await query<{ source: string }>(
+      'SELECT source FROM spaces WHERE space_key = $1',
+      [key],
+    );
+    if (existing.rows.length === 0) {
+      throw fastify.httpErrors.notFound('Space not found');
+    }
+
+    const { pagesDeleted } = await unsyncSpace(key);
+
+    await invalidateRbacCache(userId);
+    await cache.invalidate(userId, 'spaces');
+    await cache.invalidate(userId, 'pages');
+    await logAuditEvent(userId, 'SPACE_UNSYNCED', 'space', key, { pagesDeleted }, request);
+
+    return { key, deleted: true, pagesDeleted };
+  });
+```
+
+> `assertSystemAdmin` / `invalidateRbacCache` / `KeyParamSchema` / `cache` / `logAuditEvent`: import the exact symbols already used by admin-gated routes (`routes/foundation/rbac.ts`, `routes/knowledge/local-spaces.ts`). If no shared `assertSystemAdmin` exists, replicate the inline admin check those routes use.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && npx vitest run src/routes/confluence/spaces.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/routes/confluence/spaces.ts backend/src/routes/confluence/spaces.test.ts
+git commit -m "feat(spaces): DELETE /api/spaces/:key to unsync a Confluence space (#721)"
+```
+
+---
+
+### Task 3: Decouple the tab's `selectedSpaces` from the admin "all spaces" view
+
+**Files:**
+- Modify: `backend/src/core/services/rbac-service.ts` (add `getSelectedSyncSpaces`)
+- Modify: `backend/src/routes/foundation/settings.ts:33` (use it)
+- Test: `backend/src/routes/foundation/settings.test.ts` (extend) or `rbac-service` unit test
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the settings route test (real DB). After seeding an **admin** user + two synced spaces where the admin has an editor assignment for only ONE:
+
+```ts
+it('GET /settings returns only the explicitly-selected spaces for an admin (not all spaces) (#721)', async () => {
+  await query(`INSERT INTO spaces (space_key, name, source) VALUES ('ENG','Eng','confluence'),('OPS','Ops','confluence')`);
+  await query(`INSERT INTO space_role_assignments (space_key, principal_type, principal_id, role_id)
+               SELECT 'ENG','user',$1,id FROM roles WHERE name='editor' LIMIT 1`, [adminUserId]);
+
+  const res = await app.inject({ method: 'GET', url: '/api/settings' });
+  expect(res.json().selectedSpaces).toEqual(['ENG']); // NOT ['ENG','OPS']
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && npx vitest run src/routes/foundation/settings.test.ts`
+Expected: FAIL — admin currently gets all spaces (`['ENG','OPS']`).
+
+- [ ] **Step 3: Add `getSelectedSyncSpaces` and use it**
+
+In `rbac-service.ts`:
+
+```ts
+/**
+ * #721: The spaces the user has EXPLICITLY selected for sync (their editor
+ * assignments that still correspond to an existing space row) — regardless of
+ * system-admin "all spaces" access. Used by GET /settings so deselecting a space
+ * is honored for admins (getUserAccessibleSpaces would always re-include it).
+ */
+export async function getSelectedSyncSpaces(userId: string): Promise<string[]> {
+  const r = await query<{ space_key: string }>(
+    `SELECT DISTINCT sra.space_key
+       FROM space_role_assignments sra
+       JOIN roles r ON r.id = sra.role_id AND r.name = 'editor'
+       JOIN spaces s ON s.space_key = sra.space_key
+      WHERE sra.principal_type = 'user' AND sra.principal_id = $1`,
+    [userId],
+  );
+  return r.rows.map((row) => row.space_key);
+}
+```
+
+In `settings.ts:33`, replace:
+
+```ts
+    const selectedSpaces = await getSelectedSyncSpaces(request.userId);
+    selectedSpaces.sort();
+```
+
+(Update the import to add `getSelectedSyncSpaces`; leave `getUserAccessibleSpaces` for its other callers.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && npx vitest run src/routes/foundation/settings.test.ts`
+Expected: PASS.
+
+> **Edge note for reviewer:** an admin who synced spaces before this change without an editor assignment will see those spaces *unchecked* in the tab (they still appear via the `/spaces` synced list and can be re-checked or removed). This is intended per #721's decoupling.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/core/services/rbac-service.ts backend/src/routes/foundation/settings.ts backend/src/routes/foundation/settings.test.ts
+git commit -m "fix(spaces): tab selection reflects explicit sync selection, not admin-all (#721)"
+```
+
+---
+
+### Task 4: Frontend — Remove action + allow empty Save
+
+**Files:**
+- Modify: `frontend/src/features/settings/SpacesTab.tsx` (`:204` Save guard, add Remove button + confirm + mutation)
+- Test: `frontend/src/features/settings/SpacesTab.test.tsx` (extend or create)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('calls DELETE /api/spaces/:key when a space is removed and confirmed', async () => {
+  apiFetch.mockImplementation(async (url: string, opts?: { method?: string }) => {
+    if (url === '/spaces') return [{ key: 'ENG', name: 'Eng', source: 'confluence' }];
+    if (opts?.method === 'DELETE') return { key: 'ENG', deleted: true };
+    return [];
+  });
+  // render SpacesTab with selectedSpaces={['ENG']}
+  // click the space's Remove button, confirm the dialog
+  await waitFor(() =>
+    expect(apiFetch).toHaveBeenCalledWith('/spaces/ENG', expect.objectContaining({ method: 'DELETE' })),
+  );
+});
+
+it('allows saving an empty selection (Save not disabled at zero) (#721)', () => {
+  // render with selectedSpaces={[]}; the Save button must not be disabled
+  expect(screen.getByRole('button', { name: /save selection/i })).not.toBeDisabled();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/features/settings/SpacesTab.test.tsx`
+Expected: FAIL — no Remove control; Save disabled at zero.
+
+- [ ] **Step 3: Implement the Remove mutation + button + confirm, relax Save guard**
+
+Add a removal mutation:
+
+```tsx
+  const removeSpace = useMutation({
+    mutationFn: (key: string) => apiFetch(`/spaces/${encodeURIComponent(key)}`, { method: 'DELETE' }),
+    onSuccess: (_d, key) => {
+      setSelected((prev) => { const n = new Set(prev); n.delete(key); return n; });
+      queryClient.invalidateQueries({ queryKey: ['spaces'] });
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      queryClient.invalidateQueries({ queryKey: ['pages'] });
+      toast.success('Space removed — its synced pages were deleted locally');
+    },
+    onError: (err) => toast.error(err instanceof Error ? err.message : 'Failed to remove space'),
+  });
+```
+
+For each synced space row, add a Remove button that opens a confirm dialog warning:
+*"Remove this space? This deletes its synced pages locally. It does NOT delete anything in Confluence."* Use the existing dialog/confirm primitive in the codebase (search for an existing `ConfirmDialog`/Radix AlertDialog usage; reuse it). On confirm, call `removeSpace.mutate(key)`.
+
+Relax the Save guard at `SpacesTab.tsx:204` — remove `selected.size === 0` from the **Save Selection** button's `disabled` (keep `disabled` on the **Sync Selected** button at `:211`). When saving zero, surface a confirm: *"Remove all synced spaces from your selection?"* before calling `handleSave`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/features/settings/SpacesTab.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd frontend && npx eslint src/features/settings/SpacesTab.tsx
+git add frontend/src/features/settings/SpacesTab.tsx frontend/src/features/settings/SpacesTab.test.tsx
+git commit -m "feat(spaces): Remove action + allow empty save in Spaces tab (#721)"
+```
+
+---
+
+### Task 5: Docs + full verification
+
+**Files:**
+- Modify: `docs/architecture/08-flow-sync.md` (note the unsync/purge path + selection decoupling)
+
+- [ ] **Step 1:** Update `docs/architecture/08-flow-sync.md`: add the `DELETE /api/spaces/:key` → `unsyncSpace` purge path and that the Spaces tab selection now derives from explicit editor assignments.
+- [ ] **Step 2:** `cd backend && npx vitest run src/domains/confluence/services/sync-service.unsync.test.ts src/routes/confluence/spaces.test.ts src/routes/foundation/settings.test.ts` — green.
+- [ ] **Step 3:** `cd backend && npm run lint && npm run typecheck` (or workspace equivalents) — clean.
+- [ ] **Step 4:** `cd frontend && npx vitest run && npx tsc --noEmit` — clean.
+- [ ] **Step 5:** Commit docs, open PR `feat(spaces): unsync/remove a synced Confluence space (#721)` targeting `dev`.
+
+## Acceptance mapping (#721)
+- Admin can remove a space; stops syncing; pages gone locally; stays gone after refresh → Tasks 1+2 (+3 keeps it unchecked).
+- Works down to zero selected → Task 4 (relaxed Save guard).
+- Cleans pages/embeddings/attachments + all `space_role_assignments`; nothing in Confluence → Task 1 (cascade + cleanPageAttachments; no Confluence calls).
+- Non-admin deselect still loses access, no orphaned data → Task 3 + Task 1 purge.

--- a/docs/superpowers/plans/2026-06-09-issue-722-724-version-history.md
+++ b/docs/superpowers/plans/2026-06-09-issue-722-724-version-history.md
@@ -10,7 +10,7 @@
 
 **Branch:** `feature/issue-722-724-version-history` off `dev`. This is the **only** unit that adds a migration (077) and edits `@compendiq/contracts`; backend tests run `fileParallelism:false` against an isolated test Postgres; rebuild contracts (`npm run build -w @compendiq/contracts`) before running consumers.
 
-**Confluence API (verified):** list = `GET /rest/api/content/{id}/version?expand=by,message&start=&limit=` (paginated, default 20/max ~200, current version included, `_links.next` for paging). Historical body = `GET /rest/api/content/{id}?status=historical&version={n}&expand=body.storage` → `body.storage.value` XHTML. Auth `Authorization: Bearer <PAT>` (already handled by the client). All read-only.
+**Confluence API (verified):** list = `GET /rest/api/content/{id}/version?expand=by,message&start=&limit=100` (paginated, current version included, `_links.next` for paging; as-built we request `limit=100` per page). Historical body = `GET /rest/api/content/{id}?status=historical&version={n}&expand=body.storage` → `body.storage.value` XHTML. Auth `Authorization: Bearer <PAT>` (already handled by the client). All read-only. **Throttle + termination live in the client:** every request flows through the private `fetchOnce`/`acquireToken` rate limiter (`CONFLUENCE_RATE_LIMIT_RPM`), and `getPageVersions` adds a defensive `maxIterations = 1000` cap plus an empty-page break (see Task 3).
 
 ---
 
@@ -210,12 +210,18 @@ export interface ConfluenceVersionMeta {
 Add methods (reuse the private `fetch<T>` helper at `:194`, which sets the Bearer header):
 
 ```ts
-  /** #722: list a page's full version history (metadata only — cheap). */
+  /** #722: list a page's full version history (metadata only — cheap). Paginates automatically. */
   async getPageVersions(pageId: string): Promise<ConfluenceVersionMeta[]> {
     const out: ConfluenceVersionMeta[] = [];
     let start = 0;
     const limit = 100;
-    for (;;) {
+    // Defensive cap: never loop forever on a misbehaving `_links.next` (e.g. a
+    // self-referential next link). 1000 pages × 100 = 100k versions is far beyond
+    // any real page. Rate-limiting is NOT done here — every `this.fetch` goes
+    // through the private `fetchOnce`, which calls `acquireToken()`
+    // (CONFLUENCE_RATE_LIMIT_RPM), so pagination is throttled automatically.
+    const maxIterations = 1000;
+    for (let i = 0; i < maxIterations; i++) {
       const res = await this.fetch<{
         results: Array<{ number: number; when: string; by?: { displayName?: string }; message?: string; minorEdit?: boolean }>;
         size: number;
@@ -224,7 +230,8 @@ Add methods (reuse the private `fetch<T>` helper at `:194`, which sets the Beare
       for (const v of res.results) {
         out.push({ number: v.number, when: v.when, author: v.by?.displayName ?? null, message: v.message ?? null, minorEdit: v.minorEdit ?? false });
       }
-      if (!res._links?.next || res.results.length < limit) break;
+      // Stop on the last page (no `next`) or an empty page (no progress).
+      if (!res._links?.next || res.results.length === 0) break;
       start += limit;
     }
     return out;
@@ -352,13 +359,19 @@ git commit -m "feat(versions): backfill version list + lazy historical body impo
 
 ---
 
-### Task 5: Contracts — `PageVersionSummary` schema
+### Task 5: Contracts — `PageVersionSummary` + `PageVersionDetail` schemas
 
 **Files:**
 - Create/modify: `packages/contracts/src/schemas/page-versions.ts` (new) + re-export from `packages/contracts/src/index.ts`
 - Test: `packages/contracts/src/schemas/page-versions.test.ts` (if the package tests schemas) — otherwise rely on type usage
 
-- [ ] **Step 1: Add the schema**
+- [ ] **Step 1: Add the schemas**
+
+As-built, the package ships **three** schemas: the per-row summary, the
+`/versions` list response, and a single-version **detail** schema (used by
+`GET /versions/:version`, whose body is nullable for metadata-only rows). The
+route **validates** both responses with `.parse(...)`; the frontend consumes the
+inferred types.
 
 ```ts
 import { z } from 'zod';
@@ -379,9 +392,23 @@ export const PageVersionsResponseSchema = z.object({
   pageId: z.string(),
 });
 export type PageVersionsResponse = z.infer<typeof PageVersionsResponseSchema>;
+
+// Single-version GET response — body may be null for backfilled (metadata-only)
+// rows that have not yet been lazily filled; metadata fields are optional.
+export const PageVersionDetailSchema = z.object({
+  versionNumber: z.number(),
+  title: z.string(),
+  bodyHtml: z.string().nullable(),
+  bodyText: z.string().nullable(),
+  editedAt: z.string().nullable().optional(),
+  author: z.string().nullable().optional(),
+  message: z.string().nullable().optional(),
+});
+export type PageVersionDetail = z.infer<typeof PageVersionDetailSchema>;
 ```
 
-Re-export both from `packages/contracts/src/index.ts` following the existing export style.
+Re-export all three from `packages/contracts/src/index.ts` following the existing
+export style.
 
 - [ ] **Step 2: Build the package**
 
@@ -392,7 +419,7 @@ Expected: builds; new exports present in `dist`.
 
 ```bash
 git add packages/contracts/src/schemas/page-versions.ts packages/contracts/src/index.ts
-git commit -m "feat(contracts): PageVersionSummary schema for version history (#722)"
+git commit -m "feat(contracts): PageVersionSummary/PageVersionsResponse/PageVersionDetail schemas for version history (#722)"
 ```
 
 ---
@@ -483,13 +510,13 @@ Fix the synthetic current row (`:112-118`) so it never emits page-load time, and
       : null;
 ```
 
-Update the historical `.map((v) => ({ ...v, isCurrent: false }))` — it already spreads the new fields from `getVersionHistory`.
+Update the historical `.map((v) => ({ ...v, isCurrent: false }))` — it already spreads the new fields from `getVersionHistory`. **As-built the list response is returned through the contract:** `return PageVersionsResponseSchema.parse({ versions, pageId: id })` (and the early "no page" path also returns a parsed empty `{ versions: [], pageId }`).
 
 > `ctx.confluenceId`: confirm `resolveAndAuthorize` exposes the page's `confluence_id`; if not, add it to that resolver's SELECT/return. Standalone pages (`confluenceId` null) skip backfill and keep local snapshots.
 
-- [ ] **Step 5: Lazy body on single-version GET**
+- [ ] **Step 5: Lazy body on single-version GET (validated with `PageVersionDetailSchema`)**
 
-In `pages-versions.ts` GET `/pages/:id/versions/:version` (`:137+`): after loading the version, if `body_html` is null and `ctx.confluenceId` is set, call `getHistoricalBody(ctx.id, ctx.confluenceId, versionNum, client)` and return its body. Add a test asserting a metadata-only version's body is fetched and persisted on first request.
+In `pages-versions.ts` GET `/pages/:id/versions/:version` (`:168+`): after loading the version, if `body_html` is null and `ctx.confluenceId` is set, fetch + persist via `getHistoricalBody(ctx.id, ctx.confluenceId, versionNum, client)` and serve its body. As-built the response is validated with `PageVersionDetailSchema.parse(...)` (so the nullable body / optional metadata contract is enforced). Add a test asserting a metadata-only version's body is fetched and persisted on first request.
 
 - [ ] **Step 6: Run tests to verify they pass**
 
@@ -501,6 +528,34 @@ Expected: PASS.
 ```bash
 git add backend/src/domains/knowledge/services/version-tracker.ts backend/src/routes/knowledge/pages-versions.ts backend/src/routes/knowledge/pages-versions.test.ts
 git commit -m "feat(versions): backfill-on-open, real metadata, lazy body, fix current-row date (#722/#724)"
+```
+
+---
+
+### Task 6b: Restore + semantic-diff data-loss guards (as-built)
+
+Backfilled version rows are **metadata-only** (`body_html IS NULL`) until previewed. Naively restoring or diffing one would blank the live page (and, for Confluence pages, push an empty body upstream) or diff as "all content removed". The shipped implementation closes both holes; the docs must reflect it.
+
+**Files:**
+- Modify: `backend/src/domains/knowledge/services/version-tracker.ts` (`restoreVersion` body-NULL guard; `getSemanticDiff` lazy-fetch both bodies + model resolution)
+- Modify: `backend/src/routes/knowledge/pages-versions.ts` (restore + semantic-diff routes lazy-fetch before calling the service)
+- Test: `backend/src/routes/knowledge/pages-versions.test.ts` (extend)
+
+- [ ] **Step 1: Restore — lazy-fetch the historical body BEFORE restoring**
+
+In the `POST /pages/:id/versions/:version/restore` route: before calling `restoreVersion`, if the target row's `body_html IS NULL` and `ctx.confluenceId` is set, call `getHistoricalBody(ctx.id, ctx.confluenceId, targetVersion, client)` to fill it. As **defense in depth**, `restoreVersion` itself runs in a `BEGIN…COMMIT` transaction and **guards** the still-empty case — if the resolved body is still NULL/empty it `ROLLBACK`s and **throws** rather than blanking the live page or pushing an empty body to Confluence. Net effect: a page can never be blanked locally or emptied upstream by restoring a metadata-only version.
+
+- [ ] **Step 2: Semantic-diff — lazy-fetch BOTH version bodies; resolve the model server-side**
+
+In `getSemanticDiff(pageId, v1, v2, model, confluenceId, client)`: for each requested version whose stored `body_html IS NULL`, lazily fetch + persist via `getHistoricalBody` before diffing (so metadata-only rows don't diff as empty → "all content removed"). The model is resolved from the **`chat`** use-case server-side — `const { config, model: resolvedModel } = await resolveUsecase('chat')` then `chat(config, model || resolvedModel, …)` — so the client request body's `model` is optional (the route's `SemanticDiffSchema` default is only a fallback; no hardcoded model is required end-to-end). The `semantic-diff` route passes the per-user Confluence client through (best-effort; logs and continues if unavailable).
+
+- [ ] **Step 3: Test + commit**
+
+Add tests: (a) restoring a metadata-only version fetches the historical body first and restores real content (never blanks the page); (b) the restore guard throws when the body cannot be resolved; (c) semantic-diff over two metadata-only versions fetches both bodies and does not report "all content removed".
+
+```bash
+git add backend/src/domains/knowledge/services/version-tracker.ts backend/src/routes/knowledge/pages-versions.ts backend/src/routes/knowledge/pages-versions.test.ts
+git commit -m "fix(versions): lazy-fetch + guard bodies before restore/semantic-diff (#722/#724)"
 ```
 
 ---
@@ -595,7 +650,7 @@ git commit -m "feat(versions): show real Confluence edit time/author/message; ho
 - Real Confluence history incl. pre-first-sync versions → Tasks 3+4+6 (list backfill on open).
 - Synced-once page shows >1 version → list import (Task 4) not local snapshots.
 - Each entry shows real edit time + author + message → Tasks 6+7.
-- Preview/compare/AI-diff/restore work on backfilled versions → Task 6 lazy body (existing restore path reads `page_versions`).
-- Backfill idempotent, respects rate limits, logs → Tasks 2 (`ON CONFLICT`) + 4 (`log()`), client paging.
+- Preview/compare/AI-diff/restore work on backfilled versions, never losing data → Task 6 (lazy body on GET) + Task 6b (restore lazy-fetch + NULL-body ROLLBACK guard; semantic-diff lazy-fetches both bodies).
+- Backfill idempotent + throttled (no silent truncation) → Task 2 (`ON CONFLICT`) + Task 3 (`getPageVersions` paginates through `fetchOnce`/`acquireToken` rate limiter with a defensive `maxIterations` cap + empty-page break).
 - Standalone pages keep working; viewing pushes nothing to Confluence → `confluenceId` guard; all calls read-only.
 - #724: current row stable across reloads; `syncedAt` never shown as edit time → Tasks 6+7.

--- a/docs/superpowers/plans/2026-06-09-issue-722-724-version-history.md
+++ b/docs/superpowers/plans/2026-06-09-issue-722-724-version-history.md
@@ -1,0 +1,601 @@
+# Unit D — #722 + #724: Real Confluence version history Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a page's actual Confluence version history (incl. versions before first sync), with real edit timestamp + author + change message; lazily fetch historical bodies for preview/compare/restore; and stop presenting `syncedAt`/page-load time as the version date (#724).
+
+**Architecture:** New read-only Confluence client methods list versions and fetch historical bodies. Migration 077 adds `edited_at`/`author`/`message` to `page_versions`. The version **list** is backfilled (idempotent) lazily when the History dialog opens; a historical **body** is fetched lazily only when a version is previewed/compared/restored, converted through `confluenceToHtml` (ADR-003), and persisted. The `/versions` response and the timeline UI surface real metadata; local/standalone pages keep snapshot behavior with an honestly-labeled "Synced …" fallback.
+
+**Tech Stack:** Fastify 5, Postgres (real DB tests via `backend/src/test-db-helper.ts`), Confluence DC REST (`/rest/api/content/{id}/version`, `?status=historical&version={n}`), React 19 + TanStack Query, Zod contracts, Vitest.
+
+**Branch:** `feature/issue-722-724-version-history` off `dev`. This is the **only** unit that adds a migration (077) and edits `@compendiq/contracts`; backend tests run `fileParallelism:false` against an isolated test Postgres; rebuild contracts (`npm run build -w @compendiq/contracts`) before running consumers.
+
+**Confluence API (verified):** list = `GET /rest/api/content/{id}/version?expand=by,message&start=&limit=` (paginated, default 20/max ~200, current version included, `_links.next` for paging). Historical body = `GET /rest/api/content/{id}?status=historical&version={n}&expand=body.storage` → `body.storage.value` XHTML. Auth `Authorization: Bearer <PAT>` (already handled by the client). All read-only.
+
+---
+
+### Task 1: Migration 077 — Confluence version metadata columns
+
+**Files:**
+- Create: `backend/src/core/db/migrations/077_page_versions_confluence_metadata.sql`
+- Test: `backend/src/core/db/migrations/__tests__/077_page_versions_confluence_metadata.test.ts`
+
+- [ ] **Step 1: Write the failing migration test** (model on `__tests__/073_llm_audit_log.test.ts`)
+
+```ts
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { setupTestDb, teardownTestDb } from '../../../../test-db-helper.js';
+import { query } from '../../postgres.js';
+
+describe('migration 077 page_versions confluence metadata', () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
+
+  it('adds edited_at, author, message columns to page_versions', async () => {
+    const cols = await query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns WHERE table_name='page_versions'`,
+    );
+    const names = cols.rows.map((r) => r.column_name);
+    expect(names).toEqual(expect.arrayContaining(['edited_at', 'author', 'message']));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && npx vitest run src/core/db/migrations/__tests__/077_page_versions_confluence_metadata.test.ts`
+Expected: FAIL — columns absent.
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- Migration 077: real Confluence version metadata on page_versions (#722/#724)
+-- edited_at = the version's actual Confluence edit time (version.when)
+-- author    = version.by.displayName
+-- message   = version.message (change comment)
+-- All NULL for local/standalone snapshots, which keep using synced_at.
+ALTER TABLE page_versions ADD COLUMN IF NOT EXISTS edited_at TIMESTAMPTZ NULL;
+ALTER TABLE page_versions ADD COLUMN IF NOT EXISTS author TEXT NULL;
+ALTER TABLE page_versions ADD COLUMN IF NOT EXISTS message TEXT NULL;
+```
+
+(`body_html`/`body_text` are already nullable from migration 014, so metadata-only rows are allowed.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && npx vitest run src/core/db/migrations/__tests__/077_page_versions_confluence_metadata.test.ts`
+Also run the migrations integrity test: `npx vitest run src/core/db/migrations/__tests__/migrations.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/core/db/migrations/077_page_versions_confluence_metadata.sql backend/src/core/db/migrations/__tests__/077_page_versions_confluence_metadata.test.ts
+git commit -m "feat(db): migration 077 adds Confluence version metadata to page_versions (#722)"
+```
+
+---
+
+### Task 2: Persistence helpers — `upsertVersionMetadata` + `fillVersionBody`
+
+**Files:**
+- Modify: `backend/src/core/services/version-snapshot.ts`
+- Test: `backend/src/core/services/version-snapshot.test.ts` (extend or create)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('upsertVersionMetadata inserts then updates metadata idempotently', async () => {
+  const id = await seedPage(); // returns pages.id
+  await upsertVersionMetadata(id, 3, 'T', { editedAt: '2026-01-02T00:00:00Z', author: 'Ann', message: 'edit' });
+  await upsertVersionMetadata(id, 3, 'T', { editedAt: '2026-01-02T00:00:00Z', author: 'Ann', message: 'edit' }); // no dup
+  const r = await query(`SELECT author, message FROM page_versions WHERE page_id=$1 AND version_number=3`, [id]);
+  expect(r.rows).toHaveLength(1);
+  expect(r.rows[0]).toMatchObject({ author: 'Ann', message: 'edit' });
+});
+
+it('fillVersionBody fills a null body only', async () => {
+  const id = await seedPage();
+  await upsertVersionMetadata(id, 2, 'T', { editedAt: null, author: null, message: null });
+  await fillVersionBody(id, 2, '<p>hi</p>', 'hi');
+  const r = await query(`SELECT body_html FROM page_versions WHERE page_id=$1 AND version_number=2`, [id]);
+  expect(r.rows[0]!.body_html).toBe('<p>hi</p>');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && npx vitest run src/core/services/version-snapshot.test.ts`
+Expected: FAIL — functions not exported.
+
+- [ ] **Step 3: Implement the helpers**
+
+```ts
+export async function upsertVersionMetadata(
+  pageId: number,
+  versionNumber: number,
+  title: string,
+  meta: { editedAt: string | Date | null; author: string | null; message: string | null },
+): Promise<void> {
+  await query(
+    `INSERT INTO page_versions (page_id, version_number, title, edited_at, author, message)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT (page_id, version_number) DO UPDATE SET
+       edited_at = COALESCE(EXCLUDED.edited_at, page_versions.edited_at),
+       author    = COALESCE(EXCLUDED.author, page_versions.author),
+       message   = COALESCE(EXCLUDED.message, page_versions.message),
+       title     = EXCLUDED.title`,
+    [pageId, versionNumber, title, meta.editedAt, meta.author, meta.message],
+  );
+}
+
+export async function fillVersionBody(
+  pageId: number,
+  versionNumber: number,
+  bodyHtml: string,
+  bodyText: string,
+): Promise<void> {
+  await query(
+    `UPDATE page_versions SET body_html = $3, body_text = $4
+       WHERE page_id = $1 AND version_number = $2 AND body_html IS NULL`,
+    [pageId, versionNumber, bodyHtml, bodyText],
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && npx vitest run src/core/services/version-snapshot.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/core/services/version-snapshot.ts backend/src/core/services/version-snapshot.test.ts
+git commit -m "feat(versions): upsertVersionMetadata + fillVersionBody helpers (#722)"
+```
+
+---
+
+### Task 3: Confluence client — list versions + fetch historical body
+
+**Files:**
+- Modify: `backend/src/domains/confluence/services/confluence-client.ts` (add methods after `getPage` ~`:292`; add a `ConfluenceVersionMeta` interface near the `ConfluencePage` interface ~`:18`)
+- Test: `backend/src/domains/confluence/services/confluence-client.versions.test.ts` (new; mock `fetch` at the HTTP boundary like the existing client tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Mock global `fetch` (the client uses it under `fetchOnce`). Return a paginated version list then assert flattening, then a historical body:
+
+```ts
+it('getPageVersions flattens pagination and maps metadata', async () => {
+  // page 1 (limit reached) then page 2 (final)
+  fetchMock
+    .mockResolvedValueOnce(jsonResponse({ results: [{ number: 3, when: '2026-01-03T00:00:00Z', by: { displayName: 'A' }, message: 'm3' }], size: 1, _links: { next: '/next' } }))
+    .mockResolvedValueOnce(jsonResponse({ results: [{ number: 2, when: '2026-01-02T00:00:00Z', by: { displayName: 'B' } }], size: 1, _links: {} }));
+  const client = new ConfluenceClient('https://c.example.com', 'PAT');
+  const versions = await client.getPageVersions('123');
+  expect(versions.map((v) => v.number)).toEqual([3, 2]);
+  expect(versions[0]).toMatchObject({ author: 'A', message: 'm3' });
+});
+
+it('getHistoricalPageBody returns the historical storage XHTML', async () => {
+  fetchMock.mockResolvedValueOnce(jsonResponse({ body: { storage: { value: '<p>old</p>' } } }));
+  const client = new ConfluenceClient('https://c.example.com', 'PAT');
+  expect(await client.getHistoricalPageBody('123', 2)).toBe('<p>old</p>');
+});
+```
+
+> Match the existing client tests' fetch-mock helpers (`backend/src/domains/confluence/services/confluence-client*.test.ts`) for `jsonResponse`/setup.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && npx vitest run src/domains/confluence/services/confluence-client.versions.test.ts`
+Expected: FAIL — methods undefined.
+
+- [ ] **Step 3: Implement the methods**
+
+Add the interface:
+
+```ts
+export interface ConfluenceVersionMeta {
+  number: number;
+  when: string;
+  author: string | null;
+  message: string | null;
+  minorEdit: boolean;
+}
+```
+
+Add methods (reuse the private `fetch<T>` helper at `:194`, which sets the Bearer header):
+
+```ts
+  /** #722: list a page's full version history (metadata only — cheap). */
+  async getPageVersions(pageId: string): Promise<ConfluenceVersionMeta[]> {
+    const out: ConfluenceVersionMeta[] = [];
+    let start = 0;
+    const limit = 100;
+    for (;;) {
+      const res = await this.fetch<{
+        results: Array<{ number: number; when: string; by?: { displayName?: string }; message?: string; minorEdit?: boolean }>;
+        size: number;
+        _links?: { next?: string };
+      }>(`/rest/api/content/${encodeURIComponent(pageId)}/version?expand=by,message&start=${start}&limit=${limit}`, { method: 'GET' });
+      for (const v of res.results) {
+        out.push({ number: v.number, when: v.when, author: v.by?.displayName ?? null, message: v.message ?? null, minorEdit: v.minorEdit ?? false });
+      }
+      if (!res._links?.next || res.results.length < limit) break;
+      start += limit;
+    }
+    return out;
+  }
+
+  /** #722: fetch a historical version's storage-format body (read-only). */
+  async getHistoricalPageBody(pageId: string, version: number): Promise<string> {
+    const res = await this.fetch<{ body?: { storage?: { value?: string } } }>(
+      `/rest/api/content/${encodeURIComponent(pageId)}?status=historical&version=${version}&expand=body.storage`,
+      { method: 'GET' },
+    );
+    return res.body?.storage?.value ?? '';
+  }
+```
+
+> Confirm the `this.fetch` options shape (the file shows `private async fetch<T>(path, options: {...})` at `:194`); pass whatever the existing GET callers pass (e.g. `getSpaces`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && npx vitest run src/domains/confluence/services/confluence-client.versions.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/domains/confluence/services/confluence-client.ts backend/src/domains/confluence/services/confluence-client.versions.test.ts
+git commit -m "feat(confluence): client methods to list versions + fetch historical body (#722)"
+```
+
+---
+
+### Task 4: Backfill service — list import + lazy body import
+
+**Files:**
+- Create: `backend/src/domains/confluence/services/version-backfill.ts`
+- Test: `backend/src/domains/confluence/services/version-backfill.test.ts` (new; real DB + mocked client)
+
+The service needs the per-user Confluence client. Reuse the existing client factory used by sync (grep `new ConfluenceClient(` in `sync-service.ts` / a `getConfluenceClient` helper) so PAT decryption/base-url resolution is identical.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('backfillVersionHistory upserts one metadata row per Confluence version (idempotent)', async () => {
+  const pageId = await seedConfluencePage('c-1');           // pages row, confluence_id='c-1'
+  const client = { getPageVersions: vi.fn().mockResolvedValue([
+    { number: 2, when: '2026-01-02T00:00:00Z', author: 'A', message: 'm', minorEdit: false },
+    { number: 1, when: '2026-01-01T00:00:00Z', author: 'A', message: null, minorEdit: false },
+  ]) };
+  await backfillVersionHistory(pageId, 'c-1', client as never);
+  await backfillVersionHistory(pageId, 'c-1', client as never); // idempotent
+  const r = await query(`SELECT version_number, author, edited_at FROM page_versions WHERE page_id=$1 ORDER BY version_number`, [pageId]);
+  expect(r.rows.map((x) => x.version_number)).toEqual([1, 2]);
+});
+
+it('getHistoricalBody fetches, converts via confluenceToHtml, and fills the body', async () => {
+  const pageId = await seedConfluencePage('c-2');
+  await upsertVersionMetadata(pageId, 1, 'T', { editedAt: null, author: null, message: null });
+  const client = { getHistoricalPageBody: vi.fn().mockResolvedValue('<p>old</p>') };
+  const body = await getHistoricalBody(pageId, 'c-2', 1, client as never);
+  expect(body.bodyHtml).toContain('old');
+  const r = await query(`SELECT body_html FROM page_versions WHERE page_id=$1 AND version_number=1`, [pageId]);
+  expect(r.rows[0]!.body_html).toContain('old');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && npx vitest run src/domains/confluence/services/version-backfill.test.ts`
+Expected: FAIL — module/functions don't exist.
+
+- [ ] **Step 3: Implement the backfill service**
+
+```ts
+import type { ConfluenceClient } from './confluence-client.js';
+import { confluenceToHtml, htmlToText } from '../../../core/services/content-converter.js';
+import { upsertVersionMetadata, fillVersionBody } from '../../../core/services/version-snapshot.js';
+import { logger } from '../../../core/utils/logger.js';
+
+/** #722: import the version LIST (metadata only) for a Confluence-synced page. Idempotent. */
+export async function backfillVersionHistory(
+  pageId: number,
+  confluenceId: string,
+  client: ConfluenceClient,
+): Promise<{ imported: number }> {
+  const versions = await client.getPageVersions(confluenceId);
+  for (const v of versions) {
+    await upsertVersionMetadata(pageId, v.number, `v${v.number}`, {
+      editedAt: v.when ?? null,
+      author: v.author,
+      message: v.message,
+    });
+  }
+  logger.info({ pageId, confluenceId, imported: versions.length }, '#722: backfilled version metadata');
+  return { imported: versions.length };
+}
+
+/** #722: lazily fetch + persist a historical body, converting storage XHTML via ADR-003. */
+export async function getHistoricalBody(
+  pageId: number,
+  confluenceId: string,
+  versionNumber: number,
+  client: ConfluenceClient,
+): Promise<{ bodyHtml: string; bodyText: string }> {
+  const storage = await client.getHistoricalPageBody(confluenceId, versionNumber);
+  const bodyHtml = confluenceToHtml(storage, confluenceId);
+  const bodyText = htmlToText(bodyHtml);
+  await fillVersionBody(pageId, versionNumber, bodyHtml, bodyText);
+  return { bodyHtml, bodyText };
+}
+```
+
+> Use the real title for the metadata row if cheaply available; `v{n}` is an acceptable placeholder title since the UI shows the page title for the current row and the version number for historical rows.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && npx vitest run src/domains/confluence/services/version-backfill.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/domains/confluence/services/version-backfill.ts backend/src/domains/confluence/services/version-backfill.test.ts
+git commit -m "feat(versions): backfill version list + lazy historical body import (#722)"
+```
+
+---
+
+### Task 5: Contracts — `PageVersionSummary` schema
+
+**Files:**
+- Create/modify: `packages/contracts/src/schemas/page-versions.ts` (new) + re-export from `packages/contracts/src/index.ts`
+- Test: `packages/contracts/src/schemas/page-versions.test.ts` (if the package tests schemas) — otherwise rely on type usage
+
+- [ ] **Step 1: Add the schema**
+
+```ts
+import { z } from 'zod';
+
+export const PageVersionSummarySchema = z.object({
+  versionNumber: z.number(),
+  title: z.string(),
+  editedAt: z.string().nullable(),
+  syncedAt: z.string().nullable(),
+  author: z.string().nullable(),
+  message: z.string().nullable(),
+  isCurrent: z.boolean(),
+});
+export type PageVersionSummary = z.infer<typeof PageVersionSummarySchema>;
+
+export const PageVersionsResponseSchema = z.object({
+  versions: z.array(PageVersionSummarySchema),
+  pageId: z.string(),
+});
+export type PageVersionsResponse = z.infer<typeof PageVersionsResponseSchema>;
+```
+
+Re-export both from `packages/contracts/src/index.ts` following the existing export style.
+
+- [ ] **Step 2: Build the package**
+
+Run: `npm run build -w @compendiq/contracts`
+Expected: builds; new exports present in `dist`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/contracts/src/schemas/page-versions.ts packages/contracts/src/index.ts
+git commit -m "feat(contracts): PageVersionSummary schema for version history (#722)"
+```
+
+---
+
+### Task 6: Read path — backfill-on-open, real metadata, lazy body, fix current row (#724)
+
+**Files:**
+- Modify: `backend/src/domains/knowledge/services/version-tracker.ts:29-57` (`getVersionHistory` SELECT + mapping)
+- Modify: `backend/src/routes/knowledge/pages-versions.ts:92-134` (backfill on open + current-row fix) and `:137+` (lazy body on single-version GET)
+- Test: `backend/src/routes/knowledge/pages-versions.test.ts` (extend; real DB + mocked confluence client)
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+it('GET /versions returns real edited_at/author/message for historical rows (#722)', async () => {
+  // seed a confluence page + a page_versions row with edited_at/author/message
+  const res = await app.inject({ method: 'GET', url: `/api/pages/${id}/versions` });
+  const v = res.json().versions.find((x) => !x.isCurrent);
+  expect(v).toMatchObject({ author: 'Ann', message: 'typo fix' });
+  expect(v.editedAt).toBe('2026-01-02T00:00:00.000Z');
+});
+
+it('current row has editedAt:null when last_modified_at is null — no page-load time (#724)', async () => {
+  // seed page with last_modified_at = NULL
+  const res = await app.inject({ method: 'GET', url: `/api/pages/${id}/versions` });
+  const cur = res.json().versions.find((x) => x.isCurrent);
+  expect(cur.editedAt).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && npx vitest run src/routes/knowledge/pages-versions.test.ts`
+Expected: FAIL — response lacks `editedAt`/`author`/`message`; current row uses `new Date()`.
+
+- [ ] **Step 3: Extend `getVersionHistory`**
+
+Add the new columns to the SELECT and mapping in `version-tracker.ts:29-57`:
+
+```ts
+  const result = await query<{
+    version_number: number; title: string; synced_at: Date;
+    edited_at: Date | null; author: string | null; message: string | null;
+  }>(
+    `SELECT version_number, title, synced_at, edited_at, author, message
+       FROM page_versions WHERE page_id = $1 ORDER BY version_number DESC`,
+    [pageId],
+  );
+  return result.rows.map((r) => ({
+    versionNumber: r.version_number,
+    title: r.title,
+    syncedAt: r.synced_at?.toISOString() ?? null,
+    editedAt: r.edited_at?.toISOString() ?? null,
+    author: r.author,
+    message: r.message,
+  }));
+```
+
+- [ ] **Step 4: Backfill-on-open + current-row fix in the route**
+
+In `pages-versions.ts` GET `/pages/:id/versions`, before `getVersionHistory`, backfill from Confluence when the page is synced (best-effort — never fail the dialog):
+
+```ts
+    if (ctx.confluenceId) {
+      try {
+        const client = await getConfluenceClientForUser(userId); // reuse sync's factory
+        if (client) await backfillVersionHistory(ctx.id, ctx.confluenceId, client);
+      } catch (err) {
+        request.log.warn({ err, pageId: id }, '#722: version backfill skipped (Confluence unavailable)');
+      }
+    }
+    const versions = await getVersionHistory(ctx.id);
+```
+
+Fix the synthetic current row (`:112-118`) so it never emits page-load time, and carries the new fields:
+
+```ts
+    const currentVersion = currentResult.rows[0]
+      ? {
+          versionNumber: currentResult.rows[0].version,
+          title: currentResult.rows[0].title,
+          editedAt: currentResult.rows[0].last_modified_at?.toISOString() ?? null,
+          syncedAt: currentResult.rows[0].last_modified_at?.toISOString() ?? null,
+          author: null,
+          message: null,
+          isCurrent: true,
+        }
+      : null;
+```
+
+Update the historical `.map((v) => ({ ...v, isCurrent: false }))` — it already spreads the new fields from `getVersionHistory`.
+
+> `ctx.confluenceId`: confirm `resolveAndAuthorize` exposes the page's `confluence_id`; if not, add it to that resolver's SELECT/return. Standalone pages (`confluenceId` null) skip backfill and keep local snapshots.
+
+- [ ] **Step 5: Lazy body on single-version GET**
+
+In `pages-versions.ts` GET `/pages/:id/versions/:version` (`:137+`): after loading the version, if `body_html` is null and `ctx.confluenceId` is set, call `getHistoricalBody(ctx.id, ctx.confluenceId, versionNum, client)` and return its body. Add a test asserting a metadata-only version's body is fetched and persisted on first request.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd backend && npx vitest run src/routes/knowledge/pages-versions.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/domains/knowledge/services/version-tracker.ts backend/src/routes/knowledge/pages-versions.ts backend/src/routes/knowledge/pages-versions.test.ts
+git commit -m "feat(versions): backfill-on-open, real metadata, lazy body, fix current-row date (#722/#724)"
+```
+
+---
+
+### Task 7: Frontend — show real edit time + author + message; honest fallback (#724)
+
+**Files:**
+- Modify: `frontend/src/features/pages/VersionHistory.tsx:12-17` (type) and `:247-249` (render)
+- Test: `frontend/src/features/pages/VersionHistory.test.tsx` (extend or create)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('renders the real Confluence edit time + author + message when present (#722)', async () => {
+  mockVersions([{ versionNumber: 3, title: 'Guide', editedAt: '2026-01-02T15:00:00Z', syncedAt: '2026-06-09T00:00:00Z', author: 'Ann', message: 'typo fix', isCurrent: false }]);
+  // open dialog
+  expect(await screen.findByText(/Ann/)).toBeInTheDocument();
+  expect(screen.getByText(/typo fix/)).toBeInTheDocument();
+  expect(screen.queryByText(/Synced/)).not.toBeInTheDocument(); // editedAt present → no "Synced" label
+});
+
+it('falls back to a labeled "Synced …" when editedAt is null, never page-load time (#724)', async () => {
+  mockVersions([{ versionNumber: 1, title: 'Local', editedAt: null, syncedAt: '2026-06-09T00:00:00Z', author: null, message: null, isCurrent: false }]);
+  expect(await screen.findByText(/Synced/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/features/pages/VersionHistory.test.tsx`
+Expected: FAIL — type lacks the fields; render shows `syncedAt` unlabeled.
+
+- [ ] **Step 3: Update the type + render**
+
+Type (`:12-17`) — mirror the contract:
+
+```tsx
+interface PageVersionSummary {
+  versionNumber: number;
+  title: string;
+  editedAt: string | null;
+  syncedAt: string | null;
+  author: string | null;
+  message: string | null;
+  isCurrent: boolean;
+}
+```
+
+Render (`:247-249`) — prefer real edit time + author + message; honest fallback:
+
+```tsx
+                      <p className="truncate text-xs text-muted-foreground">
+                        {version.title}
+                        {version.editedAt
+                          ? <> · {new Date(version.editedAt).toLocaleString()}{version.author ? ` · ${version.author}` : ''}</>
+                          : version.syncedAt
+                            ? <> · Synced {new Date(version.syncedAt).toLocaleString()}</>
+                            : <> · —</>}
+                      </p>
+                      {version.message && (
+                        <p className="truncate text-xs text-muted-foreground/80 italic">{version.message}</p>
+                      )}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/features/pages/VersionHistory.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd frontend && npx eslint src/features/pages/VersionHistory.tsx
+git add frontend/src/features/pages/VersionHistory.tsx frontend/src/features/pages/VersionHistory.test.tsx
+git commit -m "feat(versions): show real Confluence edit time/author/message; honest Synced fallback (#722/#724)"
+```
+
+---
+
+### Task 8: Docs + full verification
+
+**Files:**
+- Modify: `docs/architecture/06-data-model.md` (page_versions new columns), `docs/architecture/08-flow-sync.md` (version backfill-on-open + lazy body), `docs/architecture/11-content-pipeline.md` (historical-body conversion via confluenceToHtml)
+
+- [ ] **Step 1:** Update the three docs above.
+- [ ] **Step 2:** `npm run build -w @compendiq/contracts` then `cd backend && npx vitest run src/core/db/migrations/__tests__/077_page_versions_confluence_metadata.test.ts src/core/services/version-snapshot.test.ts src/domains/confluence/services/confluence-client.versions.test.ts src/domains/confluence/services/version-backfill.test.ts src/routes/knowledge/pages-versions.test.ts` — green.
+- [ ] **Step 3:** `cd backend && npm run lint && npm run typecheck` — clean.
+- [ ] **Step 4:** `cd frontend && npx vitest run src/features/pages/VersionHistory.test.tsx && npx tsc --noEmit` — clean.
+- [ ] **Step 5:** Open PR `feat(versions): import real Confluence version history (#722, #724)` targeting `dev`; flag the docs/diagram updates per CLAUDE.md rule 6.
+
+## Acceptance mapping
+- Real Confluence history incl. pre-first-sync versions → Tasks 3+4+6 (list backfill on open).
+- Synced-once page shows >1 version → list import (Task 4) not local snapshots.
+- Each entry shows real edit time + author + message → Tasks 6+7.
+- Preview/compare/AI-diff/restore work on backfilled versions → Task 6 lazy body (existing restore path reads `page_versions`).
+- Backfill idempotent, respects rate limits, logs → Tasks 2 (`ON CONFLICT`) + 4 (`log()`), client paging.
+- Standalone pages keep working; viewing pushes nothing to Confluence → `confluenceId` guard; all calls read-only.
+- #724: current row stable across reloads; `syncedAt` never shown as edit time → Tasks 6+7.

--- a/docs/superpowers/plans/2026-06-09-issue-723-improve-media.md
+++ b/docs/superpowers/plans/2026-06-09-issue-723-improve-media.md
@@ -110,16 +110,46 @@ export function protectMedia(html: string): { html: string; media: ProtectedMedi
 /**
  * Re-inject protected media. Replaces `<p>TOKEN</p>` (markdown wrapped the lone
  * token in a paragraph) and bare TOKEN occurrences with the original HTML.
+ *
+ * **As-built — single combined pass with a FUNCTION replacer** (a naive
+ * per-token `replace`/`split`-`join` is unsafe and was *not* shipped):
+ * - One alternation regex over every token (raw + the turndown-escaped `\_`
+ *   spelling, so tokens survive a full `htmlToMarkdown → markdownToHtml`
+ *   round-trip) with a **function replacer**. Function replacers return their
+ *   value literally, so original media HTML containing `$`, `$&`, `$1`, `` $` ``,
+ *   `$'`, `$$` (legitimate in Confluence attachment URLs / encoded query
+ *   strings) is injected verbatim instead of being reinterpreted as
+ *   `String.replace` special patterns — **$-safe**.
+ * - A single pass is **collision-safe**: already-injected media is never
+ *   re-scanned, so an earlier entry whose original HTML literally contains a
+ *   *later* token (e.g. in an `alt` / `data-diagram-name`) can't be corrupted.
+ * - Wrapped (`<p>TOKEN</p>`) alternatives precede bare ones so the wrapping
+ *   paragraph is consumed; the bare form ends on a `(?![0-9])` boundary so
+ *   `..._1` never matches the prefix of `..._10` — **token-prefix-safe**.
  */
 export function restoreMedia(html: string, media: ProtectedMedia[]): string {
-  let out = html;
+  if (media.length === 0) return html;
+  const byMatch = new Map<string, string>();
+  const wrappedAlts: string[] = [];
+  const bareAlts: string[] = [];
   for (const { token, html: original } of media) {
-    out = out.replace(new RegExp(`<p>\\s*${token}\\s*</p>`, 'g'), original);
-    out = out.split(token).join(original);
+    const escapedToken = token.replace(/_/g, '\\_'); // CQ\_MEDIA\_PLACEHOLDER\_0
+    for (const t of [token, escapedToken]) {
+      const pat = escapeRegExp(t);
+      wrappedAlts.push(`<p>\\s*${pat}\\s*</p>`);
+      bareAlts.push(`${pat}(?![0-9])`);
+      byMatch.set(t, original);
+    }
   }
-  return out;
+  const combined = new RegExp([...wrappedAlts, ...bareAlts].join('|'), 'g');
+  return html.replace(combined, (matched) => {
+    const inner = matched.replace(/^<p>\s*/, '').replace(/\s*<\/p>$/, '').trim();
+    return byMatch.get(inner) ?? matched; // literal return — `$`-sequences not interpreted
+  });
 }
 ```
+
+> Needs a small `escapeRegExp(s)` helper (`s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')`) defined alongside these functions.
 
 > If `JSDOM` isn't directly in scope, use the same DOM-construction helper the rest of `content-converter.ts` uses (grep the file for how `htmlToConfluence` parses HTML).
 

--- a/docs/superpowers/plans/2026-06-09-issue-723-improve-media.md
+++ b/docs/superpowers/plans/2026-06-09-issue-723-improve-media.md
@@ -1,0 +1,334 @@
+# Unit C — #723: AI Improve must not destroy images / draw.io Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** AI Improve + Accept must keep images and draw.io diagrams rendering, with all `data-confluence-*` and `.confluence-drawio`/`data-diagram-name` structure intact, even if the LLM drops the line.
+
+**Architecture:** Two layers. (1) **Placeholder protection** for the improve round-trip: before `htmlToMarkdown`, swap media nodes (`<img>`, `.confluence-drawio`, `.mermaid`, layout/column) for opaque text tokens; on Accept, re-derive the same tokens from the page's current `body_html` and re-inject the originals verbatim after `markdownToHtml`, with a diff-based guard that re-appends any media the LLM dropped. (2) **Converter coverage**: a turndown rule + `markdownToHtml` reconstruction for `confluence-drawio` so the conversion is lossless for non-improve callers too.
+
+**Tech Stack:** TypeScript, jsdom, turndown (+gfm), marked; Vitest. Pure-function tests (no DB) for the converter; the apply-path change is covered by the existing route test that hits real Postgres.
+
+**Branch:** `feature/issue-723-improve-media` off `dev`.
+
+---
+
+### Task 1: `protectMedia` / `restoreMedia` in content-converter
+
+**Files:**
+- Modify: `backend/src/core/services/content-converter.ts` (add two exported functions near `htmlToMarkdown` at `:874`)
+- Test: `backend/src/core/services/content-converter.media.test.ts` (new)
+
+Token format: `CQ_MEDIA_PLACEHOLDER_<index>` — pure `[A-Z_0-9]`, so it survives turndown, `sanitizeLlmInput`, markdown, and the LLM as plain text. Media nodes protected, in document order: `img`, `div.confluence-drawio`, `div.mermaid`/`.confluence-mermaid`, `div.confluence-section`, `div.confluence-column`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { protectMedia, restoreMedia, htmlToMarkdown, markdownToHtml } from './content-converter.js';
+
+const DRAWIO = '<div class="confluence-drawio" data-diagram-name="Arch"><img src="/api/attachments/5/Arch.png" alt="d"><a class="drawio-edit-link" data-drawio="true" href="#">Edit</a></div>';
+const IMG = '<img src="/api/attachments/5/photo.png" data-confluence-image-source="attachment" data-confluence-filename="photo.png" alt="Photo">';
+
+describe('protectMedia / restoreMedia', () => {
+  it('replaces media with deterministic tokens and restores them verbatim', () => {
+    const html = `<p>Intro</p>${IMG}<p>Mid</p>${DRAWIO}<p>End</p>`;
+    const { html: protectedHtml, media } = protectMedia(html);
+    expect(protectedHtml).toContain('CQ_MEDIA_PLACEHOLDER_0');
+    expect(protectedHtml).toContain('CQ_MEDIA_PLACEHOLDER_1');
+    expect(protectedHtml).not.toContain('confluence-drawio');
+    expect(media).toHaveLength(2);
+
+    const restored = restoreMedia(protectedHtml, media);
+    expect(restored).toContain('data-diagram-name="Arch"');
+    expect(restored).toContain('data-confluence-filename="photo.png"');
+  });
+
+  it('is deterministic — same input yields the same token order', () => {
+    const html = `${IMG}${DRAWIO}`;
+    expect(protectMedia(html).media.map((m) => m.token))
+      .toEqual(protectMedia(html).media.map((m) => m.token));
+  });
+
+  it('survives a full markdown round-trip and re-injects media (LLM-drops-line safe)', () => {
+    const html = `<p>Intro</p>${DRAWIO}${IMG}`;
+    const { html: protectedHtml, media } = protectMedia(html);
+    const md = htmlToMarkdown(protectedHtml);          // tokens are plain text in MD
+    expect(md).toContain('CQ_MEDIA_PLACEHOLDER_0');
+    const back = restoreMedia(markdownToHtmlSync(md), media); // see helper note below
+    expect(back).toContain('confluence-drawio');
+    expect(back).toContain('data-confluence-filename');
+  });
+});
+```
+
+> `markdownToHtml` is async; in the test `await` it (make the test `async`) — the `markdownToHtmlSync` above is shorthand for `await markdownToHtml(md)`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && npx vitest run src/core/services/content-converter.media.test.ts`
+Expected: FAIL — `protectMedia`/`restoreMedia` not exported.
+
+- [ ] **Step 3: Implement `protectMedia` / `restoreMedia`**
+
+Add to `content-converter.ts` (reuse the module's jsdom helper used by `htmlToConfluence`/`htmlToMarkdown` — e.g. `new JSDOM(html)` or the existing `parseHtml` helper):
+
+```ts
+export interface ProtectedMedia { token: string; html: string; }
+
+const MEDIA_TOKEN_PREFIX = 'CQ_MEDIA_PLACEHOLDER_';
+const MEDIA_SELECTOR = [
+  'img',
+  'div.confluence-drawio',
+  'div.confluence-mermaid',
+  'div.mermaid',
+  'div.confluence-section',
+  'div.confluence-column',
+].join(',');
+
+/**
+ * #723: Replace rich/media nodes with opaque text tokens before the lossy
+ * HTML→Markdown→HTML round-trip used by AI Improve. Document order makes the
+ * tokens deterministic, so the same source HTML re-protected at Accept time
+ * yields the same tokens — no need to persist the map.
+ */
+export function protectMedia(html: string): { html: string; media: ProtectedMedia[] } {
+  const dom = new JSDOM(`<body>${html}</body>`);
+  const doc = dom.window.document;
+  const media: ProtectedMedia[] = [];
+  // Outermost-first: a div.confluence-drawio contains an <img>; protect the
+  // wrapper and skip its descendants.
+  const nodes = Array.from(doc.body.querySelectorAll(MEDIA_SELECTOR))
+    .filter((n) => !n.parentElement?.closest('div.confluence-drawio, div.confluence-mermaid, div.mermaid'));
+  for (const node of nodes) {
+    const token = `${MEDIA_TOKEN_PREFIX}${media.length}`;
+    media.push({ token, html: (node as Element).outerHTML });
+    node.replaceWith(doc.createTextNode(` ${token} `));
+  }
+  return { html: doc.body.innerHTML, media };
+}
+
+/**
+ * Re-inject protected media. Replaces `<p>TOKEN</p>` (markdown wrapped the lone
+ * token in a paragraph) and bare TOKEN occurrences with the original HTML.
+ */
+export function restoreMedia(html: string, media: ProtectedMedia[]): string {
+  let out = html;
+  for (const { token, html: original } of media) {
+    out = out.replace(new RegExp(`<p>\\s*${token}\\s*</p>`, 'g'), original);
+    out = out.split(token).join(original);
+  }
+  return out;
+}
+```
+
+> If `JSDOM` isn't directly in scope, use the same DOM-construction helper the rest of `content-converter.ts` uses (grep the file for how `htmlToConfluence` parses HTML).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && npx vitest run src/core/services/content-converter.media.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/core/services/content-converter.ts backend/src/core/services/content-converter.media.test.ts
+git commit -m "feat(content): protectMedia/restoreMedia for lossless AI Improve round-trip (#723)"
+```
+
+---
+
+### Task 2: Wire protection into improve (request) + apply (Accept) with a drop-guard
+
+**Files:**
+- Modify: `backend/src/routes/llm/_helpers.ts:42-66` (add `opts.protectMedia` to `assembleContextIfNeeded`)
+- Modify: `backend/src/routes/llm/llm-improve.ts:52` (pass `{ protectMedia: true }`)
+- Modify: `backend/src/routes/llm/llm-conversations.ts:112-135` (add `body_html` to SELECT; restore + guard)
+- Test: extend `backend/src/routes/llm/apply-improvement.test.ts`
+
+- [ ] **Step 1: Write the failing apply test**
+
+In `apply-improvement.test.ts` (real DB), seed a page whose `body_html` contains a draw.io diagram + an attachment image, post an `improvedMarkdown` that contains the placeholder tokens but NOT the media (simulating the LLM keeping the tokens), and assert the saved `body_html` still has both:
+
+```ts
+it('preserves drawio + image through improve→apply even if the LLM only kept the tokens (#723)', async () => {
+  const drawio = '<div class="confluence-drawio" data-diagram-name="Arch"><img src="/api/attachments/{ID}/Arch.png"></div>';
+  const img = '<img src="/api/attachments/{ID}/p.png" data-confluence-filename="p.png" data-confluence-image-source="attachment">';
+  // insert a page with body_html = `<p>Old</p>${drawio}${img}` ; capture its confluence_id + version
+  // improvedMarkdown mirrors what protectMedia+htmlToMarkdown produce:
+  const improvedMarkdown = 'Improved intro\n\nCQ_MEDIA_PLACEHOLDER_0\n\nCQ_MEDIA_PLACEHOLDER_1\n';
+
+  const res = await app.inject({ method: 'POST', url: '/api/llm/improvements/apply',
+    payload: { pageId, improvedMarkdown, version } });
+
+  expect(res.statusCode).toBe(200);
+  const saved = await query<{ body_html: string }>('SELECT body_html FROM pages WHERE id=$1', [internalId]);
+  expect(saved.rows[0]!.body_html).toContain('data-diagram-name="Arch"');
+  expect(saved.rows[0]!.body_html).toContain('data-confluence-filename="p.png"');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && npx vitest run src/routes/llm/apply-improvement.test.ts`
+Expected: FAIL — saved `body_html` lost the diagram/image.
+
+- [ ] **Step 3: Add the `protectMedia` option to `assembleContextIfNeeded`**
+
+`_helpers.ts` — import `protectMedia` and extend the signature/non-subpage branch:
+
+```ts
+export async function assembleContextIfNeeded(
+  userId: string,
+  pageId: string | undefined,
+  content: string,
+  includeSubPages?: boolean,
+  opts?: { protectMedia?: boolean },
+): Promise<{ markdown: string; multiPageSuffix: string }> {
+  if (includeSubPages && pageId) {
+    /* ...unchanged sub-page branch... */
+  }
+  const html = opts?.protectMedia ? protectMedia(content).html : content;
+  return { markdown: htmlToMarkdown(html), multiPageSuffix: '' };
+}
+```
+
+`llm-improve.ts:52` — pass the flag:
+
+```ts
+    const { markdown, multiPageSuffix } = await assembleContextIfNeeded(userId, body.pageId, content, includeSubPages, { protectMedia: true });
+```
+
+- [ ] **Step 4: Restore media + drop-guard on Accept**
+
+`llm-conversations.ts` — add `body_html` to the existing page SELECT (`:112-119`):
+
+```ts
+    const existing = await query<{
+      id: number; version: number; title: string; space_key: string;
+      source: string; confluence_id: string | null; body_html: string | null;
+    }>(
+      `SELECT id, version, title, space_key, source, confluence_id, body_html FROM pages
+       WHERE ${isNumericId ? 'id = $1' : 'confluence_id = $1'} AND deleted_at IS NULL`,
+      [isNumericId ? parseInt(pageId, 10) : pageId],
+    );
+```
+
+Replace the conversion (`:132-134`) with protect-derive + restore + guard:
+
+```ts
+    // #723: re-derive the same media tokens from the page's CURRENT body_html
+    // (deterministic, document order) and re-inject originals verbatim so AI
+    // Improve can never strip images/draw.io. Guard: re-append any media the LLM
+    // dropped entirely (token missing from the improved markdown).
+    const { media } = protectMedia(existingPage.body_html ?? '');
+    let bodyHtml = await markdownToHtml(improvedMarkdown);
+    bodyHtml = restoreMedia(bodyHtml, media);
+    const dropped = media.filter((m) => !bodyHtml.includes(m.html));
+    if (dropped.length > 0) {
+      bodyHtml += dropped.map((m) => m.html).join('\n');
+      fastify.log.warn({ pageId, dropped: dropped.length }, '#723: re-appended media dropped during AI Improve');
+    }
+    const bodyText = htmlToText(bodyHtml);
+```
+
+Import `protectMedia`, `restoreMedia` from `content-converter`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd backend && npx vitest run src/routes/llm/apply-improvement.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/routes/llm/_helpers.ts backend/src/routes/llm/llm-improve.ts backend/src/routes/llm/llm-conversations.ts backend/src/routes/llm/apply-improvement.test.ts
+git commit -m "fix(improve): protect media across the AI Improve round-trip + drop-guard (#723)"
+```
+
+---
+
+### Task 3: Converter coverage — lossless `confluence-drawio` turndown ↔ markdownToHtml
+
+**Files:**
+- Modify: `backend/src/core/services/content-converter.ts` (add a turndown rule near `:937`; add reconstruction in `markdownToHtml` at `:945`)
+- Test: `backend/src/core/services/content-converter.media.test.ts` (extend)
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+```ts
+it('drawio survives a direct htmlToMarkdown → markdownToHtml round-trip (#723 converter coverage)', async () => {
+  const html = '<div class="confluence-drawio" data-diagram-name="Net Arch"><img src="/api/attachments/5/Net%20Arch.png"></div>';
+  const md = htmlToMarkdown(html);
+  expect(md).toContain('```drawio');
+  expect(md).toContain('Net Arch');
+  const back = await markdownToHtml(md);
+  expect(back).toContain('class="confluence-drawio"');
+  expect(back).toContain('data-diagram-name="Net Arch"');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && npx vitest run src/core/services/content-converter.media.test.ts`
+Expected: FAIL — turndown flattens the drawio div; no `drawio` fence.
+
+- [ ] **Step 3: Add the turndown rule + reconstruction**
+
+In the turndown rules block (after the `panel` rule at `:929-937`):
+
+```ts
+  // #723: draw.io diagrams — emit a fenced block carrying the diagram name so
+  // markdownToHtml can rebuild the .confluence-drawio wrapper losslessly.
+  turndownService.addRule('confluenceDrawio', {
+    filter: (node) => node.nodeName === 'DIV' && node.classList.contains('confluence-drawio'),
+    replacement: (_content, node) => {
+      const name = (node as HTMLElement).getAttribute('data-diagram-name') ?? 'diagram';
+      return `\n\n\`\`\`drawio\n${name}\n\`\`\`\n\n`;
+    },
+  });
+```
+
+In `markdownToHtml` (`:945`), after the markdown→HTML conversion, post-process ```drawio fences back into the wrapper. If conversion uses `marked`, a ```drawio block becomes `<pre><code class="language-drawio">NAME\n</code></pre>`; rewrite those:
+
+```ts
+  // #723: rebuild draw.io wrappers from ```drawio fences.
+  html = html.replace(
+    /<pre><code class="language-drawio">([\s\S]*?)\n?<\/code><\/pre>/g,
+    (_m, name) => {
+      const safe = String(name).trim();
+      return `<div class="confluence-drawio" data-diagram-name="${safe.replace(/"/g, '&quot;')}"></div>`;
+    },
+  );
+```
+
+> Confirm the exact `<pre><code class="language-...">` shape your markdown lib emits (run `htmlToMarkdown`→`markdownToHtml` on a fixture and inspect) and adjust the regex to match.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && npx vitest run src/core/services/content-converter.media.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/core/services/content-converter.ts backend/src/core/services/content-converter.media.test.ts
+git commit -m "feat(content): lossless confluence-drawio turndown<->markdown rule (#723)"
+```
+
+---
+
+### Task 4: Docs + full verification
+
+**Files:**
+- Modify: `docs/architecture/11-content-pipeline.md` (note media protection in the AI Improve round-trip + the drawio fence rule)
+
+- [ ] **Step 1:** Update `docs/architecture/11-content-pipeline.md` with the placeholder-protection step and the new turndown rule.
+- [ ] **Step 2:** `cd backend && npx vitest run src/core/services/content-converter.media.test.ts src/routes/llm/apply-improvement.test.ts` — green.
+- [ ] **Step 3:** `cd backend && npm run lint && npm run typecheck` — clean.
+- [ ] **Step 4:** Open PR `fix(improve): preserve images and draw.io across AI Improve (#723)` targeting `dev`.
+
+## Acceptance mapping (#723)
+- Improve+Accept keeps image + drawio rendering → Tasks 1+2.
+- `data-confluence-*` and `.confluence-drawio`/`data-diagram-name` survive (write-back + edit button keep working) → Task 2 verbatim re-injection.
+- LLM cannot drop media → placeholder re-derivation + drop-guard (Task 2).
+- Tests cover image + drawio (+ mermaid/layout via the shared selector) → Tasks 1–3.

--- a/docs/superpowers/specs/2026-06-09-open-issues-batch-design.md
+++ b/docs/superpowers/specs/2026-06-09-open-issues-batch-design.md
@@ -1,0 +1,240 @@
+# Design: Implement open issues #718, #721, #722, #723, #724
+
+- **Date:** 2026-06-09
+- **Branch model:** feature branches off `dev`, PRs target `dev`
+- **Status:** Approved — ready for per-unit implementation plans
+
+## Summary
+
+Five filed issues are implemented in this batch. They collapse into **four
+independent work units** because #722 and #724 share the same files
+(`pages-versions.ts`, `VersionHistory.tsx`) and must be owned together. Each
+unit is implemented in its own git worktree by one member of an experimental
+agent team (TeamCreate), follows TDD, and produces a branch + PR targeting `dev`.
+
+| Unit | Issues | Touches | DB? | Contracts? | Migration? |
+|---|---|---|---|---|---|
+| **A** | #718 | frontend only | no | no | no |
+| **B** | #721 | backend + frontend | yes (purge) | maybe | no |
+| **C** | #723 | backend (converter + llm route) | apply-path test | no | no |
+| **D** | #722 + #724 | backend + frontend | yes | **yes** | **077** |
+
+Only **D** changes the migration sequence (077) and the `@compendiq/contracts`
+package, so there are no migration-number or contracts-dist collisions between
+parallel agents.
+
+## Decisions (locked)
+
+- Implement **all five** issues this round.
+- #722 depth: **metadata-list eager + lazy historical bodies** (bounded, respects
+  `CONFLUENCE_RATE_LIMIT_RPM`).
+- #723 fix: **both** placeholder-protection (round-trip safety) **and** converter
+  rules (general fidelity).
+- Unit A gates the Auto-tag button on an `aiConfigured` flag derived from the
+  **new** providers/usecase source, not the removed legacy settings fields.
+- Execution: experimental agent team, one member per unit, isolated worktrees;
+  backend units get isolated test Postgres + `fileParallelism:false`.
+
+---
+
+## Unit A — #718: restore the AI Auto-tag button (frontend only)
+
+**Root cause:** `ArticleRightPane` renders `AutoTagger` only when a derived
+`activeModel` is truthy, computed from **legacy** settings fields
+(`llmProvider`/`ollamaModel`/`openaiModel`) that ADR-021 / migration 054 emptied.
+So the button silently disappears.
+
+**Approach:**
+1. Delete the legacy `activeModel` derivation (`ArticleRightPane.tsx:207-210`).
+2. Remove `&& activeModel` from the three render gates — collapsed rail (`:511`),
+   edit mode (`:655`), read mode (`:678`).
+3. Make `AutoTagger`'s `model` prop **optional** (`AutoTagger.tsx:14-19`) and stop
+   sending `{ model }` when absent (`:29-31`) — the route resolves `auto_tag`
+   server-side (`pages-tags.ts`, `auto-tagger.ts` via `resolveUsecase('auto_tag')`).
+4. To avoid a dead button when **no** LLM is configured at all, gate on an
+   `aiConfigured` flag derived from the **new** provider/usecase source, mirroring
+   `AiContext.tsx:264-272` (`/llm/usecase-default?usecase=...` query) — not the
+   removed legacy fields.
+
+**Tests:** Rewrite `ArticleRightPane.test.tsx` to drop legacy
+`ollamaModel`/`llmProvider`; add a regression test asserting the button renders
+with the new provider model and **without** any legacy field, in read mode, edit
+mode, and the collapsed rail.
+
+**Acceptance:** button reappears below AI Improve in all three modes; clicking it
+calls `POST /pages/:id/auto-tag` with no legacy model; no dependence on removed
+`settings.llmProvider`/`openaiModel`/`ollamaModel`.
+
+---
+
+## Unit B — #721: unsync / remove a synced space (backend + frontend)
+
+**Root cause:** (1) For admins, `getUserAccessibleSpaces` returns **all** spaces,
+so the Spaces-tab "selected" set always re-includes a deselected space → deselect
+is a no-op. (2) Save/Sync are `disabled={selected.size === 0}`, so the last space
+can't be removed. (3) No endpoint deletes a synced `spaces` row + its pages.
+
+**Backend:**
+- New endpoint `DELETE /api/spaces/:key` (modeled on existing
+  `DELETE /api/spaces/local/:key`) that, for the target space:
+  - deletes its `pages` (embeddings/attachments cascade via FK) reusing the
+    existing per-space purge machinery (`purgeDeletedPages` /
+    `cleanPageAttachments` in `sync-service.ts`);
+  - deletes the `spaces` row;
+  - removes **all** `space_role_assignments` for that space (not just the caller's
+    editor row);
+  - is **read-only against Confluence** (no upstream writes);
+  - requires admin authorization.
+- Decouple the Spaces-tab "selected" set from `getUserAccessibleSpaces`. The tab's
+  selection should reflect **actually-synced spaces** (rows in `spaces`), so a
+  removal is visible to admins after refresh.
+
+**Frontend (`SpacesTab.tsx`):**
+- Add a per-space **Remove / stop syncing** action calling the new endpoint, with
+  a confirm dialog warning: *"This deletes synced pages locally — it does not
+  touch anything in Confluence."*
+- Relax `disabled={selected.size === 0}` on **Save** so an empty selection
+  persists (keep **Sync** disabled at 0).
+- After removal, refetch so the space disappears and stays gone.
+
+**Docs:** update `docs/architecture/08-flow-sync.md` (sync selection + purge path).
+
+**Acceptance:** an admin can remove a space; it stops syncing, its pages disappear
+locally, and it stays removed after refresh; removal works down to zero selected;
+cleans up pages/embeddings/attachments + all `space_role_assignments`; nothing
+deleted in Confluence; non-admin deselect still loses access without orphaned data.
+
+---
+
+## Unit C — #723: AI Improve must not destroy images / draw.io (backend)
+
+**Root cause:** AI Improve round-trips `bodyHtml` through Markdown
+(`htmlToMarkdown` → LLM → `markdownToHtml`). Markdown can't represent
+`.confluence-drawio` wrappers or `data-confluence-*` image metadata; turndown has
+no rule for them, so they're flattened/stripped and the lossy result overwrites
+the page on Accept.
+
+**Approach — both layers:**
+
+1. **Placeholder protection (primary, in the Improve round-trip):**
+   - Before `htmlToMarkdown` in `routes/llm/_helpers.ts:63`, replace `<img>`,
+     `.confluence-drawio`, mermaid, and layout/column nodes with opaque stable
+     tokens (e.g. `⟦MEDIA:0⟧`) and keep a token → original-HTML map.
+   - After `markdownToHtml` on Accept (`llm-conversations.ts:133-134`), re-inject
+     the originals verbatim by token. The LLM only ever sees/edits prose; media is
+     byte-identical.
+   - **Accept guard:** before save, diff drawio/attachment references in the
+     improved HTML vs the original; if any are missing, merge them back (defense in
+     depth) so Accept can never silently delete media.
+
+2. **Converter coverage (general fidelity):**
+   - Add a turndown rule for `confluence-drawio` (+ mermaid / layout / figure /
+     details) and a custom image rule preserving `data-confluence-*`, with matching
+     `markdownToHtml` reconstruction. Benefits every other `htmlToMarkdown` caller.
+
+**Tests:** a page containing an image + a draw.io diagram survives improve→apply
+with `data-confluence-*` and `.confluence-drawio` / `data-diagram-name` intact —
+including the "LLM drops the line" case (placeholders preserve it). Ideally cover
+mermaid/layout too.
+
+**Acceptance:** improve→Accept keeps images and diagrams rendering exactly as
+before; the Confluence write-back path (`htmlToConfluence` using
+`data-confluence-filename`) and the inline draw.io edit button keep working; the
+LLM cannot drop media.
+
+---
+
+## Unit D — #722 + #724: real Confluence version history (backend + frontend)
+
+**Root cause (#722):** Compendiq builds history forward from the first sync and
+never pulls existing Confluence history. The client has no version-history method;
+`page_versions` is filled only by local sync-time snapshots; the read path returns
+the synthetic current row + local snapshots. **(#724):** the timeline prints
+`syncedAt` (sync/snapshot time) as if it were the version's edit time, and the
+current row falls back to `new Date()` (page-load time) when `last_modified_at` is
+null.
+
+**Confluence client (`confluence-client.ts`):**
+- `getPageVersions(id, {start, limit})` → paginated list via
+  `GET /rest/api/content/{id}/version?expand=...`; each item yields `number`,
+  `when`, `by.displayName`/`by.username`, `message`, `minorEdit`. Page through
+  `_links.next` (default `limit` 20, max ~200). Cheap (metadata only).
+- `getHistoricalPageBody(id, n)` →
+  `GET /rest/api/content/{id}?status=historical&version={n}&expand=body.storage,version`
+  → XHTML storage; run through `confluenceToHtml` (ADR-003) before persisting
+  `body_html`/`body_text`, exactly like live pages.
+- Bearer-PAT auth; **read-only** (fetching historical content never mutates the
+  server). Mind documented DC stale-`version`/`modificationDate` → HTTP 500 quirks.
+
+**Schema (migration 077):**
+- Add `edited_at TIMESTAMPTZ`, `author TEXT`, `message TEXT` to `page_versions`.
+- Allow `body_html` / `body_text` to be **null** for metadata-only rows (lazy
+  bodies). Keep the `(page_id, version_number)` unique index.
+- Migration test under `migrations/__tests__/077_*.test.ts`.
+
+**Flow:**
+- During sync, eagerly upsert the **version-list metadata** (idempotent
+  `ON CONFLICT (page_id, version_number)`; update metadata when it becomes
+  available). Cheap; respects `CONFLUENCE_RATE_LIMIT_RPM`.
+- Fetch a historical **body only when** a version is previewed/compared/restored
+  and its body is null; then persist (converted) + serve. Lazy = bounded cost.
+- If any depth cap is applied, `log()` it (repo convention: no silent truncation).
+- **Standalone / local pages** (no `confluence_id` / non-Confluence space) keep the
+  local-snapshot behavior — no Confluence calls.
+
+**Read path + #724 fix:**
+- `GET /pages/:id/versions` returns real `editedAt` / `author` / `message`.
+- The timeline shows the real Confluence edit time + author + change message when
+  present; for local pages it falls back to a clearly **labeled** `Synced …`.
+- The synthetic current row returns `editedAt: null` (rendered "—"/"Unknown")
+  instead of `new Date()`, so the value is stable across reloads.
+
+**Contracts:** new `PageVersionSummary` schema in `packages/contracts/src/schemas`
+(`versionNumber`, `editedAt: string | null`, `syncedAt`, `author: string | null`,
+`message: string | null`, `isCurrent`), re-exported via the package index; frontend
+`PageVersionSummary` type mirrors it.
+
+**Restore / compare:** restore flows unchanged through `restoreVersion`
+(reads `page_versions`); preview/text-compare/AI-diff operate on the
+(lazily-filled) historical body.
+
+**Docs:** update `docs/architecture/06-data-model.md` (page_versions columns) and
+`08-flow-sync.md` (version backfill); note the historical-body conversion in
+`11-content-pipeline.md` if non-trivial.
+
+**Acceptance:** opening Version History on a Confluence-synced page shows the
+page's **actual** Confluence history (incl. versions before first sync and on a
+synced-once page); each entry shows the real edit timestamp, author, and change
+message; preview/compare/AI-diff/restore work against backfilled versions; backfill
+is idempotent, respects rate limits, and logs any cap; standalone pages keep
+working; viewing history pushes nothing to Confluence; the current row's timestamp
+is stable across reloads.
+
+---
+
+## Execution: experimental agent team (TeamCreate)
+
+- One team member per unit, each in its own git worktree off `dev`:
+  `feature/issue-718-autotag-button`, `feature/issue-721-space-unsync`,
+  `feature/issue-723-improve-media`, `feature/issue-722-724-version-history`.
+- **Parallel-infra safeguards** (known gotchas in this repo):
+  - Each **backend** unit (B, C, D) uses its **own isolated test Postgres
+    database** and runs vitest with `fileParallelism:false`; DB tests hit real
+    Postgres (never mocked).
+  - **D** owns the version-history contract (`PageVersionSummary`). **B** may add a
+    small space-unsync contract in a **different** schema file, so the two never
+    edit the same source. Because worktrees are isolated, each unit that changes
+    contracts rebuilds its **own** worktree's `@compendiq/contracts` dist (A/C, which
+    don't touch contracts, resolve to the main checkout's dist) — no cross-unit
+    collision either way.
+  - Only **D** adds a migration (077) — no number collisions.
+- Each unit: write spec → TDD implementation → `lint` + `typecheck` + `test` green
+  → branch + PR targeting `dev`. Each PR updates the relevant `docs/`,
+  `.env.example` (if applicable), and `CLAUDE.md` per the repo's documentation rule.
+
+## Out of scope / non-goals
+
+- No full eager backfill of every historical body (lazy bodies only).
+- No new Confluence **write** paths; all new Confluence calls are read-only.
+- No unrelated refactors beyond what each unit needs to land cleanly.
+- OIDC/SSO and other EE-only surfaces are untouched.

--- a/docs/superpowers/specs/2026-06-09-open-issues-batch-design.md
+++ b/docs/superpowers/specs/2026-06-09-open-issues-batch-design.md
@@ -26,8 +26,10 @@ parallel agents.
 ## Decisions (locked)
 
 - Implement **all five** issues this round.
-- #722 depth: **metadata-list eager + lazy historical bodies** (bounded, respects
-  `CONFLUENCE_RATE_LIMIT_RPM`).
+- #722 depth: **metadata-list backfilled lazily on History-dialog open + lazy
+  historical bodies** (bounded; pagination inherits the client's rate limiter /
+  `CONFLUENCE_RATE_LIMIT_RPM` token acquisition, plus a defensive max-iteration
+  cap in `getPageVersions`).
 - #723 fix: **both** placeholder-protection (round-trip safety) **and** converter
   rules (general fidelity).
 - Unit A gates the Auto-tag button on an `aiConfigured` flag derived from the
@@ -76,15 +78,35 @@ can't be removed. (3) No endpoint deletes a synced `spaces` row + its pages.
 
 **Backend:**
 - New endpoint `DELETE /api/spaces/:key` (modeled on existing
-  `DELETE /api/spaces/local/:key`) that, for the target space:
-  - deletes its `pages` (embeddings/attachments cascade via FK) reusing the
-    existing per-space purge machinery (`purgeDeletedPages` /
-    `cleanPageAttachments` in `sync-service.ts`);
+  `DELETE /api/spaces/local/:key`) backed by an exported `unsyncSpace(spaceKey)`
+  purge in the confluence domain that, for the target space:
+  - deletes its `pages` with a raw `DELETE FROM pages WHERE space_key = $1`; the
+    `page_id` FK (migration 030) cascades the delete to `page_embeddings` and
+    `page_versions`. (As-built it does **not** call `purgeDeletedPages`, which is
+    the soft-delete-reconciliation path; the unsync path is a hard purge relying on
+    the FK cascade.)
   - deletes the `spaces` row;
-  - removes **all** `space_role_assignments` for that space (not just the caller's
-    editor row);
+  - reconciles **orphaned `space_key` rows** that carry no FK to `spaces` (see the
+    orphan-reconciliation note below);
   - is **read-only against Confluence** (no upstream writes);
   - requires admin authorization.
+- **Transactionality (as-built):** all row deletes/updates run inside a single
+  `BEGIN`/`COMMIT` transaction on one pooled client (`getPool().connect()`), with
+  `ROLLBACK` + re-throw on any error. Filesystem attachment cleanup
+  (`cleanPageAttachments` per page) is **best-effort and runs OUTSIDE the
+  transaction, before it opens** — a file-cleanup failure is logged and never
+  aborts the DB work. Worst case is a few orphaned files if the transaction later
+  rolls back; a re-run of unsync sweeps them again.
+- **Orphan reconciliation (all inside the transaction):**
+  - `DELETE` all `space_role_assignments` for the space — this table holds RBAC
+    **and** encodes the sync selection (the old `user_space_selections` table was
+    migrated into it and **DROPPED in migration 040**; it no longer exists).
+  - `DELETE` `oidc_group_role_mappings` rows whose `space_key` matches the space
+    (a non-null `space_key` row maps a group into *this* space and is meaningless
+    once the space is gone; global `space_key IS NULL` rows are untouched).
+  - `UPDATE … SET space_key = NULL` on `templates` and `knowledge_requests` — these
+    may hold user-authored content, so we **detach** (retain the row, NULL the
+    nullable `space_key`) rather than destroy work.
 - Decouple the Spaces-tab "selected" set from `getUserAccessibleSpaces`. The tab's
   selection should reflect **actually-synced spaces** (rows in `spaces`), so a
   removal is visible to admins after refresh.
@@ -101,8 +123,11 @@ can't be removed. (3) No endpoint deletes a synced `spaces` row + its pages.
 
 **Acceptance:** an admin can remove a space; it stops syncing, its pages disappear
 locally, and it stays removed after refresh; removal works down to zero selected;
-cleans up pages/embeddings/attachments + all `space_role_assignments`; nothing
-deleted in Confluence; non-admin deselect still loses access without orphaned data.
+cleans up pages/embeddings/attachments + all `space_role_assignments` +
+space-scoped `oidc_group_role_mappings`, and detaches `templates` /
+`knowledge_requests` (NULL `space_key`); the DB work is atomic (single
+transaction, rollback on error); nothing deleted in Confluence; non-admin deselect
+still loses access without orphaned data.
 
 ---
 
@@ -127,10 +152,16 @@ the page on Accept.
      improved HTML vs the original; if any are missing, merge them back (defense in
      depth) so Accept can never silently delete media.
 
-2. **Converter coverage (general fidelity):**
-   - Add a turndown rule for `confluence-drawio` (+ mermaid / layout / figure /
-     details) and a custom image rule preserving `data-confluence-*`, with matching
-     `markdownToHtml` reconstruction. Benefits every other `htmlToMarkdown` caller.
+2. **Converter coverage (general fidelity, acknowledged-lossy):**
+   - Add a turndown rule for `confluence-drawio` with matching `markdownToHtml`
+     reconstruction. **As-built this rule is name-only**: it emits a ```drawio fence
+     carrying just `data-diagram-name`, and `markdownToHtml` rebuilds a bare
+     `<div class="confluence-drawio" data-diagram-name="…">` — it does **not**
+     preserve the inner `<img>` attachment ref or the inline edit link. So on the
+     pure-converter path (any non-improve `htmlToMarkdown` caller) the diagram is
+     **lossy** (degrades to name-only), not lossless. Losslessness for AI Improve is
+     guaranteed by the placeholder-protection layer above (which protects the whole
+     `div.confluence-drawio` wrapper byte-for-byte), **not** by this converter rule.
 
 **Tests:** a page containing an image + a draw.io diagram survives improve→apply
 with `data-confluence-*` and `.confluence-drawio` / `data-diagram-name` intact —
@@ -155,10 +186,15 @@ current row falls back to `new Date()` (page-load time) when `last_modified_at` 
 null.
 
 **Confluence client (`confluence-client.ts`):**
-- `getPageVersions(id, {start, limit})` → paginated list via
-  `GET /rest/api/content/{id}/version?expand=...`; each item yields `number`,
-  `when`, `by.displayName`/`by.username`, `message`, `minorEdit`. Page through
-  `_links.next` (default `limit` 20, max ~200). Cheap (metadata only).
+- `getPageVersions(id)` → paginated list via
+  `GET /rest/api/content/{id}/version?expand=by,message&start=&limit=100`; each
+  item yields `number`, `when`, `by.displayName`, `message`, `minorEdit`. Pages
+  through `_links.next` (limit 100). Cheap (metadata only). **Throttle/cap live
+  here:** every request goes through the client's private `fetchOnce`, which calls
+  `acquireToken()` (the per-instance rate limiter / `CONFLUENCE_RATE_LIMIT_RPM`), so
+  pagination is automatically throttled; a defensive `maxIterations = 1000` guard
+  plus an empty-results break guarantee termination even on a misbehaving
+  self-referential `_links.next`.
 - `getHistoricalPageBody(id, n)` →
   `GET /rest/api/content/{id}?status=historical&version={n}&expand=body.storage,version`
   → XHTML storage; run through `confluenceToHtml` (ADR-003) before persisting
@@ -173,12 +209,15 @@ null.
 - Migration test under `migrations/__tests__/077_*.test.ts`.
 
 **Flow:**
-- During sync, eagerly upsert the **version-list metadata** (idempotent
-  `ON CONFLICT (page_id, version_number)`; update metadata when it becomes
-  available). Cheap; respects `CONFLUENCE_RATE_LIMIT_RPM`.
+- **Lazily** upsert the **version-list metadata** when the History dialog opens
+  (`GET /pages/:id/versions`), not eagerly during sync — best-effort, never fails
+  the dialog. Idempotent `ON CONFLICT (page_id, version_number)`; metadata is
+  updated when it becomes available. Cheap; throttled by the client rate limiter
+  (see above).
 - Fetch a historical **body only when** a version is previewed/compared/restored
   and its body is null; then persist (converted) + serve. Lazy = bounded cost.
-- If any depth cap is applied, `log()` it (repo convention: no silent truncation).
+- The list-pagination cap/break and the rate-limit throttle both live in
+  `getPageVersions`/`fetchOnce` (no silent truncation in normal operation).
 - **Standalone / local pages** (no `confluence_id` / non-Confluence space) keep the
   local-snapshot behavior — no Confluence calls.
 
@@ -190,25 +229,39 @@ null.
   instead of `new Date()`, so the value is stable across reloads.
 
 **Contracts:** new `PageVersionSummary` schema in `packages/contracts/src/schemas`
-(`versionNumber`, `editedAt: string | null`, `syncedAt`, `author: string | null`,
-`message: string | null`, `isCurrent`), re-exported via the package index; frontend
-`PageVersionSummary` type mirrors it.
+(`versionNumber`, `title`, `editedAt: string | null`, `syncedAt: string | null`,
+`author: string | null`, `message: string | null`, `isCurrent`), re-exported via
+the package index; frontend `PageVersionSummary` type mirrors it. As-built the
+package also adds `PageVersionsResponseSchema` (`{ versions, pageId }`) and a new
+`PageVersionDetailSchema` for the single-version response (nullable `bodyHtml` /
+`bodyText`, optional metadata). The route **validates** its responses with
+`PageVersionsResponseSchema.parse(...)` / `PageVersionDetailSchema.parse(...)`.
 
-**Restore / compare:** restore flows unchanged through `restoreVersion`
-(reads `page_versions`); preview/text-compare/AI-diff operate on the
-(lazily-filled) historical body.
+**Restore / compare (data-loss fix):** backfilled rows are metadata-only
+(`body_html IS NULL`) until previewed.
+- **Restore** first lazy-fetches a NULL (never-previewed) historical body via
+  `getHistoricalBody` *before* restoring; `restoreVersion` additionally guards
+  (ROLLBACK + throw) if the resolved body is still empty, rather than blanking the
+  live page or pushing an empty body upstream to Confluence.
+- **Semantic-diff (AI-diff)** lazy-fetches **both** versions' bodies before diffing
+  (so metadata-only rows don't diff as "all content removed"), and resolves its
+  model from the `chat` use-case server-side (`resolveUsecase('chat')`,
+  `model || resolvedModel`) — no hardcoded model is required from the client.
+- Preview/text-compare operate on the (lazily-filled) historical body.
 
 **Docs:** update `docs/architecture/06-data-model.md` (page_versions columns) and
 `08-flow-sync.md` (version backfill); note the historical-body conversion in
 `11-content-pipeline.md` if non-trivial.
 
-**Acceptance:** opening Version History on a Confluence-synced page shows the
-page's **actual** Confluence history (incl. versions before first sync and on a
-synced-once page); each entry shows the real edit timestamp, author, and change
-message; preview/compare/AI-diff/restore work against backfilled versions; backfill
-is idempotent, respects rate limits, and logs any cap; standalone pages keep
-working; viewing history pushes nothing to Confluence; the current row's timestamp
-is stable across reloads.
+**Acceptance:** opening Version History on a Confluence-synced page lazily backfills
+and shows the page's **actual** Confluence history (incl. versions before first
+sync and on a synced-once page); each entry shows the real edit timestamp, author,
+and change message; preview/compare/AI-diff/restore work against backfilled
+versions (lazy-fetching NULL bodies first, with the restore data-loss guard);
+backfill is idempotent and throttled by the client rate limiter (pagination cap in
+`getPageVersions`); standalone pages keep working; viewing history pushes nothing to
+Confluence; the current row's `editedAt` is `null` (rendered "—"/"Unknown") and
+stable across reloads.
 
 ---
 


### PR DESCRIPTION
## Summary
Adds the design spec and per-unit implementation plans used to deliver the five issues, under `docs/superpowers/`.

- `docs/superpowers/specs/2026-06-09-open-issues-batch-design.md` — approved design decomposing the work into four units.
- `docs/superpowers/plans/2026-06-09-issue-*.md` — one TDD plan per unit.

Docs only; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)