### PR TITLE
fix(security): block stored XSS via local attachments served with client-controlled Content-Type

### DIFF
--- a/backend/src/routes/knowledge/local-attachments.test.ts
+++ b/backend/src/routes/knowledge/local-attachments.test.ts
@@ -184,6 +184,83 @@ describe('Local Attachment Routes', () => {
     expect(serviceMocks.putLocalAttachment).not.toHaveBeenCalled();
   });
 
+  // ── upload MIME allowlist (#735 stored-XSS hardening) ──────────────────
+
+  it('rejects a text/html data URI with 400 UNSUPPORTED_CONTENT_TYPE', async () => {
+    const html = '<script>alert(document.domain)</script>';
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/local-attachments/42/evil.html',
+      payload: { dataUri: `data:text/html;base64,${Buffer.from(html).toString('base64')}` },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('UNSUPPORTED_CONTENT_TYPE');
+    expect(serviceMocks.putLocalAttachment).not.toHaveBeenCalled();
+  });
+
+  it('rejects a text/javascript data URI with 400 UNSUPPORTED_CONTENT_TYPE', async () => {
+    const js = 'fetch("/steal?t="+localStorage.token)';
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/local-attachments/42/x.js',
+      payload: { dataUri: `data:text/javascript;base64,${Buffer.from(js).toString('base64')}` },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('UNSUPPORTED_CONTENT_TYPE');
+    expect(serviceMocks.putLocalAttachment).not.toHaveBeenCalled();
+  });
+
+  it('rejects MIME allowlist bypass attempts via uppercase (TEXT/HTML)', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/local-attachments/42/evil.html',
+      payload: { dataUri: 'data:TEXT/HTML;base64,AAAA' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('UNSUPPORTED_CONTENT_TYPE');
+    expect(serviceMocks.putLocalAttachment).not.toHaveBeenCalled();
+  });
+
+  it('rejects an application/octet-stream data URI (not on the allowlist)', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/local-attachments/42/blob.bin',
+      payload: { dataUri: 'data:application/octet-stream;base64,AAAA' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('UNSUPPORTED_CONTENT_TYPE');
+    expect(serviceMocks.putLocalAttachment).not.toHaveBeenCalled();
+  });
+
+  it('accepts an application/pdf data URI', async () => {
+    serviceMocks.putLocalAttachment.mockResolvedValueOnce({
+      id: 10,
+      pageId: 42,
+      filename: 'doc.pdf',
+      contentType: 'application/pdf',
+      sizeBytes: 8,
+      sha256: 'sha',
+      createdBy: 'test-user-id',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/local-attachments/42/doc.pdf',
+      payload: { dataUri: `data:application/pdf;base64,${Buffer.from('%PDF-1.4').toString('base64')}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(serviceMocks.putLocalAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: 'application/pdf' }),
+    );
+  });
+
   // ── GET one: SVG response hardening ────────────────────────────────────
 
   it('sets CSP sandbox + content-disposition=attachment on SVG responses', async () => {
@@ -238,6 +315,133 @@ describe('Local Attachment Routes', () => {
     expect(res.headers['content-type']).toContain('png');
     expect(res.headers['content-disposition']).toBe('inline');
     expect(res.headers['content-security-policy']).toBeUndefined();
+  });
+
+  // ── GET one: server-derived Content-Type (#735 stored-XSS hardening) ───
+  //
+  // The stored (client-supplied) content_type must never be echoed for
+  // inline rendering. Content-Type is derived server-side from the filename
+  // extension; anything that is not a safe raster image is forced to
+  // download (`content-disposition: attachment`) with CSP `sandbox`, and
+  // every response carries `x-content-type-options: nosniff`.
+
+  const baseRecord = {
+    id: 100,
+    pageId: 42,
+    sizeBytes: 10,
+    sha256: 'sha',
+    createdBy: 'test-user-id',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it('does not serve a previously-stored text/html row inline as text/html', async () => {
+    serviceMocks.getLocalAttachment.mockResolvedValueOnce({
+      data: Buffer.from('<script>alert(1)</script>'),
+      record: { ...baseRecord, filename: 'evil.html', contentType: 'text/html' },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/local-attachments/42/evil.html',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).not.toContain('text/html');
+    expect(res.headers['content-type']).toContain('application/octet-stream');
+    expect(res.headers['content-disposition']).toBe('attachment');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['content-security-policy']).toBe('sandbox');
+  });
+
+  it('does not serve a previously-stored text/javascript row as JavaScript', async () => {
+    serviceMocks.getLocalAttachment.mockResolvedValueOnce({
+      data: Buffer.from('fetch("/steal")'),
+      record: { ...baseRecord, filename: 'x.js', contentType: 'text/javascript' },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/local-attachments/42/x.js',
+    });
+
+    expect(res.statusCode).toBe(200);
+    // With nosniff + a non-JS Content-Type, <script src> refuses to execute.
+    expect(res.headers['content-type']).not.toContain('javascript');
+    expect(res.headers['content-type']).toContain('application/octet-stream');
+    expect(res.headers['content-disposition']).toBe('attachment');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('derives Content-Type from the filename, not the stored MIME', async () => {
+    // Stored MIME claims image/png but the filename is .html — the
+    // extension allowlist wins and the file is forced to download.
+    serviceMocks.getLocalAttachment.mockResolvedValueOnce({
+      data: Buffer.from('<script>alert(1)</script>'),
+      record: { ...baseRecord, filename: 'spoofed.html', contentType: 'image/png' },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/local-attachments/42/spoofed.html',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('application/octet-stream');
+    expect(res.headers['content-disposition']).toBe('attachment');
+  });
+
+  it('serves raster images inline with nosniff', async () => {
+    serviceMocks.getLocalAttachment.mockResolvedValueOnce({
+      data: Buffer.from(VALID_PNG_B64, 'base64'),
+      record: { ...baseRecord, filename: 'photo.png', contentType: 'image/png' },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/local-attachments/42/photo.png',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('image/png');
+    expect(res.headers['content-disposition']).toBe('inline');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('serves PDFs as attachment with a server-derived application/pdf type', async () => {
+    serviceMocks.getLocalAttachment.mockResolvedValueOnce({
+      data: Buffer.from('%PDF-1.4'),
+      record: { ...baseRecord, filename: 'doc.pdf', contentType: 'application/pdf' },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/local-attachments/42/doc.pdf',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('application/pdf');
+    expect(res.headers['content-disposition']).toBe('attachment');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('serves .drawio XML siblings as attachment with CSP sandbox', async () => {
+    serviceMocks.getLocalAttachment.mockResolvedValueOnce({
+      data: Buffer.from('<mxfile/>'),
+      record: { ...baseRecord, filename: 'diagram.drawio', contentType: 'application/xml' },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/local-attachments/42/diagram.drawio',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('application/xml');
+    // XML can smuggle XHTML/script — never render it inline.
+    expect(res.headers['content-disposition']).toBe('attachment');
+    expect(res.headers['content-security-policy']).toBe('sandbox');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
   });
 
   // ── XML sibling: filename transform + write ────────────────────────────

--- a/backend/src/routes/knowledge/local-attachments.ts
+++ b/backend/src/routes/knowledge/local-attachments.ts
@@ -19,7 +19,42 @@ import {
   LocalAttachmentError,
   MAX_LOCAL_ATTACHMENT_BYTES,
 } from '../../core/services/local-attachment-service.js';
+import { getMimeType } from '../../domains/confluence/services/attachment-handler.js';
 import { logger } from '../../core/utils/logger.js';
+
+/**
+ * Upload-time MIME allowlist (#735). Local attachments exist for editor
+ * images, draw.io PNG exports, and document files — never for active
+ * content. `text/html`, `text/javascript`, etc. would be stored same-origin
+ * under /api/local-attachments and turn into stored XSS, so anything not on
+ * this list is rejected with 400. The draw.io XML sibling does not pass
+ * through this check — it arrives via the separate `xml` body field and is
+ * stored server-side as `application/xml`.
+ */
+const ALLOWED_UPLOAD_MIME_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+  'application/pdf',
+]);
+
+/**
+ * MIME types that may render inline in the browser. Restricted to inert
+ * raster images: SVG/XML/PDF/unknown are forced to download with CSP
+ * `sandbox` because they can carry script (SVG, XHTML-in-XML) or embed
+ * active content (PDF). Content-Type is derived server-side from the
+ * filename extension (`getMimeType`, unknown → application/octet-stream) —
+ * the stored, client-supplied MIME is never echoed back (#735).
+ */
+const INLINE_SAFE_MIME_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
 
 const PageIdParamSchema = z.object({
   pageId: z.coerce.number().int().positive(),
@@ -32,8 +67,9 @@ const PageIdAndFilenameParamSchema = z.object({
 
 const PutLocalAttachmentBodySchema = z.object({
   /**
-   * Base64 data URI. Accepts any image/* MIME (draw.io PNGs, pasted JPEGs,
-   * SVGs) plus `application/*`. Non-data-URI values are rejected.
+   * Base64 data URI. The MIME must be on `ALLOWED_UPLOAD_MIME_TYPES`
+   * (raster images, SVG, PDF) — active/text types such as `text/html` are
+   * rejected with 400 (#735). Non-data-URI values are rejected.
    */
   dataUri: z.string().min(1, 'dataUri is required'),
   /**
@@ -43,12 +79,16 @@ const PutLocalAttachmentBodySchema = z.object({
   xml: z.string().max(25 * 1024 * 1024, 'XML exceeds 25 MB limit').optional(),
 });
 
-/** Parse `data:<mime>;base64,<payload>` → `{ contentType, buffer }`. */
+/**
+ * Parse `data:<mime>;base64,<payload>` → `{ contentType, buffer }`.
+ * The MIME is lowercased so the allowlist check in the PUT handler cannot
+ * be bypassed with `data:TEXT/HTML;…`.
+ */
 function decodeDataUri(dataUri: string): { contentType: string; buffer: Buffer } | null {
   const match = /^data:([^;]+);base64,(.+)$/.exec(dataUri);
   if (!match) return null;
-  const contentType = match[1]!.trim();
-  if (!/^[a-z0-9.+-]+\/[a-z0-9.+-]+$/i.test(contentType)) return null;
+  const contentType = match[1]!.trim().toLowerCase();
+  if (!/^[a-z0-9.+-]+\/[a-z0-9.+-]+$/.test(contentType)) return null;
   try {
     const buffer = Buffer.from(match[2]!, 'base64');
     return { contentType, buffer };
@@ -103,23 +143,29 @@ export async function localAttachmentsRoutes(fastify: FastifyInstance): Promise<
     const { pageId, filename } = PageIdAndFilenameParamSchema.parse(request.params);
     try {
       const { data, record } = await getLocalAttachment(pageId, filename, request.userId);
+      // #735: Content-Type is derived server-side from the filename
+      // extension (`getMimeType`, unknown → application/octet-stream),
+      // mirroring the Confluence attachment route. The stored MIME is
+      // client-supplied at upload time and is never echoed back, so a
+      // pre-existing `text/html` / `text/javascript` row cannot render or
+      // execute same-origin. Only inert raster images render inline;
+      // everything else (SVG, XML, PDF, unknown) downloads with CSP
+      // `sandbox` as defence in depth.
+      const mimeType = getMimeType(record.filename);
+      const inline = INLINE_SAFE_MIME_TYPES.has(mimeType);
       reply
-        .header('content-type', record.contentType)
+        .header('content-type', mimeType)
+        .header('x-content-type-options', 'nosniff')
         .header('cache-control', 'private, max-age=3600')
-        // SVG comes with the same sandbox+attachment hardening as the
-        // Confluence route to keep the attack surface identical.
-        .header(
-          'content-disposition',
-          record.contentType.includes('svg') ? 'attachment' : 'inline',
-        );
-      if (record.contentType.includes('svg')) {
+        .header('content-disposition', inline ? 'inline' : 'attachment');
+      if (!inline) {
         reply.header('content-security-policy', 'sandbox');
       }
-      // `data` is the raw attachment bytes — not HTML. Content-Type is the
-      // stored MIME (png/jpeg/xml/svg); SVGs additionally carry CSP
-      // `sandbox` + `content-disposition: attachment` to block inline
-      // script execution. Semgrep's "writing to Response" rule can't
-      // distinguish binary downloads from HTML bodies.
+      // `data` is the raw attachment bytes — not HTML. The Content-Type is
+      // allowlisted above (inline = raster images only; anything else is a
+      // sandboxed download), so this cannot reflect active content.
+      // Semgrep's "writing to Response" rule can't distinguish binary
+      // downloads from HTML bodies.
       // nosemgrep
       return reply.send(data);
     } catch (err) {
@@ -147,6 +193,16 @@ export async function localAttachmentsRoutes(fastify: FastifyInstance): Promise<
     if (!decoded) {
       reply.code(400);
       return { error: 'BAD_DATA_URI', message: 'dataUri must be a base64-encoded data URI' };
+    }
+    // #735: reject active/text MIME types (text/html, text/javascript, …)
+    // at the door — anything stored here is served same-origin under
+    // /api/local-attachments and must never be script-capable.
+    if (!ALLOWED_UPLOAD_MIME_TYPES.has(decoded.contentType)) {
+      reply.code(400);
+      return {
+        error: 'UNSUPPORTED_CONTENT_TYPE',
+        message: `Unsupported content type: ${decoded.contentType}. Allowed: ${[...ALLOWED_UPLOAD_MIME_TYPES].join(', ')}`,
+      };
     }
     if (decoded.buffer.length > MAX_LOCAL_ATTACHMENT_BYTES) {
       reply.code(413);


### PR DESCRIPTION
## Root cause

`PUT /api/local-attachments/:pageId/:filename` accepted **any** syntactically valid MIME in the upload data URI (`decodeDataUri` only checked the `type/subtype` shape), stored it verbatim in `local_attachments.content_type`, and `GET` echoed it back with `content-disposition: inline` for everything except SVG. An authenticated user could upload `evil.html` (`text/html`) plus `x.js` (`text/javascript`) to any **shared** standalone page and have them rendered/executed same-origin under `/api/local-attachments/...` — stored XSS reaching the `localStorage` access token (CWE-79). The route set no `nosniff`/CSP itself, so the entire mitigation rested on the nginx proxy.

## Fix (`backend/src/routes/knowledge/local-attachments.ts`)

Mirrors the already-hardened Confluence attachment route:

- **Upload-time MIME allowlist** — data-URI MIME must be one of `image/png|jpeg|jpg|gif|webp|svg+xml` or `application/pdf`; everything else (incl. `text/html`, `text/javascript`) → `400 UNSUPPORTED_CONTENT_TYPE`. MIME is lowercased before the check so `TEXT/HTML` can't bypass it. The draw.io `.drawio` sibling is unaffected (separate `xml` field, server-assigned `application/xml`).
- **Server-derived Content-Type on GET** — response type comes from the filename extension via the same `getMimeType` allowlist used by `routes/confluence/attachments.ts` (unknown → `application/octet-stream`). The stored client-supplied MIME is never echoed, which also **defuses pre-existing malicious rows** (`evil.html` stored as `text/html` now downloads as `application/octet-stream`).
- **Inline only for inert raster images** (png/jpeg/gif/webp). SVG, XML/`.drawio`, PDF, and unknown types get `Content-Disposition: attachment` + `Content-Security-Policy: sandbox`.
- **`X-Content-Type-Options: nosniff` on every GET response** — defense on the route itself, not just at nginx; with a non-JS Content-Type this kills the `<script src>` chain-around described in the issue.

Legitimate flows verified unaffected: draw.io save/drain PUTs `image/png` data URIs (allowed); diagram editing fetches the PNG via `fetch()` → blob (ignores `Content-Disposition`, `.png` still derives `image/png`); editor `<img>` rendering of raster images stays `inline`.

## Test evidence

TDD: 10 new regression tests added to `backend/src/routes/knowledge/local-attachments.test.ts`, watched fail (10 failed / 17 passed), then pass after the fix:

- PUT rejects `text/html`, `text/javascript`, `TEXT/HTML` (case bypass), `application/octet-stream` with 400; accepts `application/pdf`
- GET never serves a previously-stored `text/html` row as HTML, nor `text/javascript` as JS (octet-stream + attachment + nosniff + sandbox)
- GET derives Content-Type from filename, not stored MIME (spoofed `.html` w/ `image/png` row → download)
- Raster images still served inline with nosniff; PDFs `application/pdf` + attachment; `.drawio` XML attachment + sandbox

```
vitest run src/routes/knowledge/local-attachments.test.ts src/core/services/local-attachment-service.test.ts
Test Files  2 passed (2)   Tests  40 passed (40)   (service suite against real Postgres)
```

`npm run lint -w backend` and `npm run typecheck -w backend` both clean.

## Notes

- No contract change needed — error shape reuses the route's existing `{ error, message }` envelope.
- Behavior change: SVG/PDF/XML/unknown local attachments now download instead of rendering inline (security hardening; no frontend flow renders them inline).
- No architecture diagram applies (route-level hardening; no structural/flow change) — flagging per CLAUDE.md rule 6.

Fixes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)