### PR TITLE
fix(llm): block cross-user writes to private standalone pages via improvements/apply (IDOR)

### DIFF
--- a/backend/src/routes/llm/apply-improvement-idor.test.ts
+++ b/backend/src/routes/llm/apply-improvement-idor.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { setupTestDb, truncateAllTables, teardownTestDb, isDbAvailable } from '../../test-db-helper.js';
+import { query } from '../../core/db/postgres.js';
+import { buildApp } from '../../app.js';
+import { generateAccessToken } from '../../core/plugins/auth.js';
+
+// Regression tests for #734: IDOR on POST /api/llm/improvements/apply.
+// Any authenticated user could overwrite another user's *private* standalone
+// page because the handler resolved the page without checking
+// created_by_user_id / visibility. These tests run against real Postgres
+// (test-db-helper) with the full app (real auth, real route), mirroring the
+// llm-providers.test.ts pattern. Confluence-sourced pages are out of scope:
+// that branch pushes through the caller's own Confluence client, so
+// Confluence ACLs apply.
+
+const dbAvailable = await isDbAvailable();
+
+const ORIGINAL_TITLE = 'Owner private notes';
+const ORIGINAL_HTML = '<p>Original secret content</p>';
+const ORIGINAL_TEXT = 'Original secret content';
+const ORIGINAL_VERSION = 3;
+
+async function createUser(username: string): Promise<{ token: string; userId: string }> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO users (username, password_hash) VALUES ($1, 'fakehash') RETURNING id`,
+    [username],
+  );
+  const userId = result.rows[0]!.id;
+  await query('INSERT INTO user_settings (user_id) VALUES ($1)', [userId]);
+  const token = await generateAccessToken({ sub: userId, username, role: 'user' });
+  return { token, userId };
+}
+
+async function createStandalonePage(opts: {
+  ownerId: string;
+  visibility: 'private' | 'shared';
+  title?: string;
+}): Promise<number> {
+  const res = await query<{ id: number }>(
+    `INSERT INTO pages (
+       title, body_html, body_text, version, source,
+       created_by_user_id, visibility, embedding_dirty, embedding_status
+     ) VALUES ($1, $2, $3, $4, 'standalone', $5, $6, FALSE, 'not_embedded')
+     RETURNING id`,
+    [opts.title ?? ORIGINAL_TITLE, ORIGINAL_HTML, ORIGINAL_TEXT, ORIGINAL_VERSION, opts.ownerId, opts.visibility],
+  );
+  return res.rows[0]!.id;
+}
+
+async function fetchPage(id: number) {
+  const res = await query<{ title: string; body_html: string; body_text: string; version: number }>(
+    'SELECT title, body_html, body_text, version FROM pages WHERE id = $1',
+    [id],
+  );
+  return res.rows[0]!;
+}
+
+function applyPayload(pageId: number, extra: Record<string, unknown> = {}) {
+  return {
+    method: 'POST' as const,
+    url: '/api/llm/improvements/apply',
+    payload: JSON.stringify({
+      pageId: String(pageId),
+      improvedMarkdown: '# Overwritten\n\nAttacker controlled content.',
+      ...extra,
+    }),
+  };
+}
+
+let app: FastifyInstance;
+let owner: { token: string; userId: string };
+let attacker: { token: string; userId: string };
+
+beforeAll(async () => {
+  if (!dbAvailable) return;
+  await setupTestDb();
+  app = await buildApp();
+  await app.ready();
+}, 30_000);
+
+afterAll(async () => {
+  if (!dbAvailable) return;
+  await app?.close();
+  await teardownTestDb();
+});
+
+beforeEach(async () => {
+  if (!dbAvailable) return;
+  await truncateAllTables();
+  owner = await createUser('idor_owner');
+  attacker = await createUser('idor_attacker');
+});
+
+describe.skipIf(!dbAvailable)('POST /api/llm/improvements/apply — standalone page IDOR (#734)', () => {
+  it('returns 404 for a cross-user apply on a private standalone page and leaves content unchanged', async () => {
+    const pageId = await createStandalonePage({ ownerId: owner.userId, visibility: 'private' });
+
+    // No `version` in the payload — the exact lock-bypass vector from the issue.
+    const response = await app.inject({
+      ...applyPayload(pageId, { title: 'pwned' }),
+      headers: { authorization: `Bearer ${attacker.token}`, 'content-type': 'application/json' },
+    });
+
+    expect(response.statusCode).toBe(404);
+    // The response must not leak the page's real title or version.
+    expect(response.body).not.toContain(ORIGINAL_TITLE);
+    expect(response.body).not.toContain(`"version":${ORIGINAL_VERSION}`);
+
+    const page = await fetchPage(pageId);
+    expect(page.title).toBe(ORIGINAL_TITLE);
+    expect(page.body_html).toBe(ORIGINAL_HTML);
+    expect(page.body_text).toBe(ORIGINAL_TEXT);
+    expect(page.version).toBe(ORIGINAL_VERSION);
+  });
+
+  it('returns 404 (not 409) for a stale-version cross-user apply — no existence oracle', async () => {
+    const pageId = await createStandalonePage({ ownerId: owner.userId, visibility: 'private' });
+
+    // A 409 here would confirm the page exists and that its version is > 1.
+    const response = await app.inject({
+      ...applyPayload(pageId, { version: 1 }),
+      headers: { authorization: `Bearer ${attacker.token}`, 'content-type': 'application/json' },
+    });
+
+    expect(response.statusCode).toBe(404);
+
+    const page = await fetchPage(pageId);
+    expect(page.body_html).toBe(ORIGINAL_HTML);
+    expect(page.version).toBe(ORIGINAL_VERSION);
+  });
+
+  it('still lets the owner apply an improvement to their own private standalone page', async () => {
+    const pageId = await createStandalonePage({ ownerId: owner.userId, visibility: 'private' });
+
+    const response = await app.inject({
+      ...applyPayload(pageId, { version: ORIGINAL_VERSION, title: 'Improved title' }),
+      headers: { authorization: `Bearer ${owner.token}`, 'content-type': 'application/json' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ id: pageId, title: 'Improved title', version: ORIGINAL_VERSION + 1 });
+
+    const page = await fetchPage(pageId);
+    expect(page.title).toBe('Improved title');
+    expect(page.body_html).toContain('Overwritten');
+    expect(page.version).toBe(ORIGINAL_VERSION + 1);
+  });
+
+  it('still lets any authenticated user apply an improvement to a shared standalone page', async () => {
+    const pageId = await createStandalonePage({ ownerId: owner.userId, visibility: 'shared', title: 'Team page' });
+
+    const response = await app.inject({
+      ...applyPayload(pageId, { version: ORIGINAL_VERSION }),
+      headers: { authorization: `Bearer ${attacker.token}`, 'content-type': 'application/json' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ id: pageId, title: 'Team page', version: ORIGINAL_VERSION + 1 });
+
+    const page = await fetchPage(pageId);
+    expect(page.body_html).toContain('Overwritten');
+    expect(page.version).toBe(ORIGINAL_VERSION + 1);
+  });
+});

--- a/backend/src/routes/llm/apply-improvement-media.test.ts
+++ b/backend/src/routes/llm/apply-improvement-media.test.ts
@@ -137,6 +137,9 @@ describe('POST /api/llm/improvements/apply — drop-guard with REAL restoreMedia
           rows: [{
             id: 42, version: 5, title: 'My Article', space_key: 'OPS',
             source: 'standalone', confluence_id: null, body_html: bodyHtmlWithMedia,
+            // #734: the page-resolve query now returns ownership fields; the
+            // test user must own this private standalone page to write it.
+            created_by_user_id: 'user-123', visibility: 'private',
           }],
         });
       }
@@ -176,6 +179,8 @@ describe('POST /api/llm/improvements/apply — drop-guard with REAL restoreMedia
           rows: [{
             id: 42, version: 5, title: 'My Article', space_key: 'OPS',
             source: 'standalone', confluence_id: null, body_html: bodyHtmlWithMedia,
+            // #734: owner of the private standalone page (see test above).
+            created_by_user_id: 'user-123', visibility: 'private',
           }],
         });
       }

--- a/backend/src/routes/llm/llm-conversations.ts
+++ b/backend/src/routes/llm/llm-conversations.ts
@@ -112,8 +112,10 @@ export async function llmConversationRoutes(fastify: FastifyInstance) {
     const existing = await query<{
       id: number; version: number; title: string; space_key: string;
       source: string; confluence_id: string | null; body_html: string | null;
+      created_by_user_id: string | null; visibility: string;
     }>(
-      `SELECT id, version, title, space_key, source, confluence_id, body_html FROM pages
+      `SELECT id, version, title, space_key, source, confluence_id, body_html,
+              created_by_user_id, visibility FROM pages
        WHERE ${isNumericId ? 'id = $1' : 'confluence_id = $1'} AND deleted_at IS NULL`,
       [isNumericId ? parseInt(pageId, 10) : pageId],
     );
@@ -122,6 +124,22 @@ export async function llmConversationRoutes(fastify: FastifyInstance) {
     }
 
     const existingPage = existing.rows[0]!;
+
+    // IDOR guard (#734): a standalone page is writable only by its owner
+    // unless it is explicitly shared — same rule as PATCH /pages/:id.
+    // Respond 404 (not 403/409) so another user's private page never leaks
+    // its existence, title, or version; this must run before the version
+    // check below to avoid a 404-vs-409 existence oracle. Confluence-sourced
+    // pages are not gated here: that branch pushes through the caller's own
+    // Confluence client, so Confluence ACLs apply.
+    if (
+      existingPage.source === 'standalone' &&
+      existingPage.created_by_user_id !== userId &&
+      existingPage.visibility !== 'shared'
+    ) {
+      throw fastify.httpErrors.notFound('Page not found');
+    }
+
     const currentVersion = existingPage.version;
     const pageTitle = title ?? existingPage.title;
 


### PR DESCRIPTION
## Root cause

`POST /api/llm/improvements/apply` (`backend/src/routes/llm/llm-conversations.ts`) resolved the target page by caller-supplied `pageId` with only `deleted_at IS NULL` — it never selected or checked `created_by_user_id` / `visibility`. For `source = 'standalone'` it then ran the raw `UPDATE pages …` with attacker-controlled markdown, so **any authenticated user could overwrite another user's private standalone page** (IDOR, CWE-639) and learn its title/version from the response. A stale `version` also returned a 409, confirming the page's existence. Confluence-sourced pages were never affected: that branch pushes through the caller's own Confluence client, so Confluence ACLs apply.

## Fix

- The page-resolve query now also selects `created_by_user_id` and `visibility`.
- Standalone pages are rejected with **404 "Page not found"** unless the caller owns the page or it is `visibility = 'shared'` — the same rule `PATCH /pages/:id` enforces (`pages-crud.ts`). 404 (not 403) so existence/title/version of another user's private page never leaks.
- The guard runs **before** the optimistic-lock check, closing the 404-vs-409 existence oracle.
- Confluence branch unchanged (covered upstream by Confluence ACLs via `getClientForUser(userId)`).

## Optimistic-lock tradeoff (deliberately unchanged)

The issue suggested making `version` required in `ApplyImprovementRequestSchema`. The contract is left as-is (`version` optional) and the lock semantics are unchanged, because:

- The frontend (`ImproveMode.tsx`) always sends `version`, but the contract documents it as optional and the sibling `PATCH /pages/:id` standalone path uses the identical `version !== undefined && version < currentVersion` check — requiring it here would break contract-conforming API callers and diverge from the canonical page-edit route.
- With ownership enforced, omitting `version` is no longer a security bypass: it only skips lost-update detection among writers already authorized for the page (and such a writer can trivially read the current version first anyway).

If we want `version` to be mandatory, that should be a coordinated contract + frontend + `PATCH /pages/:id` change in a follow-up.

## Tests (TDD — failing first, real Postgres, full app with real auth)

New `backend/src/routes/llm/apply-improvement-idor.test.ts` (test-db-helper + `buildApp()` + real JWTs; before the fix the two cross-user cases failed with 200-overwrite and 409 respectively):

- cross-user apply on a private standalone page (no `version` — the exact bypass vector) → **404**, response leaks nothing, DB row byte-identical
- cross-user apply with stale `version` → **404, not 409** (no existence oracle), content unchanged
- owner apply on own private page → still **200**, version bumped, content updated
- any-user apply on a shared page → still **200** (shared pages are intentionally any-user-editable)

Updated `apply-improvement-media.test.ts` mocks to carry the new ownership fields (test user owns the standalone page).

```
Test Files  3 passed (3)   apply-improvement-idor / apply-improvement / apply-improvement-media
     Tests  16 passed (16)
Test Files  2 passed (2)   llm-conversations / app
     Tests  24 passed (24)
```

`npm run lint -w backend` and `npm run typecheck -w backend` clean.

## Docs note (CLAUDE.md rule 6)

No architecture diagram structurally changes: `docs/architecture/11-content-pipeline.md` documents the apply route's media restore mechanics only, and the auth-flow diagrams cover authentication, not per-route authorization. Flagging here per the rule in case maintainers want the ownership rule noted somewhere.

Fixes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)