### PR TITLE
fix(queue): legacy mode (USE_BULLMQ=false) silently no-oped enqueueJob

### DIFF
--- a/backend/src/core/services/queue-service.test.ts
+++ b/backend/src/core/services/queue-service.test.ts
@@ -328,6 +328,58 @@ describe('queue-service', () => {
     });
   });
 
+  // ─── BullMQ mode (USE_BULLMQ=true) — startQueueWorkers ─────────────────
+  // Guards the data-retention scheduler relocation (issue #741 follow-up):
+  // the upsertJobScheduler call moved out of registerAllWorkers (which now
+  // also runs in legacy mode and must stay Redis-pure) into the BullMQ-only
+  // branch of startQueueWorkers. The legacy-purity test below only proves the
+  // call is GONE from legacy mode — this one proves it still HAPPENS in
+  // BullMQ mode, on the right queue, with the right id and repeat options.
+  describe('BullMQ mode (USE_BULLMQ=true) — scheduler registration', () => {
+    const ORIGINAL_USE_BULLMQ = process.env.USE_BULLMQ;
+
+    beforeEach(() => {
+      process.env.USE_BULLMQ = 'true';
+    });
+
+    afterEach(() => {
+      if (ORIGINAL_USE_BULLMQ === undefined) {
+        delete process.env.USE_BULLMQ;
+      } else {
+        process.env.USE_BULLMQ = ORIGINAL_USE_BULLMQ;
+      }
+    });
+
+    it('startQueueWorkers registers the daily data-retention scheduler on the maintenance queue', async () => {
+      const { startQueueWorkers } = await import('./queue-service.js');
+      await startQueueWorkers();
+
+      const maintenance = queueStubs.get('maintenance');
+      expect(maintenance).toBeDefined();
+      expect(maintenance!.upsertJobScheduler).toHaveBeenCalledWith(
+        'data-retention-scheduler',
+        { every: 24 * 60 * 60 * 1000 },
+        { name: 'data-retention' },
+      );
+    });
+
+    it('startQueueWorkers also keeps the maintenance queue repeatable (token cleanup) — two schedulers on one queue', async () => {
+      const { startQueueWorkers } = await import('./queue-service.js');
+      await startQueueWorkers();
+
+      const maintenance = queueStubs.get('maintenance')!;
+      // maintenance-scheduler comes from the workerDef repeatPattern;
+      // data-retention-scheduler from the explicit post-loop registration.
+      // Asserting both proves the relocation didn't mistarget or collapse them.
+      expect(maintenance.upsertJobScheduler).toHaveBeenCalledTimes(2);
+      expect(maintenance.upsertJobScheduler).toHaveBeenCalledWith(
+        'maintenance-scheduler',
+        { every: 24 * 60 * 60 * 1000 },
+        { name: 'maintenance' },
+      );
+    });
+  });
+
   // ─── Issue #741 — legacy mode (USE_BULLMQ=false) ──────────────────────
   // enqueueJob's inline fallback must actually execute the registered
   // processor (it previously found no workerDefs because registerAllWorkers

--- a/backend/src/core/services/queue-service.test.ts
+++ b/backend/src/core/services/queue-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ─── BullMQ mock wiring ──────────────────────────────────────────────────
 // Each test needs fine-grained control over Job methods (getState, remove).
@@ -71,6 +71,67 @@ vi.mock('bullmq', () => ({
     this.on = vi.fn();
     this.close = vi.fn().mockResolvedValue(undefined);
   },
+}));
+
+// ─── Legacy-mode module mocks (issue #741) ───────────────────────────────
+// `startLegacyWorkers()` / the registered processors dynamically import these
+// modules. `vi.hoisted` keeps the vi.fn references stable across the
+// `vi.resetModules()` call in beforeEach (factories re-run on re-import, but
+// they all close over this same object).
+
+const legacy = vi.hoisted(() => ({
+  startSyncWorker: vi.fn(),
+  stopSyncWorker: vi.fn(),
+  runScheduledSync: vi.fn(),
+  startQualityWorker: vi.fn(),
+  stopQualityWorker: vi.fn(),
+  triggerQualityBatch: vi.fn(),
+  processBatch: vi.fn(),
+  startSummaryWorker: vi.fn(),
+  stopSummaryWorker: vi.fn(),
+  triggerSummaryBatch: vi.fn(),
+  runSummaryBatch: vi.fn(),
+  startTokenCleanupWorker: vi.fn(),
+  stopTokenCleanupWorker: vi.fn(),
+  startRetentionWorker: vi.fn(),
+  stopRetentionWorker: vi.fn(),
+  runRetentionCleanup: vi.fn(),
+  runReembedAllJob: vi.fn(),
+}));
+
+vi.mock('../../domains/confluence/services/sync-service.js', () => ({
+  startSyncWorker: legacy.startSyncWorker,
+  stopSyncWorker: legacy.stopSyncWorker,
+  runScheduledSync: legacy.runScheduledSync,
+}));
+
+vi.mock('../../domains/knowledge/services/quality-worker.js', () => ({
+  startQualityWorker: legacy.startQualityWorker,
+  stopQualityWorker: legacy.stopQualityWorker,
+  triggerQualityBatch: legacy.triggerQualityBatch,
+  processBatch: legacy.processBatch,
+}));
+
+vi.mock('../../domains/knowledge/services/summary-worker.js', () => ({
+  startSummaryWorker: legacy.startSummaryWorker,
+  stopSummaryWorker: legacy.stopSummaryWorker,
+  triggerSummaryBatch: legacy.triggerSummaryBatch,
+  runSummaryBatch: legacy.runSummaryBatch,
+}));
+
+vi.mock('./token-cleanup-service.js', () => ({
+  startTokenCleanupWorker: legacy.startTokenCleanupWorker,
+  stopTokenCleanupWorker: legacy.stopTokenCleanupWorker,
+}));
+
+vi.mock('./data-retention-service.js', () => ({
+  startRetentionWorker: legacy.startRetentionWorker,
+  stopRetentionWorker: legacy.stopRetentionWorker,
+  runRetentionCleanup: legacy.runRetentionCleanup,
+}));
+
+vi.mock('../../domains/llm/services/embedding-service.js', () => ({
+  runReembedAllJob: legacy.runReembedAllJob,
 }));
 
 vi.mock('../db/postgres.js', () => ({
@@ -264,6 +325,125 @@ describe('queue-service', () => {
 
       // Stub got created lazily
       expect(queueStubs.has('reembed-all')).toBe(true);
+    });
+  });
+
+  // ─── Issue #741 — legacy mode (USE_BULLMQ=false) ──────────────────────
+  // enqueueJob's inline fallback must actually execute the registered
+  // processor (it previously found no workerDefs because registerAllWorkers
+  // only ran in the BullMQ branch), and a rejecting processor must be logged
+  // instead of becoming a process-fatal unhandled rejection.
+  describe('legacy mode (USE_BULLMQ=false) — issue #741', () => {
+    const ORIGINAL_USE_BULLMQ = process.env.USE_BULLMQ;
+
+    beforeEach(() => {
+      process.env.USE_BULLMQ = 'false';
+      // Fake timers so startLegacyWorkers' 30s initial-batch setTimeout does
+      // not leave a real pending timer behind after each test.
+      vi.useFakeTimers();
+      legacy.triggerQualityBatch.mockResolvedValue(undefined);
+      legacy.triggerSummaryBatch.mockResolvedValue(undefined);
+      legacy.runReembedAllJob.mockResolvedValue('processed=0 failed=0 total=0');
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      if (ORIGINAL_USE_BULLMQ === undefined) {
+        delete process.env.USE_BULLMQ;
+      } else {
+        process.env.USE_BULLMQ = ORIGINAL_USE_BULLMQ;
+      }
+    });
+
+    it('enqueueJob runs the registered reembed-all processor inline after startQueueWorkers()', async () => {
+      const { startQueueWorkers, enqueueJob } = await import('./queue-service.js');
+      await startQueueWorkers();
+
+      // Legacy interval workers still start (ordering regression guard).
+      expect(legacy.startSyncWorker).toHaveBeenCalledOnce();
+      expect(legacy.startQualityWorker).toHaveBeenCalledOnce();
+
+      const id = await enqueueJob(
+        'reembed-all',
+        { triggeredAt: 't' },
+        { jobId: 'reembed-all' },
+      );
+      expect(id).toBe('reembed-all');
+
+      // Fire-and-forget inline execution — wait for the async processor.
+      await vi.waitFor(() => {
+        expect(legacy.runReembedAllJob).toHaveBeenCalledOnce();
+      });
+      expect(legacy.runReembedAllJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'reembed-all',
+          name: 'reembed-all',
+          data: { triggeredAt: 't' },
+        }),
+      );
+    });
+
+    it('does not create any BullMQ queues or schedulers in legacy mode', async () => {
+      const { startQueueWorkers } = await import('./queue-service.js');
+      await startQueueWorkers();
+
+      // Registering worker defs for the inline fallback must not open Redis
+      // connections — no Queue construction, no upsertJobScheduler.
+      expect(queueStubs.size).toBe(0);
+    });
+
+    it('logs instead of crashing when an inline processor rejects', async () => {
+      legacy.runReembedAllJob.mockRejectedValue(new Error('embed boom'));
+      const { startQueueWorkers, enqueueJob } = await import('./queue-service.js');
+      const { logger } = await import('../utils/logger.js');
+      await startQueueWorkers();
+
+      await enqueueJob('reembed-all', {}, { jobId: 'reembed-all' });
+
+      // The rejection must be caught and logged — an uncaught rejection here
+      // would be process-fatal on modern Node.
+      await vi.waitFor(() => {
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            err: expect.objectContaining({ message: 'embed boom' }),
+            queueName: 'reembed-all',
+          }),
+          expect.any(String),
+        );
+      });
+    });
+
+    it('warns when enqueueJob targets a queue with no registered processor', async () => {
+      const { startQueueWorkers, enqueueJob } = await import('./queue-service.js');
+      const { logger } = await import('../utils/logger.js');
+      await startQueueWorkers();
+
+      const id = await enqueueJob('no-such-queue', {});
+
+      expect(id).toContain('no-such-queue');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ queueName: 'no-such-queue' }),
+        expect.any(String),
+      );
+    });
+
+    it('catches rejections from the delayed initial quality/summary batch trigger', async () => {
+      legacy.triggerQualityBatch.mockRejectedValue(new Error('quality boom'));
+      const { startQueueWorkers } = await import('./queue-service.js');
+      const { logger } = await import('../utils/logger.js');
+      await startQueueWorkers();
+
+      // Fire the 30s initial-batch setTimeout.
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await vi.waitFor(() => {
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            err: expect.objectContaining({ message: 'quality boom' }),
+          }),
+          expect.any(String),
+        );
+      });
     });
   });
 });

--- a/backend/src/core/services/queue-service.ts
+++ b/backend/src/core/services/queue-service.ts
@@ -104,15 +104,19 @@ function registerWorkerDef(def: WorkerDef): void {
  * Registers repeatable jobs and starts processing.
  */
 export async function startQueueWorkers(): Promise<void> {
+  // Register worker definitions in BOTH modes: the BullMQ branch wires them
+  // into Workers below; the legacy branch needs them so enqueueJob()'s
+  // inline-processor fallback can find something to execute (issue #741 —
+  // without this, e.g. POST /api/admin/embedding/reembed silently no-oped
+  // when USE_BULLMQ=false).
+  registerAllWorkers();
+
   if (!USE_BULLMQ) {
     logger.info('BullMQ disabled (USE_BULLMQ=false), using setInterval workers');
     return startLegacyWorkers();
   }
 
   logger.info('Starting BullMQ queue workers...');
-
-  // Register all worker definitions
-  await registerAllWorkers();
 
   // Create workers for each definition
   for (const def of workerDefs) {
@@ -176,6 +180,17 @@ export async function startQueueWorkers(): Promise<void> {
     }
   }
 
+  // Schedule additional data retention job (daily, on the maintenance queue).
+  // Lives here (not in registerAllWorkers) because it opens a Redis-backed
+  // queue — registerAllWorkers also runs in legacy mode and must stay pure.
+  const retentionHours = 24;
+  const maintenanceQueue = getOrCreateQueue('maintenance');
+  await maintenanceQueue.upsertJobScheduler(
+    'data-retention-scheduler',
+    { every: retentionHours * 60 * 60 * 1000 },
+    { name: 'data-retention' },
+  );
+
   // Register analytics-aggregation queue for future EE use
   getOrCreateQueue('analytics-aggregation');
 
@@ -225,7 +240,8 @@ export async function stopQueueWorkers(): Promise<void> {
  *     That's the "collapse concurrent POSTs" semantic.
  *
  * When BullMQ is disabled (`USE_BULLMQ=false`) this runs the queue's
- * registered processor inline synchronously (legacy fallback behaviour).
+ * registered processor inline, fire-and-forget (legacy fallback behaviour).
+ * Processor errors are logged, not propagated to the caller.
  */
 export async function enqueueJob(
   queueName: string,
@@ -238,14 +254,30 @@ export async function enqueueJob(
     if (def) {
       // Fire-and-forget inline execution. We don't await so the caller
       // observes the same "enqueue returns before processing finishes"
-      // contract as the BullMQ path.
-      void def.processor({
-        id: fakeId,
-        name: queueName,
-        data,
-        updateProgress: async () => {},
-        remove: async () => {},
-      } as unknown as Job);
+      // contract as the BullMQ path. The .catch() is mandatory — a processor
+      // rejection would otherwise be an unhandled rejection (process-fatal
+      // on modern Node). Issue #741.
+      def
+        .processor({
+          id: fakeId,
+          name: queueName,
+          data,
+          updateProgress: async () => {},
+          remove: async () => {},
+        } as unknown as Job)
+        .catch((err: unknown) => {
+          logger.error(
+            { err, queueName, jobId: fakeId },
+            'Legacy inline job processor failed',
+          );
+        });
+    } else {
+      // No registered processor — surface this loudly instead of silently
+      // returning a fake id for work that will never run (issue #741).
+      logger.warn(
+        { queueName },
+        'enqueueJob: no registered worker for queue in legacy mode — job will not run',
+      );
     }
     return fakeId;
   }
@@ -334,12 +366,16 @@ export async function getQueueMetrics(): Promise<
 
 // ─── Register all workers ────────────────────────────────────────────────────
 
-async function registerAllWorkers(): Promise<void> {
+/**
+ * Populate `workerDefs`. Runs in BOTH modes (issue #741): BullMQ mode turns
+ * each def into a Worker; legacy mode uses the defs for enqueueJob()'s inline
+ * fallback. Must stay pure — no Queue creation / Redis access here.
+ */
+function registerAllWorkers(): void {
   const syncInterval = parseInt(process.env.SYNC_INTERVAL_MIN ?? '15', 10);
   const qualityInterval = parseInt(process.env.QUALITY_CHECK_INTERVAL_MINUTES ?? '60', 10);
   const summaryInterval = parseInt(process.env.SUMMARY_CHECK_INTERVAL_MINUTES ?? '60', 10);
   const tokenCleanupHours = parseInt(process.env.TOKEN_CLEANUP_INTERVAL_HOURS ?? '24', 10);
-  const retentionHours = 24;
 
   // Sync worker
   registerWorkerDef({
@@ -406,14 +442,6 @@ async function registerAllWorkers(): Promise<void> {
     },
   });
 
-  // Schedule additional data retention job (daily, on the maintenance queue)
-  const maintenanceQueue = getOrCreateQueue('maintenance');
-  await maintenanceQueue.upsertJobScheduler(
-    'data-retention-scheduler',
-    { every: retentionHours * 60 * 60 * 1000 },
-    { name: 'data-retention' },
-  );
-
   // Re-embed-all worker (issue #257) — NO repeatPattern: triggered on-demand
   // by `enqueueReembedAll` via `POST /api/admin/embedding/reembed`.
   // Concurrency 1 so a global re-embed is a true exclusive operation.
@@ -452,10 +480,15 @@ async function startLegacyWorkers(): Promise<void> {
   startTokenCleanupWorker();
   startRetentionWorker();
 
-  // Initial batches after 30s delay
-  setTimeout(async () => {
-    await triggerQualityBatch();
-    await triggerSummaryBatch();
+  // Initial batches after 30s delay. The .catch() prevents a batch failure
+  // from becoming an unhandled rejection inside the timer callback (#741).
+  setTimeout(() => {
+    (async () => {
+      await triggerQualityBatch();
+      await triggerSummaryBatch();
+    })().catch((err: unknown) => {
+      logger.error({ err }, 'Legacy initial batch trigger failed');
+    });
   }, 30_000);
 }
 

--- a/backend/src/core/services/queue-service.ts
+++ b/backend/src/core/services/queue-service.ts
@@ -238,6 +238,10 @@ export async function stopQueueWorkers(): Promise<void> {
  *     NOT remove it — the duplicate `add()` is ignored by BullMQ (emitting a
  *     `duplicated` event) and the second caller observes the same jobId.
  *     That's the "collapse concurrent POSTs" semantic.
+ *   - This idempotency model is BullMQ-only: legacy mode ignores `opts.jobId`
+ *     and runs the processor for every call, so concurrent POSTs do NOT
+ *     collapse there — reembed self-guards downstream via the Redis
+ *     embedding lock instead.
  *
  * When BullMQ is disabled (`USE_BULLMQ=false`) this runs the queue's
  * registered processor inline, fire-and-forget (legacy fallback behaviour).
@@ -372,6 +376,11 @@ export async function getQueueMetrics(): Promise<
  * fallback. Must stay pure — no Queue creation / Redis access here.
  */
 function registerAllWorkers(): void {
+  // Re-entrancy guard: startQueueWorkers() is called once at startup today,
+  // but a second call must not duplicate every def (legacy enqueueJob picks
+  // the FIRST match; BullMQ mode would double-create Workers).
+  workerDefs.length = 0;
+
   const syncInterval = parseInt(process.env.SYNC_INTERVAL_MIN ?? '15', 10);
   const qualityInterval = parseInt(process.env.QUALITY_CHECK_INTERVAL_MINUTES ?? '60', 10);
   const summaryInterval = parseInt(process.env.SUMMARY_CHECK_INTERVAL_MINUTES ?? '60', 10);


### PR DESCRIPTION
## Root cause

`workerDefs` is populated only by `registerAllWorkers()`, which ran **only** in the BullMQ branch of `startQueueWorkers()`. With `USE_BULLMQ=false` (documented, supported toggle), `startLegacyWorkers()` never registered any defs, so `enqueueJob()`'s inline fallback found no processor, executed nothing, and still returned a generated job id. Net effect: `POST /api/admin/embedding/reembed` reported success while no re-embed ever ran in legacy deployments.

Two latent crash vectors on the same paths: the inline `void def.processor(...)` had no `.catch()`, and the legacy 30s initial-batch trigger used `setTimeout(async () => { await ... })` — either rejection became an unhandled promise rejection (process-fatal on modern Node).

## Fix (`backend/src/core/services/queue-service.ts`)

- `registerAllWorkers()` now runs in **both** modes, before the legacy branch returns. It is now a pure, synchronous registration function: the `data-retention-scheduler` `upsertJobScheduler` call moved into the BullMQ branch of `startQueueWorkers()`, so legacy mode never opens a Redis-backed BullMQ queue (covered by a regression test asserting zero `Queue` constructions in legacy mode).
- The inline fire-and-forget processor invocation now has `.catch(err => logger.error(...))`; when no processor is registered for the queue, a `logger.warn` is emitted instead of silently returning a fake id.
- The initial-batch `setTimeout` body is wrapped so rejections are logged (`Legacy initial batch trigger failed`) instead of crashing the process.
- `enqueueJob` JSDoc corrected ("inline, fire-and-forget", errors logged not propagated).

## Test evidence (TDD)

5 new regression tests in `backend/src/core/services/queue-service.test.ts` under `legacy mode (USE_BULLMQ=false) — issue #741`, written first and observed failing (4 failed + 1 unhandled `Error: quality boom` rejection caught by Vitest, reproducing the issue exactly):

- `enqueueJob runs the registered reembed-all processor inline after startQueueWorkers()`
- `does not create any BullMQ queues or schedulers in legacy mode` (guard for the scheduler move)
- `logs instead of crashing when an inline processor rejects`
- `warns when enqueueJob targets a queue with no registered processor`
- `catches rejections from the delayed initial quality/summary batch trigger`

After the fix:
- `queue-service.test.ts`: 15/15 passed (10 pre-existing + 5 new), no unhandled errors
- `embedding-service.test.ts` + `health.test.ts` (the other importers of queue-service): 102/102 passed
- `npm run lint -w backend` and `npm run typecheck -w backend`: clean

Mocking follows the existing suite's pattern (BullMQ `Queue`/`Worker` stubs, DB `query` and logger mocks); legacy worker modules are mocked at the module boundary since CI cannot reach Confluence/Ollama.

## Diagrams

Checked `docs/architecture/02-container.md` — it only states that workers "fall back to interval-based polling when `USE_BULLMQ=false`", which is unchanged by this fix (no structural change), so no diagram update is needed.

Fixes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-up (c7ed3da)

Addressed the adversarial-review findings:

1. **[warning] BullMQ-side coverage for the relocated data-retention scheduler** — added a `USE_BULLMQ=true` `startQueueWorkers()` test block (using the suite's existing `queueStubs` constructor-capture pattern) asserting `upsertJobScheduler('data-retention-scheduler', { every: 86_400_000 }, { name: 'data-retention' })` fires on the `maintenance` queue, plus that the queue's own `maintenance-scheduler` repeatable is still registered (2 calls total — proves the relocation neither dropped nor mistargeted either). Red-check: temporarily commenting out the upsert made both new tests fail while the legacy-purity test stayed green — exactly the one-directional gap the review flagged — then restored.
2. **[info] JSDoc idempotency divergence** — `enqueueJob`'s idempotency section now documents that the `jobId` collapse-concurrent-POSTs model is BullMQ-only; legacy mode ignores `opts.jobId` (reembed self-guards via the downstream Redis embedding lock).
3. **[info] `registerAllWorkers()` re-entrancy** — clears `workerDefs` at the top so a second `startQueueWorkers()` call can't duplicate defs. Verified no test relies on accumulation (each test gets a fresh module via `vi.resetModules()`).

Gates after follow-up: `queue-service.test.ts` 17/17, `embedding-service.test.ts` 87/87 (104 total), backend lint + typecheck clean.
