### PR TITLE
fix(security): require admin + SSRF guard on POST /api/setup/llm-test

### DIFF
--- a/backend/src/core/utils/ssrf-guard.test.ts
+++ b/backend/src/core/utils/ssrf-guard.test.ts
@@ -9,6 +9,7 @@ vi.mock('node:dns/promises', () => ({
 import {
   validateUrl,
   validateUrlWithDns,
+  validateUrlSyntaxAndProtocol,
   SsrfError,
   addAllowedBaseUrl,
   addAllowedBaseUrlSilent,
@@ -187,6 +188,56 @@ describe('SSRF Guard', () => {
         expect(e).toBeInstanceOf(SsrfError);
         expect((e as SsrfError).name).toBe('SsrfError');
       }
+    });
+  });
+
+  describe('validateUrlSyntaxAndProtocol (non-mutating, admin-trust flows)', () => {
+    afterEach(() => {
+      clearAllowedBaseUrls();
+    });
+
+    it('should allow public HTTP(S) URLs', () => {
+      expect(() => validateUrlSyntaxAndProtocol('http://api.example.com/v1')).not.toThrow();
+      expect(() => validateUrlSyntaxAndProtocol('https://api.openai.com/v1')).not.toThrow();
+    });
+
+    it('should allow private-network and loopback hosts (auth gate is the control)', () => {
+      expect(() => validateUrlSyntaxAndProtocol('http://localhost:11434/v1')).not.toThrow();
+      expect(() => validateUrlSyntaxAndProtocol('http://127.0.0.1:11434/v1')).not.toThrow();
+      expect(() => validateUrlSyntaxAndProtocol('http://10.0.0.5:8000/v1')).not.toThrow();
+      expect(() => validateUrlSyntaxAndProtocol('http://192.168.1.50:1234/v1')).not.toThrow();
+      expect(() => validateUrlSyntaxAndProtocol('http://vllm.internal:8000/v1')).not.toThrow();
+    });
+
+    it('should block non-HTTP(S) protocols', () => {
+      expect(() => validateUrlSyntaxAndProtocol('file:///etc/passwd')).toThrow(SsrfError);
+      expect(() => validateUrlSyntaxAndProtocol('ftp://internal.server/file')).toThrow(/protocol.*not allowed/);
+      expect(() => validateUrlSyntaxAndProtocol('gopher://internal.server')).toThrow(SsrfError);
+    });
+
+    it('should throw SsrfError on unparseable URLs', () => {
+      expect(() => validateUrlSyntaxAndProtocol('not-a-url')).toThrow(SsrfError);
+      expect(() => validateUrlSyntaxAndProtocol('not-a-url')).toThrow(/invalid URL/);
+      expect(() => validateUrlSyntaxAndProtocol('')).toThrow(SsrfError);
+    });
+
+    it('should never mutate the global allowlist', () => {
+      expect(getAllowedBaseUrlCount()).toBe(0);
+      validateUrlSyntaxAndProtocol('http://10.0.0.5:8000/v1');
+      expect(() => validateUrlSyntaxAndProtocol('ftp://blocked.example')).toThrow(SsrfError);
+      expect(getAllowedBaseUrlCount()).toBe(0);
+      // validateUrl must still apply full private-network blocking afterwards
+      expect(() => validateUrl('http://10.0.0.5:8000/v1')).toThrow(SsrfError);
+    });
+
+    it('should not consult the allowlist (private host passes with or without an entry)', () => {
+      addAllowedBaseUrlSilent('http://10.0.0.5:8000');
+      expect(() => validateUrlSyntaxAndProtocol('http://10.0.0.5:8000/v1')).not.toThrow();
+      removeAllowedBaseUrlSilent('http://10.0.0.5:8000');
+      expect(() => validateUrlSyntaxAndProtocol('http://10.0.0.5:8000/v1')).not.toThrow();
+      // ...but protocol restrictions hold even for allowlisted origins
+      addAllowedBaseUrlSilent('ftp://10.0.0.5:8000');
+      expect(() => validateUrlSyntaxAndProtocol('ftp://10.0.0.5:8000')).toThrow(SsrfError);
     });
   });
 

--- a/backend/src/core/utils/ssrf-guard.ts
+++ b/backend/src/core/utils/ssrf-guard.ts
@@ -215,6 +215,42 @@ export class SsrfError extends Error {
 }
 
 /**
+ * Non-mutating syntax + protocol validation: the URL must parse and use
+ * HTTP(S). Private/internal hosts are NOT blocked, and the process-global
+ * allowlist is neither consulted nor modified.
+ *
+ * Use for admin-gated flows that probe a caller-supplied URL WITHOUT
+ * persisting it (e.g. the setup wizard's `POST /setup/llm-test`). For such
+ * flows the effective policy of `validateUrl` on an allowlisted origin is
+ * exactly "parses + HTTP(S)"; calling this directly avoids round-tripping
+ * the global allowlist, which would transiently exempt the origin for every
+ * other flow on the pod and race concurrent allowlist mutations from the
+ * admin provider routes (PR #751 review). The caller's auth gate
+ * (`requireAdmin`) is the real control — the same trust model as the admin
+ * LLM-provider routes.
+ *
+ * Returns the parsed URL so `validateUrl` can build on it without
+ * re-parsing.
+ *
+ * @throws SsrfError when the URL fails to parse or uses a non-HTTP(S) protocol
+ */
+export function validateUrlSyntaxAndProtocol(urlString: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    throw new SsrfError('SSRF blocked: invalid URL');
+  }
+
+  // Block non-HTTP(S) protocols
+  if (!ALLOWED_PROTOCOLS.includes(parsed.protocol)) {
+    throw new SsrfError(`SSRF blocked: protocol '${parsed.protocol}' is not allowed. Only HTTP(S) permitted.`);
+  }
+
+  return parsed;
+}
+
+/**
  * Validates a URL to prevent SSRF attacks.
  * Blocks private IPs, internal hostnames, and non-HTTP(S) protocols.
  *
@@ -227,17 +263,11 @@ export class SsrfError extends Error {
  * @throws SsrfError if the URL targets a private/internal address
  */
 export function validateUrl(urlString: string): void {
-  let parsed: URL;
-  try {
-    parsed = new URL(urlString);
-  } catch {
-    throw new SsrfError('SSRF blocked: invalid URL');
-  }
-
-  // Block non-HTTP(S) protocols
-  if (!ALLOWED_PROTOCOLS.includes(parsed.protocol)) {
-    throw new SsrfError(`SSRF blocked: protocol '${parsed.protocol}' is not allowed. Only HTTP(S) permitted.`);
-  }
+  // Parse + protocol checks are shared with `validateUrlSyntaxAndProtocol`.
+  // The protocol check intentionally runs BEFORE the allowlist
+  // short-circuit below — that ordering is load-bearing (see the
+  // PROTOCOL_BLOCK / ALLOWLIST_HIT notes in routes/llm/llm-providers.ts).
+  const parsed = validateUrlSyntaxAndProtocol(urlString);
 
   // Allow explicitly trusted origins (e.g., user-configured Confluence URLs)
   if (allowedOrigins.has(parsed.origin.toLowerCase())) {

--- a/backend/src/routes/foundation/setup.test.ts
+++ b/backend/src/routes/foundation/setup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi, beforeEach } from 'vitest';
 import Fastify from 'fastify';
 import sensible from '@fastify/sensible';
 import cookie from '@fastify/cookie';
@@ -412,6 +412,12 @@ describe('Setup routes', () => {
         clearAllowedBaseUrls();
       });
 
+      // Hygiene: never leak entries into the module-global allowlist for
+      // other suites sharing this worker (PR #751 review follow-up).
+      afterEach(() => {
+        clearAllowedBaseUrls();
+      });
+
       it('should return 401 for unauthenticated requests without any outbound call', async () => {
         mockAuthenticate.mockRejectedValueOnce(
           Object.assign(new Error('Invalid or expired token'), { statusCode: 401 }),
@@ -469,7 +475,7 @@ describe('Setup routes', () => {
         expect(body.models).toEqual([]);
         expect(mockCheckHealth).not.toHaveBeenCalled();
         expect(mockListModels).not.toHaveBeenCalled();
-        // The speculative allowlist entry must not survive the rejection
+        // Validation is non-mutating — nothing reaches the global allowlist
         expect(getAllowedBaseUrlCount()).toBe(0);
       });
 
@@ -503,7 +509,7 @@ describe('Setup routes', () => {
         );
       });
 
-      it('should remove the ephemeral allowlist entry after a successful test', async () => {
+      it('should never mutate the global SSRF allowlist on a successful probe', async () => {
         expect(getAllowedBaseUrlCount()).toBe(0);
 
         const response = await app.inject({
@@ -519,7 +525,7 @@ describe('Setup routes', () => {
         expect(() => validateUrl('http://10.0.0.7:11434/v1')).toThrow(/SSRF blocked/);
       });
 
-      it('should remove the ephemeral allowlist entry after a failed test', async () => {
+      it('should never mutate the global SSRF allowlist on a failed probe', async () => {
         mockCheckHealth.mockRejectedValueOnce(new Error('Connection refused'));
         mockListModels.mockRejectedValueOnce(new Error('Connection refused'));
 
@@ -534,7 +540,38 @@ describe('Setup routes', () => {
         expect(getAllowedBaseUrlCount()).toBe(0);
       });
 
-      it('should keep a pre-existing allowlist entry (e.g. a configured provider origin)', async () => {
+      it('should not widen the global allowlist even transiently while the probe is in flight', async () => {
+        // Guards against the ephemeral add/revoke round-trip from a previous
+        // revision: during the (untimed) outbound probe, the origin must NOT
+        // be allowlisted for unrelated flows on this pod (e.g. image import).
+        let countDuringProbe = -1;
+        let probedOriginAllowedDuringProbe = true;
+        mockCheckHealth.mockImplementationOnce(async () => {
+          countDuringProbe = getAllowedBaseUrlCount();
+          try {
+            validateUrl('http://10.0.0.9:11434/v1');
+          } catch {
+            probedOriginAllowedDuringProbe = false;
+          }
+          return { connected: true };
+        });
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/setup/llm-test',
+          payload: { provider: 'ollama', baseUrl: 'http://10.0.0.9:11434' },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(JSON.parse(response.body).success).toBe(true);
+        expect(countDuringProbe).toBe(0);
+        expect(probedOriginAllowedDuringProbe).toBe(false);
+      });
+
+      it('should leave a pre-existing allowlist entry untouched (no cross-route revocation)', async () => {
+        // A persisted provider's origin (added by the admin routes /
+        // bootstrap) must survive a probe of the same origin — the probe
+        // must not revoke entries it does not own.
         addAllowedBaseUrlSilent('http://10.1.2.3:11434');
         expect(getAllowedBaseUrlCount()).toBe(1);
 

--- a/backend/src/routes/foundation/setup.test.ts
+++ b/backend/src/routes/foundation/setup.test.ts
@@ -54,8 +54,20 @@ vi.mock('../../core/utils/logger.js', () => ({
 // Must import after mocks
 import { query } from '../../core/db/postgres.js';
 import { setupRoutes } from './setup.js';
+// Real (unmocked) SSRF guard — the route under test must drive it correctly.
+import {
+  addAllowedBaseUrlSilent,
+  clearAllowedBaseUrls,
+  getAllowedBaseUrlCount,
+  validateUrl,
+} from '../../core/utils/ssrf-guard.js';
 
 const mockQuery = query as ReturnType<typeof vi.fn>;
+
+// Controllable auth passthroughs so individual tests can simulate 401/403
+// (mirrors the vi.spyOn passthrough pattern used by sibling route tests).
+const mockAuthenticate = vi.fn(async (_request: unknown) => {});
+const mockRequireAdmin = vi.fn(async (_request: unknown) => {});
 
 describe('Setup routes', () => {
   let app: ReturnType<typeof Fastify>;
@@ -65,9 +77,10 @@ describe('Setup routes', () => {
     await app.register(sensible);
     await app.register(cookie);
 
-    // Decorate with authenticate and requireAdmin
-    app.decorate('authenticate', async () => {});
-    app.decorate('requireAdmin', async () => {});
+    // Decorate with authenticate and requireAdmin, delegating to mocks so
+    // tests can simulate unauthenticated (401) and non-admin (403) callers.
+    app.decorate('authenticate', (request: unknown) => mockAuthenticate(request));
+    app.decorate('requireAdmin', (request: unknown) => mockRequireAdmin(request));
 
     // Add ZodError handler matching app.ts behavior
     app.setErrorHandler((error: Error & { statusCode?: number }, _request, reply) => {
@@ -390,6 +403,151 @@ describe('Setup routes', () => {
       });
 
       expect(response.statusCode).toBe(400);
+    });
+
+    // ─── Security: admin gate + SSRF guard (issue #736) ──────────────────
+
+    describe('security: admin gate + SSRF guard (issue #736)', () => {
+      beforeEach(() => {
+        clearAllowedBaseUrls();
+      });
+
+      it('should return 401 for unauthenticated requests without any outbound call', async () => {
+        mockAuthenticate.mockRejectedValueOnce(
+          Object.assign(new Error('Invalid or expired token'), { statusCode: 401 }),
+        );
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/setup/llm-test',
+          payload: { provider: 'ollama', baseUrl: 'http://localhost:11434' },
+        });
+
+        expect(response.statusCode).toBe(401);
+        expect(mockCheckHealth).not.toHaveBeenCalled();
+        expect(mockListModels).not.toHaveBeenCalled();
+      });
+
+      it('should return 403 for authenticated non-admin users without any outbound call', async () => {
+        mockRequireAdmin.mockRejectedValueOnce(
+          Object.assign(new Error('Admin access required'), { statusCode: 403 }),
+        );
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/setup/llm-test',
+          payload: { provider: 'ollama', baseUrl: 'http://10.0.0.1:11434' },
+        });
+
+        expect(response.statusCode).toBe(403);
+        expect(mockCheckHealth).not.toHaveBeenCalled();
+        expect(mockListModels).not.toHaveBeenCalled();
+      });
+
+      it('should run the requireAdmin gate on every request', async () => {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/setup/llm-test',
+          payload: { provider: 'ollama', baseUrl: 'http://localhost:11434' },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(mockRequireAdmin).toHaveBeenCalledTimes(1);
+      });
+
+      it('should block non-HTTP(S) protocols without any outbound call', async () => {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/setup/llm-test',
+          payload: { provider: 'openai', baseUrl: 'ftp://internal-files.example.com' },
+        });
+
+        expect(response.statusCode).toBe(200);
+        const body = JSON.parse(response.body);
+        expect(body.success).toBe(false);
+        expect(body.error).toMatch(/SSRF blocked/);
+        expect(body.models).toEqual([]);
+        expect(mockCheckHealth).not.toHaveBeenCalled();
+        expect(mockListModels).not.toHaveBeenCalled();
+        // The speculative allowlist entry must not survive the rejection
+        expect(getAllowedBaseUrlCount()).toBe(0);
+      });
+
+      it('should allow private-network hosts for admins (same policy as admin provider routes)', async () => {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/setup/llm-test',
+          payload: { provider: 'ollama', baseUrl: 'http://192.168.1.50:11434' },
+        });
+
+        expect(response.statusCode).toBe(200);
+        const body = JSON.parse(response.body);
+        expect(body.success).toBe(true);
+        expect(mockCheckHealth).toHaveBeenCalledWith(
+          expect.objectContaining({ baseUrl: 'http://192.168.1.50:11434/v1' }),
+        );
+      });
+
+      it('should still allow the default localhost Ollama URL (wizard auto-detect)', async () => {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/setup/llm-test',
+          payload: { provider: 'ollama' },
+        });
+
+        expect(response.statusCode).toBe(200);
+        const body = JSON.parse(response.body);
+        expect(body.success).toBe(true);
+        expect(mockCheckHealth).toHaveBeenCalledWith(
+          expect.objectContaining({ baseUrl: 'http://localhost:11434/v1' }),
+        );
+      });
+
+      it('should remove the ephemeral allowlist entry after a successful test', async () => {
+        expect(getAllowedBaseUrlCount()).toBe(0);
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/setup/llm-test',
+          payload: { provider: 'ollama', baseUrl: 'http://10.0.0.7:11434' },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(JSON.parse(response.body).success).toBe(true);
+        expect(getAllowedBaseUrlCount()).toBe(0);
+        // Origin must NOT be retained as an SSRF bypass for other flows
+        expect(() => validateUrl('http://10.0.0.7:11434/v1')).toThrow(/SSRF blocked/);
+      });
+
+      it('should remove the ephemeral allowlist entry after a failed test', async () => {
+        mockCheckHealth.mockRejectedValueOnce(new Error('Connection refused'));
+        mockListModels.mockRejectedValueOnce(new Error('Connection refused'));
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/setup/llm-test',
+          payload: { provider: 'ollama', baseUrl: 'http://10.0.0.8:11434' },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(JSON.parse(response.body).success).toBe(false);
+        expect(getAllowedBaseUrlCount()).toBe(0);
+      });
+
+      it('should keep a pre-existing allowlist entry (e.g. a configured provider origin)', async () => {
+        addAllowedBaseUrlSilent('http://10.1.2.3:11434');
+        expect(getAllowedBaseUrlCount()).toBe(1);
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/setup/llm-test',
+          payload: { provider: 'ollama', baseUrl: 'http://10.1.2.3:11434' },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(getAllowedBaseUrlCount()).toBe(1);
+        expect(() => validateUrl('http://10.1.2.3:11434')).not.toThrow();
+      });
     });
   });
 });

--- a/backend/src/routes/foundation/setup.ts
+++ b/backend/src/routes/foundation/setup.ts
@@ -22,9 +22,7 @@ import {
 } from '../../domains/llm/services/openai-compatible-client.js';
 import { decryptPat } from '../../core/utils/crypto.js';
 import {
-  addAllowedBaseUrlSilent,
-  removeAllowedBaseUrlSilent,
-  validateUrl,
+  validateUrlSyntaxAndProtocol,
   SsrfError,
 } from '../../core/utils/ssrf-guard.js';
 import { logger } from '../../core/utils/logger.js';
@@ -212,29 +210,26 @@ export async function setupRoutes(fastify: FastifyInstance) {
     }
     if (!baseUrl.endsWith('/v1')) baseUrl += '/v1';
 
-    // SSRF guard (issue #736) — same policy as the admin LLM-provider routes
-    // (`routes/llm/llm-providers.ts`): allowlist BEFORE validating so
-    // private-network LLM endpoints (local Ollama, LAN LM Studio, on-prem
-    // vLLM — including the wizard's localhost default) aren't rejected by
-    // the private-network checks, while protocol restrictions (HTTP/S only)
-    // still apply because `validateUrl` runs the protocol check before the
-    // allowlist short-circuit. The trust model is "authenticated admin
-    // pastes a URL and we trust the host" — identical to the admin routes.
+    // SSRF guard (issue #736) — same EFFECTIVE policy as the admin
+    // LLM-provider routes (`routes/llm/llm-providers.ts`): an authenticated
+    // admin pastes a URL and we trust the host, so only URL syntax and the
+    // HTTP(S)-protocol restriction are enforced. Private-network endpoints
+    // (local Ollama, LAN LM Studio, on-prem vLLM — including the wizard's
+    // localhost default) must pass; `requireAdmin` is the real control.
     //
-    // Unlike the admin routes, nothing is persisted here, so the allowlist
-    // entry is strictly ephemeral: the *silent* variants skip the multi-pod
-    // broadcast, and the entry is removed after the probe unless the origin
-    // was already allowlisted (e.g. by an existing provider row), so the
-    // test never widens the SSRF allowlist for other flows.
-    const addedToAllowlist = addAllowedBaseUrlSilent(baseUrl);
-    const revokeEphemeralAllowlistEntry = () => {
-      if (addedToAllowlist) removeAllowedBaseUrlSilent(baseUrl);
-    };
-
+    // The admin routes get that policy by allowlisting before validating —
+    // correct there because the origin is persisted. Nothing is persisted
+    // here, so the probe validates NON-MUTATINGLY instead of round-tripping
+    // the process-global allowlist. A previous revision did add/validate/
+    // revoke and (a) transiently exempted the origin for every other flow
+    // on this pod for the probe's full duration, and (b) raced concurrent
+    // admin provider writes for the same origin: their `addAllowedBaseUrl`
+    // no-ops on a present entry (no pub/sub broadcast), then this route's
+    // revoke stripped the persisted provider's allowlist entry until
+    // restart (PR #751 review follow-up).
     try {
-      validateUrl(baseUrl);
+      validateUrlSyntaxAndProtocol(baseUrl);
     } catch (err) {
-      revokeEphemeralAllowlistEntry();
       if (err instanceof SsrfError) {
         logger.debug({ provider: body.provider, error: err.message }, 'LLM connection test blocked by SSRF guard');
         return { success: false, error: err.message, models: [] };
@@ -269,8 +264,6 @@ export async function setupRoutes(fastify: FastifyInstance) {
         error: message,
         models: [],
       };
-    } finally {
-      revokeEphemeralAllowlistEntry();
     }
   });
 }

--- a/backend/src/routes/foundation/setup.ts
+++ b/backend/src/routes/foundation/setup.ts
@@ -21,6 +21,12 @@ import {
   type ProviderConfig,
 } from '../../domains/llm/services/openai-compatible-client.js';
 import { decryptPat } from '../../core/utils/crypto.js';
+import {
+  addAllowedBaseUrlSilent,
+  removeAllowedBaseUrlSilent,
+  validateUrl,
+  SsrfError,
+} from '../../core/utils/ssrf-guard.js';
 import { logger } from '../../core/utils/logger.js';
 
 const SALT_ROUNDS = 12;
@@ -185,10 +191,16 @@ export async function setupRoutes(fastify: FastifyInstance) {
    * POST /api/setup/llm-test
    *
    * Tests LLM connectivity without persisting any configuration.
-   * Requires authentication (admin must be created first).
+   *
+   * Requires ADMIN (issue #736): the wizard creates and signs in the admin
+   * (POST /setup/admin returns tokens) before this step ever runs, so the
+   * legitimate first-run caller always holds the admin role. Post-setup it
+   * is an admin-only action (wizard rerun / resume). Without this gate any
+   * self-registered user could use the reflected connect/HTTP errors as a
+   * blind SSRF oracle for internal network recon (CWE-918).
    */
   fastify.post('/setup/llm-test', {
-    preHandler: fastify.authenticate,
+    preHandler: [fastify.authenticate, fastify.requireAdmin],
   }, async (request) => {
     const body = LlmTestSchema.parse(request.body);
 
@@ -199,6 +211,36 @@ export async function setupRoutes(fastify: FastifyInstance) {
       baseUrl = body.provider === 'openai' ? 'https://api.openai.com/v1' : 'http://localhost:11434/v1';
     }
     if (!baseUrl.endsWith('/v1')) baseUrl += '/v1';
+
+    // SSRF guard (issue #736) — same policy as the admin LLM-provider routes
+    // (`routes/llm/llm-providers.ts`): allowlist BEFORE validating so
+    // private-network LLM endpoints (local Ollama, LAN LM Studio, on-prem
+    // vLLM — including the wizard's localhost default) aren't rejected by
+    // the private-network checks, while protocol restrictions (HTTP/S only)
+    // still apply because `validateUrl` runs the protocol check before the
+    // allowlist short-circuit. The trust model is "authenticated admin
+    // pastes a URL and we trust the host" — identical to the admin routes.
+    //
+    // Unlike the admin routes, nothing is persisted here, so the allowlist
+    // entry is strictly ephemeral: the *silent* variants skip the multi-pod
+    // broadcast, and the entry is removed after the probe unless the origin
+    // was already allowlisted (e.g. by an existing provider row), so the
+    // test never widens the SSRF allowlist for other flows.
+    const addedToAllowlist = addAllowedBaseUrlSilent(baseUrl);
+    const revokeEphemeralAllowlistEntry = () => {
+      if (addedToAllowlist) removeAllowedBaseUrlSilent(baseUrl);
+    };
+
+    try {
+      validateUrl(baseUrl);
+    } catch (err) {
+      revokeEphemeralAllowlistEntry();
+      if (err instanceof SsrfError) {
+        logger.debug({ provider: body.provider, error: err.message }, 'LLM connection test blocked by SSRF guard');
+        return { success: false, error: err.message, models: [] };
+      }
+      throw err;
+    }
 
     const cfg: ProviderConfig = {
       providerId: 'setup-wizard',
@@ -227,6 +269,8 @@ export async function setupRoutes(fastify: FastifyInstance) {
         error: message,
         models: [],
       };
+    } finally {
+      revokeEphemeralAllowlistEntry();
     }
   });
 }


### PR DESCRIPTION
## Root cause

`POST /api/setup/llm-test` (`backend/src/routes/foundation/setup.ts`) was guarded by `fastify.authenticate` only and built a `ProviderConfig` straight from the caller-supplied `baseUrl`, then called `checkHealth`/`listModels` (which `undiciFetch` the URL with no host validation). Since self-registration is open, **any authenticated non-admin** could probe arbitrary internal hosts/ports and read the reflected `success`/`error` distinction (connection refused vs. timeout vs. HTTP status) — a blind SSRF oracle (CWE-918). The admin provider routes (`routes/llm/llm-providers.ts`) already required admin and used the SSRF allowlist; this setup route was the inconsistent one.

## Fix

`backend/src/routes/foundation/setup.ts` + `backend/src/core/utils/ssrf-guard.ts`:

1. **Admin gate** — `preHandler: [fastify.authenticate, fastify.requireAdmin]` (same shape as the admin LLM-provider routes; `requireAdmin` also audit-logs denied attempts).
2. **Non-mutating SSRF guard** — the probe applies the *same effective policy* as the admin LLM-provider routes (an authenticated admin pastes a URL and we trust the host: URL must parse + HTTP/S only; private-network hosts allowed) **without touching the process-global allowlist**. That policy is extracted into a new exported primitive `validateUrlSyntaxAndProtocol()` in `core/utils/ssrf-guard.ts`; `validateUrl()` now delegates its parse+protocol prefix to it, preserving the load-bearing protocol-before-allowlist ordering. Blocked URLs (`ftp://`, unparseable, etc.) return `{ success: false, error }` with **no outbound request**; the wizard's `http://localhost:11434` default, auto-detect, and LAN/on-prem LLM hosts remain usable for admins. Since the endpoint persists nothing, no allowlist entry is ever created, broadcast, or revoked by a connectivity test.

## Gating rationale (wizard compatibility)

Verified against the frontend wizard flow (`frontend/src/features/setup/`): the step order is Welcome → Admin → LLM → Confluence. `AdminStep` calls `POST /api/setup/admin`, which atomically creates the admin **and returns access/refresh tokens**; the wizard stores them via `setAuth(...)` before `LlmStep` mounts. So the legitimate first-run caller of `/setup/llm-test` (including the auto-detect call on mount) is always authenticated *as the admin*. The resume path only jumps to the LLM step when an admin already exists, and the `?rerun=true` path is an explicit admin action — `requireAdmin` is therefore safe in all wizard flows, and the SSRF guard applies unconditionally. No frontend change needed.

## Test evidence

TDD: 3 new tests failed against the unfixed route (missing `requireAdmin` wiring ×2, `ftp://` URL fetched with `success: true`), then passed after the fix.

Regression tests in `backend/src/routes/foundation/setup.test.ts` (`security: admin gate + SSRF guard (issue #736)`):
- 401 unauthenticated / 403 non-admin — no outbound call either way
- `requireAdmin` gate runs on every request
- non-HTTP(S) protocol blocked with `SSRF blocked` error, no outbound call, allowlist untouched
- private-network host still allowed for admins (policy parity with admin provider routes)
- default localhost Ollama URL still works (wizard auto-detect)
- global SSRF allowlist never mutated by a probe — after success, after failure, and **transiently while the probe is in flight** (instrumented `checkHealth` mock asserts the origin is not allowlisted mid-probe)
- pre-existing allowlist entry (configured provider origin) preserved — no cross-route revocation
- `afterEach` allowlist hygiene so no entry leaks into sibling suites

New unit coverage in `backend/src/core/utils/ssrf-guard.test.ts` for `validateUrlSyntaxAndProtocol`: public + private + loopback hosts pass, non-HTTP(S) protocols and unparseable URLs throw `SsrfError`, and the allowlist is neither consulted nor mutated.

Results (after review follow-up):
- `setup.test.ts` + `ssrf-guard.test.ts`: **96/96 passed**
- `llm-providers.test.ts` + `settings.test.ts`: **43/43 passed**
- `npm run lint -w backend` and `npm run typecheck -w backend`: clean

## Diagrams

No `docs/architecture/*.md` update needed: the change is a route-level guard with no structural impact (no new module/table/flow). `07-flow-auth.md` does not depict setup-wizard routes. `docs/SECURITY-AUDIT.md` / `docs/CONSISTENCY-ANALYSIS-REPORT.md` mention the old gating but are dated point-in-time snapshots (2026-04-03), so they were left as historical records.

## Review follow-up (db2d3f6c)

Adversarial review of the first revision found two flaws in its "ephemeral allowlist" design (add origin to the process-global allowlist → validate → fetch → revoke in `finally`):

1. **Cross-route revocation race** — while a probe of origin X was in flight, a concurrent `POST/PATCH /admin/llm-providers` persisting the same origin no-opped its `addAllowedBaseUrl(X)` (entry already present → no pub/sub broadcast), then the probe's `finally` removed X — leaving a persisted provider whose origin was allowlisted on **no** pod until restart. The admin routes guard this class with `revokeAllowlistIfUnused`; the setup route bypassed it.
2. **Transient global widening** — between add and revoke (the probe's full, untimed duration) the origin was allowlisted for *every* flow on the pod, e.g. `POST /api/pages/:id/images/import` (reachable by regular users) short-circuits private-IP/DNS checks for allowlisted origins.

Resolution: the probe validation is now **non-mutating** (`validateUrlSyntaxAndProtocol`), which eliminates both findings structurally — there is no add, no revoke, no window, and no entry to race over. Wizard-visible behavior is byte-identical. The test suite now asserts the allowlist is never mutated (including mid-probe) instead of asserting correct ephemeral-entry lifecycle, and the last test's leaked `addAllowedBaseUrlSilent` entry is cleaned up via `afterEach`.

Fixes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)
