### PR TITLE
fix(security): enforce per-space/page RBAC on knowledge routes (IDOR, #733)

### DIFF
--- a/backend/src/domains/knowledge/services/duplicate-detector.integration.test.ts
+++ b/backend/src/domains/knowledge/services/duplicate-detector.integration.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../../test-db-helper.js';
+import { query } from '../../../core/db/postgres.js';
+import pgvector from 'pgvector';
+import { findDuplicates } from './duplicate-detector.js';
+
+// Deterministic 1024-dim vector. All fixture pages share the same vector so
+// every candidate sits at cosine distance 0 from the source — well inside the
+// default 0.15 threshold. What separates results is purely the RBAC filter.
+function fakeVec(seed: number): number[] {
+  return Array.from({ length: 1024 }, (_, i) => Math.sin((i + 1) * seed) * 0.01);
+}
+
+const USER_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'; // viewer on TEAMA only
+const USER_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'; // owner of a private standalone page
+const ADMIN = '99999999-9999-9999-9999-999999999999'; // system admin
+
+const dbAvailable = await isDbAvailable();
+
+describe.skipIf(!dbAvailable)('duplicate-detector integration — RBAC kNN filter (#733)', () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  }, 30_000);
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables();
+    // Re-seed system roles that migration 039 inserts on fresh install;
+    // truncateAllTables wipes them, so restore the ones we reference below.
+    await query(
+      `INSERT INTO roles (name, display_name, is_system, permissions) VALUES
+         ('viewer', 'Viewer', TRUE, ARRAY['read'])
+       ON CONFLICT (name) DO NOTHING`,
+    );
+    await query(
+      `INSERT INTO users (id, username, email, role, password_hash) VALUES
+         ($1::uuid, 'user-a', 'a@test', 'user', 'x'),
+         ($2::uuid, 'user-b', 'b@test', 'user', 'x'),
+         ($3::uuid, 'admin', 'admin@test', 'admin', 'x')`,
+      [USER_A, USER_B, ADMIN],
+    );
+    await query(
+      `INSERT INTO spaces (space_key, space_name) VALUES ('TEAMA', 'Team A'), ('SECRET', 'Secret')`,
+    );
+    // USER_A may only read TEAMA
+    const role = await query<{ id: number }>(`SELECT id FROM roles WHERE name = 'viewer'`);
+    await query(
+      `INSERT INTO space_role_assignments (space_key, principal_type, principal_id, role_id)
+       VALUES ('TEAMA', 'user', $1, $2)`,
+      [USER_A, role.rows[0]!.id],
+    );
+  });
+
+  async function seedPage(opts: {
+    confluenceId: string | null;
+    source: 'confluence' | 'standalone';
+    spaceKey: string | null;
+    title: string;
+    visibility?: string;
+    createdBy?: string;
+    vec: number[];
+  }): Promise<number> {
+    const page = await query<{ id: number }>(
+      `INSERT INTO pages (confluence_id, source, space_key, title, body_text, body_storage, body_html,
+                          visibility, created_by_user_id)
+       VALUES ($1, $2, $3, $4, $4, '', '', $5, $6)
+       RETURNING id`,
+      [opts.confluenceId, opts.source, opts.spaceKey, opts.title,
+       opts.visibility ?? 'shared', opts.createdBy ?? null],
+    );
+    const pageId = page.rows[0]!.id;
+    await query(
+      `INSERT INTO page_embeddings (page_id, chunk_index, chunk_text, embedding, metadata)
+       VALUES ($1, 0, $2, $3, '{}'::jsonb)`,
+      [pageId, opts.title, pgvector.toSql(opts.vec)],
+    );
+    return pageId;
+  }
+
+  it('excludes near-duplicates from inaccessible spaces and others-private standalone pages', async () => {
+    const vec = fakeVec(7);
+    await seedPage({ confluenceId: 'src-1', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy guide', vec });
+    await seedPage({ confluenceId: 'dup-a', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy guide copy', vec });
+    await seedPage({ confluenceId: 'dup-secret', source: 'confluence', spaceKey: 'SECRET', title: 'Secret deploy guide', vec });
+    await seedPage({ confluenceId: null, source: 'standalone', spaceKey: null, title: 'Shared note', visibility: 'shared', createdBy: USER_B, vec });
+    await seedPage({ confluenceId: null, source: 'standalone', spaceKey: null, title: 'Private note', visibility: 'private', createdBy: USER_B, vec });
+
+    const results = await findDuplicates(USER_A, 'src-1');
+    const ids = results.map((r) => r.confluenceId);
+    const titles = results.map((r) => r.title);
+
+    // Accessible candidates are returned…
+    expect(ids).toContain('dup-a');
+    expect(titles).toContain('Shared note');
+    // …but nothing from the SECRET space and no foreign private articles.
+    expect(ids).not.toContain('dup-secret');
+    expect(titles).not.toContain('Secret deploy guide');
+    expect(titles).not.toContain('Private note');
+  });
+
+  it('returns [] when the source page itself is in an inaccessible space (no existence oracle)', async () => {
+    const vec = fakeVec(11);
+    await seedPage({ confluenceId: 'secret-src', source: 'confluence', spaceKey: 'SECRET', title: 'Secret source', vec });
+    await seedPage({ confluenceId: 'secret-dup', source: 'confluence', spaceKey: 'SECRET', title: 'Secret source copy', vec });
+
+    const results = await findDuplicates(USER_A, 'secret-src');
+
+    // Identical response to a nonexistent page — no metadata leak.
+    expect(results).toEqual([]);
+  });
+
+  it('still returns cross-space duplicates for system admins', async () => {
+    const vec = fakeVec(13);
+    await seedPage({ confluenceId: 'src-1', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy guide', vec });
+    await seedPage({ confluenceId: 'dup-secret', source: 'confluence', spaceKey: 'SECRET', title: 'Secret deploy guide', vec });
+
+    const results = await findDuplicates(ADMIN, 'src-1');
+
+    expect(results.map((r) => r.confluenceId)).toContain('dup-secret');
+  });
+
+  it('includes the caller-owned private standalone pages as candidates', async () => {
+    const vec = fakeVec(17);
+    await seedPage({ confluenceId: 'src-1', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy guide', vec });
+    await seedPage({ confluenceId: null, source: 'standalone', spaceKey: null, title: 'My private draft', visibility: 'private', createdBy: USER_A, vec });
+
+    const results = await findDuplicates(USER_A, 'src-1');
+
+    expect(results.map((r) => r.title)).toContain('My private draft');
+  });
+});

--- a/backend/src/domains/knowledge/services/duplicate-detector.test.ts
+++ b/backend/src/domains/knowledge/services/duplicate-detector.test.ts
@@ -88,12 +88,14 @@ describe('DuplicateDetector', () => {
       // Restore pool mock after reset
       mocks.mockPool.connect.mockResolvedValue(mocks.mockClient);
       mocks.mockClient.release.mockResolvedValue(undefined);
+      // #733: findDuplicates now resolves the caller's accessible spaces
+      mocks.mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
     });
 
     it('should return duplicate candidates when source page exists and neighbors found', async () => {
       // Step 1: preliminary query — source page found
       mocks.mockQuery.mockResolvedValueOnce({
-        rows: [{ id: 42, title: 'Source Page' }],
+        rows: [{ id: 42, title: 'Source Page', space_key: 'DEV' }],
       });
       // Step 2: client.query('BEGIN')
       mocks.mockClientQuery.mockResolvedValueOnce(undefined);
@@ -141,7 +143,7 @@ describe('DuplicateDetector', () => {
     it('should return [] when source page has no embeddings (CTE returns empty)', async () => {
       // Step 1: preliminary query — source page found
       mocks.mockQuery.mockResolvedValueOnce({
-        rows: [{ id: 42, title: 'Source Page' }],
+        rows: [{ id: 42, title: 'Source Page', space_key: 'DEV' }],
       });
       // Step 2: client.query('BEGIN')
       mocks.mockClientQuery.mockResolvedValueOnce(undefined);
@@ -161,7 +163,7 @@ describe('DuplicateDetector', () => {
     it('should use sourcePageId (integer) in CTE params, not confluenceId string', async () => {
       // Source page found with id=99
       mocks.mockQuery.mockResolvedValueOnce({
-        rows: [{ id: 99, title: 'Source Page' }],
+        rows: [{ id: 99, title: 'Source Page', space_key: 'DEV' }],
       });
       mocks.mockClientQuery.mockResolvedValueOnce(undefined); // BEGIN
       mocks.mockClientQuery.mockResolvedValueOnce(undefined); // SET LOCAL
@@ -172,7 +174,8 @@ describe('DuplicateDetector', () => {
 
       // The CTE query call is the 3rd client.query call (index 2)
       const cteCall = mocks.mockClientQuery.mock.calls[2];
-      expect(cteCall[1]).toEqual([99, 15]); // [sourcePageId=99, limit*3=5*3=15]
+      // [sourcePageId=99, limit*3=15, accessibleSpaces, userId] (#733)
+      expect(cteCall[1]).toEqual([99, 15, ['DEV'], 'user-1']);
       // First param should be integer 99 (not the string 'conf-source')
       expect(typeof cteCall[1][0]).toBe('number');
 
@@ -185,9 +188,46 @@ describe('DuplicateDetector', () => {
       expect(cteSQL).not.toContain('pe2.confluence_id');
     });
 
+    // ── #733 RBAC regressions ───────────────────────────────────────────
+
+    it('returns [] when the source page is in an inaccessible space (#733)', async () => {
+      mocks.mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
+      mocks.mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 42, title: 'Restricted Page', space_key: 'SECRET' }],
+      });
+
+      const result = await findDuplicates('user-1', 'conf-restricted');
+
+      expect(result).toEqual([]);
+      // Critical: the kNN query must never run for an inaccessible source.
+      expect(mocks.mockPool.connect).not.toHaveBeenCalled();
+    });
+
+    it('applies the RBAC space/visibility filter to the kNN query (#733)', async () => {
+      mocks.mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+      mocks.mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 42, title: 'Source Page', space_key: 'DEV' }],
+      });
+      mocks.mockClientQuery.mockResolvedValueOnce(undefined); // BEGIN
+      mocks.mockClientQuery.mockResolvedValueOnce(undefined); // SET LOCAL
+      mocks.mockClientQuery.mockResolvedValueOnce({ rows: [] }); // CTE
+      mocks.mockClientQuery.mockResolvedValueOnce(undefined); // COMMIT
+
+      await findDuplicates('user-1', 'conf-source');
+
+      const cteCall = mocks.mockClientQuery.mock.calls[2];
+      const cteSQL = cteCall[0] as string;
+      // Same retrieval scope as rag-service: Confluence pages restricted to
+      // accessible spaces; standalone pages by shared/own-private visibility.
+      expect(cteSQL).toContain("cp2.source = 'confluence' AND cp2.space_key = ANY($3::text[])");
+      expect(cteSQL).toContain("cp2.source = 'standalone' AND cp2.visibility = 'shared'");
+      expect(cteSQL).toContain("cp2.visibility = 'private' AND cp2.created_by_user_id = $4");
+      expect(cteCall[1]).toEqual([42, 30, ['DEV', 'OPS'], 'user-1']);
+    });
+
     it('should filter out candidates exceeding distanceThreshold', async () => {
       mocks.mockQuery.mockResolvedValueOnce({
-        rows: [{ id: 42, title: 'Source Page' }],
+        rows: [{ id: 42, title: 'Source Page', space_key: 'DEV' }],
       });
       mocks.mockClientQuery.mockResolvedValueOnce(undefined); // BEGIN
       mocks.mockClientQuery.mockResolvedValueOnce(undefined); // SET LOCAL
@@ -237,7 +277,7 @@ describe('DuplicateDetector', () => {
 
       // findDuplicates for 'page-a': preliminary SELECT
       mocks.mockQuery.mockResolvedValueOnce({
-        rows: [{ id: 10, title: 'Page A' }],
+        rows: [{ id: 10, title: 'Page A', space_key: 'DEV' }],
       });
       // findDuplicates: BEGIN, SET LOCAL, CTE (1 neighbor), COMMIT
       mocks.mockClientQuery.mockResolvedValueOnce(undefined); // BEGIN
@@ -267,7 +307,7 @@ describe('DuplicateDetector', () => {
       });
 
       // findDuplicates for 'page-a' → finds page-b
-      mocks.mockQuery.mockResolvedValueOnce({ rows: [{ id: 10, title: 'Page A' }] });
+      mocks.mockQuery.mockResolvedValueOnce({ rows: [{ id: 10, title: 'Page A', space_key: 'DEV' }] });
       mocks.mockClientQuery
         .mockResolvedValueOnce(undefined) // BEGIN
         .mockResolvedValueOnce(undefined) // SET LOCAL
@@ -277,7 +317,7 @@ describe('DuplicateDetector', () => {
         .mockResolvedValueOnce(undefined); // COMMIT
 
       // findDuplicates for 'page-b' → finds page-a (same pair, should be deduplicated)
-      mocks.mockQuery.mockResolvedValueOnce({ rows: [{ id: 20, title: 'Page B' }] });
+      mocks.mockQuery.mockResolvedValueOnce({ rows: [{ id: 20, title: 'Page B', space_key: 'DEV' }] });
       mocks.mockClientQuery
         .mockResolvedValueOnce(undefined) // BEGIN
         .mockResolvedValueOnce(undefined) // SET LOCAL

--- a/backend/src/domains/knowledge/services/duplicate-detector.ts
+++ b/backend/src/domains/knowledge/services/duplicate-detector.ts
@@ -39,6 +39,10 @@ function tokenJaccardSimilarity(a: string, b: string): number {
 /**
  * Find duplicate/near-duplicate pages for a given page using pgvector kNN.
  * Computes average embedding for the source page, then finds nearest neighbors.
+ *
+ * RBAC (#733): both the source page and the candidate set are restricted to
+ * what `userId` can read — Confluence pages in accessible spaces plus shared
+ * or own-private standalone articles. An inaccessible source returns [].
  */
 export async function findDuplicates(
   userId: string,
@@ -50,16 +54,27 @@ export async function findDuplicates(
 ): Promise<DuplicateCandidate[]> {
   const { distanceThreshold = 0.15, limit = 10 } = options;
 
+  // #733: resolve the caller's readable space set once — it gates both the
+  // source page and the kNN candidates (mirrors scanAllDuplicates and the
+  // rag-service retrieval filters).
+  const accessibleSpaces = await getUserAccessibleSpaces(userId);
+
   // Get the source page id and title for title similarity comparison
-  const sourcePageResult = await query<{ id: number; title: string }>(
-    'SELECT id, title FROM pages WHERE confluence_id = $1 AND deleted_at IS NULL',
+  const sourcePageResult = await query<{ id: number; title: string; space_key: string | null }>(
+    'SELECT id, title, space_key FROM pages WHERE confluence_id = $1 AND deleted_at IS NULL',
     [confluenceId],
   );
   if (sourcePageResult.rows.length === 0) {
     return [];
   }
-  const sourceTitle = sourcePageResult.rows[0]!.title;
-  const sourcePageId = sourcePageResult.rows[0]!.id;
+  const sourcePage = sourcePageResult.rows[0]!;
+  // #733: a source page outside the caller's accessible spaces behaves
+  // exactly like a nonexistent one — no existence oracle, no neighbor leak.
+  if (!sourcePage.space_key || !accessibleSpaces.includes(sourcePage.space_key)) {
+    return [];
+  }
+  const sourceTitle = sourcePage.title;
+  const sourcePageId = sourcePage.id;
 
   // Use a dedicated client for SET LOCAL
   const client = await getPool().connect();
@@ -89,9 +104,17 @@ export async function findDuplicates(
        source_avg
        WHERE pe2.page_id != $1
          AND source_avg.avg_embedding IS NOT NULL
+         AND (
+           (cp2.source = 'confluence' AND cp2.space_key = ANY($3::text[]))
+           OR (cp2.source = 'standalone' AND cp2.visibility = 'shared')
+           OR (cp2.source = 'standalone' AND cp2.visibility = 'private' AND cp2.created_by_user_id = $4)
+         )
        ORDER BY cp2.confluence_id, pe2.embedding <=> source_avg.avg_embedding
        LIMIT $2`,
-      [sourcePageId, limit * 3], // Over-fetch to filter later
+      // #733: over-fetch to filter later; candidates restricted to the same
+      // retrieval scope as rag-service (accessible Confluence spaces +
+      // shared / own-private standalone articles).
+      [sourcePageId, limit * 3, accessibleSpaces, userId],
     );
 
     await client.query('COMMIT');

--- a/backend/src/routes/knowledge/auto-tag.test.ts
+++ b/backend/src/routes/knowledge/auto-tag.test.ts
@@ -89,6 +89,12 @@ vi.mock('../../core/db/postgres.js', () => ({
   closePool: vi.fn(),
 }));
 
+// #733: routes check page access via rbac-service before tagging
+const mockUserCanAccessPage = vi.fn().mockResolvedValue(true);
+vi.mock('../../core/services/rbac-service.js', () => ({
+  userCanAccessPage: (...args: unknown[]) => mockUserCanAccessPage(...args),
+}));
+
 describe('POST /api/pages/:id/auto-tag', () => {
   let app: ReturnType<typeof Fastify>;
 
@@ -131,6 +137,7 @@ describe('POST /api/pages/:id/auto-tag', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockQueryFn.mockResolvedValue({ rows: [{ id: 1, confluence_id: 'conf-1', labels: ['existing'] }], rowCount: 1 });
+    mockUserCanAccessPage.mockResolvedValue(true);
   });
 
   it('should return suggested tags on success', async () => {
@@ -306,6 +313,7 @@ describe('PUT /api/pages/:id/labels (#442 — integer PK fix)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUserCanAccessPage.mockResolvedValue(true);
   });
 
   it('should add labels using integer PK in the URL', async () => {

--- a/backend/src/routes/knowledge/comments.test.ts
+++ b/backend/src/routes/knowledge/comments.test.ts
@@ -385,8 +385,8 @@ describe('Comments routes', () => {
   // --- POST /api/comments/:id/resolve ---
 
   describe('POST /api/comments/:id/resolve', () => {
-    it('should resolve a top-level comment', async () => {
-      mockQuery.mockResolvedValueOnce({ rows: [{ parent_id: null }] });
+    it('should resolve a top-level comment when the user can access the page', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ parent_id: null, page_id: 1 }] });
       mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
       const response = await app.inject({
@@ -397,10 +397,11 @@ describe('Comments routes', () => {
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
       expect(body.success).toBe(true);
+      expect(mockUserCanAccessPage).toHaveBeenCalledWith(TEST_USER_ID, 1);
     });
 
     it('should reject resolving a reply', async () => {
-      mockQuery.mockResolvedValueOnce({ rows: [{ parent_id: 5 }] });
+      mockQuery.mockResolvedValueOnce({ rows: [{ parent_id: 5, page_id: 1 }] });
 
       const response = await app.inject({
         method: 'POST',
@@ -420,13 +421,33 @@ describe('Comments routes', () => {
 
       expect(response.statusCode).toBe(404);
     });
+
+    // ── #733 RBAC / IDOR regressions ──────────────────────────────────
+
+    it('should return 404 and not update when the user cannot access the comment\'s page (#733)', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ parent_id: null, page_id: 42 }] });
+      mockUserCanAccessPage.mockResolvedValue(false);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/comments/1/resolve',
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(mockUserCanAccessPage).toHaveBeenCalledWith(TEST_USER_ID, 42);
+      // Critical: state unchanged — no UPDATE may run for an inaccessible page.
+      const updateCall = mockQuery.mock.calls.find(
+        (call) => typeof call[0] === 'string' && (call[0] as string).includes('UPDATE comments'),
+      );
+      expect(updateCall).toBeUndefined();
+    });
   });
 
   // --- POST /api/comments/:id/unresolve ---
 
   describe('POST /api/comments/:id/unresolve', () => {
-    it('should unresolve a top-level comment', async () => {
-      mockQuery.mockResolvedValueOnce({ rows: [{ parent_id: null }] });
+    it('should unresolve a top-level comment when the user can access the page', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ parent_id: null, page_id: 1 }] });
       mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
       const response = await app.inject({
@@ -437,10 +458,11 @@ describe('Comments routes', () => {
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
       expect(body.success).toBe(true);
+      expect(mockUserCanAccessPage).toHaveBeenCalledWith(TEST_USER_ID, 1);
     });
 
     it('should reject unresolving a reply', async () => {
-      mockQuery.mockResolvedValueOnce({ rows: [{ parent_id: 3 }] });
+      mockQuery.mockResolvedValueOnce({ rows: [{ parent_id: 3, page_id: 1 }] });
 
       const response = await app.inject({
         method: 'POST',
@@ -449,6 +471,26 @@ describe('Comments routes', () => {
 
       expect(response.statusCode).toBe(400);
     });
+
+    // ── #733 RBAC / IDOR regressions ──────────────────────────────────
+
+    it('should return 404 and not update when the user cannot access the comment\'s page (#733)', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ parent_id: null, page_id: 42 }] });
+      mockUserCanAccessPage.mockResolvedValue(false);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/comments/1/unresolve',
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(mockUserCanAccessPage).toHaveBeenCalledWith(TEST_USER_ID, 42);
+      // Critical: state unchanged — no UPDATE may run for an inaccessible page.
+      const updateCall = mockQuery.mock.calls.find(
+        (call) => typeof call[0] === 'string' && (call[0] as string).includes('UPDATE comments'),
+      );
+      expect(updateCall).toBeUndefined();
+    });
   });
 
   // --- POST /api/comments/:id/reactions ---
@@ -456,7 +498,7 @@ describe('Comments routes', () => {
   describe('POST /api/comments/:id/reactions', () => {
     it('should add a reaction when it does not exist', async () => {
       // Comment exists
-      mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
+      mockQuery.mockResolvedValueOnce({ rows: [{ page_id: 1 }] });
       // No existing reaction
       mockQuery.mockResolvedValueOnce({ rows: [] });
       // INSERT reaction
@@ -472,11 +514,12 @@ describe('Comments routes', () => {
       const body = JSON.parse(response.body);
       expect(body.action).toBe('added');
       expect(body.emoji).toBe('👍');
+      expect(mockUserCanAccessPage).toHaveBeenCalledWith(TEST_USER_ID, 1);
     });
 
     it('should remove a reaction when it already exists (toggle)', async () => {
       // Comment exists
-      mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
+      mockQuery.mockResolvedValueOnce({ rows: [{ page_id: 1 }] });
       // Existing reaction found
       mockQuery.mockResolvedValueOnce({ rows: [{}] });
       // DELETE reaction
@@ -504,6 +547,28 @@ describe('Comments routes', () => {
       });
 
       expect(response.statusCode).toBe(404);
+    });
+
+    // ── #733 RBAC / IDOR regressions ──────────────────────────────────
+
+    it('should return 404 and not toggle when the user cannot access the comment\'s page (#733)', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ page_id: 42 }] });
+      mockUserCanAccessPage.mockResolvedValue(false);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/comments/1/reactions',
+        payload: { emoji: '👍' },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(mockUserCanAccessPage).toHaveBeenCalledWith(TEST_USER_ID, 42);
+      // Critical: state unchanged — reactions may be neither read, added,
+      // nor removed for comments on an inaccessible page.
+      const reactionTouch = mockQuery.mock.calls.find(
+        (call) => typeof call[0] === 'string' && (call[0] as string).includes('comment_reactions'),
+      );
+      expect(reactionTouch).toBeUndefined();
     });
   });
 
@@ -585,6 +650,8 @@ describe('Comments routes – admin delete', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    // The real userCanAccessPage short-circuits to true for system admins.
+    mockUserCanAccessPage.mockResolvedValue(true);
   });
 
   it('should allow admin to delete any comment', async () => {
@@ -600,5 +667,48 @@ describe('Comments routes – admin delete', () => {
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(response.body);
     expect(body.success).toBe(true);
+  });
+
+  // ── #733: admins (page-access bypass) keep full thread moderation ──
+
+  it('should allow admin to resolve a comment (#733)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ parent_id: null, page_id: 7 }] });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/comments/1/resolve',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body).success).toBe(true);
+  });
+
+  it('should allow admin to unresolve a comment (#733)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ parent_id: null, page_id: 7 }] });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/comments/1/unresolve',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body).success).toBe(true);
+  });
+
+  it('should allow admin to toggle a reaction (#733)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ page_id: 7 }] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/comments/1/reactions',
+      payload: { emoji: '👍' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body).action).toBe('added');
   });
 });

--- a/backend/src/routes/knowledge/comments.test.ts
+++ b/backend/src/routes/knowledge/comments.test.ts
@@ -17,6 +17,12 @@ vi.mock('../../core/utils/logger.js', () => ({
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }));
 
+// #733: comment routes must enforce per-page RBAC access
+const mockUserCanAccessPage = vi.fn();
+vi.mock('../../core/services/rbac-service.js', () => ({
+  userCanAccessPage: (...args: unknown[]) => mockUserCanAccessPage(...args),
+}));
+
 import { commentsRoutes } from './comments.js';
 
 const TEST_USER_ID = '11111111-1111-1111-1111-111111111111';
@@ -63,6 +69,8 @@ describe('Comments routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    // Default: the caller can access the page (#733)
+    mockUserCanAccessPage.mockResolvedValue(true);
   });
 
   // --- GET /api/pages/:pageId/comments ---
@@ -149,14 +157,31 @@ describe('Comments routes', () => {
       expect(body.comments[0].reactions['👍']).toEqual(['testuser', 'otheruser']);
       expect(body.comments[0].reactions['❤️']).toEqual(['testuser']);
     });
+
+    // ── #733 RBAC / IDOR regressions ──────────────────────────────────
+
+    it('should return 404 when the user cannot access the page (#733)', async () => {
+      mockUserCanAccessPage.mockResolvedValue(false);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/pages/1/comments',
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(mockUserCanAccessPage).toHaveBeenCalledWith(TEST_USER_ID, 1);
+      // Critical: no comment rows may be fetched for an inaccessible page.
+      const commentFetch = mockQuery.mock.calls.find(
+        (call) => typeof call[0] === 'string' && (call[0] as string).includes('FROM comments'),
+      );
+      expect(commentFetch).toBeUndefined();
+    });
   });
 
   // --- POST /api/pages/:pageId/comments ---
 
   describe('POST /api/pages/:pageId/comments', () => {
     it('should create a top-level comment', async () => {
-      // Page exists check
-      mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
       // INSERT comment
       mockQuery.mockResolvedValueOnce({
         rows: [{
@@ -185,7 +210,8 @@ describe('Comments routes', () => {
     });
 
     it('should return 404 when page does not exist', async () => {
-      mockQuery.mockResolvedValueOnce({ rows: [] }); // page check fails
+      // userCanAccessPage returns false for nonexistent pages (#733)
+      mockUserCanAccessPage.mockResolvedValue(false);
 
       const response = await app.inject({
         method: 'POST',
@@ -197,8 +223,6 @@ describe('Comments routes', () => {
     });
 
     it('should create a reply to an existing comment', async () => {
-      // Page exists
-      mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
       // Parent comment exists
       mockQuery.mockResolvedValueOnce({ rows: [{ id: 5, page_id: 1 }] });
       // INSERT reply
@@ -227,8 +251,6 @@ describe('Comments routes', () => {
     });
 
     it('should extract @mentions and store them', async () => {
-      // Page exists
-      mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
       // INSERT comment
       mockQuery.mockResolvedValueOnce({
         rows: [{
@@ -275,6 +297,30 @@ describe('Comments routes', () => {
       });
 
       expect(response.statusCode).toBe(400);
+    });
+
+    // ── #733 RBAC / IDOR regressions ──────────────────────────────────
+
+    it('should return 404 and not insert when the user cannot access the page (#733)', async () => {
+      mockUserCanAccessPage.mockResolvedValue(false);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/1/comments',
+        payload: { body: 'sneaky @admin ping', bodyHtml: '<p>sneaky</p>' },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(mockUserCanAccessPage).toHaveBeenCalledWith(TEST_USER_ID, 1);
+      // Critical: no comment INSERT and no mention notifications.
+      const insertCall = mockQuery.mock.calls.find(
+        (call) => typeof call[0] === 'string' && (call[0] as string).includes('INSERT INTO comments'),
+      );
+      expect(insertCall).toBeUndefined();
+      const mentionCall = mockQuery.mock.calls.find(
+        (call) => typeof call[0] === 'string' && (call[0] as string).includes('comment_mentions'),
+      );
+      expect(mentionCall).toBeUndefined();
     });
   });
 

--- a/backend/src/routes/knowledge/comments.ts
+++ b/backend/src/routes/knowledge/comments.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { query } from '../../core/db/postgres.js';
+import { userCanAccessPage } from '../../core/services/rbac-service.js';
 import { logger } from '../../core/utils/logger.js';
 
 // --- Zod schemas ---
@@ -113,9 +114,18 @@ export async function commentsRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
 
   // GET /api/pages/:pageId/comments — list threads for a page
-  fastify.get('/pages/:pageId/comments', async (request) => {
+  fastify.get('/pages/:pageId/comments', async (request, reply) => {
     const { pageId } = PageIdParamSchema.parse(request.params);
     const { includeResolved } = ListCommentsQuerySchema.parse(request.query);
+    const userId = request.userId;
+
+    // #733: only users who can access the page may read its comment threads
+    // (bodies, authors, reactions). userCanAccessPage is false for missing
+    // pages too — 404 in both cases so restricted pages are
+    // indistinguishable from nonexistent ones.
+    if (!(await userCanAccessPage(userId, pageId))) {
+      return reply.notFound('Page not found');
+    }
 
     let resolvedFilter = '';
     if (includeResolved === 'false') {
@@ -194,9 +204,10 @@ export async function commentsRoutes(fastify: FastifyInstance) {
     const { body, bodyHtml, parentId, anchorType, anchorData } = CreateCommentSchema.parse(request.body);
     const userId = request.userId;
 
-    // Verify page exists
-    const pageCheck = await query('SELECT id FROM pages WHERE id = $1', [pageId]);
-    if (pageCheck.rows.length === 0) {
+    // #733: verify the page exists AND the caller can access it — posting
+    // onto a restricted page would also fan out @mention notifications.
+    // userCanAccessPage is false for missing pages too; 404 in both cases.
+    if (!(await userCanAccessPage(userId, pageId))) {
       return reply.notFound('Page not found');
     }
 

--- a/backend/src/routes/knowledge/comments.ts
+++ b/backend/src/routes/knowledge/comments.ts
@@ -328,12 +328,19 @@ export async function commentsRoutes(fastify: FastifyInstance) {
     const { id } = CommentIdParamSchema.parse(request.params);
     const userId = request.userId;
 
-    const existing = await query<{ parent_id: number | null }>(
-      'SELECT parent_id FROM comments WHERE id = $1 AND deleted_at IS NULL',
+    const existing = await query<{ parent_id: number | null; page_id: number }>(
+      'SELECT parent_id, page_id FROM comments WHERE id = $1 AND deleted_at IS NULL',
       [id],
     );
 
     if (existing.rows.length === 0) {
+      return reply.notFound('Comment not found');
+    }
+
+    // #733: only users who can access the parent page may resolve its
+    // threads. 404 (before the top-level check) so inaccessible comments
+    // are indistinguishable from nonexistent ones — no existence oracle.
+    if (!(await userCanAccessPage(userId, existing.rows[0]!.page_id))) {
       return reply.notFound('Comment not found');
     }
 
@@ -355,12 +362,17 @@ export async function commentsRoutes(fastify: FastifyInstance) {
     const { id } = CommentIdParamSchema.parse(request.params);
     const userId = request.userId;
 
-    const existing = await query<{ parent_id: number | null }>(
-      'SELECT parent_id FROM comments WHERE id = $1 AND deleted_at IS NULL',
+    const existing = await query<{ parent_id: number | null; page_id: number }>(
+      'SELECT parent_id, page_id FROM comments WHERE id = $1 AND deleted_at IS NULL',
       [id],
     );
 
     if (existing.rows.length === 0) {
+      return reply.notFound('Comment not found');
+    }
+
+    // #733: same page-access gate as /resolve — 404, no existence oracle.
+    if (!(await userCanAccessPage(userId, existing.rows[0]!.page_id))) {
       return reply.notFound('Comment not found');
     }
 
@@ -384,11 +396,18 @@ export async function commentsRoutes(fastify: FastifyInstance) {
     const userId = request.userId;
 
     // Verify comment exists
-    const commentCheck = await query(
-      'SELECT id FROM comments WHERE id = $1 AND deleted_at IS NULL',
+    const commentCheck = await query<{ page_id: number }>(
+      'SELECT page_id FROM comments WHERE id = $1 AND deleted_at IS NULL',
       [id],
     );
     if (commentCheck.rows.length === 0) {
+      return reply.notFound('Comment not found');
+    }
+
+    // #733: only users who can access the parent page may react to its
+    // comments. 404 so inaccessible comments are indistinguishable from
+    // nonexistent ones — no existence oracle.
+    if (!(await userCanAccessPage(userId, commentCheck.rows[0]!.page_id))) {
       return reply.notFound('Comment not found');
     }
 

--- a/backend/src/routes/knowledge/local-spaces.test.ts
+++ b/backend/src/routes/knowledge/local-spaces.test.ts
@@ -30,6 +30,14 @@ vi.mock('../../core/db/postgres.js', () => ({
   closePool: vi.fn(),
 }));
 
+// #733: per-page / per-space RBAC checks on move/reorder/breadcrumb
+const mockUserCanAccessPage = vi.fn();
+const mockGetUserAccessibleSpaces = vi.fn();
+vi.mock('../../core/services/rbac-service.js', () => ({
+  userCanAccessPage: (...args: unknown[]) => mockUserCanAccessPage(...args),
+  getUserAccessibleSpaces: (...args: unknown[]) => mockGetUserAccessibleSpaces(...args),
+}));
+
 describe('Local Spaces Routes', () => {
   let app: ReturnType<typeof Fastify>;
 
@@ -74,6 +82,9 @@ describe('Local Spaces Routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: page access allowed; no Confluence space assignments.
+    mockUserCanAccessPage.mockResolvedValue(true);
+    mockGetUserAccessibleSpaces.mockResolvedValue([]);
   });
 
   // ── GET /api/spaces/local ─────────────────────────────────────────────
@@ -395,5 +406,155 @@ describe('Local Spaces Routes', () => {
     });
 
     expect(response.statusCode).toBe(404);
+  });
+
+  // ── #733 RBAC / IDOR regressions ──────────────────────────────────────
+
+  it('move: returns 404 when the user cannot access the source page (#733)', async () => {
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 10, parent_id: null, space_key: 'SECRET', source: 'confluence', path: '/10' }],
+    });
+    mockUserCanAccessPage.mockResolvedValue(false);
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/pages/10/move',
+      payload: { parentId: null, spaceKey: 'PROJ' },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(mockUserCanAccessPage).toHaveBeenCalledWith('test-user-id', 10);
+    // Critical: the page must not be moved.
+    const updateCall = mockQueryFn.mock.calls.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('UPDATE pages'),
+    );
+    expect(updateCall).toBeUndefined();
+  });
+
+  it('move: returns 403 when the target space is a Confluence space the user cannot access (#733)', async () => {
+    // Source page is accessible (default mock), target space is not.
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 10, parent_id: null, space_key: 'PROJ', source: 'standalone', path: '/10' }],
+    });
+    // Target space lookup → Confluence-synced space
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ source: 'confluence' }] });
+    mockGetUserAccessibleSpaces.mockResolvedValue(['OTHER']);
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/pages/10/move',
+      payload: { parentId: null, spaceKey: 'RESTRICTED' },
+    });
+
+    expect(response.statusCode).toBe(403);
+    const updateCall = mockQueryFn.mock.calls.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('UPDATE pages'),
+    );
+    expect(updateCall).toBeUndefined();
+  });
+
+  it('move: returns 400 when the target space does not exist (#733)', async () => {
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 10, parent_id: null, space_key: 'PROJ', source: 'standalone', path: '/10' }],
+    });
+    // Target space lookup → no such space
+    mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/pages/10/move',
+      payload: { parentId: null, spaceKey: 'NOPE' },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('move: allows moving into an accessible Confluence space (#733)', async () => {
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 10, parent_id: null, space_key: 'PROJ', source: 'standalone', path: '/10' }],
+    });
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ source: 'confluence' }] });
+    mockGetUserAccessibleSpaces.mockResolvedValue(['TEAMB']);
+    // UPDATE page + descendants
+    mockQueryFn.mockResolvedValue({ rows: [] });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/pages/10/move',
+      payload: { parentId: null, spaceKey: 'TEAMB' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload).spaceKey).toBe('TEAMB');
+  });
+
+  it('move: allows moving into a local space without an RBAC assignment (#733)', async () => {
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 10, parent_id: null, space_key: null, source: 'standalone', path: '/10' }],
+    });
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ source: 'local' }] });
+    mockQueryFn.mockResolvedValue({ rows: [] });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/pages/10/move',
+      payload: { parentId: null, spaceKey: 'MYLOCAL' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    // Local spaces are accessible to all authenticated users — no RBAC lookup.
+    expect(mockGetUserAccessibleSpaces).not.toHaveBeenCalled();
+  });
+
+  it('reorder: returns 404 when the user cannot access the page (#733)', async () => {
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ id: 10 }] });
+    mockUserCanAccessPage.mockResolvedValue(false);
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/pages/10/reorder',
+      payload: { sortOrder: 3 },
+    });
+
+    expect(response.statusCode).toBe(404);
+    const updateCall = mockQueryFn.mock.calls.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('UPDATE pages'),
+    );
+    expect(updateCall).toBeUndefined();
+  });
+
+  it('breadcrumb: returns 404 when the user cannot access the page (#733)', async () => {
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 10, title: 'Restricted', parent_id: null, space_key: 'SECRET', path: '/10' }],
+    });
+    mockUserCanAccessPage.mockResolvedValue(false);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages/10/breadcrumb',
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(mockUserCanAccessPage).toHaveBeenCalledWith('test-user-id', 10);
+  });
+
+  it('breadcrumb: returns the parent chain when the user can access the page (#733)', async () => {
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [{ id: 10, title: 'Child', parent_id: '5', space_key: 'PROJ', path: '/5/10' }],
+    });
+    // Ancestors batch fetch
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ id: 5, title: 'Parent' }] });
+    // Space name lookup
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ space_name: 'Project Docs', source: 'local' }] });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages/10/breadcrumb',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.payload);
+    expect(body.ancestors).toEqual([{ id: 5, title: 'Parent' }]);
+    expect(body.current).toEqual({ id: 10, title: 'Child' });
   });
 });

--- a/backend/src/routes/knowledge/local-spaces.ts
+++ b/backend/src/routes/knowledge/local-spaces.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { query } from '../../core/db/postgres.js';
 import { RedisCache } from '../../core/services/redis-cache.js';
 import { logAuditEvent } from '../../core/services/audit-service.js';
+import { userCanAccessPage, getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
 import { z } from 'zod';
 
 const CreateLocalSpaceSchema = z.object({
@@ -304,8 +305,35 @@ export async function localSpacesRoutes(fastify: FastifyInstance) {
     }
 
     const page = existing.rows[0]!;
+
+    // #733: the caller must be able to access the page being moved. 404 (not
+    // 403) so restricted pages are indistinguishable from nonexistent ones.
+    if (!(await userCanAccessPage(userId, page.id))) {
+      throw fastify.httpErrors.notFound('Page not found');
+    }
+
     const newParentId = body.parentId !== undefined ? body.parentId : page.parent_id;
     const newSpaceKey = body.spaceKey ?? page.space_key;
+
+    // #733: when the move changes the page's space, the target space must
+    // exist and be writable by the caller. Confluence-synced spaces require
+    // an RBAC space assignment; local spaces are accessible to all
+    // authenticated users (same model as POST /api/pages and the page tree).
+    if (newSpaceKey !== null && newSpaceKey !== page.space_key) {
+      const targetSpace = await query<{ source: string }>(
+        'SELECT source FROM spaces WHERE space_key = $1',
+        [newSpaceKey],
+      );
+      if (targetSpace.rows.length === 0) {
+        throw fastify.httpErrors.badRequest('Target space not found');
+      }
+      if (targetSpace.rows[0]!.source !== 'local') {
+        const accessibleSpaces = await getUserAccessibleSpaces(userId);
+        if (!accessibleSpaces.includes(newSpaceKey)) {
+          throw fastify.httpErrors.forbidden('You do not have access to the target space');
+        }
+      }
+    }
 
     // If new parent is specified, verify it exists
     if (newParentId !== null) {
@@ -386,6 +414,11 @@ export async function localSpacesRoutes(fastify: FastifyInstance) {
       throw fastify.httpErrors.notFound('Page not found');
     }
 
+    // #733: the caller must be able to access the page being reordered.
+    if (!(await userCanAccessPage(userId, existing.rows[0]!.id))) {
+      throw fastify.httpErrors.notFound('Page not found');
+    }
+
     await query(
       'UPDATE pages SET sort_order = $1 WHERE id = $2',
       [body.sortOrder, id],
@@ -400,6 +433,7 @@ export async function localSpacesRoutes(fastify: FastifyInstance) {
 
   // GET /api/pages/:id/breadcrumb - get parent chain for breadcrumb display
   fastify.get('/pages/:id/breadcrumb', async (request) => {
+    const userId = request.userId;
     const { id } = IdParamSchema.parse(request.params);
 
     const page = await query<{
@@ -414,6 +448,12 @@ export async function localSpacesRoutes(fastify: FastifyInstance) {
     );
 
     if (page.rows.length === 0) {
+      throw fastify.httpErrors.notFound('Page not found');
+    }
+
+    // #733: the breadcrumb leaks titles/structure of the page and all its
+    // ancestors — require page access; 404 to avoid an existence oracle.
+    if (!(await userCanAccessPage(userId, page.rows[0]!.id))) {
       throw fastify.httpErrors.notFound('Page not found');
     }
 

--- a/backend/src/routes/knowledge/page-labels.test.ts
+++ b/backend/src/routes/knowledge/page-labels.test.ts
@@ -74,6 +74,12 @@ vi.mock('../../core/db/postgres.js', () => ({
   closePool: vi.fn(),
 }));
 
+// #733: routes check page access via rbac-service before mutating labels
+const mockUserCanAccessPage = vi.fn().mockResolvedValue(true);
+vi.mock('../../core/services/rbac-service.js', () => ({
+  userCanAccessPage: (...args: unknown[]) => mockUserCanAccessPage(...args),
+}));
+
 import { getClientForUser } from '../../domains/confluence/services/sync-service.js';
 
 describe('PUT /api/pages/:id/labels', () => {
@@ -119,6 +125,7 @@ describe('PUT /api/pages/:id/labels', () => {
     vi.clearAllMocks();
     // Mock returns integer PK + confluence_id (required after #442 fix)
     mockQueryFn.mockResolvedValue({ rows: [{ id: 1, confluence_id: 'page-1', labels: ['existing-tag'] }], rowCount: 1 });
+    mockUserCanAccessPage.mockResolvedValue(true);
   });
 
   it('should add labels to a page', async () => {

--- a/backend/src/routes/knowledge/pages-tags.test.ts
+++ b/backend/src/routes/knowledge/pages-tags.test.ts
@@ -52,6 +52,12 @@ vi.mock('../../core/db/postgres.js', () => ({
   closePool: vi.fn(),
 }));
 
+// --- Mock: rbac-service (#733 per-page access checks) ---
+const mockUserCanAccessPage = vi.fn();
+vi.mock('../../core/services/rbac-service.js', () => ({
+  userCanAccessPage: (...args: unknown[]) => mockUserCanAccessPage(...args),
+}));
+
 // =============================================================================
 // Test Suite 1: Auth-required tests
 // =============================================================================
@@ -149,6 +155,7 @@ describe('POST /api/pages/:id/apply-tags', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockQueryFn.mockResolvedValue({ rows: [{ id: 1, confluence_id: 'conf-1', labels: ['existing'] }], rowCount: 1 });
+    mockUserCanAccessPage.mockResolvedValue(true);
   });
 
   it('should apply valid tags and return merged labels', async () => {
@@ -253,6 +260,7 @@ describe('PUT /api/pages/:id/labels - tag CRUD', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUserCanAccessPage.mockResolvedValue(true);
   });
 
   it('should add a tag to a page', async () => {
@@ -372,6 +380,9 @@ describe('POST /api/pages/:id/auto-tag — resolver fallback (#214)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // #733: the route now resolves the page and checks access before tagging
+    mockQueryFn.mockResolvedValue({ rows: [{ id: 1 }], rowCount: 1 });
+    mockUserCanAccessPage.mockResolvedValue(true);
   });
 
   it('consults the resolver when the client omits `model` and routes with the resolved model', async () => {
@@ -444,5 +455,103 @@ describe('POST /api/pages/:id/auto-tag — resolver fallback (#214)', () => {
 
     expect(response.statusCode).toBe(400);
     expect(mockAutoTagPage).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Test Suite 5: #733 RBAC / IDOR — per-page access checks
+// =============================================================================
+
+describe('pages-tags routes — RBAC access checks (#733)', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof ZodError) {
+        reply.status(400).send({
+          error: 'ValidationError',
+          message: error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join('; '),
+          statusCode: 400,
+        });
+        return;
+      }
+      reply.status(error.statusCode ?? 500).send({ error: error.message, statusCode: error.statusCode ?? 500 });
+    });
+
+    app.decorate('authenticate', async (request: { userId: string }) => {
+      request.userId = 'test-user-id';
+    });
+    app.decorate('requireAdmin', async () => {});
+    app.decorate('redis', {});
+    app.decorateRequest('userId', '');
+
+    await app.register(pagesTagRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Page exists, but the caller cannot access it.
+    mockQueryFn.mockResolvedValue({ rows: [{ id: 77, confluence_id: 'conf-77', labels: [] }], rowCount: 1 });
+    mockUserCanAccessPage.mockResolvedValue(false);
+  });
+
+  it('POST /pages/:id/auto-tag returns 404 for an inaccessible page and never reaches the LLM', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/77/auto-tag',
+      payload: { model: 'm' },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(mockUserCanAccessPage).toHaveBeenCalledWith('test-user-id', 77);
+    expect(mockAutoTagPage).not.toHaveBeenCalled();
+  });
+
+  it('POST /pages/:id/apply-tags returns 404 for an inaccessible page and never mutates labels', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/77/apply-tags',
+      payload: { tags: ['architecture'] },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(mockApplyTags).not.toHaveBeenCalled();
+  });
+
+  it('PUT /pages/:id/labels returns 404 for an inaccessible page and never updates or syncs upstream', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/pages/77/labels',
+      payload: { addLabels: ['leaked'] },
+    });
+
+    expect(response.statusCode).toBe(404);
+    // Critical: no UPDATE may run (which would also push labels to Confluence).
+    const updateCall = mockQueryFn.mock.calls.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('UPDATE pages'),
+    );
+    expect(updateCall).toBeUndefined();
+  });
+
+  it('resolves confluence_id-style ids before the access check (apply-tags)', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/conf-77/apply-tags',
+      payload: { tags: ['architecture'] },
+    });
+
+    expect(response.statusCode).toBe(404);
+    // The lookup must use confluence_id for non-numeric ids.
+    const lookupCall = mockQueryFn.mock.calls[0];
+    expect(lookupCall[0]).toContain('confluence_id = $1');
+    expect(mockUserCanAccessPage).toHaveBeenCalledWith('test-user-id', 77);
   });
 });

--- a/backend/src/routes/knowledge/pages-tags.ts
+++ b/backend/src/routes/knowledge/pages-tags.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { query } from '../../core/db/postgres.js';
 import { RedisCache } from '../../core/services/redis-cache.js';
+import { userCanAccessPage } from '../../core/services/rbac-service.js';
 import { getClientForUser } from '../../domains/confluence/services/sync-service.js';
 import { autoTagPage, applyTags, autoTagAllPages, ALLOWED_TAGS, AllowedTag } from '../../domains/knowledge/services/auto-tagger.js';
 import { resolveUsecase } from '../../domains/llm/services/llm-provider-resolver.js';
@@ -8,6 +9,27 @@ import { z } from 'zod';
 import { logger } from '../../core/utils/logger.js';
 
 const IdParamSchema = z.object({ id: z.string().min(1) });
+
+/**
+ * #733: resolve a page id (integer PK or confluence_id — same resolution as
+ * the auto-tagger service) and enforce the caller's RBAC access to it.
+ * Throws 404 for both missing and inaccessible pages so restricted pages are
+ * indistinguishable from nonexistent ones (no existence oracle).
+ */
+async function assertPageAccess(
+  fastify: FastifyInstance,
+  userId: string,
+  pageId: string,
+): Promise<void> {
+  const isNumericId = /^\d+$/.test(pageId);
+  const result = await query<{ id: number }>(
+    `SELECT id FROM pages WHERE ${isNumericId ? 'id = $1' : 'confluence_id = $1'} AND deleted_at IS NULL`,
+    [isNumericId ? parseInt(pageId, 10) : pageId],
+  );
+  if (result.rows.length === 0 || !(await userCanAccessPage(userId, result.rows[0]!.id))) {
+    throw fastify.httpErrors.notFound('Page not found');
+  }
+}
 // `model` is optional: when omitted, the route resolves the auto_tag use-case
 // assignment from admin settings (issue #214). Frontend can stop asking the
 // user to pick a model for auto-tag once the admin has configured one.
@@ -35,6 +57,10 @@ export async function pagesTagRoutes(fastify: FastifyInstance) {
     const { id } = IdParamSchema.parse(request.params);
     const userId = request.userId;
     const { model: bodyModel } = AutoTagBodySchema.parse(request.body);
+
+    // #733: RBAC — reject before reading page content or shipping it to the LLM.
+    await assertPageAccess(fastify, userId, id);
+
     // Resolve the use-case to determine the concrete model when the caller
     // omits one. The auto-tagger itself resolves the provider config
     // internally, so we only need to surface the model name here for the
@@ -82,6 +108,9 @@ export async function pagesTagRoutes(fastify: FastifyInstance) {
     const userId = request.userId;
     const { tags } = ApplyTagsBodySchema.parse(request.body);
 
+    // #733: RBAC — reject before mutating labels or syncing to Confluence.
+    await assertPageAccess(fastify, userId, id);
+
     // Validate tags against allowed list
     const allowedSet = new Set<string>(ALLOWED_TAGS);
     const validTags = tags.filter((t) => allowedSet.has(t)) as AllowedTag[];
@@ -119,6 +148,12 @@ export async function pagesTagRoutes(fastify: FastifyInstance) {
     }
 
     const page = existing.rows[0]!;
+
+    // #733: RBAC — reject before mutating labels or pushing them upstream.
+    if (!(await userCanAccessPage(userId, page.id))) {
+      throw fastify.httpErrors.notFound('Page not found');
+    }
+
     let labels = page.labels || [];
 
     // Remove labels


### PR DESCRIPTION
## Root cause

Several `knowledge` routes resolved a page by id and acted on it without the per-space / per-page authorization check the rest of the domain enforces via `getUserAccessibleSpaces` / `userCanAccessPage` (broken access control / IDOR, CWE-639). In RBAC deployments (`space_role_assignments`, migration `039_rbac.sql`) a non-admin with access to one space could read or modify pages in spaces they cannot see — and `move` escalated to full content disclosure by relocating a restricted page into a readable space.

## Fix per route

All page-access denials return **404** (not 403) so restricted pages are indistinguishable from nonexistent ones, matching the existing pattern in `pages-crud.ts` (`GET /api/pages/:id`).

| Route | Fix |
|---|---|
| `PUT /api/pages/:id/move` | `userCanAccessPage` on the source page (404). Target `spaceKey` must exist (400) and, for Confluence-synced spaces, be in `getUserAccessibleSpaces` (403). Local spaces stay open to all authenticated users — same model as `POST /api/pages` and the page tree. |
| `PUT /api/pages/:id/reorder` | `userCanAccessPage` (404) before the sort-order update. |
| `GET /api/pages/:id/breadcrumb` | `userCanAccessPage` (404) before leaking title/ancestor structure. |
| `GET /api/pages/:pageId/comments` | `userCanAccessPage` (404) before returning thread bodies/authors/reactions. |
| `POST /api/pages/:pageId/comments` | Bare existence check replaced with `userCanAccessPage` (404) — also blocks `@mention` notification fan-out onto restricted pages. |
| `POST /api/pages/:id/auto-tag` | Access asserted before reading `body_html` and shipping it to the LLM. |
| `POST /api/pages/:id/apply-tags`, `PUT /api/pages/:id/labels` | Access asserted before mutating `labels` and before pushing `addLabels`/`removeLabel` upstream to Confluence. |
| `GET /api/pages/:id/duplicates` | The previously dead `userId` arg of `findDuplicates` is now live: an inaccessible source page behaves like a missing one (`[]`), and the kNN query is filtered with the same retrieval scope as `rag-service` / `scanAllDuplicates` — Confluence pages in accessible spaces + shared / own-private standalone articles. |

## Test evidence

TDD: 18 new regression tests written first and confirmed failing, then implementation, then green.

- `local-spaces.test.ts` — move source 404 / target 403 / target 400 / accessible-Confluence + local-space allowed; reorder 404; breadcrumb 404 + allowed path (mutations asserted not to run on denial).
- `comments.test.ts` — GET 404 with no comment fetch; POST 404 with no INSERT and no mention writes.
- `pages-tags.test.ts` — auto-tag/apply-tags/labels 404 with no LLM call, no label mutation, no Confluence sync; confluence_id-style id resolution.
- `duplicate-detector.test.ts` — inaccessible source returns `[]` without touching the pool; RBAC filter + params asserted on the kNN SQL.
- `duplicate-detector.integration.test.ts` (new, real Postgres + pgvector) — cross-space neighbors and foreign private standalone pages excluded; inaccessible source indistinguishable from missing; admins still see cross-space duplicates; own-private standalone pages still included.

Local runs (dedicated test Postgres):
- Affected files: 7 files, 113 tests passed.
- Full `routes/knowledge/` + `domains/knowledge/`: 48 files, 740 tests passed.
- `rag-service.integration.test.ts` + `core/services/` + `app.test.ts`: 38 files, 603 passed / 2 skipped.
- `npm run lint -w backend` and `npm run typecheck -w backend` clean.

## Architecture diagrams

No diagram update needed: this extends the **existing** per-page RBAC pattern (`userCanAccessPage` / `getUserAccessibleSpaces`, already documented in `docs/architecture/09-flow-rag-chat.md`) to additional knowledge routes — the auth/RBAC flow structure itself is unchanged. Flagging per CLAUDE.md rule 6 in case maintainers want the route list mirrored somewhere.

Fixes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-up

Adversarial review flagged that `POST /comments/:id/resolve`, `/unresolve`, and `/reactions` still resolved a comment by id with only an existence check — a non-admin with no access to a page could resolve/unresolve threads or toggle reactions on comments of inaccessible pages (same IDOR class this PR eliminates elsewhere in `comments.ts`).

Fixed in 93e92ee9: all three routes now resolve the comment's `page_id` and gate on `userCanAccessPage`, returning **404** on denial — identical to the list/create pattern (no existence oracle, access check before the top-level/400 check so replies on restricted pages don't leak). Author-restricted `PATCH`/`DELETE /comments/:id` are unchanged.

Tests added per route in `comments.test.ts`: denied non-admin → 404 with no `UPDATE comments` / `comment_reactions` queries executed (state unchanged); permitted user and admin (page-access bypass) still succeed. Local: `comments.test.ts` 31 passed; branch's other knowledge suites (auto-tag, local-spaces, page-labels, pages-tags, duplicate-detector unit + integration) 88 passed; backend lint + typecheck clean.
