### PR TITLE
fix(auth): revoke API access immediately on deactivation and role change

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,9 @@ BACKEND_PORT=3051
 # LOG_LEVEL=info                        # Pino log level: 'fatal','error','warn','info','debug','trace' (default: info)
 
 # --- Session ---
-# ACCESS_TOKEN_EXPIRY=1h      # JWT access token lifetime (default: 1h). Accepts jose duration format: '30m', '1h', '2h', etc.
+# ACCESS_TOKEN_EXPIRY=1h      # JWT access token lifetime (default: 1h, maximum: 24h). Accepts jose duration format: '30m', '1h', '2h', etc.
+                              # Capped at 24h (#737): the lifetime bounds how long a deactivated/demoted account could keep
+                              # API access if revocation checks were unavailable. Use the 7-day refresh token for session longevity.
 # TOKEN_CLEANUP_INTERVAL_HOURS=24  # How often to run expired refresh token cleanup (default: 24h)
 
 # LEGACY LLM env vars (bootstrap-only fallback, used only on fresh install

--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,8 @@ BACKEND_PORT=3051
 # --- Session ---
 # ACCESS_TOKEN_EXPIRY=1h      # JWT access token lifetime (default: 1h, maximum: 24h). Accepts jose duration format: '30m', '1h', '2h', etc.
                               # Capped at 24h (#737): the lifetime bounds how long a deactivated/demoted account could keep
-                              # API access if revocation checks were unavailable. Use the 7-day refresh token for session longevity.
+                              # API access if revocation checks were unavailable. Values above 24h are clamped to 24h at
+                              # startup with a warning logged. Use the 7-day refresh token for session longevity.
 # TOKEN_CLEANUP_INTERVAL_HOURS=24  # How often to run expired refresh token cleanup (default: 24h)
 
 # LEGACY LLM env vars (bootstrap-only fallback, used only on fresh install

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -77,6 +77,7 @@ import { registerKnowledgeRelationshipProducers } from './domains/knowledge/serv
 import { initSsrfAllowlistBus } from './core/services/ssrf-allowlist-bus.js';
 import { initPresenceBus } from './core/services/presence-service.js';
 import { initCacheBus, close as closeCacheBus } from './core/services/redis-cache-bus.js';
+import { initUserSecurityCacheBus } from './core/services/user-security-cache.js';
 import { initProviderCacheBus } from './domains/llm/services/cache-bus.js';
 import { buildTrustProxyFn } from './core/utils/trusted-proxy.js';
 import {
@@ -232,6 +233,13 @@ export async function buildApp() {
   app.addHook('onClose', async () => {
     await closeCacheBus();
   });
+
+  // ── User security cache bus (#737) ───────────────────────────────
+  // Subscribes the per-user liveness/role cache (checked by `authenticate`
+  // on every request) to `user:security:changed` so deactivation and role
+  // changes invalidate across pods immediately. Must run AFTER initCacheBus.
+  // Without a working bus the cache's 30s TTL bounds the staleness.
+  initUserSecurityCacheBus();
 
   // ── LLM provider cache-bus subscriber (EE #113 sub-PR 1d) ────────
   // Wires the cluster subscriber for `provider:cache:bump` and

--- a/backend/src/core/plugins/auth.revocation.test.ts
+++ b/backend/src/core/plugins/auth.revocation.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../test-db-helper.js';
+import { query } from '../db/postgres.js';
+import { buildApp } from '../../app.js';
+import { generateAccessToken, generateRefreshToken } from './auth.js';
+import { _resetForTests } from '../services/user-security-cache.js';
+
+/**
+ * Regression tests for issue #737 — deactivated/demoted users must NOT
+ * retain API access until their access token expires.
+ *
+ * `authenticate` historically validated the JWT statelessly: `deactivated_at`
+ * and `role` were only re-checked at /login and /refresh, so an admin
+ * deactivating or demoting a user had no effect on already-issued access
+ * tokens (up to ACCESS_TOKEN_EXPIRY, env-configurable). These tests drive
+ * the full route → service → cache-invalidation path and assert the victim's
+ * previously-working token is rejected on the very next request.
+ *
+ * Routes used:
+ *   - GET  /api/notifications          — plain authenticated route
+ *   - GET  /api/admin/audit-log        — requireAdmin route
+ *   - POST /api/admin/users/:id/deactivate|reactivate, PUT/DELETE …/users/:id
+ */
+
+async function createUser(username: string, role: 'admin' | 'user'): Promise<string> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO users (username, password_hash, role)
+     VALUES ($1, 'fakehash', $2) RETURNING id`,
+    [username, role],
+  );
+  return result.rows[0]!.id;
+}
+
+const dbAvailable = await isDbAvailable();
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  if (!dbAvailable) return;
+  await setupTestDb();
+  app = await buildApp();
+  await app.ready();
+}, 30_000);
+
+afterAll(async () => {
+  if (!dbAvailable) return;
+  await app?.close();
+  await teardownTestDb();
+});
+
+beforeEach(async () => {
+  if (!dbAvailable) return;
+  await truncateAllTables();
+  _resetForTests();
+});
+
+function authed(token: string) {
+  return { authorization: `Bearer ${token}` };
+}
+
+describe.skipIf(!dbAvailable)('access-token revocation on deactivation/role change (#737)', () => {
+  it('baseline: an active user with a valid token gets 200', async () => {
+    const userId = await createUser('rev_baseline', 'user');
+    const token = await generateAccessToken({ sub: userId, username: 'rev_baseline', role: 'user' });
+
+    const res = await app.inject({ method: 'GET', url: '/api/notifications', headers: authed(token) });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('rejects an already-issued access token immediately after deactivation', async () => {
+    const adminId = await createUser('rev_admin1', 'admin');
+    const adminToken = await generateAccessToken({ sub: adminId, username: 'rev_admin1', role: 'admin' });
+    const victimId = await createUser('rev_victim1', 'user');
+    const victimToken = await generateAccessToken({ sub: victimId, username: 'rev_victim1', role: 'user' });
+
+    // Victim makes a successful request first so the security state is cached
+    // — proves the deactivation path actively invalidates the cache rather
+    // than relying on a cold lookup.
+    const before = await app.inject({ method: 'GET', url: '/api/notifications', headers: authed(victimToken) });
+    expect(before.statusCode).toBe(200);
+
+    const deact = await app.inject({
+      method: 'POST',
+      url: `/api/admin/users/${victimId}/deactivate`,
+      headers: authed(adminToken),
+      payload: { reason: 'offboarded' },
+    });
+    expect(deact.statusCode).toBe(200);
+
+    const after = await app.inject({ method: 'GET', url: '/api/notifications', headers: authed(victimToken) });
+    expect(after.statusCode).toBe(401);
+  });
+
+  it('rejects a demoted admin\'s already-issued admin token immediately', async () => {
+    const actorId = await createUser('rev_actor2', 'admin');
+    const actorToken = await generateAccessToken({ sub: actorId, username: 'rev_actor2', role: 'admin' });
+    const victimId = await createUser('rev_demoted2', 'admin');
+    const victimToken = await generateAccessToken({ sub: victimId, username: 'rev_demoted2', role: 'admin' });
+
+    const before = await app.inject({ method: 'GET', url: '/api/admin/audit-log', headers: authed(victimToken) });
+    expect(before.statusCode).toBe(200);
+
+    const demote = await app.inject({
+      method: 'PUT',
+      url: `/api/admin/users/${victimId}`,
+      headers: authed(actorToken),
+      payload: { role: 'user' },
+    });
+    expect(demote.statusCode).toBe(200);
+
+    // The stale admin token must be rejected on BOTH admin and plain routes
+    // — its role claim no longer matches the DB, so the client is forced to
+    // re-authenticate (refresh tokens were revoked by the demotion).
+    const adminAfter = await app.inject({ method: 'GET', url: '/api/admin/audit-log', headers: authed(victimToken) });
+    expect(adminAfter.statusCode).toBe(401);
+
+    const plainAfter = await app.inject({ method: 'GET', url: '/api/notifications', headers: authed(victimToken) });
+    expect(plainAfter.statusCode).toBe(401);
+  });
+
+  it('revokes the victim\'s refresh tokens on role change', async () => {
+    const actorId = await createUser('rev_actor3', 'admin');
+    const actorToken = await generateAccessToken({ sub: actorId, username: 'rev_actor3', role: 'admin' });
+    const victimId = await createUser('rev_demoted3', 'admin');
+    await generateRefreshToken({ sub: victimId, username: 'rev_demoted3', role: 'admin' });
+
+    const tokensBefore = await query<{ c: string }>(
+      `SELECT COUNT(*)::text AS c FROM refresh_tokens WHERE user_id = $1`,
+      [victimId],
+    );
+    expect(tokensBefore.rows[0]!.c).toBe('1');
+
+    const demote = await app.inject({
+      method: 'PUT',
+      url: `/api/admin/users/${victimId}`,
+      headers: authed(actorToken),
+      payload: { role: 'user' },
+    });
+    expect(demote.statusCode).toBe(200);
+
+    const tokensAfter = await query<{ c: string }>(
+      `SELECT COUNT(*)::text AS c FROM refresh_tokens WHERE user_id = $1`,
+      [victimId],
+    );
+    expect(tokensAfter.rows[0]!.c).toBe('0');
+  });
+
+  it('rejects a stale user token after promotion (role claim no longer matches)', async () => {
+    const actorId = await createUser('rev_actor4', 'admin');
+    const actorToken = await generateAccessToken({ sub: actorId, username: 'rev_actor4', role: 'admin' });
+    const victimId = await createUser('rev_promoted4', 'user');
+    const victimToken = await generateAccessToken({ sub: victimId, username: 'rev_promoted4', role: 'user' });
+
+    const before = await app.inject({ method: 'GET', url: '/api/notifications', headers: authed(victimToken) });
+    expect(before.statusCode).toBe(200);
+
+    const promote = await app.inject({
+      method: 'PUT',
+      url: `/api/admin/users/${victimId}`,
+      headers: authed(actorToken),
+      payload: { role: 'admin' },
+    });
+    expect(promote.statusCode).toBe(200);
+
+    const after = await app.inject({ method: 'GET', url: '/api/notifications', headers: authed(victimToken) });
+    expect(after.statusCode).toBe(401);
+  });
+
+  it('an update that does not change the role leaves the session working', async () => {
+    const actorId = await createUser('rev_actor5', 'admin');
+    const actorToken = await generateAccessToken({ sub: actorId, username: 'rev_actor5', role: 'admin' });
+    const victimId = await createUser('rev_renamed5', 'user');
+    const victimToken = await generateAccessToken({ sub: victimId, username: 'rev_renamed5', role: 'user' });
+
+    const update = await app.inject({
+      method: 'PUT',
+      url: `/api/admin/users/${victimId}`,
+      headers: authed(actorToken),
+      payload: { displayName: 'Renamed User' },
+    });
+    expect(update.statusCode).toBe(200);
+
+    const after = await app.inject({ method: 'GET', url: '/api/notifications', headers: authed(victimToken) });
+    expect(after.statusCode).toBe(200);
+  });
+
+  it('restores access after reactivation without requiring a new token', async () => {
+    const adminId = await createUser('rev_admin6', 'admin');
+    const adminToken = await generateAccessToken({ sub: adminId, username: 'rev_admin6', role: 'admin' });
+    const victimId = await createUser('rev_victim6', 'user');
+    const victimToken = await generateAccessToken({ sub: victimId, username: 'rev_victim6', role: 'user' });
+
+    await app.inject({
+      method: 'POST',
+      url: `/api/admin/users/${victimId}/deactivate`,
+      headers: authed(adminToken),
+      payload: {},
+    });
+    const whileDeactivated = await app.inject({ method: 'GET', url: '/api/notifications', headers: authed(victimToken) });
+    expect(whileDeactivated.statusCode).toBe(401);
+
+    const react = await app.inject({
+      method: 'POST',
+      url: `/api/admin/users/${victimId}/reactivate`,
+      headers: authed(adminToken),
+    });
+    expect(react.statusCode).toBe(200);
+
+    const after = await app.inject({ method: 'GET', url: '/api/notifications', headers: authed(victimToken) });
+    expect(after.statusCode).toBe(200);
+  });
+
+  it('rejects the token of a hard-deleted user immediately', async () => {
+    const adminId = await createUser('rev_admin7', 'admin');
+    const adminToken = await generateAccessToken({ sub: adminId, username: 'rev_admin7', role: 'admin' });
+    const victimId = await createUser('rev_deleted7', 'user');
+    const victimToken = await generateAccessToken({ sub: victimId, username: 'rev_deleted7', role: 'user' });
+
+    const before = await app.inject({ method: 'GET', url: '/api/notifications', headers: authed(victimToken) });
+    expect(before.statusCode).toBe(200);
+
+    const del = await app.inject({
+      method: 'DELETE',
+      url: `/api/admin/users/${victimId}`,
+      headers: authed(adminToken),
+    });
+    expect(del.statusCode).toBe(204);
+
+    const after = await app.inject({ method: 'GET', url: '/api/notifications', headers: authed(victimToken) });
+    expect(after.statusCode).toBe(401);
+  });
+});

--- a/backend/src/core/plugins/auth.test.ts
+++ b/backend/src/core/plugins/auth.test.ts
@@ -79,4 +79,36 @@ describe('generateAccessToken expiry', () => {
       'Invalid ACCESS_TOKEN_EXPIRY format: "banana"',
     );
   });
+
+  // #737: ACCESS_TOKEN_EXPIRY is the upper bound on how long a revoked /
+  // demoted account could keep API access if every faster invalidation
+  // layer failed. Cap it at 24h so the format regex can no longer admit
+  // effectively-unbounded lifetimes like '999d'.
+  it('should accept the 24h boundary value', async () => {
+    process.env.ACCESS_TOKEN_EXPIRY = '24h';
+    const { generateAccessToken } = await import('./auth.js');
+
+    const now = Math.floor(Date.now() / 1000);
+    const token = await generateAccessToken(payload);
+    const secret = new TextEncoder().encode(JWT_SECRET);
+    const { payload: decoded } = await jose.jwtVerify(token, secret, { issuer: 'compendiq' });
+
+    const diff = (decoded.exp as number) - now;
+    expect(diff).toBeGreaterThanOrEqual(86395);
+    expect(diff).toBeLessThanOrEqual(86405);
+  });
+
+  it('should throw at import time when ACCESS_TOKEN_EXPIRY exceeds 24h (999d)', async () => {
+    process.env.ACCESS_TOKEN_EXPIRY = '999d';
+    await expect(() => import('./auth.js')).rejects.toThrow(
+      /ACCESS_TOKEN_EXPIRY.*24h/,
+    );
+  });
+
+  it('should throw at import time when ACCESS_TOKEN_EXPIRY exceeds 24h (25h)', async () => {
+    process.env.ACCESS_TOKEN_EXPIRY = '25h';
+    await expect(() => import('./auth.js')).rejects.toThrow(
+      /ACCESS_TOKEN_EXPIRY.*24h/,
+    );
+  });
 });

--- a/backend/src/core/plugins/auth.test.ts
+++ b/backend/src/core/plugins/auth.test.ts
@@ -13,6 +13,14 @@ import * as jose from 'jose';
 
 const JWT_SECRET = 'a-test-secret-that-is-at-least-32-chars-long!!';
 
+// Mock the logger so the 24h-clamp tests can assert the startup warning.
+// vi.resetModules() in afterEach re-runs this factory on the next import, so
+// each test sees a fresh mock instance — fetch it via dynamic import AFTER
+// importing auth.js to get the same instance auth.js wrote to.
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
 describe('generateAccessToken expiry', () => {
   const payload = { sub: 'user-1', username: 'testuser', role: 'user' as const };
 
@@ -82,11 +90,14 @@ describe('generateAccessToken expiry', () => {
 
   // #737: ACCESS_TOKEN_EXPIRY is the upper bound on how long a revoked /
   // demoted account could keep API access if every faster invalidation
-  // layer failed. Cap it at 24h so the format regex can no longer admit
-  // effectively-unbounded lifetimes like '999d'.
-  it('should accept the 24h boundary value', async () => {
+  // layer failed. Values above 24h are CLAMPED to 24h with a loud startup
+  // warning (#756 review) — previously-valid configs like '48h' or '7d'
+  // must not turn into a hard boot failure on unattended upgrade. Only an
+  // invalid FORMAT still fails startup.
+  it('should accept the 24h boundary value without warning', async () => {
     process.env.ACCESS_TOKEN_EXPIRY = '24h';
     const { generateAccessToken } = await import('./auth.js');
+    const { logger } = await import('../utils/logger.js');
 
     const now = Math.floor(Date.now() / 1000);
     const token = await generateAccessToken(payload);
@@ -96,19 +107,47 @@ describe('generateAccessToken expiry', () => {
     const diff = (decoded.exp as number) - now;
     expect(diff).toBeGreaterThanOrEqual(86395);
     expect(diff).toBeLessThanOrEqual(86405);
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it('should throw at import time when ACCESS_TOKEN_EXPIRY exceeds 24h (999d)', async () => {
+  it('should clamp ACCESS_TOKEN_EXPIRY above 24h (999d) to 24h and log a warning instead of failing boot', async () => {
     process.env.ACCESS_TOKEN_EXPIRY = '999d';
-    await expect(() => import('./auth.js')).rejects.toThrow(
-      /ACCESS_TOKEN_EXPIRY.*24h/,
+    const { generateAccessToken } = await import('./auth.js');
+    const { logger } = await import('../utils/logger.js');
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ configured: '999d', effective: '24h' }),
+      expect.stringContaining('24h'),
     );
+
+    const now = Math.floor(Date.now() / 1000);
+    const token = await generateAccessToken(payload);
+    const secret = new TextEncoder().encode(JWT_SECRET);
+    const { payload: decoded } = await jose.jwtVerify(token, secret, { issuer: 'compendiq' });
+
+    // Token is issued with the clamped 24h lifetime, not the configured 999d.
+    const diff = (decoded.exp as number) - now;
+    expect(diff).toBeGreaterThanOrEqual(86395);
+    expect(diff).toBeLessThanOrEqual(86405);
   });
 
-  it('should throw at import time when ACCESS_TOKEN_EXPIRY exceeds 24h (25h)', async () => {
+  it('should clamp ACCESS_TOKEN_EXPIRY above 24h (25h) to 24h and log a warning instead of failing boot', async () => {
     process.env.ACCESS_TOKEN_EXPIRY = '25h';
-    await expect(() => import('./auth.js')).rejects.toThrow(
-      /ACCESS_TOKEN_EXPIRY.*24h/,
+    const { generateAccessToken } = await import('./auth.js');
+    const { logger } = await import('../utils/logger.js');
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ configured: '25h', effective: '24h' }),
+      expect.stringContaining('24h'),
     );
+
+    const now = Math.floor(Date.now() / 1000);
+    const token = await generateAccessToken(payload);
+    const secret = new TextEncoder().encode(JWT_SECRET);
+    const { payload: decoded } = await jose.jwtVerify(token, secret, { issuer: 'compendiq' });
+
+    const diff = (decoded.exp as number) - now;
+    expect(diff).toBeGreaterThanOrEqual(86395);
+    expect(diff).toBeLessThanOrEqual(86405);
   });
 });

--- a/backend/src/core/plugins/auth.ts
+++ b/backend/src/core/plugins/auth.ts
@@ -7,13 +7,30 @@ import { logger } from '../utils/logger.js';
 import { userHasPermission, userHasGlobalPermission } from '../services/rbac-service.js';
 import { enterRbacScope } from '../services/rbac-request-scope.js';
 import { logAuditEvent } from '../services/audit-service.js';
+import { getUserSecurityState } from '../services/user-security-cache.js';
 
 const JWT_ISSUER = 'compendiq';
 const ACCESS_TOKEN_EXPIRY = process.env.ACCESS_TOKEN_EXPIRY ?? '1h';
 // Validate expiry format at startup — jose accepts: Ns, Nm, Nh, Nd
-if (!/^\d+[smhd]$/.test(ACCESS_TOKEN_EXPIRY)) {
+const ACCESS_TOKEN_EXPIRY_MATCH = /^(\d+)([smhd])$/.exec(ACCESS_TOKEN_EXPIRY);
+if (!ACCESS_TOKEN_EXPIRY_MATCH) {
   throw new Error(
     `Invalid ACCESS_TOKEN_EXPIRY format: "${ACCESS_TOKEN_EXPIRY}". Expected format: <number><s|m|h|d> (e.g., "1h", "30m", "7d")`,
+  );
+}
+// #737: cap the access-token lifetime at 24h. The lifetime is the worst-case
+// window a deactivated/demoted account keeps API access if every faster
+// invalidation layer (user-security cache + cache-bus) failed, so it must
+// not be effectively unbounded (the old regex admitted e.g. '999d').
+const EXPIRY_UNIT_SECONDS: Record<string, number> = { s: 1, m: 60, h: 3_600, d: 86_400 };
+const MAX_ACCESS_TOKEN_EXPIRY_SECONDS = 24 * 3_600;
+if (
+  Number(ACCESS_TOKEN_EXPIRY_MATCH[1]) * EXPIRY_UNIT_SECONDS[ACCESS_TOKEN_EXPIRY_MATCH[2]!]! >
+  MAX_ACCESS_TOKEN_EXPIRY_SECONDS
+) {
+  throw new Error(
+    `ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" exceeds the maximum of 24h. ` +
+      'Long-lived access tokens defeat deactivation/role-change revocation (#737) — use the 7-day refresh token for session longevity instead.',
   );
 }
 const REFRESH_TOKEN_EXPIRY_DAYS = 7;
@@ -199,6 +216,27 @@ export default fp(async (fastify: FastifyInstance) => {
     try {
       const token = authHeader.slice(7);
       const payload = await verifyToken(token);
+
+      // #737: cached liveness/role check so deactivation, hard-delete and
+      // role changes take effect on already-issued access tokens within
+      // USER_SECURITY_CACHE_TTL_MS (30s; immediate on pods that receive the
+      // cache-bus invalidation) instead of the full token lifetime. On the
+      // hot path this is a Map lookup — the DB is consulted at most once
+      // per user per TTL window. 'unknown' (DB lookup failed with nothing
+      // cached) soft-fails to the token claims so a transient DB blip
+      // cannot 401 every in-flight session.
+      const security = await getUserSecurityState(payload.sub);
+      if (security.kind === 'deactivated' || security.kind === 'missing') {
+        throw new Error(`User account is ${security.kind === 'missing' ? 'deleted' : 'deactivated'}`);
+      }
+      if (security.kind === 'active' && security.role !== payload.role) {
+        // Stale privilege claim (demoted or promoted since issuance) —
+        // reject so the client re-authenticates and gets a token whose
+        // role matches the DB. Role changes also revoke refresh tokens
+        // (admin-user-service), so a demoted admin must log in again.
+        throw new Error('Token role no longer matches the user record');
+      }
+
       request.userId = payload.sub;
       request.username = payload.username;
       request.userRole = payload.role;

--- a/backend/src/core/plugins/auth.ts
+++ b/backend/src/core/plugins/auth.ts
@@ -10,27 +10,35 @@ import { logAuditEvent } from '../services/audit-service.js';
 import { getUserSecurityState } from '../services/user-security-cache.js';
 
 const JWT_ISSUER = 'compendiq';
-const ACCESS_TOKEN_EXPIRY = process.env.ACCESS_TOKEN_EXPIRY ?? '1h';
+const CONFIGURED_ACCESS_TOKEN_EXPIRY = process.env.ACCESS_TOKEN_EXPIRY ?? '1h';
 // Validate expiry format at startup — jose accepts: Ns, Nm, Nh, Nd
-const ACCESS_TOKEN_EXPIRY_MATCH = /^(\d+)([smhd])$/.exec(ACCESS_TOKEN_EXPIRY);
+const ACCESS_TOKEN_EXPIRY_MATCH = /^(\d+)([smhd])$/.exec(CONFIGURED_ACCESS_TOKEN_EXPIRY);
 if (!ACCESS_TOKEN_EXPIRY_MATCH) {
   throw new Error(
-    `Invalid ACCESS_TOKEN_EXPIRY format: "${ACCESS_TOKEN_EXPIRY}". Expected format: <number><s|m|h|d> (e.g., "1h", "30m", "7d")`,
+    `Invalid ACCESS_TOKEN_EXPIRY format: "${CONFIGURED_ACCESS_TOKEN_EXPIRY}". Expected format: <number><s|m|h|d> (e.g., "1h", "30m", "7d")`,
   );
 }
 // #737: cap the access-token lifetime at 24h. The lifetime is the worst-case
 // window a deactivated/demoted account keeps API access if every faster
 // invalidation layer (user-security cache + cache-bus) failed, so it must
 // not be effectively unbounded (the old regex admitted e.g. '999d').
+// Over-cap values are CLAMPED with a loud warning rather than failing boot
+// (#756 review) — '48h' or '7d' were valid configs before the cap, and an
+// unattended upgrade must not take an existing deployment down. An invalid
+// FORMAT still fails fast above.
 const EXPIRY_UNIT_SECONDS: Record<string, number> = { s: 1, m: 60, h: 3_600, d: 86_400 };
 const MAX_ACCESS_TOKEN_EXPIRY_SECONDS = 24 * 3_600;
-if (
+const ACCESS_TOKEN_EXPIRY =
   Number(ACCESS_TOKEN_EXPIRY_MATCH[1]) * EXPIRY_UNIT_SECONDS[ACCESS_TOKEN_EXPIRY_MATCH[2]!]! >
   MAX_ACCESS_TOKEN_EXPIRY_SECONDS
-) {
-  throw new Error(
-    `ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" exceeds the maximum of 24h. ` +
-      'Long-lived access tokens defeat deactivation/role-change revocation (#737) — use the 7-day refresh token for session longevity instead.',
+    ? '24h'
+    : CONFIGURED_ACCESS_TOKEN_EXPIRY;
+if (ACCESS_TOKEN_EXPIRY !== CONFIGURED_ACCESS_TOKEN_EXPIRY) {
+  logger.warn(
+    { configured: CONFIGURED_ACCESS_TOKEN_EXPIRY, effective: ACCESS_TOKEN_EXPIRY },
+    `SECURITY: ACCESS_TOKEN_EXPIRY "${CONFIGURED_ACCESS_TOKEN_EXPIRY}" exceeds the 24h cap — clamping to 24h. ` +
+      'The access-token lifetime bounds how long a deactivated or demoted account could keep API access ' +
+      'if every faster revocation layer failed (#737); use the 7-day refresh token for session longevity instead.',
   );
 }
 const REFRESH_TOKEN_EXPIRY_DAYS = 7;

--- a/backend/src/core/services/admin-user-service.test.ts
+++ b/backend/src/core/services/admin-user-service.test.ts
@@ -98,6 +98,58 @@ describe.skipIf(!dbAvailable)('admin-user-service (#304)', () => {
     expect(patched.role).toBe('user');
   });
 
+  it('updateUser role change revokes all refresh tokens for the target (#737)', async () => {
+    await seedAdmin('other-admin'); // so demotion below passes the last-admin guard
+    const targetId = await seedAdmin('demotee');
+    await query(
+      `INSERT INTO refresh_tokens (jti, user_id, family, expires_at)
+       VALUES ($1, $2, $3, NOW() + INTERVAL '7 days')`,
+      ['role-change-jti', targetId, 'role-change-family'],
+    );
+
+    const patched = await updateUser(targetId, { role: 'user' });
+    expect(patched.role).toBe('user');
+
+    const tokens = await query(`SELECT 1 FROM refresh_tokens WHERE user_id = $1`, [targetId]);
+    expect(tokens.rows.length).toBe(0);
+  });
+
+  it('updateUser without a role change keeps refresh tokens (#737)', async () => {
+    const { user: target } = await createUser({
+      username: 'keep-tokens',
+      role: 'user',
+      password: 'x12345678',
+    });
+    await query(
+      `INSERT INTO refresh_tokens (jti, user_id, family, expires_at)
+       VALUES ($1, $2, $3, NOW() + INTERVAL '7 days')`,
+      ['keep-jti', target.id, 'keep-family'],
+    );
+
+    await updateUser(target.id, { displayName: 'Still Here' });
+
+    const tokens = await query(`SELECT 1 FROM refresh_tokens WHERE user_id = $1`, [target.id]);
+    expect(tokens.rows.length).toBe(1);
+  });
+
+  it('updateUser with the same role value keeps refresh tokens (#737)', async () => {
+    const { user: target } = await createUser({
+      username: 'same-role',
+      role: 'user',
+      password: 'x12345678',
+    });
+    await query(
+      `INSERT INTO refresh_tokens (jti, user_id, family, expires_at)
+       VALUES ($1, $2, $3, NOW() + INTERVAL '7 days')`,
+      ['same-role-jti', target.id, 'same-role-family'],
+    );
+
+    await updateUser(target.id, { role: 'user' });
+
+    const tokens = await query(`SELECT 1 FROM refresh_tokens WHERE user_id = $1`, [target.id]);
+    expect(tokens.rows.length).toBe(1);
+  });
+
   it('deactivateUser self-deactivate refused', async () => {
     const adminId = await seedAdmin();
     await expect(

--- a/backend/src/core/services/admin-user-service.ts
+++ b/backend/src/core/services/admin-user-service.ts
@@ -11,6 +11,7 @@ import { randomUUID } from 'node:crypto';
 import type { PoolClient } from 'pg';
 import { query, getPool } from '../db/postgres.js';
 import { logger } from '../utils/logger.js';
+import { invalidateUserSecurityState } from './user-security-cache.js';
 import type { AdminUser, AdminUserRole } from '@compendiq/contracts';
 
 const BCRYPT_ROUNDS = 10;
@@ -179,6 +180,7 @@ export async function updateUser(id: string, patch: UpdateUserOptions): Promise<
     const updates: string[] = [];
     const values: unknown[] = [];
     let i = 1;
+    let roleChanged = false;
 
     if (patch.email !== undefined) {
       updates.push(`email = $${i++}`);
@@ -192,6 +194,7 @@ export async function updateUser(id: string, patch: UpdateUserOptions): Promise<
       if (existing.role === 'admin' && patch.role !== 'admin') {
         await assertNotLastActiveAdminTx(client, id);
       }
+      roleChanged = patch.role !== existing.role;
       updates.push(`role = $${i++}`);
       values.push(patch.role);
     }
@@ -213,7 +216,21 @@ export async function updateUser(id: string, patch: UpdateUserOptions): Promise<
     if (res.rows.length === 0) {
       throw new AdminUserServiceError('NOT_FOUND', 'User not found');
     }
+    if (roleChanged) {
+      // #737: a role change crosses a privilege boundary — revoke every
+      // refresh token (mirrors deactivateUser) so the user cannot silently
+      // refresh back to a token carrying the old role. Already-issued
+      // access tokens are rejected by the user-security check in
+      // `authenticate` (cache invalidated below, after COMMIT).
+      await client.query(
+        `DELETE FROM refresh_tokens WHERE user_id = $1`,
+        [id],
+      );
+    }
     await client.query('COMMIT');
+    if (roleChanged) {
+      await invalidateUserSecurityState(id);
+    }
     return rowToAdminUser(res.rows[0]!);
   } catch (err: unknown) {
     await client.query('ROLLBACK').catch(() => {});
@@ -280,6 +297,10 @@ export async function deactivateUser(
       [targetUserId],
     );
     await client.query('COMMIT');
+    // #737: drop the cached security state (local + cache-bus) so the
+    // per-request check in `authenticate` rejects already-issued access
+    // tokens immediately instead of after the cache TTL.
+    await invalidateUserSecurityState(targetUserId);
     return rowToAdminUser(updated.rows[0]!);
   } catch (err) {
     await client.query('ROLLBACK').catch(() => {});
@@ -304,6 +325,10 @@ export async function reactivateUser(targetUserId: string): Promise<AdminUser> {
   if (res.rows.length === 0) {
     throw new AdminUserServiceError('NOT_FOUND', 'User not found');
   }
+  // #737: clear the cached 'deactivated' state so the user regains access
+  // immediately (they still need to log in again — refresh tokens were
+  // deleted on deactivation).
+  await invalidateUserSecurityState(targetUserId);
   return rowToAdminUser(res.rows[0]!);
 }
 
@@ -366,6 +391,9 @@ export async function deleteUser(
       throw new AdminUserServiceError('NOT_FOUND', 'User not found');
     }
     await client.query('COMMIT');
+    // #737: reject any still-circulating access token for the deleted user
+    // immediately (the per-request check maps a missing row to 401).
+    await invalidateUserSecurityState(targetUserId);
     logger.info(
       { targetUserId, actor: opts.actorUserId },
       'admin-user-service: deleted user',

--- a/backend/src/core/services/redis-cache-bus.ts
+++ b/backend/src/core/services/redis-cache-bus.ts
@@ -42,7 +42,8 @@ export type CacheBusChannel =
   | 'confluence:allowlist:changed'
   | 'sync:conflict:policy:changed'
   | 'pii:policy:changed'
-  | 'license:changed';
+  | 'license:changed'
+  | 'user:security:changed';
 
 type Handler<T = unknown> = (payload: T) => void | Promise<void>;
 

--- a/backend/src/core/services/user-security-cache.test.ts
+++ b/backend/src/core/services/user-security-cache.test.ts
@@ -16,6 +16,11 @@
  *   - invalidateUserSecurityState(userId) clears the local entry AND
  *     publishes on the 'user:security:changed' cache-bus channel so peer
  *     pods invalidate too.
+ *   - Invalidation fences in-flight loads (per-user generation counter): a
+ *     load whose SELECT was already running when the invalidation landed may
+ *     have snapshotted pre-COMMIT state, so its result must NOT be cached —
+ *     otherwise the stale "active/old-role" answer would be re-cached for a
+ *     full TTL window on the very pod that handled the admin action.
  *   - initUserSecurityCacheBus() wires the subscriber (clear one entry per
  *     message) + an onReconnect handler (clear everything — missed pub/sub
  *     messages are not replayed). Idempotent.
@@ -188,6 +193,70 @@ describe('user-security-cache (#737)', () => {
       expect(state).toEqual({ kind: 'deactivated' });
       expect(mockQuery).toHaveBeenCalledTimes(2);
     });
+
+    // #756 review: TOCTOU between invalidation and an in-flight load. The
+    // load's SELECT may have snapshotted pre-COMMIT state; if it resolves
+    // AFTER the invalidation, caching its result would re-extend the stale
+    // "active" answer for a full TTL window on the acting pod.
+    it('does not re-cache a stale in-flight load that resolves after an invalidation', async () => {
+      let resolveSlow: (v: unknown) => void;
+      mockQuery.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSlow = resolve;
+        }),
+      );
+      const staleLoad = getUserSecurityState(USER_ID);
+
+      // Admin deactivation COMMITs and invalidates while the SELECT is in flight.
+      await invalidateUserSecurityState(USER_ID);
+
+      // The stale "still active" row arrives AFTER the invalidation ran.
+      resolveSlow!(activeRow('admin'));
+      await expect(staleLoad).resolves.toEqual({ kind: 'active', role: 'admin' });
+
+      // The stale result must NOT have been cached: the next call re-reads
+      // the DB and sees the committed deactivation.
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ role: 'admin', deactivated_at: new Date() }],
+      });
+      const after = await getUserSecurityState(USER_ID);
+      expect(after).toEqual({ kind: 'deactivated' });
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+
+      // …and the fresh 'deactivated' entry stays cached (the stale load did
+      // not overwrite it).
+      const cached = await getUserSecurityState(USER_ID);
+      expect(cached).toEqual({ kind: 'deactivated' });
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('a lookup arriving after the invalidation starts a fresh load instead of joining the stale one', async () => {
+      let resolveSlow: (v: unknown) => void;
+      mockQuery.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSlow = resolve;
+        }),
+      );
+      const staleLoad = getUserSecurityState(USER_ID);
+
+      await invalidateUserSecurityState(USER_ID);
+
+      // The post-invalidation lookup must hit the DB (fresh, post-COMMIT
+      // read) rather than being deduplicated onto the stale in-flight load.
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ role: 'user', deactivated_at: new Date() }],
+      });
+      const fresh = await getUserSecurityState(USER_ID);
+      expect(fresh).toEqual({ kind: 'deactivated' });
+
+      // The slow stale load resolves last — it must not clobber the fresh entry.
+      resolveSlow!(activeRow('user'));
+      await staleLoad;
+
+      const cached = await getUserSecurityState(USER_ID);
+      expect(cached).toEqual({ kind: 'deactivated' });
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('cache-bus subscriber', () => {
@@ -222,6 +291,33 @@ describe('user-security-cache (#737)', () => {
       expect(mockQuery).toHaveBeenCalledTimes(2);
     });
 
+    it('fences an in-flight load against a bus invalidation from a peer pod', async () => {
+      initUserSecurityCacheBus();
+      const handler = mockSubscribe.mock.calls[0]![1] as (payload: unknown) => void;
+
+      let resolveSlow: (v: unknown) => void;
+      mockQuery.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSlow = resolve;
+        }),
+      );
+      const staleLoad = getUserSecurityState(USER_ID);
+
+      // A peer pod deactivated the user while our SELECT was in flight.
+      handler({ userId: USER_ID });
+
+      resolveSlow!(activeRow('user'));
+      await expect(staleLoad).resolves.toEqual({ kind: 'active', role: 'user' });
+
+      // The stale result must not have been cached.
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ role: 'user', deactivated_at: new Date() }],
+      });
+      const after = await getUserSecurityState(USER_ID);
+      expect(after).toEqual({ kind: 'deactivated' });
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
     it('clears the whole cache on a malformed bus payload (fail safe)', async () => {
       initUserSecurityCacheBus();
       mockQuery.mockResolvedValueOnce(activeRow('admin'));
@@ -245,6 +341,32 @@ describe('user-security-cache (#737)', () => {
 
       mockQuery.mockResolvedValueOnce(activeRow('admin'));
       await getUserSecurityState(USER_ID);
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('fences in-flight loads against a full-cache clear (bus reconnect)', async () => {
+      initUserSecurityCacheBus();
+      const reconnect = mockOnReconnect.mock.calls[0]![0] as () => void;
+
+      let resolveSlow: (v: unknown) => void;
+      mockQuery.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSlow = resolve;
+        }),
+      );
+      const staleLoad = getUserSecurityState(USER_ID);
+
+      // The bus reconnects mid-load → missed invalidations may exist, so the
+      // whole cache is cleared; the in-flight result may be stale too.
+      reconnect();
+
+      resolveSlow!(activeRow('admin'));
+      await staleLoad;
+
+      // Next lookup must re-read the DB, not serve the fenced stale result.
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      const after = await getUserSecurityState(USER_ID);
+      expect(after).toEqual({ kind: 'missing' });
       expect(mockQuery).toHaveBeenCalledTimes(2);
     });
   });

--- a/backend/src/core/services/user-security-cache.test.ts
+++ b/backend/src/core/services/user-security-cache.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for the per-user security-state cache (#737).
+ *
+ * Contract:
+ *   - getUserSecurityState(userId) reads `role` + `deactivated_at` from the
+ *     users table and caches the result in-process for
+ *     USER_SECURITY_CACHE_TTL_MS.
+ *   - Within the TTL, repeated calls do NOT hit the DB (hot-path safety —
+ *     `authenticate` calls this on every request).
+ *   - After the TTL, the next call re-reads from the DB.
+ *   - Concurrent calls during a cache miss share one in-flight query.
+ *   - Row states map to: active (with role) / deactivated / missing.
+ *   - DB errors soft-fail: stale last-known value if one exists, otherwise
+ *     'unknown' (callers treat 'unknown' as "proceed on token claims" so a
+ *     transient DB blip cannot 401 every request — mirrors cached-setting).
+ *   - invalidateUserSecurityState(userId) clears the local entry AND
+ *     publishes on the 'user:security:changed' cache-bus channel so peer
+ *     pods invalidate too.
+ *   - initUserSecurityCacheBus() wires the subscriber (clear one entry per
+ *     message) + an onReconnect handler (clear everything — missed pub/sub
+ *     messages are not replayed). Idempotent.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockQuery = vi.fn();
+vi.mock('../db/postgres.js', () => ({
+  query: (sql: string, params?: unknown[]) => mockQuery(sql, params),
+}));
+
+const mockPublish = vi.fn();
+const mockSubscribe = vi.fn();
+const mockOnReconnect = vi.fn();
+vi.mock('./redis-cache-bus.js', () => ({
+  publish: (channel: string, payload: unknown) => mockPublish(channel, payload),
+  subscribe: (channel: string, handler: (payload: unknown) => void) =>
+    mockSubscribe(channel, handler),
+  onReconnect: (handler: () => void | Promise<void>) => mockOnReconnect(handler),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+  getUserSecurityState,
+  invalidateUserSecurityState,
+  initUserSecurityCacheBus,
+  USER_SECURITY_CACHE_TTL_MS,
+  _resetForTests,
+} from './user-security-cache.js';
+import { logger } from '../utils/logger.js';
+
+const USER_ID = '11111111-1111-1111-1111-111111111111';
+
+function activeRow(role = 'admin') {
+  return { rows: [{ role, deactivated_at: null }] };
+}
+
+describe('user-security-cache (#737)', () => {
+  beforeEach(() => {
+    _resetForTests();
+    mockQuery.mockReset();
+    mockPublish.mockReset().mockResolvedValue(undefined);
+    mockSubscribe.mockReset().mockReturnValue(() => {});
+    mockOnReconnect.mockReset().mockReturnValue(() => {});
+    vi.mocked(logger.warn).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('state mapping', () => {
+    it('returns active + role for a live user row', async () => {
+      mockQuery.mockResolvedValueOnce(activeRow('admin'));
+
+      const state = await getUserSecurityState(USER_ID);
+
+      expect(state).toEqual({ kind: 'active', role: 'admin' });
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('FROM users'),
+        [USER_ID],
+      );
+    });
+
+    it('returns deactivated when deactivated_at is set', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ role: 'user', deactivated_at: new Date() }],
+      });
+
+      const state = await getUserSecurityState(USER_ID);
+      expect(state).toEqual({ kind: 'deactivated' });
+    });
+
+    it('returns missing when the user row is gone', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const state = await getUserSecurityState(USER_ID);
+      expect(state).toEqual({ kind: 'missing' });
+    });
+  });
+
+  describe('TTL caching (hot path)', () => {
+    it('serves repeated calls within the TTL from cache without re-querying', async () => {
+      mockQuery.mockResolvedValueOnce(activeRow('user'));
+
+      await getUserSecurityState(USER_ID);
+      await getUserSecurityState(USER_ID);
+      await getUserSecurityState(USER_ID);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-reads from the DB after the TTL elapses', async () => {
+      vi.useFakeTimers();
+      mockQuery.mockResolvedValueOnce(activeRow('admin'));
+      await getUserSecurityState(USER_ID);
+
+      vi.advanceTimersByTime(USER_SECURITY_CACHE_TTL_MS + 1);
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ role: 'user', deactivated_at: null }],
+      });
+      const state = await getUserSecurityState(USER_ID);
+
+      expect(state).toEqual({ kind: 'active', role: 'user' });
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('deduplicates concurrent lookups into a single in-flight query', async () => {
+      let resolveQuery: (v: unknown) => void;
+      mockQuery.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveQuery = resolve;
+        }),
+      );
+
+      const p1 = getUserSecurityState(USER_ID);
+      const p2 = getUserSecurityState(USER_ID);
+      resolveQuery!(activeRow('user'));
+
+      const [s1, s2] = await Promise.all([p1, p2]);
+      expect(s1).toEqual({ kind: 'active', role: 'user' });
+      expect(s2).toEqual({ kind: 'active', role: 'user' });
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('DB-error soft-fail', () => {
+    it('returns unknown and logs a warn when the lookup fails with no cached value', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('pool exhausted'));
+
+      const state = await getUserSecurityState(USER_ID);
+
+      expect(state).toEqual({ kind: 'unknown' });
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('returns the stale last-known state when a re-read fails after TTL expiry', async () => {
+      vi.useFakeTimers();
+      mockQuery.mockResolvedValueOnce(activeRow('admin'));
+      await getUserSecurityState(USER_ID);
+
+      vi.advanceTimersByTime(USER_SECURITY_CACHE_TTL_MS + 1);
+      mockQuery.mockRejectedValueOnce(new Error('pool exhausted'));
+
+      const state = await getUserSecurityState(USER_ID);
+      expect(state).toEqual({ kind: 'active', role: 'admin' });
+    });
+  });
+
+  describe('invalidation', () => {
+    it('clears the local entry and publishes on the cache-bus', async () => {
+      mockQuery.mockResolvedValueOnce(activeRow('admin'));
+      await getUserSecurityState(USER_ID);
+
+      await invalidateUserSecurityState(USER_ID);
+
+      expect(mockPublish).toHaveBeenCalledWith('user:security:changed', {
+        userId: USER_ID,
+      });
+
+      // Next read must hit the DB again even though the TTL has not elapsed.
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ role: 'admin', deactivated_at: new Date() }],
+      });
+      const state = await getUserSecurityState(USER_ID);
+      expect(state).toEqual({ kind: 'deactivated' });
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('cache-bus subscriber', () => {
+    it('subscribes to user:security:changed and registers a reconnect handler', () => {
+      initUserSecurityCacheBus();
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'user:security:changed',
+        expect.any(Function),
+      );
+      expect(mockOnReconnect).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('is idempotent — a second init does not double-subscribe', () => {
+      initUserSecurityCacheBus();
+      initUserSecurityCacheBus();
+
+      expect(mockSubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the matching entry when a bus message arrives', async () => {
+      initUserSecurityCacheBus();
+      mockQuery.mockResolvedValueOnce(activeRow('admin'));
+      await getUserSecurityState(USER_ID);
+
+      const handler = mockSubscribe.mock.calls[0]![1] as (payload: unknown) => void;
+      handler({ userId: USER_ID });
+
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      const state = await getUserSecurityState(USER_ID);
+      expect(state).toEqual({ kind: 'missing' });
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears the whole cache on a malformed bus payload (fail safe)', async () => {
+      initUserSecurityCacheBus();
+      mockQuery.mockResolvedValueOnce(activeRow('admin'));
+      await getUserSecurityState(USER_ID);
+
+      const handler = mockSubscribe.mock.calls[0]![1] as (payload: unknown) => void;
+      handler('not-an-object');
+
+      mockQuery.mockResolvedValueOnce(activeRow('admin'));
+      await getUserSecurityState(USER_ID);
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears the whole cache after a bus reconnect (missed messages are not replayed)', async () => {
+      initUserSecurityCacheBus();
+      mockQuery.mockResolvedValueOnce(activeRow('admin'));
+      await getUserSecurityState(USER_ID);
+
+      const reconnect = mockOnReconnect.mock.calls[0]![0] as () => void;
+      reconnect();
+
+      mockQuery.mockResolvedValueOnce(activeRow('admin'));
+      await getUserSecurityState(USER_ID);
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/backend/src/core/services/user-security-cache.ts
+++ b/backend/src/core/services/user-security-cache.ts
@@ -1,0 +1,165 @@
+/**
+ * Per-user security-state cache (#737).
+ *
+ * `authenticate` historically validated access tokens statelessly — `role`
+ * came from the JWT payload and `deactivated_at` was only re-checked at
+ * /login and /refresh. A deactivated or demoted user therefore kept full API
+ * access until their access token expired (ACCESS_TOKEN_EXPIRY, env-tunable).
+ *
+ * This module gives the auth hot path a cheap liveness/role check:
+ *
+ *   - getUserSecurityState(userId) → active(role) | deactivated | missing |
+ *     unknown. Backed by one `SELECT role, deactivated_at FROM users` per
+ *     user per TTL window (30s); everything in between is a Map lookup.
+ *   - invalidateUserSecurityState(userId) → clears the local entry AND
+ *     publishes on the 'user:security:changed' cache-bus channel so peer
+ *     pods drop their entries too (MULTI_INSTANCE deployments).
+ *   - initUserSecurityCacheBus() → wires the subscriber + reconnect handler.
+ *     Must run after initCacheBus(); idempotent (initProviderCacheBus
+ *     precedent).
+ *
+ * Revocation-latency bound: on the pod that handles the admin action, and on
+ * every pod reachable via the cache-bus, invalidation is immediate (the next
+ * request re-reads from Postgres). Pods without a working bus fall back to
+ * the TTL — at most USER_SECURITY_CACHE_TTL_MS (30s) of staleness, far below
+ * any permitted access-token lifetime (capped at 24h in auth.ts).
+ *
+ * Soft-fail: DB errors return the stale last-known state when one exists,
+ * otherwise 'unknown'. Callers treat 'unknown' as "proceed on token claims"
+ * — mirroring the cached-setting precedent — so a transient DB blip cannot
+ * turn into a 401 storm on the request hot path.
+ */
+
+import { query } from '../db/postgres.js';
+import { logger } from '../utils/logger.js';
+import { publish, subscribe, onReconnect } from './redis-cache-bus.js';
+
+/** Upper bound on revocation latency for pods that miss the cache-bus event. */
+export const USER_SECURITY_CACHE_TTL_MS = 30_000;
+
+/** Safety valve so the cache cannot grow unbounded under adversarial subs. */
+const MAX_ENTRIES = 10_000;
+
+export type UserSecurityState =
+  /** User exists and is active; `role` is the current DB role. */
+  | { kind: 'active'; role: string }
+  /** users.deactivated_at is set — reject the request. */
+  | { kind: 'deactivated' }
+  /** No users row for this id (hard-deleted) — reject the request. */
+  | { kind: 'missing' }
+  /** DB lookup failed and nothing cached — caller falls back to token claims. */
+  | { kind: 'unknown' };
+
+interface CacheEntry {
+  state: UserSecurityState;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const pending = new Map<string, Promise<UserSecurityState>>();
+let busWired = false;
+
+export async function getUserSecurityState(userId: string): Promise<UserSecurityState> {
+  const entry = cache.get(userId);
+  if (entry && entry.expiresAt > Date.now()) {
+    return entry.state;
+  }
+
+  // Stampede guard: concurrent requests for the same user during a cache
+  // miss share a single in-flight query.
+  const inFlight = pending.get(userId);
+  if (inFlight) return inFlight;
+
+  const load = loadFromDb(userId);
+  pending.set(userId, load);
+  return load;
+}
+
+async function loadFromDb(userId: string): Promise<UserSecurityState> {
+  try {
+    const res = await query<{ role: string; deactivated_at: Date | null }>(
+      'SELECT role, deactivated_at FROM users WHERE id = $1',
+      [userId],
+    );
+    const row = res.rows[0];
+    const state: UserSecurityState = !row
+      ? { kind: 'missing' }
+      : row.deactivated_at !== null
+        ? { kind: 'deactivated' }
+        : { kind: 'active', role: row.role };
+
+    if (cache.size >= MAX_ENTRIES) evictForSpace();
+    cache.set(userId, { state, expiresAt: Date.now() + USER_SECURITY_CACHE_TTL_MS });
+    return state;
+  } catch (err) {
+    logger.warn(
+      { err, userId },
+      'user-security-cache: lookup failed — soft-failing to last-known state',
+    );
+    // Keep serving the expired entry during a DB outage; the next request
+    // retries the read. With no prior entry the caller proceeds on token
+    // claims ('unknown') — same behaviour as before #737.
+    const stale = cache.get(userId);
+    return stale ? stale.state : { kind: 'unknown' };
+  } finally {
+    pending.delete(userId);
+  }
+}
+
+function evictForSpace(): void {
+  const now = Date.now();
+  for (const [key, value] of cache) {
+    if (value.expiresAt <= now) cache.delete(key);
+  }
+  // Still full of live entries → drop the oldest-inserted one (Map order).
+  if (cache.size >= MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+}
+
+/**
+ * Drop the cached state for a user and broadcast the invalidation to peer
+ * pods. Call after any privilege-boundary mutation (deactivate, reactivate,
+ * role change, delete). The local delete makes the change effective on this
+ * pod immediately; the publish covers the rest of the cluster (no-op in
+ * single-pod mode, where the TTL is the backstop).
+ */
+export async function invalidateUserSecurityState(userId: string): Promise<void> {
+  cache.delete(userId);
+  await publish('user:security:changed', { userId });
+}
+
+/**
+ * Wire the cluster subscriber. Idempotent — second call is a no-op. MUST be
+ * called after `initCacheBus(app.redis)`; if the bus is inactive (single-pod
+ * soft-fail) the subscription is a no-op and the TTL bounds staleness.
+ */
+export function initUserSecurityCacheBus(): void {
+  if (busWired) return;
+  busWired = true;
+
+  subscribe<{ userId?: unknown }>('user:security:changed', (payload) => {
+    const userId =
+      payload && typeof payload === 'object' && typeof payload.userId === 'string'
+        ? payload.userId
+        : null;
+    if (userId) {
+      cache.delete(userId);
+    } else {
+      // Malformed advice — fail safe by re-reading everyone on next request.
+      cache.clear();
+    }
+  });
+
+  // Redis pub/sub does not replay messages missed during a disconnect, so
+  // cold-flush everything once the bus is back.
+  onReconnect(() => cache.clear());
+}
+
+/** Test seam: clear cached state so tests don't leak entries across cases. */
+export function _resetForTests(): void {
+  cache.clear();
+  pending.clear();
+  busWired = false;
+}

--- a/backend/src/core/services/user-security-cache.ts
+++ b/backend/src/core/services/user-security-cache.ts
@@ -19,10 +19,15 @@
  *     precedent).
  *
  * Revocation-latency bound: on the pod that handles the admin action, and on
- * every pod reachable via the cache-bus, invalidation is immediate (the next
- * request re-reads from Postgres). Pods without a working bus fall back to
- * the TTL — at most USER_SECURITY_CACHE_TTL_MS (30s) of staleness, far below
- * any permitted access-token lifetime (capped at 24h in auth.ts).
+ * every pod reachable via the cache-bus, invalidation is immediate — the
+ * next lookup re-reads from Postgres, and a per-user generation fence stops
+ * an in-flight load (whose SELECT may have snapshotted pre-COMMIT state)
+ * from re-caching the stale result after the invalidation ran. Requests
+ * already awaiting that in-flight load may still see the pre-mutation state
+ * once — they raced the admin action either way — but it is never cached.
+ * Pods without a working bus fall back to the TTL — at most
+ * USER_SECURITY_CACHE_TTL_MS (30s) of staleness, far below any permitted
+ * access-token lifetime (clamped to 24h in auth.ts).
  *
  * Soft-fail: DB errors return the stale last-known state when one exists,
  * otherwise 'unknown'. Callers treat 'unknown' as "proceed on token claims"
@@ -59,6 +64,55 @@ const cache = new Map<string, CacheEntry>();
 const pending = new Map<string, Promise<UserSecurityState>>();
 let busWired = false;
 
+// Invalidation fence (#756 review). An invalidation that lands while a
+// loadFromDb SELECT is in flight cannot recall that query — and the row it
+// read may predate the invalidating transaction's COMMIT. Without a fence
+// the load would `cache.set` the stale "active/old-role" result AFTER the
+// invalidation ran, re-caching it for a full TTL window on the very pod
+// that handled the admin action. Every invalidation therefore bumps a
+// per-user generation (full-cache clears bump `clearGeneration`); a load
+// snapshots the fence before its SELECT and skips `cache.set` when the
+// fence moved. `userGenerations` is never pruned — it only grows via
+// admin privilege mutations on real user ids, so its size is bounded by
+// the user count.
+const userGenerations = new Map<string, number>();
+let clearGeneration = 0;
+
+interface InvalidationFence {
+  userGeneration: number;
+  clearGeneration: number;
+}
+
+function snapshotFence(userId: string): InvalidationFence {
+  return {
+    userGeneration: userGenerations.get(userId) ?? 0,
+    clearGeneration,
+  };
+}
+
+function fenceMoved(userId: string, before: InvalidationFence): boolean {
+  return (
+    (userGenerations.get(userId) ?? 0) !== before.userGeneration ||
+    clearGeneration !== before.clearGeneration
+  );
+}
+
+/** Local-pod part of an invalidation: drop the entry, fence the in-flight
+ * load (its result may be a pre-COMMIT snapshot) and detach it from
+ * `pending` so the next lookup starts a fresh post-COMMIT read instead of
+ * joining the stale one. */
+function invalidateLocal(userId: string): void {
+  cache.delete(userId);
+  pending.delete(userId);
+  userGenerations.set(userId, (userGenerations.get(userId) ?? 0) + 1);
+}
+
+function clearAllLocal(): void {
+  cache.clear();
+  pending.clear();
+  clearGeneration += 1;
+}
+
 export async function getUserSecurityState(userId: string): Promise<UserSecurityState> {
   const entry = cache.get(userId);
   if (entry && entry.expiresAt > Date.now()) {
@@ -70,12 +124,17 @@ export async function getUserSecurityState(userId: string): Promise<UserSecurity
   const inFlight = pending.get(userId);
   if (inFlight) return inFlight;
 
-  const load = loadFromDb(userId);
+  const load = loadFromDb(userId).finally(() => {
+    // Only deregister our own load — an invalidation may have already
+    // removed it and a newer (post-COMMIT) load may have taken the slot.
+    if (pending.get(userId) === load) pending.delete(userId);
+  });
   pending.set(userId, load);
   return load;
 }
 
 async function loadFromDb(userId: string): Promise<UserSecurityState> {
+  const fence = snapshotFence(userId);
   try {
     const res = await query<{ role: string; deactivated_at: Date | null }>(
       'SELECT role, deactivated_at FROM users WHERE id = $1',
@@ -88,8 +147,14 @@ async function loadFromDb(userId: string): Promise<UserSecurityState> {
         ? { kind: 'deactivated' }
         : { kind: 'active', role: row.role };
 
-    if (cache.size >= MAX_ENTRIES) evictForSpace();
-    cache.set(userId, { state, expiresAt: Date.now() + USER_SECURITY_CACHE_TTL_MS });
+    // An invalidation landed while the SELECT was in flight → our row may be
+    // a pre-COMMIT snapshot. Return it to the callers that were already
+    // waiting (they raced the admin action either way) but do NOT cache it;
+    // the next lookup re-reads the committed state.
+    if (!fenceMoved(userId, fence)) {
+      if (cache.size >= MAX_ENTRIES) evictForSpace();
+      cache.set(userId, { state, expiresAt: Date.now() + USER_SECURITY_CACHE_TTL_MS });
+    }
     return state;
   } catch (err) {
     logger.warn(
@@ -101,8 +166,6 @@ async function loadFromDb(userId: string): Promise<UserSecurityState> {
     // claims ('unknown') — same behaviour as before #737.
     const stale = cache.get(userId);
     return stale ? stale.state : { kind: 'unknown' };
-  } finally {
-    pending.delete(userId);
   }
 }
 
@@ -121,12 +184,14 @@ function evictForSpace(): void {
 /**
  * Drop the cached state for a user and broadcast the invalidation to peer
  * pods. Call after any privilege-boundary mutation (deactivate, reactivate,
- * role change, delete). The local delete makes the change effective on this
- * pod immediately; the publish covers the rest of the cluster (no-op in
+ * role change, delete). The local invalidation makes the change effective on
+ * this pod immediately — it also fences any in-flight DB load whose SELECT
+ * may have snapshotted pre-COMMIT state, so the stale result cannot be
+ * re-cached afterwards. The publish covers the rest of the cluster (no-op in
  * single-pod mode, where the TTL is the backstop).
  */
 export async function invalidateUserSecurityState(userId: string): Promise<void> {
-  cache.delete(userId);
+  invalidateLocal(userId);
   await publish('user:security:changed', { userId });
 }
 
@@ -145,21 +210,23 @@ export function initUserSecurityCacheBus(): void {
         ? payload.userId
         : null;
     if (userId) {
-      cache.delete(userId);
+      invalidateLocal(userId);
     } else {
       // Malformed advice — fail safe by re-reading everyone on next request.
-      cache.clear();
+      clearAllLocal();
     }
   });
 
   // Redis pub/sub does not replay messages missed during a disconnect, so
   // cold-flush everything once the bus is back.
-  onReconnect(() => cache.clear());
+  onReconnect(() => clearAllLocal());
 }
 
 /** Test seam: clear cached state so tests don't leak entries across cases. */
 export function _resetForTests(): void {
   cache.clear();
   pending.clear();
+  userGenerations.clear();
+  clearGeneration = 0;
   busWired = false;
 }

--- a/docs/ADMIN-GUIDE.md
+++ b/docs/ADMIN-GUIDE.md
@@ -119,7 +119,7 @@ curl http://localhost:3051/api/health
 | `FRONTEND_URL` | `http://localhost:5273` | CORS origin **and** the origin the post-login OIDC redirect is built from. Behind a reverse proxy with SSO, set this to your public origin (see [OIDC / SSO](#oidc--sso)). |
 | `FRONTEND_PORT` | `5273` | Host port mapped to the frontend container (Docker Compose only) |
 | `LOG_LEVEL` | `info` | Pino log level: `fatal`, `error`, `warn`, `info`, `debug`, `trace` |
-| `ACCESS_TOKEN_EXPIRY` | `1h` | JWT access token lifetime (jose duration format: `30m`, `1h`, `2h`) |
+| `ACCESS_TOKEN_EXPIRY` | `1h` | JWT access token lifetime (jose duration format: `30m`, `1h`, `2h`). Maximum `24h` — the backend refuses to start with a longer value, since the token lifetime is the worst-case window a deactivated or demoted account could retain API access. Deactivation and role changes normally take effect within seconds (≤ 30s) via the per-user security check. |
 
 ### LLM Provider
 

--- a/docs/ADMIN-GUIDE.md
+++ b/docs/ADMIN-GUIDE.md
@@ -119,7 +119,7 @@ curl http://localhost:3051/api/health
 | `FRONTEND_URL` | `http://localhost:5273` | CORS origin **and** the origin the post-login OIDC redirect is built from. Behind a reverse proxy with SSO, set this to your public origin (see [OIDC / SSO](#oidc--sso)). |
 | `FRONTEND_PORT` | `5273` | Host port mapped to the frontend container (Docker Compose only) |
 | `LOG_LEVEL` | `info` | Pino log level: `fatal`, `error`, `warn`, `info`, `debug`, `trace` |
-| `ACCESS_TOKEN_EXPIRY` | `1h` | JWT access token lifetime (jose duration format: `30m`, `1h`, `2h`). Maximum `24h` — the backend refuses to start with a longer value, since the token lifetime is the worst-case window a deactivated or demoted account could retain API access. Deactivation and role changes normally take effect within seconds (≤ 30s) via the per-user security check. |
+| `ACCESS_TOKEN_EXPIRY` | `1h` | JWT access token lifetime (jose duration format: `30m`, `1h`, `2h`). Maximum `24h` — a longer value is clamped to `24h` at startup and a warning is logged, since the token lifetime is the worst-case window a deactivated or demoted account could retain API access. An invalid format (e.g. `banana`) still fails startup. Deactivation and role changes normally take effect within seconds (≤ 30s) via the per-user security check. |
 
 ### LLM Provider
 

--- a/docs/architecture/07-flow-auth.md
+++ b/docs/architecture/07-flow-auth.md
@@ -60,6 +60,59 @@ sequenceDiagram
 and records `audit_log(action='logout')`. The access token is short-lived
 enough that blacklisting is not needed in CE; EE may add it.
 
+## Per-request revocation check (#737)
+
+`authenticate` does not trust the JWT alone: after signature verification it
+consults a per-user security-state cache so **deactivation, hard-delete and
+role changes take effect on already-issued access tokens** instead of only at
+`/login` and `/refresh`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client (stale token)
+    participant BE as authenticate (auth.ts)
+    participant UC as user-security-cache
+    participant DB as Postgres (users)
+    participant RB as Redis cache-bus
+
+    C->>BE: request + Bearer JWT
+    BE->>BE: jose.jwtVerify (HS256)
+    BE->>UC: getUserSecurityState(sub)
+    alt cache fresh (< 30s)
+        UC-->>BE: cached state (Map lookup, no I/O)
+    else miss / expired / invalidated
+        UC->>DB: SELECT role, deactivated_at FROM users
+        DB-->>UC: row
+        UC-->>BE: active(role) | deactivated | missing
+    end
+    alt deactivated or missing
+        BE-->>C: 401
+    else token role ≠ DB role
+        BE-->>C: 401 (client must re-authenticate)
+    else active + role matches
+        BE->>BE: proceed (RBAC scope, route handler)
+    end
+
+    Note over RB,UC: Admin deactivates / demotes / deletes a user →<br/>admin-user-service deletes refresh_tokens,<br/>clears the local cache entry and publishes<br/>`user:security:changed` — peer pods drop their entry too.
+```
+
+Properties:
+
+- **Hot-path cost**: a `Map` lookup per request; at most one indexed
+  single-row `SELECT` per user per 30s window per pod
+  (`USER_SECURITY_CACHE_TTL_MS`).
+- **Revocation latency bound**: immediate on the pod that handled the admin
+  action and on every pod subscribed to the cache-bus; ≤ 30s on pods without
+  a working bus (single-pod soft-fail mode). `ACCESS_TOKEN_EXPIRY` is capped
+  at 24h as the absolute worst-case backstop.
+- **Role change = privilege boundary**: `updateUser` revokes all refresh
+  tokens (mirroring deactivation), so a demoted admin cannot refresh back to
+  an admin token — they must log in again.
+- **Soft-fail**: if the `users` lookup fails and nothing is cached, the
+  request proceeds on the token claims (pre-#737 behaviour) so a transient DB
+  blip cannot 401 every session.
+
 ## OIDC flow (Enterprise Edition)
 
 Routes registered only when the EE plugin is loaded **and**
@@ -101,6 +154,8 @@ posts to a JSON endpoint and only then receives the real JWT.
 | Concern | File |
 |---------|------|
 | JWT plugin, decorators | `backend/src/core/plugins/auth.ts` |
+| Per-user security-state cache (#737) | `backend/src/core/services/user-security-cache.ts` |
+| Refresh-token revocation on deactivate / role change | `backend/src/core/services/admin-user-service.ts` |
 | Routes (register / login / refresh / logout) | `backend/src/routes/foundation/auth.ts` |
 | OIDC routes (EE only) | `@compendiq/enterprise` (loaded via `core/enterprise/loader.ts`) |
 | Frontend session init | `frontend/src/shared/hooks/useSessionInit.ts` |

--- a/docs/architecture/07-flow-auth.md
+++ b/docs/architecture/07-flow-auth.md
@@ -94,7 +94,7 @@ sequenceDiagram
         BE->>BE: proceed (RBAC scope, route handler)
     end
 
-    Note over RB,UC: Admin deactivates / demotes / deletes a user →<br/>admin-user-service deletes refresh_tokens,<br/>clears the local cache entry and publishes<br/>`user:security:changed` — peer pods drop their entry too.
+    Note over RB,UC: Admin deactivates / demotes / deletes a user →<br/>admin-user-service deletes refresh_tokens,<br/>invalidates the local cache entry (and fences any<br/>in-flight DB load) and publishes<br/>`user:security:changed` — peer pods drop their entry too.
 ```
 
 Properties:
@@ -104,8 +104,14 @@ Properties:
   (`USER_SECURITY_CACHE_TTL_MS`).
 - **Revocation latency bound**: immediate on the pod that handled the admin
   action and on every pod subscribed to the cache-bus; ≤ 30s on pods without
-  a working bus (single-pod soft-fail mode). `ACCESS_TOKEN_EXPIRY` is capped
-  at 24h as the absolute worst-case backstop.
+  a working bus (single-pod soft-fail mode). Invalidation bumps a per-user
+  generation that fences in-flight loads: a `SELECT` that snapshotted
+  pre-COMMIT state cannot re-cache the stale "active/old-role" answer after
+  the invalidation ran (requests already awaiting that load may see the
+  pre-mutation state once — they raced the admin action — but it is never
+  cached). `ACCESS_TOKEN_EXPIRY` is capped at 24h as the absolute worst-case
+  backstop; values above 24h are clamped at startup with a warning (an
+  invalid format still fails startup).
 - **Role change = privilege boundary**: `updateUser` revokes all refresh
   tokens (mirroring deactivation), so a demoted admin cannot refresh back to
   an admin token — they must log in again.


### PR DESCRIPTION
## Root cause

`fastify.authenticate` validated access tokens statelessly: `request.userRole` came straight from the JWT payload, and `deactivated_at` / `role` were only re-checked at `/login` and `/refresh`. An admin deactivating or demoting a user therefore had **no effect on already-issued access tokens** — and `ACCESS_TOKEN_EXPIRY` was env-configurable with no upper bound (the format regex accepted e.g. `999d`), so an offboarded or compromised account could keep full API access (including LLM/RAG over restricted content) indefinitely.

## Design

**Per-user security-state cache on the auth hot path** (`backend/src/core/services/user-security-cache.ts`), reusing the existing Redis cache-bus for cluster invalidation:

- `authenticate` now calls `getUserSecurityState(sub)` after JWT verification. The state (`active(role)` / `deactivated` / `missing`) is backed by one indexed single-row `SELECT role, deactivated_at FROM users` per user per **30s TTL window** (`USER_SECURITY_CACHE_TTL_MS`); every request in between is a `Map` lookup, with in-flight dedup so a cache miss never stampedes the DB. No raw per-request Postgres query.
- `deactivated` or `missing` → 401. Token `role` ≠ DB role → 401 (generic `Invalid or expired token`, no account-state oracle), forcing the client to re-authenticate.
- **Role change now revokes all refresh tokens** in the same transaction as the `UPDATE` (mirrors deactivation), so a demoted admin cannot refresh back into an admin-role token — they must log in again. Updates that don't change the role leave sessions untouched.
- **Cluster invalidation:** deactivate / reactivate / role change / delete clear the local cache entry and publish on a new `user:security:changed` channel of the existing `redis-cache-bus` (`initUserSecurityCacheBus()` wired in `app.ts` after `initCacheBus`, idempotent per the `initProviderCacheBus` precedent). Bus reconnect clears the whole cache since pub/sub has no replay. Every invalidation also bumps a **per-user generation fence** so an in-flight DB load whose `SELECT` snapshotted pre-COMMIT state cannot re-cache the stale result after the invalidation ran (see Review follow-up).
- **Soft-fail:** if the `users` lookup fails and nothing is cached, the request proceeds on token claims (matches the `cached-setting` soft-fail precedent) — a transient DB blip cannot 401 every in-flight session.
- **`ACCESS_TOKEN_EXPIRY` capped at 24h** at startup: the boundary `24h` is accepted; values above 24h are **clamped to 24h with a prominent startup warning** (they do not fail boot, so previously-valid configs like `48h`/`7d` survive unattended upgrades). An invalid format (e.g. `banana`) still fails startup with the pre-existing error message.

**Revocation-latency bound (documented in `docs/architecture/07-flow-auth.md` and `docs/ADMIN-GUIDE.md`):** immediate on the pod that handled the admin action and on every cache-bus subscriber (MULTI_INSTANCE) — the entry and any in-flight load are invalidated, and the generation fence prevents stale re-caching; requests already awaiting an in-flight load may observe the pre-mutation state once (they raced the admin action), but it is never cached. ≤ 30s on a pod running in single-pod soft-fail mode without the bus; ≤ 24h only in the degenerate case where every invalidation layer is down.

No DB migration — the check reads the existing `users.role` / `users.deactivated_at` columns, so `06-data-model.md` is unaffected; the auth-flow diagram (`07-flow-auth.md`) gained a revocation sequence diagram per the repo's diagram rule. No contract changes were needed (`packages/contracts` untouched).

## Test evidence

TDD: regression tests written first and observed failing (deactivated/demoted victims kept 200; `999d` accepted), then green after the fix.

- `backend/src/core/plugins/auth.revocation.test.ts` (new, 8 integration tests, real Postgres + `buildApp`): deactivation/demotion/promotion/hard-delete reject the victim's previously-working token on the very next request; role change deletes the victim's `refresh_tokens` rows; non-role updates and reactivation keep/restore access.
- `backend/src/core/services/user-security-cache.test.ts` (new, 18 unit tests): state mapping, TTL caching + expiry, concurrent-lookup dedup, DB-error soft-fail (unknown / stale last-known), invalidation publish, invalidation fencing of in-flight loads (local / bus / reconnect), bus subscribe/reconnect semantics, idempotent init.
- `backend/src/core/services/admin-user-service.test.ts` (+3): role change revokes refresh tokens; no-op and same-role updates don't.
- `backend/src/core/plugins/auth.test.ts` (+3): 24h boundary accepted without warning; `999d` and `25h` clamped to 24h with a startup warning.

All targeted suites green — latest run: 59 tests / 4 files (auth plugin, user-security-cache, auth.revocation, admin-user-service) plus the wider integration suites listed in earlier revisions. `npm run lint -w backend` and `npm run typecheck -w backend` clean.

## Review follow-up (93aaeff3)

Adversarial review of this PR surfaced two warnings, both fixed:

1. **TOCTOU between invalidation and an in-flight cache load** (`user-security-cache.ts`): `invalidateUserSecurityState` and the bus handler only deleted the cache entry — they did not fence the in-flight `loadFromDb`. A load whose `SELECT` snapshotted pre-COMMIT state could `cache.set` the stale "active/old-role" result *after* the invalidation ran, re-caching it for a full 30s on the very pod that handled the deactivation. Fixed with a per-user generation counter (full-cache clears bump a separate clear-generation): every invalidation bumps the fence and detaches the in-flight promise from the dedup map; `loadFromDb` snapshots the fence before its `SELECT` and skips `cache.set` if it moved. Four regression tests interleave a slow mocked DB load with local-, bus- and reconnect-triggered invalidations and assert the stale result is neither cached nor able to clobber a fresher entry. Module header and `07-flow-auth.md` updated to state the fenced guarantee precisely.
2. **⚠️ Behavior change — `ACCESS_TOKEN_EXPIRY` over 24h no longer fails boot**: the hard startup failure introduced earlier in this PR could take down an existing deployment on unattended upgrade (configs like `48h`/`7d` were valid before). Over-cap values are now **clamped to 24h** with a prominent `logger.warn` (`SECURITY: ACCESS_TOKEN_EXPIRY "<value>" exceeds the 24h cap — clamping to 24h…`); an invalid *format* still fails startup as before. `.env.example` and `docs/ADMIN-GUIDE.md` updated accordingly. Operators who intentionally set a longer lifetime should watch for the warning and move session longevity to the 7-day refresh token.

Fixes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)
