### PR TITLE
fix(queue): honor rediss:// TLS, ACL username, and db index in BullMQ Redis connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ POSTGRES_URL=postgresql://kb_user:changeme-postgres@localhost:5432/kb_creator
 POSTGRES_TEST_URL=postgresql://kb_user:changeme-postgres@localhost:5433/kb_creator_test
 
 # --- Redis ---
+# Full URL surface is honored by both Redis clients (node-redis and BullMQ/ioredis):
+#   rediss:// scheme = TLS, optional ACL username, optional /N database index,
+#   e.g. rediss://app-user:secret@redis.internal:6380/2
 REDIS_URL=redis://:changeme-redis@localhost:6379
 
 # --- BullMQ Job Queue ---

--- a/.env.example
+++ b/.env.example
@@ -24,9 +24,12 @@ POSTGRES_URL=postgresql://kb_user:changeme-postgres@localhost:5432/kb_creator
 POSTGRES_TEST_URL=postgresql://kb_user:changeme-postgres@localhost:5433/kb_creator_test
 
 # --- Redis ---
-# Full URL surface is honored by both Redis clients (node-redis and BullMQ/ioredis):
-#   rediss:// scheme = TLS, optional ACL username, optional /N database index,
+# Both Redis clients (node-redis and BullMQ/ioredis) support:
+#   rediss:// scheme = TLS, optional ACL username:password (percent-encoded),
+#   optional numeric /N database index,
 #   e.g. rediss://app-user:secret@redis.internal:6380/2
+# Not supported on the BullMQ side: IPv6 bracket hosts and query parameters;
+# a non-numeric database path is ignored.
 REDIS_URL=redis://:changeme-redis@localhost:6379
 
 # --- BullMQ Job Queue ---

--- a/backend/src/core/services/queue-service.ts
+++ b/backend/src/core/services/queue-service.ts
@@ -8,9 +8,10 @@
  * Uses ioredis (BullMQ's native client) which coexists with the existing node-redis client.
  */
 
-import { Queue, Worker, type Job, type ConnectionOptions } from 'bullmq';
+import { Queue, Worker, type Job } from 'bullmq';
 import { query } from '../db/postgres.js';
 import { logger } from '../utils/logger.js';
+import { getRedisConnectionOpts } from '../utils/redis-connection.js';
 
 // ─── Feature flag ────────────────────────────────────────────────────────────
 
@@ -21,27 +22,10 @@ export function isBullMQEnabled(): boolean {
 }
 
 // ─── Connection ──────────────────────────────────────────────────────────────
-
-function getRedisConnectionOpts(): ConnectionOptions {
-  const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return {
-      host: 'localhost',
-      port: 6379,
-      maxRetriesPerRequest: null,
-    };
-  }
-
-  return {
-    host: parsed.hostname,
-    port: parseInt(parsed.port || '6379', 10),
-    password: parsed.password || undefined,
-    maxRetriesPerRequest: null, // Required by BullMQ
-  };
-}
+//
+// REDIS_URL parsing lives in core/utils/redis-connection.ts (shared with the
+// webhook outbox poller) so TLS (`rediss://`), ACL username, and db index are
+// honored consistently across every BullMQ connection (issue #742).
 
 // ─── Queue / Worker registry ─────────────────────────────────────────────────
 

--- a/backend/src/core/services/webhook-delivery.ts
+++ b/backend/src/core/services/webhook-delivery.ts
@@ -49,11 +49,12 @@
  *     `getWebhookDeliveryQueue()` to keep the keyspace in sync.
  */
 
-import { Worker, type Job, type ConnectionOptions } from 'bullmq';
+import { Worker, type Job } from 'bullmq';
 import { Agent, fetch as undiciFetch } from 'undici';
 
 import { getPool } from '../db/postgres.js';
 import { logger } from '../utils/logger.js';
+import { getRedisConnectionOpts } from '../utils/redis-connection.js';
 import { assertNonSsrfUrl, SsrfError } from '../utils/ssrf-guard.js';
 import { decryptPat } from '../utils/crypto.js';
 import { logAuditEvent } from './audit-service.js';
@@ -166,27 +167,13 @@ interface RuntimeConfig {
   userAgent: string;
 }
 
-// ─── Redis connection (mirror poller + queue-service) ────────────────────
-
-function getRedisConnectionOpts(): ConnectionOptions {
-  const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return {
-      host: 'localhost',
-      port: 6379,
-      maxRetriesPerRequest: null,
-    };
-  }
-  return {
-    host: parsed.hostname,
-    port: parseInt(parsed.port || '6379', 10),
-    password: parsed.password || undefined,
-    maxRetriesPerRequest: null,
-  };
-}
+// ─── Redis connection ────────────────────────────────────────────────────
+//
+// REDIS_URL parsing lives in core/utils/redis-connection.ts — shared with
+// the outbox poller (producer) and queue-service so this consumer Worker
+// always lands on the same Redis db / TLS / credentials as the queue it
+// consumes (issue #742). Regression-guarded by
+// webhook-delivery.worker-connection.test.ts.
 
 // ─── Module state ────────────────────────────────────────────────────────
 

--- a/backend/src/core/services/webhook-delivery.worker-connection.test.ts
+++ b/backend/src/core/services/webhook-delivery.worker-connection.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression test (issue #742 follow-up): the webhook-delivery `Worker`
+ * MUST build its Redis connection options via the shared parser in
+ * `core/utils/redis-connection.ts`.
+ *
+ * A drifted local copy of the parser previously dropped `rediss://` TLS,
+ * the ACL username, and the `/N` db index. Because the outbox poller
+ * (producer) already used the shared parser, a REDIS_URL like
+ * `redis://host:6379/2` split the pipeline: the poller enqueued jobs into
+ * db 2 while the worker listened on db 0 — webhooks silently never
+ * delivered.
+ *
+ * Mirrors queue-service.test.ts: bullmq is mocked at the module boundary
+ * with constructor-capturing stubs, so no real Redis or Postgres is
+ * needed — these tests assert wiring, not delivery behaviour (that lives
+ * in webhook-delivery.test.ts).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+interface CapturedCtorCall {
+  queueName: string;
+  opts: { connection?: unknown } | undefined;
+}
+
+const workerCtorCalls: CapturedCtorCall[] = [];
+const queueCtorCalls: CapturedCtorCall[] = [];
+
+vi.mock('bullmq', () => ({
+  // Real constructor functions so `new Queue(...)` / `new Worker(...)`
+  // work — arrow functions are not constructible (same pattern as
+  // queue-service.test.ts).
+  Queue: function (
+    this: Record<string, unknown>,
+    queueName: string,
+    opts?: { connection?: unknown },
+  ) {
+    queueCtorCalls.push({ queueName, opts });
+    this.close = vi.fn().mockResolvedValue(undefined);
+  },
+  Worker: function (
+    this: Record<string, unknown>,
+    queueName: string,
+    _processor: unknown,
+    opts?: { connection?: unknown },
+  ) {
+    workerCtorCalls.push({ queueName, opts });
+    this.on = vi.fn();
+    this.close = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('webhook-delivery worker — Redis connection wiring', () => {
+  beforeEach(() => {
+    workerCtorCalls.length = 0;
+    queueCtorCalls.length = 0;
+    // Fresh module state (cachedTeardown, worker singleton, the poller's
+    // queue handle) per test.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('passes the shared parser output (TLS, ACL username, db index) to the Worker', async () => {
+    const url = 'rediss://app-user:s%40cret@redis.internal:6390/2';
+    vi.stubEnv('REDIS_URL', url);
+
+    const { getRedisConnectionOpts } = await import('../utils/redis-connection.js');
+    const { initWebhookDeliveryWorker } = await import('./webhook-delivery.js');
+
+    const teardown = await initWebhookDeliveryWorker();
+    try {
+      expect(workerCtorCalls).toHaveLength(1);
+      expect(workerCtorCalls[0]!.queueName).toBe('webhook-delivery');
+      // The Worker's connection must be exactly what the shared parser
+      // produces for the same URL…
+      expect(workerCtorCalls[0]!.opts?.connection).toEqual(
+        getRedisConnectionOpts(url),
+      );
+      // …and explicitly carry the full supported surface, so this test
+      // still fails loudly if the shared parser itself regresses.
+      expect(workerCtorCalls[0]!.opts?.connection).toEqual({
+        host: 'redis.internal',
+        port: 6390,
+        username: 'app-user',
+        password: 's@cret',
+        db: 2,
+        tls: {},
+        maxRetriesPerRequest: null,
+      });
+    } finally {
+      await teardown();
+    }
+  });
+
+  it('worker (consumer) and shared delivery queue (producer) use identical connection options', async () => {
+    // A db-index URL is the exact split that originally broke delivery:
+    // producer on db 2, consumer on db 0.
+    vi.stubEnv('REDIS_URL', 'redis://localhost:6379/2');
+
+    const { initWebhookDeliveryWorker } = await import('./webhook-delivery.js');
+
+    const teardown = await initWebhookDeliveryWorker();
+    try {
+      // initWebhookDeliveryWorker eagerly builds the shared queue handle
+      // via getWebhookDeliveryQueue() (poller module).
+      expect(queueCtorCalls).toHaveLength(1);
+      expect(queueCtorCalls[0]!.queueName).toBe('webhook-delivery');
+      expect(workerCtorCalls).toHaveLength(1);
+      expect(workerCtorCalls[0]!.opts?.connection).toEqual(
+        queueCtorCalls[0]!.opts?.connection,
+      );
+    } finally {
+      await teardown();
+    }
+  });
+});

--- a/backend/src/core/services/webhook-outbox-poller.test.ts
+++ b/backend/src/core/services/webhook-outbox-poller.test.ts
@@ -38,6 +38,7 @@ import {
   __resetWebhookOutboxPollerForTests,
   __closeWebhookDeliveryQueueForTests,
 } from './webhook-outbox-poller.js';
+import { getRedisConnectionOpts } from '../utils/redis-connection.js';
 
 // ─── Environment probe ───────────────────────────────────────────────────
 
@@ -74,19 +75,6 @@ async function checkRedisReachable(): Promise<boolean> {
 const dbAvailable = await isDbAvailable();
 const redisAvailable = dbAvailable ? await checkRedisReachable() : false;
 const canRun = dbAvailable && redisAvailable;
-
-// ─── Redis connection opts (mirror the service under test) ───────────────
-
-function getRedisConnectionOpts() {
-  const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
-  const parsed = new URL(url);
-  return {
-    host: parsed.hostname,
-    port: parseInt(parsed.port || '6379', 10),
-    password: parsed.password || undefined,
-    maxRetriesPerRequest: null,
-  };
-}
 
 // ─── Helpers ────────────────────────────────────────────────────────────
 

--- a/backend/src/core/services/webhook-outbox-poller.ts
+++ b/backend/src/core/services/webhook-outbox-poller.ts
@@ -47,10 +47,11 @@
  * bootstrap registration.
  */
 
-import { Queue, type ConnectionOptions } from 'bullmq';
+import { Queue } from 'bullmq';
 import type { PoolClient } from 'pg';
 import { getPool } from '../db/postgres.js';
 import { logger } from '../utils/logger.js';
+import { getRedisConnectionOpts } from '../utils/redis-connection.js';
 
 // ─── Tunables ────────────────────────────────────────────────────────────
 
@@ -60,28 +61,6 @@ const DEFAULT_STALE_DISPATCH_THRESHOLD_MS = 5 * 60 * 1_000; // 5 min
 
 /** Queue name shared with the Phase D delivery worker. */
 export const WEBHOOK_DELIVERY_QUEUE = 'webhook-delivery';
-
-// ─── Redis connection (mirror queue-service.ts — one source of truth) ───
-
-function getRedisConnectionOpts(): ConnectionOptions {
-  const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return {
-      host: 'localhost',
-      port: 6379,
-      maxRetriesPerRequest: null,
-    };
-  }
-  return {
-    host: parsed.hostname,
-    port: parseInt(parsed.port || '6379', 10),
-    password: parsed.password || undefined,
-    maxRetriesPerRequest: null,
-  };
-}
 
 // ─── Singleton queue handle ──────────────────────────────────────────────
 //

--- a/backend/src/core/utils/redis-connection.test.ts
+++ b/backend/src/core/utils/redis-connection.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getRedisConnectionOpts } from './redis-connection.js';
+
+describe('getRedisConnectionOpts', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('parses a plain redis:// URL into host/port only', () => {
+    const opts = getRedisConnectionOpts('redis://localhost:6379');
+    expect(opts).toEqual({
+      host: 'localhost',
+      port: 6379,
+      maxRetriesPerRequest: null,
+    });
+    expect(opts.tls).toBeUndefined();
+    expect(opts.username).toBeUndefined();
+    expect(opts.password).toBeUndefined();
+    expect(opts.db).toBeUndefined();
+  });
+
+  it('maps rediss:// to tls: {} (TLS enabled)', () => {
+    const opts = getRedisConnectionOpts('rediss://redis.example.com:6380');
+    expect(opts.tls).toEqual({});
+    expect(opts.host).toBe('redis.example.com');
+    expect(opts.port).toBe(6380);
+  });
+
+  it('does NOT set tls for plain redis://', () => {
+    const opts = getRedisConnectionOpts('redis://redis.example.com:6379');
+    expect(opts.tls).toBeUndefined();
+  });
+
+  it('preserves the ACL username', () => {
+    const opts = getRedisConnectionOpts(
+      'redis://app-user:secret@redis.example.com:6379',
+    );
+    expect(opts.username).toBe('app-user');
+    expect(opts.password).toBe('secret');
+  });
+
+  it('supports password-only URLs (redis://:pass@host)', () => {
+    const opts = getRedisConnectionOpts('redis://:changeme-redis@localhost:6379');
+    expect(opts.password).toBe('changeme-redis');
+    expect(opts.username).toBeUndefined();
+  });
+
+  it('preserves the /N database index as a number', () => {
+    const opts = getRedisConnectionOpts('redis://localhost:6379/2');
+    expect(opts.db).toBe(2);
+  });
+
+  it('omits db for a bare or trailing-slash path', () => {
+    expect(getRedisConnectionOpts('redis://localhost:6379').db).toBeUndefined();
+    expect(getRedisConnectionOpts('redis://localhost:6379/').db).toBeUndefined();
+  });
+
+  it('ignores a non-numeric db path', () => {
+    expect(getRedisConnectionOpts('redis://localhost:6379/abc').db).toBeUndefined();
+  });
+
+  it('defaults the port to 6379 when omitted', () => {
+    const opts = getRedisConnectionOpts('redis://myhost');
+    expect(opts.host).toBe('myhost');
+    expect(opts.port).toBe(6379);
+  });
+
+  it('decodes percent-encoded credentials (matches node-redis behavior)', () => {
+    const opts = getRedisConnectionOpts('redis://app%40user:p%40ss%2Fword@host:6379');
+    expect(opts.username).toBe('app@user');
+    expect(opts.password).toBe('p@ss/word');
+  });
+
+  it('combines TLS, ACL credentials, and db index from one rediss:// URL', () => {
+    const opts = getRedisConnectionOpts('rediss://worker:hunter2@redis.internal:6390/3');
+    expect(opts).toEqual({
+      host: 'redis.internal',
+      port: 6390,
+      username: 'worker',
+      password: 'hunter2',
+      db: 3,
+      tls: {},
+      maxRetriesPerRequest: null,
+    });
+  });
+
+  it('falls back to localhost:6379 on an unparseable URL', () => {
+    const opts = getRedisConnectionOpts('not a url');
+    expect(opts).toEqual({
+      host: 'localhost',
+      port: 6379,
+      maxRetriesPerRequest: null,
+    });
+  });
+
+  it('always sets maxRetriesPerRequest: null (required by BullMQ)', () => {
+    expect(getRedisConnectionOpts('redis://h:1').maxRetriesPerRequest).toBeNull();
+    expect(getRedisConnectionOpts('://broken').maxRetriesPerRequest).toBeNull();
+  });
+
+  it('reads REDIS_URL from the environment when called without arguments', () => {
+    vi.stubEnv('REDIS_URL', 'rediss://env-user:env-pass@env-host:7000/1');
+    const opts = getRedisConnectionOpts();
+    expect(opts).toEqual({
+      host: 'env-host',
+      port: 7000,
+      username: 'env-user',
+      password: 'env-pass',
+      db: 1,
+      tls: {},
+      maxRetriesPerRequest: null,
+    });
+  });
+
+  it('defaults to redis://localhost:6379 when REDIS_URL is unset', () => {
+    vi.stubEnv('REDIS_URL', '');
+    const original = process.env.REDIS_URL;
+    delete process.env.REDIS_URL;
+    try {
+      const opts = getRedisConnectionOpts();
+      expect(opts).toEqual({
+        host: 'localhost',
+        port: 6379,
+        maxRetriesPerRequest: null,
+      });
+    } finally {
+      process.env.REDIS_URL = original;
+    }
+  });
+});

--- a/backend/src/core/utils/redis-connection.test.ts
+++ b/backend/src/core/utils/redis-connection.test.ts
@@ -93,6 +93,21 @@ describe('getRedisConnectionOpts', () => {
     });
   });
 
+  it('falls back to localhost defaults on malformed percent-encoding instead of throwing', () => {
+    // WHATWG URL parsing accepts an invalid %-sequence in the userinfo, but
+    // decodeURIComponent throws URIError on it. Per the documented contract
+    // the parser must degrade to the localhost fallback, never throw at
+    // Queue/Worker construction time.
+    const fallback = {
+      host: 'localhost',
+      port: 6379,
+      maxRetriesPerRequest: null,
+    };
+    expect(() => getRedisConnectionOpts('redis://:pa%zzword@host:6390')).not.toThrow();
+    expect(getRedisConnectionOpts('redis://:pa%zzword@host:6390')).toEqual(fallback);
+    expect(getRedisConnectionOpts('redis://bad%user:pw@host:6390')).toEqual(fallback);
+  });
+
   it('always sets maxRetriesPerRequest: null (required by BullMQ)', () => {
     expect(getRedisConnectionOpts('redis://h:1').maxRetriesPerRequest).toBeNull();
     expect(getRedisConnectionOpts('://broken').maxRetriesPerRequest).toBeNull();

--- a/backend/src/core/utils/redis-connection.ts
+++ b/backend/src/core/utils/redis-connection.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared REDIS_URL → ioredis connection-options parser for BullMQ.
+ *
+ * Single source of truth for every BullMQ `Queue`/`Worker` connection
+ * (queue-service.ts, webhook-outbox-poller.ts). The node-redis client
+ * (core/plugins/redis.ts) consumes REDIS_URL verbatim, so this parser must
+ * honor the full URL surface — `rediss://` (TLS), the ACL username, and the
+ * `/N` database index — or the two clients silently diverge (issue #742:
+ * TLS downgrade, wrong-user auth failures, cross-db key collisions).
+ *
+ * Option names per ioredis `RedisOptions`: `tls` (empty object enables TLS,
+ * equivalent to a `rediss://` URL), `username`, `password`, `db` (number).
+ * Credentials are percent-decoded to match node-redis URL semantics.
+ */
+
+export interface RedisConnectionOpts {
+  host: string;
+  port: number;
+  username?: string;
+  password?: string;
+  /** Redis logical database index from the URL path (`/N`). */
+  db?: number;
+  /** Empty object = enable TLS with default verification (`rediss://`). */
+  tls?: Record<string, never>;
+  /** Required by BullMQ: blocking commands must never exhaust retries. */
+  maxRetriesPerRequest: null;
+}
+
+/**
+ * Parse a Redis URL (defaults to `REDIS_URL`, falling back to
+ * `redis://localhost:6379`) into ioredis/BullMQ connection options.
+ * Unparseable URLs fall back to localhost defaults.
+ */
+export function getRedisConnectionOpts(
+  url: string = process.env.REDIS_URL ?? 'redis://localhost:6379',
+): RedisConnectionOpts {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return {
+      host: 'localhost',
+      port: 6379,
+      maxRetriesPerRequest: null,
+    };
+  }
+
+  const opts: RedisConnectionOpts = {
+    host: parsed.hostname,
+    port: parseInt(parsed.port || '6379', 10),
+    maxRetriesPerRequest: null,
+  };
+
+  if (parsed.protocol === 'rediss:') {
+    opts.tls = {};
+  }
+  if (parsed.username) {
+    opts.username = decodeURIComponent(parsed.username);
+  }
+  if (parsed.password) {
+    opts.password = decodeURIComponent(parsed.password);
+  }
+
+  const dbMatch = /^\/(\d+)$/.exec(parsed.pathname);
+  if (dbMatch) {
+    opts.db = parseInt(dbMatch[1]!, 10);
+  }
+
+  return opts;
+}

--- a/backend/src/core/utils/redis-connection.ts
+++ b/backend/src/core/utils/redis-connection.ts
@@ -2,11 +2,21 @@
  * Shared REDIS_URL → ioredis connection-options parser for BullMQ.
  *
  * Single source of truth for every BullMQ `Queue`/`Worker` connection
- * (queue-service.ts, webhook-outbox-poller.ts). The node-redis client
- * (core/plugins/redis.ts) consumes REDIS_URL verbatim, so this parser must
- * honor the full URL surface — `rediss://` (TLS), the ACL username, and the
- * `/N` database index — or the two clients silently diverge (issue #742:
- * TLS downgrade, wrong-user auth failures, cross-db key collisions).
+ * (queue-service.ts, webhook-outbox-poller.ts, webhook-delivery.ts). The
+ * node-redis client (core/plugins/redis.ts) consumes REDIS_URL verbatim,
+ * so this parser must agree with it on the URL features we support, or
+ * the two clients silently diverge (issue #742: TLS downgrade, wrong-user
+ * auth failures, cross-db key collisions).
+ *
+ * Supported URL surface (deliberately narrow):
+ *   - `redis://` and `rediss://` schemes (`rediss:` enables TLS)
+ *   - optional `user:pass@` userinfo, percent-decoded
+ *   - optional numeric `/N` path → `db` (non-numeric paths are ignored)
+ *
+ * NOT translated for ioredis: IPv6 bracket hosts and query parameters
+ * (e.g. `?family=`). A URL that fails WHATWG parsing — or credentials
+ * with malformed percent-encoding — falls back to the localhost defaults
+ * instead of throwing at Queue/Worker construction time.
  *
  * Option names per ioredis `RedisOptions`: `tls` (empty object enables TLS,
  * equivalent to a `rediss://` URL), `username`, `password`, `db` (number).
@@ -29,14 +39,41 @@ export interface RedisConnectionOpts {
 /**
  * Parse a Redis URL (defaults to `REDIS_URL`, falling back to
  * `redis://localhost:6379`) into ioredis/BullMQ connection options.
- * Unparseable URLs fall back to localhost defaults.
+ * Unparseable URLs — including malformed percent-encoding in the
+ * credentials — fall back to localhost defaults.
  */
 export function getRedisConnectionOpts(
   url: string = process.env.REDIS_URL ?? 'redis://localhost:6379',
 ): RedisConnectionOpts {
-  let parsed: URL;
   try {
-    parsed = new URL(url);
+    const parsed = new URL(url);
+
+    const opts: RedisConnectionOpts = {
+      host: parsed.hostname,
+      port: parseInt(parsed.port || '6379', 10),
+      maxRetriesPerRequest: null,
+    };
+
+    if (parsed.protocol === 'rediss:') {
+      opts.tls = {};
+    }
+    // decodeURIComponent stays inside this try block: WHATWG URL parsing
+    // accepts invalid %-sequences in the userinfo, but decoding them throws
+    // URIError — which must degrade to the documented fallback, not escape
+    // into Queue/Worker construction.
+    if (parsed.username) {
+      opts.username = decodeURIComponent(parsed.username);
+    }
+    if (parsed.password) {
+      opts.password = decodeURIComponent(parsed.password);
+    }
+
+    const dbMatch = /^\/(\d+)$/.exec(parsed.pathname);
+    if (dbMatch) {
+      opts.db = parseInt(dbMatch[1]!, 10);
+    }
+
+    return opts;
   } catch {
     return {
       host: 'localhost',
@@ -44,27 +81,4 @@ export function getRedisConnectionOpts(
       maxRetriesPerRequest: null,
     };
   }
-
-  const opts: RedisConnectionOpts = {
-    host: parsed.hostname,
-    port: parseInt(parsed.port || '6379', 10),
-    maxRetriesPerRequest: null,
-  };
-
-  if (parsed.protocol === 'rediss:') {
-    opts.tls = {};
-  }
-  if (parsed.username) {
-    opts.username = decodeURIComponent(parsed.username);
-  }
-  if (parsed.password) {
-    opts.password = decodeURIComponent(parsed.password);
-  }
-
-  const dbMatch = /^\/(\d+)$/.exec(parsed.pathname);
-  if (dbMatch) {
-    opts.db = parseInt(dbMatch[1]!, 10);
-  }
-
-  return opts;
 }


### PR DESCRIPTION
## Root cause

The hand-rolled `REDIS_URL` parser used for every BullMQ connection (`backend/src/core/services/queue-service.ts:25-44`) extracted only `hostname`, `port`, and `password`. A `rediss:` scheme, an ACL `username`, or a `/N` database path were silently discarded, so BullMQ connected **plaintext**, as the **`default` user**, to **db 0** — while the node-redis client (`core/plugins/redis.ts`) consumes the same env var verbatim and honors all of it. The same parser was copy-duplicated in `webhook-outbox-poller.ts:66-84` (whose comment claimed "one source of truth"), mirrored inside `webhook-outbox-poller.test.ts`, **and duplicated a further time in `webhook-delivery.ts:171-189`** (the BullMQ `Worker` consumer — initially missed; fixed in the review follow-up below).

Impact: silent TLS downgrade for queue traffic (job payloads carry page content / webhook payloads), auth failures or cross-db key collisions on hardened Redis. (#742, severity medium.)

## Fix

- New shared util **`backend/src/core/utils/redis-connection.ts`** — single `getRedisConnectionOpts(url?)` parser:
  - `rediss:` → `tls: {}` (ioredis-documented equivalent of a `rediss://` URL)
  - `username` / `password` preserved, percent-decoded to match node-redis URL semantics
  - `/N` path → `db: N` (number, per ioredis `RedisOptions`); bare/trailing-slash/non-numeric paths leave `db` unset
  - keeps `maxRetriesPerRequest: null` (required by BullMQ) and the existing localhost fallback for unparseable URLs — now **including malformed percent-encoding** (URIError degrades to the fallback instead of throwing at Queue/Worker construction)
- `queue-service.ts`, `webhook-outbox-poller.ts`, and `webhook-delivery.ts` now import it; all duplicated parsers are deleted, as is the mirror copy in `webhook-outbox-poller.test.ts`.
- `.env.example` documents the supported URL surface **with its limits**: `rediss://` TLS, ACL `username:password` (percent-encoded), numeric `/N` db index. Not translated for the BullMQ/ioredis side: IPv6 bracket hosts and query parameters; non-numeric db paths are ignored.

Option names verified against the ioredis README (`RedisOptions`: `username`, `password`, `db`, `tls: {}` ≡ `rediss://`), not guessed.

## Test evidence (TDD)

New pure unit suite `backend/src/core/utils/redis-connection.test.ts` (16 tests) written first and watched fail (`Cannot find module './redis-connection.js'`), then pass after implementation. Covers: plain `redis://` unchanged, `rediss://` → `tls`, ACL username preserved, `/2` db index preserved, password-only `redis://:pass@host`, percent-decoding, malformed percent-encoding fallback, default port, invalid-URL fallback, env-var default path, combined `rediss://user:pw@host:port/db`.

Targeted run (dedicated Postgres + live Redis):

```
vitest run src/core/utils/redis-connection.test.ts \
           src/core/services/webhook-delivery.worker-connection.test.ts \
           src/core/services/webhook-delivery.test.ts \
           src/core/services/webhook-outbox-poller.test.ts \
           src/core/services/queue-service.test.ts
Test Files  5 passed (5)
     Tests  48 passed | 2 skipped (50)   # skips = pre-existing env-probe placeholders
```

The webhook-outbox-poller integration suite exercises the shared parser against a real password-only Redis URL end-to-end. `npm run lint -w backend` and `npm run typecheck -w backend` both clean.

## Merge adjacency with #750

PR #750 (`feature/issue-741-legacy-enqueue-noop`) modifies `queue-service.ts` in the worker-registration / legacy-enqueue regions (line ~104 onward). This PR touches only the import block and the lines 25-44 connection-parser region — verified non-overlapping against that branch's diff, so the two merge cleanly in either order. The follow-up commit does not touch `queue-service.ts` at all.

## Review follow-up (commit f318b4d6)

Addresses all findings from the adversarial review:

1. **[critical] Third parser copy in `webhook-delivery.ts` (consumer) deleted.** The BullMQ `Worker` consuming the `webhook-delivery` queue still used a drifted local parser while the outbox poller (producer) used the shared util — with a `/N` db index the poller enqueued into db N while the worker listened on db 0 (webhooks silently never delivered); `rediss://` TLS and the ACL username were also dropped on the consumer. The Worker now imports `core/utils/redis-connection.ts`. New regression suite `webhook-delivery.worker-connection.test.ts` (bullmq mocked at the module boundary, mirroring `queue-service.test.ts`) proves the Worker connection equals the shared parser output for a full-surface `rediss://user:pass@host:port/db` URL, plus a producer/consumer connection-parity case on a db-index URL. Both tests written first and watched fail against the old local parser.
2. **[warning] `decodeURIComponent` moved inside the guarded path** in `redis-connection.ts`. Malformed percent-encoding (e.g. `redis://:pa%zzword@host`) previously escaped as a raw `URIError` at Queue construction; it now falls back to localhost defaults per the documented contract. Unit test added (written first, watched fail with `URIError: URI malformed`).
3. **[info] Tempered overselling.** Util docstring now lists all three consumers and states the supported URL surface precisely (no IPv6 bracket hosts, no query params, non-numeric db ignored); `.env.example` comment reworded accordingly.

Fixes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)
