### PR TITLE
fix(smtp): keep masked password sentinel off the live transport; DB smtp_enabled authoritative

### DIFF
--- a/backend/src/core/services/email-service.test.ts
+++ b/backend/src/core/services/email-service.test.ts
@@ -10,8 +10,10 @@ vi.mock('nodemailer', () => {
   };
 });
 
+const mockDbQuery = vi.fn().mockResolvedValue({ rows: [] });
+
 vi.mock('../db/postgres.js', () => ({
-  query: vi.fn().mockResolvedValue({ rows: [] }),
+  query: (...args: unknown[]) => mockDbQuery(...args),
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -50,5 +52,66 @@ describe('email-service', () => {
     const result = await sendTestEmail('admin@test.com');
     expect(result.success).toBe(false);
     expect(result.error).toContain('not configured');
+  });
+
+  // issue #743 — the masked-password sentinel round-tripped by the admin UI
+  // must never overwrite the real password (live transport or DB persist).
+  describe('stripMaskedSmtpPass (#743)', () => {
+    it('removes the masked sentinel from a config patch', async () => {
+      const { stripMaskedSmtpPass, SMTP_PASS_MASK } = await import('./email-service.js');
+      const stripped = stripMaskedSmtpPass({ host: 'smtp.test.com', pass: SMTP_PASS_MASK });
+      expect(stripped.pass).toBeUndefined();
+      expect(stripped.host).toBe('smtp.test.com');
+    });
+
+    it('keeps a real password untouched', async () => {
+      const { stripMaskedSmtpPass } = await import('./email-service.js');
+      expect(stripMaskedSmtpPass({ pass: 'real-secret' }).pass).toBe('real-secret');
+    });
+
+    it('keeps an empty password so admins can still clear it', async () => {
+      const { stripMaskedSmtpPass } = await import('./email-service.js');
+      expect(stripMaskedSmtpPass({ pass: '' }).pass).toBe('');
+    });
+
+    it('leaves a patch without pass untouched', async () => {
+      const { stripMaskedSmtpPass } = await import('./email-service.js');
+      expect(stripMaskedSmtpPass({ host: 'smtp.test.com' })).toEqual({ host: 'smtp.test.com' });
+    });
+  });
+
+  // issue #743 — the DB value must be authoritative when present; previously
+  // `smtp_enabled === 'true' || _config.enabled` meant SMTP_ENABLED=true in
+  // env could never be disabled via the admin UI across restarts.
+  describe('initEmailService smtp_enabled precedence (#743)', () => {
+    it('smtp_enabled=false in DB disables SMTP even when env enabled it', async () => {
+      const { initEmailService, updateSmtpConfig, getSmtpConfig } = await import('./email-service.js');
+      updateSmtpConfig({ enabled: true }); // simulates SMTP_ENABLED=true bootstrap
+      mockDbQuery.mockResolvedValueOnce({
+        rows: [{ setting_key: 'smtp_enabled', setting_value: 'false' }],
+      });
+      await initEmailService();
+      expect(getSmtpConfig().enabled).toBe(false);
+    });
+
+    it('smtp_enabled=true in DB enables SMTP even when env did not', async () => {
+      const { initEmailService, updateSmtpConfig, getSmtpConfig } = await import('./email-service.js');
+      updateSmtpConfig({ enabled: false });
+      mockDbQuery.mockResolvedValueOnce({
+        rows: [{ setting_key: 'smtp_enabled', setting_value: 'true' }],
+      });
+      await initEmailService();
+      expect(getSmtpConfig().enabled).toBe(true);
+    });
+
+    it('falls back to the current (env) value when smtp_enabled is absent from DB', async () => {
+      const { initEmailService, updateSmtpConfig, getSmtpConfig } = await import('./email-service.js');
+      updateSmtpConfig({ enabled: true });
+      mockDbQuery.mockResolvedValueOnce({
+        rows: [{ setting_key: 'smtp_host', setting_value: 'db.example.com' }],
+      });
+      await initEmailService();
+      expect(getSmtpConfig().enabled).toBe(true);
+    });
   });
 });

--- a/backend/src/core/services/email-service.ts
+++ b/backend/src/core/services/email-service.ts
@@ -62,6 +62,29 @@ function getTransporter(): Transporter | null {
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 /**
+ * Masked-password sentinel returned by `getSmtpConfig()` and round-tripped
+ * by the admin UI on save.
+ */
+export const SMTP_PASS_MASK = '••••••••';
+
+/**
+ * Strip the masked-password sentinel from a config patch (issue #743).
+ *
+ * The admin UI round-trips the mask from `GET /admin/smtp` when saving other
+ * settings. Apply this guard once, before BOTH the live `updateSmtpConfig()`
+ * call and the admin_settings persist, so the literal mask never overwrites
+ * the real password. An empty string is kept so admins can still clear it.
+ */
+export function stripMaskedSmtpPass(config: Partial<SmtpConfig>): Partial<SmtpConfig> {
+  if (config.pass !== SMTP_PASS_MASK) {
+    return config;
+  }
+  const stripped = { ...config };
+  delete stripped.pass;
+  return stripped;
+}
+
+/**
  * Update SMTP configuration at runtime (from admin settings).
  */
 export function updateSmtpConfig(config: Partial<SmtpConfig>): void {
@@ -91,7 +114,7 @@ export function updateSmtpConfig(config: Partial<SmtpConfig>): void {
 export function getSmtpConfig(): Omit<SmtpConfig, 'pass'> & { pass: string } {
   return {
     ..._config,
-    pass: _config.pass ? '••••••••' : '',
+    pass: _config.pass ? SMTP_PASS_MASK : '',
   };
 }
 
@@ -179,7 +202,9 @@ export async function initEmailService(): Promise<void> {
         user: settings['smtp_user'] ?? _config.user,
         pass: settings['smtp_pass'] ?? _config.pass,
         from: settings['smtp_from'] ?? _config.from,
-        enabled: settings['smtp_enabled'] === 'true' || _config.enabled,
+        // DB value is authoritative when present (issue #743) — otherwise an
+        // SMTP_ENABLED=true env bootstrap could never be disabled via the UI.
+        enabled: settings['smtp_enabled'] !== undefined ? settings['smtp_enabled'] === 'true' : _config.enabled,
       });
     }
   } catch (err) {

--- a/backend/src/routes/foundation/admin.test.ts
+++ b/backend/src/routes/foundation/admin.test.ts
@@ -39,6 +39,18 @@ vi.mock('../../core/utils/logger.js', () => ({
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }));
 
+// issue #743 — mock nodemailer at the boundary so the SMTP route tests can
+// assert which credentials reach the live transport.
+vi.mock('nodemailer', () => {
+  const sendMail = vi.fn().mockResolvedValue({ messageId: 'test-123' });
+  const close = vi.fn();
+  return {
+    default: {
+      createTransport: vi.fn().mockReturnValue({ sendMail, close }),
+    },
+  };
+});
+
 // LLM provider + per-use-case assignment routes have moved to
 // `/admin/llm-providers` + `/admin/llm-usecases` — see the dedicated tests in
 // `backend/src/routes/llm/llm-providers.test.ts` and `.../llm-usecases.test.ts`.
@@ -63,6 +75,7 @@ vi.mock('../../domains/llm/services/llm-queue.js', () => ({
   setLlmMaxQueueDepthClusterWide: vi.fn().mockResolvedValue(undefined),
 }));
 
+import nodemailer from 'nodemailer';
 import { listErrors, resolveError, getErrorSummary } from '../../core/services/error-tracker.js';
 import { query as mockQuery } from '../../core/db/postgres.js';
 import { _resetStreamCapCache } from '../../core/services/sse-stream-limiter.js';
@@ -803,6 +816,113 @@ describe('Admin routes', () => {
         payload: { adminAccessDeniedRetentionDays: 30.5 },
       });
       expect(response.statusCode).toBe(400);
+    });
+  });
+
+  // ========================
+  // SMTP settings — masked password sentinel (issue #743)
+  // ========================
+  // GET /admin/smtp masks the password as '••••••••'; the admin UI round-trips
+  // that value on save. The mask must never reach the live transport nor be
+  // persisted to admin_settings.
+  describe('PUT /api/admin/smtp - masked password sentinel (#743)', () => {
+    const SMTP_MASK = '••••••••';
+
+    it('keeps the real password on the live transport when the masked sentinel is round-tripped', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [], rowCount: 0 });
+
+      // 1. Admin saves real credentials.
+      let response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/smtp',
+        payload: {
+          host: 'smtp.test.local',
+          port: 587,
+          secure: false,
+          user: 'mailer',
+          pass: 'real-secret-password',
+          from: 'noreply@test.local',
+          enabled: true,
+        },
+      });
+      expect(response.statusCode).toBe(200);
+
+      // 2. GET returns the masked password, which the UI round-trips on the
+      //    next save (here: changing the port).
+      const getResponse = await app.inject({ method: 'GET', url: '/api/admin/smtp' });
+      expect(getResponse.statusCode).toBe(200);
+      expect(JSON.parse(getResponse.body).pass).toBe(SMTP_MASK);
+
+      response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/smtp',
+        payload: {
+          host: 'smtp.test.local',
+          port: 2525,
+          secure: false,
+          user: 'mailer',
+          pass: SMTP_MASK,
+          from: 'noreply@test.local',
+          enabled: true,
+        },
+      });
+      expect(response.statusCode).toBe(200);
+
+      // 3. The transport created for the next send must use the real
+      //    password — not the literal mask.
+      const testResponse = await app.inject({
+        method: 'POST',
+        url: '/api/admin/smtp/test',
+        payload: { to: 'admin@test.local' },
+      });
+      expect(testResponse.statusCode).toBe(200);
+      expect(JSON.parse(testResponse.body).success).toBe(true);
+
+      const createCalls = (nodemailer.createTransport as ReturnType<typeof vi.fn>).mock.calls;
+      expect(createCalls.length).toBeGreaterThan(0);
+      const transportOptions = createCalls[createCalls.length - 1][0] as {
+        port: number;
+        auth?: { user: string; pass: string };
+      };
+      expect(transportOptions.port).toBe(2525);
+      expect(transportOptions.auth?.pass).toBe('real-secret-password');
+    });
+
+    it('does not persist the masked sentinel to admin_settings', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/smtp',
+        payload: { host: 'smtp.other.local', pass: SMTP_MASK, enabled: true },
+      });
+      expect(response.statusCode).toBe(200);
+
+      const calls = (mockQuery as ReturnType<typeof vi.fn>).mock.calls as Array<[string, unknown[]]>;
+      const upsert = calls.find(([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO admin_settings'));
+      expect(upsert).toBeDefined();
+      const persistedKeys = upsert?.[1][0] as string[];
+      expect(persistedKeys).toContain('smtp_host');
+      expect(persistedKeys).not.toContain('smtp_pass');
+    });
+
+    it('persists a real (non-masked) password to admin_settings', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/smtp',
+        payload: { pass: 'brand-new-password' },
+      });
+      expect(response.statusCode).toBe(200);
+
+      const calls = (mockQuery as ReturnType<typeof vi.fn>).mock.calls as Array<[string, unknown[]]>;
+      const upsert = calls.find(([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO admin_settings'));
+      expect(upsert).toBeDefined();
+      const persistedKeys = upsert?.[1][0] as string[];
+      const persistedValues = upsert?.[1][1] as string[];
+      expect(persistedKeys).toContain('smtp_pass');
+      expect(persistedValues[persistedKeys.indexOf('smtp_pass')]).toBe('brand-new-password');
     });
   });
 });

--- a/backend/src/routes/foundation/admin.ts
+++ b/backend/src/routes/foundation/admin.ts
@@ -21,7 +21,7 @@ import { getRateLimits, upsertRateLimits } from '../../core/services/rate-limit-
 import { getStreamCap, invalidateStreamCapCache } from '../../core/services/sse-stream-limiter.js';
 import { sanitizeLlmInput } from '../../core/utils/sanitize-llm-input.js';
 import { ALLOWED_FTS_LANGUAGES } from '../../core/services/fts-language.js';
-import { getSmtpConfig, updateSmtpConfig, sendTestEmail } from '../../core/services/email-service.js';
+import { getSmtpConfig, updateSmtpConfig, sendTestEmail, stripMaskedSmtpPass } from '../../core/services/email-service.js';
 
 const AuditLogQuerySchema = z.object({
   userId: z.string().optional(),
@@ -525,7 +525,9 @@ export async function adminRoutes(fastify: FastifyInstance) {
   });
 
   fastify.put('/admin/smtp', async (request) => {
-    const body = SmtpUpdateSchema.parse(request.body);
+    // #743 — one shared guard: strip the masked-password sentinel round-tripped
+    // by the UI before BOTH the live-transport update and the DB persist below.
+    const body = stripMaskedSmtpPass(SmtpUpdateSchema.parse(request.body));
     updateSmtpConfig(body);
 
     // Persist to admin_settings table
@@ -534,7 +536,7 @@ export async function adminRoutes(fastify: FastifyInstance) {
     if (body.port !== undefined) entries.push({ key: 'smtp_port', value: String(body.port) });
     if (body.secure !== undefined) entries.push({ key: 'smtp_secure', value: String(body.secure) });
     if (body.user !== undefined) entries.push({ key: 'smtp_user', value: body.user });
-    if (body.pass !== undefined && body.pass !== '••••••••') entries.push({ key: 'smtp_pass', value: body.pass });
+    if (body.pass !== undefined) entries.push({ key: 'smtp_pass', value: body.pass });
     if (body.from !== undefined) entries.push({ key: 'smtp_from', value: body.from });
     if (body.enabled !== undefined) entries.push({ key: 'smtp_enabled', value: String(body.enabled) });
 


### PR DESCRIPTION
## Root cause

`PUT /api/admin/smtp` (`backend/src/routes/foundation/admin.ts`) called `updateSmtpConfig(body)` with the **raw** parsed body. The admin UI round-trips the masked password (`'••••••••'`) it received from `GET /admin/smtp`, so the in-memory `_config.pass` became the literal mask, the transporter was torn down and recreated with the mask as the SMTP password, and outgoing email failed until a process restart. The mask guard existed **only** on the DB-persist path (`body.pass !== '••••••••'`) — duplicated logic that had drifted.

Related: `initEmailService()` computed `enabled: settings['smtp_enabled'] === 'true' || _config.enabled`, so once `SMTP_ENABLED=true` was set in env, SMTP could never be disabled via the UI across restarts.

## Fix (surgical, per issue recommendation)

- **One shared guard**: new `stripMaskedSmtpPass()` (+ exported `SMTP_PASS_MASK` constant) in `backend/src/core/services/email-service.ts`, applied **once** in the PUT handler before *both* the live-transport update and the `admin_settings` persist. Empty string still passes through so admins can clear the password.
- **DB-authoritative enabled flag**: `enabled: settings['smtp_enabled'] !== undefined ? settings['smtp_enabled'] === 'true' : _config.enabled` in `initEmailService()`.

## Test evidence (TDD — written first, watched fail, then pass)

Failing before the fix:
- `admin.test.ts` › *keeps the real password on the live transport when the masked sentinel is round-tripped* — reproduced the bug exactly: nodemailer (mocked at the boundary) received `auth.pass = '••••••••'` instead of the real password.
- `email-service.test.ts` › *smtp_enabled=false in DB disables SMTP even when env enabled it* — got `true`, expected `false`.
- 4 × `stripMaskedSmtpPass` unit tests (function didn't exist).

After the fix: `npx vitest run src/core/services/email-service.test.ts src/routes/foundation/admin.test.ts` → **2 files, 59 tests passed** (10 new). `npm run lint -w backend` and `npm run typecheck -w backend` clean.

## Note for reviewers

#738 (encrypt `smtp_pass` at rest) will follow up on these same files; this diff deliberately does **not** restructure the persist path beyond the mask-sentinel and enabled-flag logic so that PR rebases cleanly.

Fixes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)