### PR TITLE
fix(confluence): unsync attachment cleanup keyed by confluence_id; typed ConfluenceError for non-JSON 2xx (#746)

### DIFF
--- a/backend/src/domains/confluence/services/confluence-client.test.ts
+++ b/backend/src/domains/confluence/services/confluence-client.test.ts
@@ -162,6 +162,27 @@ describe('ConfluenceClient', () => {
         'Confluence API error: HTTP 500: Internal Server Error',
       );
     });
+
+    it('should throw a typed ConfluenceError with a body excerpt for non-JSON 2xx responses (#746)', async () => {
+      const client = new ConfluenceClient(baseUrl, pat);
+      // e.g. a reverse proxy / SSO portal answering 200 with an HTML login page
+      mockRequest.mockResolvedValue({
+        statusCode: 200,
+        body: { text: async () => '<!DOCTYPE html><html><head><title>Sign in</title></head><body>SSO</body></html>' },
+      } as never);
+
+      const err = await client.getSpaces().then(
+        () => null,
+        (e: unknown) => e,
+      );
+
+      expect(err).toBeInstanceOf(ConfluenceError);
+      expect((err as ConfluenceError).statusCode).toBe(200);
+      expect((err as ConfluenceError).message).toContain('non-JSON');
+      expect((err as ConfluenceError).message).toContain('<!DOCTYPE html');
+      // Not a transient error — withRetry must rethrow without retrying.
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('getSpaces homepage expansion', () => {

--- a/backend/src/domains/confluence/services/confluence-client.ts
+++ b/backend/src/domains/confluence/services/confluence-client.ts
@@ -193,7 +193,19 @@ export class ConfluenceClient {
       throw error;
     }
 
-    return JSON.parse(text) as T;
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      // A 2xx response whose body isn't JSON (e.g. a reverse proxy or SSO
+      // portal answering 200 with an HTML login page) must surface as a typed
+      // ConfluenceError with a body excerpt — not a raw SyntaxError whose
+      // opaque "Unexpected token" message aborts the whole sync (#746).
+      logger.error({ statusCode, url, body: text.slice(0, 500) }, 'Confluence API returned non-JSON response');
+      throw new ConfluenceError(
+        `Confluence API returned non-JSON response (HTTP ${statusCode}): ${text.slice(0, 200)}`,
+        statusCode,
+      );
+    }
   }
 
   /**

--- a/backend/src/domains/confluence/services/sync-service.ts
+++ b/backend/src/domains/confluence/services/sync-service.ts
@@ -1437,15 +1437,21 @@ async function purgeDeletedPages(spaceKey: string): Promise<void> {
 export async function unsyncSpace(spaceKey: string): Promise<{ pagesDeleted: number }> {
   // Best-effort, non-transactional filesystem cleanup BEFORE the DB
   // transaction. A failure here must never abort the row deletes.
-  const pages = await query<{ id: number }>(
-    'SELECT id FROM pages WHERE space_key = $1',
+  // Attachment directories are keyed by confluence_id for synced pages
+  // (syncImageAttachments, the serving route in routes/confluence/attachments.ts)
+  // and by the integer PK only for standalone pages (confluence_id IS NULL) —
+  // passing the SERIAL id for a synced page would delete nothing and orphan
+  // the real data/attachments/<confluence_id> directory (#746).
+  const pages = await query<{ id: number; confluence_id: string | null }>(
+    'SELECT id, confluence_id FROM pages WHERE space_key = $1',
     [spaceKey],
   );
   for (const p of pages.rows) {
+    const attachmentKey = p.confluence_id ?? String(p.id);
     try {
-      await cleanPageAttachments('', String(p.id));
+      await cleanPageAttachments('', attachmentKey);
     } catch (err) {
-      logger.warn({ err, pageId: p.id, spaceKey }, 'unsyncSpace: attachment cleanup failed (continuing)');
+      logger.warn({ err, pageId: p.id, attachmentKey, spaceKey }, 'unsyncSpace: attachment cleanup failed (continuing)');
     }
   }
 

--- a/backend/src/domains/confluence/services/sync-service.unsync.test.ts
+++ b/backend/src/domains/confluence/services/sync-service.unsync.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, stat, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
 import { setupTestDb, truncateAllTables, teardownTestDb } from '../../../test-db-helper.js';
 import { query, getPool } from '../../../core/db/postgres.js';
-import { unsyncSpace } from './sync-service.js';
+
+// The attachment handler resolves its on-disk root from process.env.ATTACHMENTS_DIR
+// at module-load time, so we point it at a throwaway temp dir BEFORE importing the
+// module under test (hence the dynamic import in beforeAll — same pattern as
+// pasted-image-uploader.test.ts).
+let tmpRoot: string;
+let unsyncSpace: typeof import('./sync-service.js')['unsyncSpace'];
+const originalAttachmentsDir = process.env.ATTACHMENTS_DIR;
 
 /**
  * Seed one row in every space-scoped table for two spaces: `target` (the one we
@@ -73,12 +83,23 @@ async function seedSpace(spaceKey: string): Promise<{ pageId: number; templateId
 }
 
 describe('unsyncSpace', () => {
+  beforeAll(async () => {
+    tmpRoot = await mkdtemp(path.join(tmpdir(), 'unsync-attach-'));
+    process.env.ATTACHMENTS_DIR = tmpRoot;
+    ({ unsyncSpace } = await import('./sync-service.js'));
+  });
   beforeEach(async () => {
     await setupTestDb();
     await truncateAllTables();
   });
   afterAll(async () => {
     await teardownTestDb();
+    await rm(tmpRoot, { recursive: true, force: true });
+    if (originalAttachmentsDir) {
+      process.env.ATTACHMENTS_DIR = originalAttachmentsDir;
+    } else {
+      delete process.env.ATTACHMENTS_DIR;
+    }
   });
 
   it('deletes the space, its pages (cascading versions/embeddings), and role assignments', async () => {
@@ -107,6 +128,39 @@ describe('unsyncSpace', () => {
     expect((await query(`SELECT 1 FROM pages WHERE space_key='ENG'`)).rows).toHaveLength(0);
     expect((await query(`SELECT 1 FROM page_versions WHERE page_id=$1`, [pageId])).rows).toHaveLength(0);
     expect((await query(`SELECT 1 FROM space_role_assignments WHERE space_key='ENG'`)).rows).toHaveLength(0);
+  });
+
+  it('removes attachment dirs keyed by confluence_id, falling back to id for standalone pages (#746)', async () => {
+    await ensureRoles();
+    await query(
+      `INSERT INTO spaces (space_key, space_name, source) VALUES ('ENG','Engineering','confluence')`,
+    );
+    // Confluence-synced page: attachments are cached under data/attachments/<confluence_id>
+    // (see syncImageAttachments and routes/confluence/attachments.ts).
+    await query(
+      `INSERT INTO pages (confluence_id, space_key, title, body_text, body_storage, body_html, source)
+       VALUES ('98765','ENG','Synced','text','','','confluence')`,
+    );
+    // Standalone page: confluence_id IS NULL, attachments keyed by the integer PK.
+    const standalone = await query<{ id: number }>(
+      `INSERT INTO pages (confluence_id, space_key, title, body_text, body_storage, body_html, source)
+       VALUES (NULL,'ENG','Local','text','','','standalone') RETURNING id`,
+    );
+
+    // Test-only paths built from literals/serials under a mkdtemp root. nosemgrep
+    const confDir = path.join(tmpRoot, '98765');
+    const standaloneDir = path.join(tmpRoot, String(standalone.rows[0]!.id));
+    await mkdir(confDir, { recursive: true });
+    await writeFile(path.join(confDir, 'diagram.png'), 'png-bytes');
+    await mkdir(standaloneDir, { recursive: true });
+    await writeFile(path.join(standaloneDir, 'pasted.png'), 'png-bytes');
+
+    const result = await unsyncSpace('ENG');
+    expect(result.pagesDeleted).toBe(2);
+
+    // Both cached attachment directories are swept — no orphaned files on disk.
+    await expect(stat(confDir)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(stat(standaloneDir)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it('returns pagesDeleted=0 when the space has no pages', async () => {


### PR DESCRIPTION
Fixes two Confluence sync bugs from #746.

## Bug 1: `unsyncSpace` orphans attachment files on disk

**Root cause** — `backend/src/domains/confluence/services/sync-service.ts` (`unsyncSpace`): the pre-transaction filesystem sweep selected the integer SERIAL PK (`SELECT id FROM pages …`) and called `cleanPageAttachments('', String(p.id))`. Attachment directories are keyed by **Confluence ID** everywhere else (`syncImageAttachments(..., page.id, ...)`, the deletion reconciler in `detectDeletedPages` / `purgeDeletedPages`, and the serving route `routes/confluence/attachments.ts`). The sweep therefore deleted a nonexistent `data/attachments/<integerId>` and left every real `data/attachments/<confluenceId>` directory behind — each space unsync leaked all of that space's cached attachments.

**Fix** — select `id, confluence_id` and pass `confluence_id ?? String(id)`: confluence_id for synced pages, integer-PK fallback only for standalone pages (`confluence_id IS NULL`), matching the resolution the rest of the pipeline uses (same coalesce pattern as `pages-crud.ts`'s `parentLookupId`).

## Bug 2: `fetchOnce` throws a raw `SyntaxError` on non-JSON 2xx

**Root cause** — `backend/src/domains/confluence/services/confluence-client.ts` (`fetchOnce`): any `statusCode < 400` path ended in a bare `return JSON.parse(text)`. A reverse proxy / SSO portal returning `200` with an HTML login page made `JSON.parse` throw a raw `SyntaxError`; `isTransientError` returns false for it, so `withRetry` rethrew and the whole sync aborted with an opaque "Unexpected token <".

**Fix** — wrap the parse in try/catch and throw a typed `ConfluenceError` carrying the status code and a 200-char body excerpt (mirroring the existing `>=400` branch), plus a structured `logger.error` with a 500-char excerpt.

## Tests (TDD — both written first and observed failing)

- `sync-service.unsync.test.ts` › *removes attachment dirs keyed by confluence_id, falling back to id for standalone pages (#746)* — real-Postgres integration test; seeds a synced page (`confluence_id='98765'`) and a standalone page (`confluence_id IS NULL`), creates both attachment dirs under a temp `ATTACHMENTS_DIR`, and asserts both are gone after `unsyncSpace`. Failed before the fix (confluence-keyed dir survived), passes after.
- `confluence-client.test.ts` › *should throw a typed ConfluenceError with a body excerpt for non-JSON 2xx responses (#746)* — undici mocked at the HTTP boundary returning `200` + HTML; asserts `ConfluenceError` (not `SyntaxError`), `statusCode === 200`, message contains the excerpt, and no retry occurs. Failed before the fix (raw `SyntaxError`), passes after.

Full affected suites green: 11 test files / 301 tests (all `confluence-client*` + `sync-service*` + `attachment-handler` suites) plus `routes/confluence/spaces.test.ts` (12 tests). `npm run lint -w backend` (`--max-warnings=0`) and `npm run typecheck -w backend` clean.

No architecture-diagram impact: no compose/domain/boundary/migration/flow changes — two-line-scale behavior fixes inside existing confluence-domain services.

Fixes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)