### PR TITLE
fix(security): encrypt smtp_pass at rest + harden PAT key derivation (HKDF-SHA256)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@
 
 # --- Required Secrets (MUST change in production) ---
 JWT_SECRET=change-me-to-a-random-32-char-string-min
+# PAT_ENCRYPTION_KEY must be at least 32 bytes (UTF-8). The full value is fed
+# through HKDF-SHA256 to derive the AES-256-GCM key, so every character
+# contributes — longer is better. Also encrypts smtp_pass at rest.
 PAT_ENCRYPTION_KEY=change-me-to-a-random-32-char-string-min
 
 # --- PostgreSQL ---
@@ -177,6 +180,10 @@ BACKEND_PORT=3051
 #
 # The plain PAT_ENCRYPTION_KEY above is treated as version 0 (legacy fallback).
 # Once all PATs have been re-encrypted with the new key, remove the old key.
+#
+# AES keys are derived via HKDF-SHA256 over the full passphrase (>= 32 UTF-8
+# bytes). Data encrypted before the HKDF migration (truncation-derived keys)
+# stays decryptable and is upgraded automatically on re-encryption / rotation.
 
 # === OpenTelemetry (optional) ===
 # OTEL_ENABLED=false                          # Set to 'true' to enable OpenTelemetry tracing (default: false)

--- a/backend/src/core/services/email-service.integration.test.ts
+++ b/backend/src/core/services/email-service.integration.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock nodemailer at the boundary — no SMTP traffic from tests.
+vi.mock('nodemailer', () => {
+  const sendMail = vi.fn().mockResolvedValue({ messageId: 'test-123' });
+  const close = vi.fn();
+  return {
+    default: {
+      createTransport: vi.fn().mockReturnValue({ sendMail, close }),
+    },
+  };
+});
+
+// Real Postgres, with one seam: the wrapper lets a test inject a concurrent
+// write between initEmailService's SELECT and its write-back UPDATE — the
+// race that the conditional `AND setting_value = $2` guard must survive
+// (#762 review follow-up). Every statement still executes against the DB.
+const hooks = vi.hoisted(() => ({
+  afterSmtpSelect: null as null | (() => Promise<void>),
+}));
+
+vi.mock('../db/postgres.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db/postgres.js')>();
+  return {
+    ...actual,
+    query: async (text: string, params?: unknown[]) => {
+      const result = await actual.query(text, params);
+      if (hooks.afterSmtpSelect && text.includes(`LIKE 'smtp_%'`)) {
+        const hook = hooks.afterSmtpSelect;
+        hooks.afterSmtpSelect = null;
+        await hook();
+      }
+      return result;
+    },
+  };
+});
+
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../test-db-helper.js';
+import { query } from '../db/postgres.js';
+import { encryptPat, decryptPat } from '../utils/crypto.js';
+import { initEmailService } from './email-service.js';
+
+const dbAvailable = await isDbAvailable();
+
+describe.skipIf(!dbAvailable)(
+  'initEmailService smtp_pass write-backs — real Postgres (#738 / #762 review follow-up)',
+  () => {
+    beforeAll(async () => {
+      await setupTestDb();
+    });
+
+    afterAll(async () => {
+      await teardownTestDb();
+    });
+
+    beforeEach(async () => {
+      await truncateAllTables();
+      hooks.afterSmtpSelect = null;
+    });
+
+    afterEach(() => {
+      delete process.env.PAT_ENCRYPTION_KEY_V1;
+    });
+
+    async function seedSmtpSettings(pass: string): Promise<void> {
+      await query(
+        `INSERT INTO admin_settings (setting_key, setting_value, updated_at)
+         SELECT key, value, NOW()
+         FROM unnest($1::text[], $2::text[]) AS t(key, value)`,
+        [
+          ['smtp_host', 'smtp_user', 'smtp_pass', 'smtp_enabled'],
+          ['db.example.com', 'mailer', pass, 'true'],
+        ],
+      );
+    }
+
+    async function readSmtpPass(): Promise<string> {
+      const r = await query<{ setting_value: string }>(
+        `SELECT setting_value FROM admin_settings WHERE setting_key = 'smtp_pass'`,
+      );
+      return r.rows[0]!.setting_value;
+    }
+
+    it('upgrades a legacy plaintext smtp_pass in place against the real schema', async () => {
+      await seedSmtpSettings('plain-old-secret');
+
+      await initEmailService();
+
+      const stored = await readSmtpPass();
+      expect(stored).toMatch(/^h\d+:/);
+      expect(decryptPat(stored)).toBe('plain-old-secret');
+    });
+
+    it('upgrades an smtp_pass on a stale key version in place (re-encrypt-on-read)', async () => {
+      await seedSmtpSettings(encryptPat('rotate-me')); // h0 under PAT_ENCRYPTION_KEY
+      process.env.PAT_ENCRYPTION_KEY_V1 = 'versioned-key-one-at-least-32-chars!!';
+
+      await initEmailService();
+
+      const stored = await readSmtpPass();
+      expect(stored).toMatch(/^h1:/);
+      expect(decryptPat(stored)).toBe('rotate-me');
+    });
+
+    it('does not clobber a concurrent PUT /admin/smtp during the startup write-back (lost update)', async () => {
+      await seedSmtpSettings('old-secret'); // legacy plaintext → triggers the write-back
+      const concurrentCipher = encryptPat('brand-new-secret');
+
+      // Simulates an admin saving a NEW password between the startup SELECT
+      // and the legacy-upgrade UPDATE of this pod.
+      hooks.afterSmtpSelect = async () => {
+        await query(
+          `UPDATE admin_settings SET setting_value = $1, updated_at = NOW()
+           WHERE setting_key = 'smtp_pass'`,
+          [concurrentCipher],
+        );
+      };
+
+      await initEmailService();
+
+      // The concurrent value must win: the write-back is conditional on the
+      // value originally read, so 0 rows match and nothing is overwritten.
+      const stored = await readSmtpPass();
+      expect(stored).toBe(concurrentCipher);
+      expect(decryptPat(stored)).toBe('brand-new-secret');
+    });
+  },
+);

--- a/backend/src/core/services/email-service.test.ts
+++ b/backend/src/core/services/email-service.test.ts
@@ -20,6 +20,9 @@ vi.mock('../utils/logger.js', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
+import nodemailer from 'nodemailer';
+import { encryptPat, decryptPat } from '../utils/crypto.js';
+
 describe('email-service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -112,6 +115,103 @@ describe('email-service', () => {
       });
       await initEmailService();
       expect(getSmtpConfig().enabled).toBe(true);
+    });
+  });
+
+  // issue #738 — smtp_pass is stored encrypted in admin_settings; legacy rows
+  // written before this change are plaintext and must keep working (and get
+  // re-encrypted at rest on startup).
+  describe('initEmailService smtp_pass encryption at rest (#738)', () => {
+    const lastTransportOptions = (): { auth?: { user: string; pass: string } } => {
+      const calls = (nodemailer.createTransport as ReturnType<typeof vi.fn>).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      return calls[calls.length - 1][0] as { auth?: { user: string; pass: string } };
+    };
+
+    const findWriteBack = () =>
+      mockDbQuery.mock.calls.find(
+        ([sql]) => typeof sql === 'string' && sql.includes('UPDATE admin_settings'),
+      );
+
+    it('decrypts an encrypted smtp_pass from admin_settings', async () => {
+      const { initEmailService, sendEmail } = await import('./email-service.js');
+      mockDbQuery.mockResolvedValueOnce({
+        rows: [
+          { setting_key: 'smtp_host', setting_value: 'db.example.com' },
+          { setting_key: 'smtp_user', setting_value: 'mailer' },
+          { setting_key: 'smtp_pass', setting_value: encryptPat('db-secret') },
+          { setting_key: 'smtp_enabled', setting_value: 'true' },
+        ],
+      });
+
+      await initEmailService();
+      await sendEmail('x@example.com', 'subject', '<p>hi</p>');
+
+      expect(lastTransportOptions().auth?.pass).toBe('db-secret');
+      // Already encrypted — nothing to migrate.
+      expect(findWriteBack()).toBeUndefined();
+    });
+
+    it('treats a legacy plaintext smtp_pass as the password and re-encrypts it at rest', async () => {
+      const { initEmailService, sendEmail } = await import('./email-service.js');
+      mockDbQuery.mockResolvedValueOnce({
+        rows: [
+          { setting_key: 'smtp_host', setting_value: 'db.example.com' },
+          { setting_key: 'smtp_user', setting_value: 'mailer' },
+          { setting_key: 'smtp_pass', setting_value: 'plain-old-secret' },
+          { setting_key: 'smtp_enabled', setting_value: 'true' },
+        ],
+      });
+
+      await initEmailService();
+
+      // The plaintext value keeps working as the live password...
+      await sendEmail('x@example.com', 'subject', '<p>hi</p>');
+      expect(lastTransportOptions().auth?.pass).toBe('plain-old-secret');
+
+      // ...and is re-encrypted in admin_settings.
+      const writeBack = findWriteBack();
+      expect(writeBack).toBeDefined();
+      const persisted = (writeBack![1] as string[])[0];
+      expect(persisted).toMatch(/^h\d+:/);
+      expect(decryptPat(persisted)).toBe('plain-old-secret');
+    });
+
+    it('uses a value that fails decryption as-is, without write-back', async () => {
+      const { initEmailService, sendEmail } = await import('./email-service.js');
+      // Structurally valid ciphertext for a key version that is not configured.
+      const undecryptable = `v9:${'a'.repeat(32)}:${'b'.repeat(32)}:${'c'.repeat(32)}`;
+      mockDbQuery.mockResolvedValueOnce({
+        rows: [
+          { setting_key: 'smtp_host', setting_value: 'db.example.com' },
+          { setting_key: 'smtp_user', setting_value: 'mailer' },
+          { setting_key: 'smtp_pass', setting_value: undecryptable },
+          { setting_key: 'smtp_enabled', setting_value: 'true' },
+        ],
+      });
+
+      await initEmailService();
+      await sendEmail('x@example.com', 'subject', '<p>hi</p>');
+
+      expect(lastTransportOptions().auth?.pass).toBe(undecryptable);
+      // Not plaintext — must NOT be double-encrypted at rest.
+      expect(findWriteBack()).toBeUndefined();
+    });
+
+    it('keeps an empty stored smtp_pass empty', async () => {
+      const { initEmailService, getSmtpConfig } = await import('./email-service.js');
+      mockDbQuery.mockResolvedValueOnce({
+        rows: [
+          { setting_key: 'smtp_host', setting_value: 'db.example.com' },
+          { setting_key: 'smtp_pass', setting_value: '' },
+          { setting_key: 'smtp_enabled', setting_value: 'true' },
+        ],
+      });
+
+      await initEmailService();
+
+      expect(getSmtpConfig().pass).toBe('');
+      expect(findWriteBack()).toBeUndefined();
     });
   });
 });

--- a/backend/src/core/services/email-service.test.ts
+++ b/backend/src/core/services/email-service.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { randomBytes, createCipheriv } from 'crypto';
 
 vi.mock('nodemailer', () => {
   const sendMail = vi.fn().mockResolvedValue({ messageId: 'test-123' });
@@ -26,6 +27,11 @@ import { encryptPat, decryptPat } from '../utils/crypto.js';
 describe('email-service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Some #738 tests register a higher key version to simulate rotation.
+    delete process.env.PAT_ENCRYPTION_KEY_V1;
   });
 
   it('sendEmail returns false when SMTP is not configured', async () => {
@@ -169,12 +175,85 @@ describe('email-service', () => {
       await sendEmail('x@example.com', 'subject', '<p>hi</p>');
       expect(lastTransportOptions().auth?.pass).toBe('plain-old-secret');
 
-      // ...and is re-encrypted in admin_settings.
+      // ...and is re-encrypted in admin_settings — conditional on the exact
+      // value read, so a concurrent PUT /admin/smtp during startup is never
+      // overwritten with a re-encryption of the OLD password (#762 review).
       const writeBack = findWriteBack();
       expect(writeBack).toBeDefined();
-      const persisted = (writeBack![1] as string[])[0];
+      const [sql, params] = writeBack! as [string, string[]];
+      expect(sql).toContain('setting_value = $2');
+      expect(params[1]).toBe('plain-old-secret');
+      const persisted = params[0];
       expect(persisted).toMatch(/^h\d+:/);
       expect(decryptPat(persisted)).toBe('plain-old-secret');
+    });
+
+    // #762 review follow-up — the documented rotation procedure (rotate key,
+    // remove old key) must not strand smtp_pass: a value that decrypts with a
+    // NON-latest key version is upgraded on read, defense in depth alongside
+    // the rotation endpoint's admin_settings sweep.
+    it('re-encrypts a smtp_pass stored under a stale key version, conditional on the read value', async () => {
+      const { initEmailService, sendEmail } = await import('./email-service.js');
+      const staleCipher = encryptPat('rotate-me'); // h0 under PAT_ENCRYPTION_KEY
+      process.env.PAT_ENCRYPTION_KEY_V1 = 'versioned-key-one-at-least-32-chars!!';
+
+      mockDbQuery.mockResolvedValueOnce({
+        rows: [
+          { setting_key: 'smtp_host', setting_value: 'db.example.com' },
+          { setting_key: 'smtp_user', setting_value: 'mailer' },
+          { setting_key: 'smtp_pass', setting_value: staleCipher },
+          { setting_key: 'smtp_enabled', setting_value: 'true' },
+        ],
+      });
+
+      await initEmailService();
+
+      // The decrypted password is live...
+      await sendEmail('x@example.com', 'subject', '<p>hi</p>');
+      expect(lastTransportOptions().auth?.pass).toBe('rotate-me');
+
+      // ...and the row is upgraded to the latest key version, conditional on
+      // the exact value read (lost-update guard).
+      const writeBack = findWriteBack();
+      expect(writeBack).toBeDefined();
+      const [sql, params] = writeBack! as [string, string[]];
+      expect(sql).toContain('setting_value = $2');
+      expect(params[1]).toBe(staleCipher);
+      expect(params[0]).toMatch(/^h1:/);
+      expect(decryptPat(params[0]!)).toBe('rotate-me');
+    });
+
+    it('re-encrypts a pre-HKDF (v{N}) smtp_pass ciphertext on read', async () => {
+      const { initEmailService, sendEmail } = await import('./email-service.js');
+      // Fixture built with the real pre-#738 algorithm: AES key = first 32
+      // chars of the passphrase as UTF-8, no KDF.
+      const legacyKey = Buffer.from(process.env.PAT_ENCRYPTION_KEY!.slice(0, 32), 'utf-8');
+      const iv = randomBytes(16);
+      const cipher = createCipheriv('aes-256-gcm', legacyKey, iv, { authTagLength: 16 });
+      let ct = cipher.update('pre-hkdf-secret', 'utf-8', 'hex');
+      ct += cipher.final('hex');
+      const legacyCipher = `v0:${iv.toString('hex')}:${cipher.getAuthTag().toString('hex')}:${ct}`;
+
+      mockDbQuery.mockResolvedValueOnce({
+        rows: [
+          { setting_key: 'smtp_host', setting_value: 'db.example.com' },
+          { setting_key: 'smtp_user', setting_value: 'mailer' },
+          { setting_key: 'smtp_pass', setting_value: legacyCipher },
+          { setting_key: 'smtp_enabled', setting_value: 'true' },
+        ],
+      });
+
+      await initEmailService();
+      await sendEmail('x@example.com', 'subject', '<p>hi</p>');
+      expect(lastTransportOptions().auth?.pass).toBe('pre-hkdf-secret');
+
+      const writeBack = findWriteBack();
+      expect(writeBack).toBeDefined();
+      const [sql, params] = writeBack! as [string, string[]];
+      expect(sql).toContain('setting_value = $2');
+      expect(params[1]).toBe(legacyCipher);
+      expect(params[0]).toMatch(/^h0:/); // upgraded derivation, same key version
+      expect(decryptPat(params[0]!)).toBe('pre-hkdf-secret');
     });
 
     it('uses a value that fails decryption as-is, without write-back', async () => {

--- a/backend/src/core/services/email-service.ts
+++ b/backend/src/core/services/email-service.ts
@@ -12,7 +12,7 @@
 
 import nodemailer, { type Transporter } from 'nodemailer';
 import { logger } from '../utils/logger.js';
-import { decryptPat, encryptPat, isEncryptedSecretFormat } from '../utils/crypto.js';
+import { decryptPat, encryptPat, isEncryptedSecretFormat, reEncryptPat } from '../utils/crypto.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 
@@ -183,23 +183,34 @@ export async function sendTestEmail(to: string): Promise<{ success: boolean; err
  *
  * Values are persisted encrypted with the versioned `encryptPat()` helpers,
  * but rows written before encryption-at-rest landed contain the plaintext
- * password. Those are detected by format and kept working as-is (the caller
- * re-encrypts them in place). A value that looks encrypted but fails to
- * decrypt (e.g. its key version was rotated away) is used verbatim so it is
- * never double-encrypted; SMTP auth will fail loudly instead of silently.
+ * password. Those are detected by format and kept working as-is. A value
+ * that looks encrypted but fails to decrypt (e.g. its key version was
+ * rotated away) is used verbatim so it is never double-encrypted; SMTP auth
+ * will fail loudly instead of silently.
+ *
+ * `reEncrypted` carries the ciphertext the caller should write back to
+ * admin_settings (conditionally on the value it read): the encryption of a
+ * legacy plaintext row, or the upgrade of a ciphertext that decrypted under
+ * a stale key version / the pre-HKDF derivation. The latter is defense in
+ * depth for key rotation (#762 review follow-up): even if the rotation
+ * endpoint's sweep was never run, smtp_pass converges onto the latest key
+ * before the operator removes the old one. `null` = nothing to persist.
  */
-function readStoredSmtpPass(stored: string): { pass: string; isLegacyPlaintext: boolean } {
+function readStoredSmtpPass(stored: string): { pass: string; reEncrypted: string | null } {
   if (stored === '') {
-    return { pass: '', isLegacyPlaintext: false };
+    return { pass: '', reEncrypted: null };
   }
   if (!isEncryptedSecretFormat(stored)) {
-    return { pass: stored, isLegacyPlaintext: true };
+    return { pass: stored, reEncrypted: encryptPat(stored) };
   }
   try {
-    return { pass: decryptPat(stored), isLegacyPlaintext: false };
+    const pass = decryptPat(stored);
+    // Upgrade-on-read: reEncryptPat() returns non-null only when the stored
+    // ciphertext uses an old key version or the pre-HKDF derivation.
+    return { pass, reEncrypted: reEncryptPat(stored) };
   } catch (err) {
     logger.warn({ err }, 'Stored smtp_pass looks encrypted but failed to decrypt; using the stored value as-is');
-    return { pass: stored, isLegacyPlaintext: false };
+    return { pass: stored, reEncrypted: null };
   }
 }
 
@@ -235,18 +246,22 @@ export async function initEmailService(): Promise<void> {
         enabled: settings['smtp_enabled'] !== undefined ? settings['smtp_enabled'] === 'true' : _config.enabled,
       });
 
-      // issue #738 — migrate legacy plaintext rows to encrypted-at-rest so
-      // existing deployments converge without the admin re-saving settings.
-      if (passResult?.isLegacyPlaintext) {
+      // issue #738 — converge the at-rest value without the admin re-saving
+      // settings: encrypt legacy plaintext rows and upgrade ciphertexts that
+      // sit on a stale key version / pre-HKDF derivation. The UPDATE is
+      // conditional on the exact value read above so a concurrent
+      // PUT /admin/smtp during startup is never overwritten with a
+      // re-encryption of the OLD password (#762 review follow-up).
+      if (storedPass !== undefined && passResult?.reEncrypted) {
         try {
           await query(
             `UPDATE admin_settings SET setting_value = $1, updated_at = NOW()
-             WHERE setting_key = 'smtp_pass'`,
-            [encryptPat(passResult.pass)],
+             WHERE setting_key = 'smtp_pass' AND setting_value = $2`,
+            [passResult.reEncrypted, storedPass],
           );
-          logger.info('Re-encrypted legacy plaintext smtp_pass in admin_settings');
+          logger.info('Re-encrypted smtp_pass in admin_settings with the latest encryption key');
         } catch (err) {
-          logger.warn({ err }, 'Failed to re-encrypt legacy plaintext smtp_pass in admin_settings');
+          logger.warn({ err }, 'Failed to re-encrypt smtp_pass in admin_settings');
         }
       }
     }

--- a/backend/src/core/services/email-service.ts
+++ b/backend/src/core/services/email-service.ts
@@ -12,6 +12,7 @@
 
 import nodemailer, { type Transporter } from 'nodemailer';
 import { logger } from '../utils/logger.js';
+import { decryptPat, encryptPat, isEncryptedSecretFormat } from '../utils/crypto.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 
@@ -178,6 +179,31 @@ export async function sendTestEmail(to: string): Promise<{ success: boolean; err
 }
 
 /**
+ * Resolve the smtp_pass value stored in admin_settings (issue #738).
+ *
+ * Values are persisted encrypted with the versioned `encryptPat()` helpers,
+ * but rows written before encryption-at-rest landed contain the plaintext
+ * password. Those are detected by format and kept working as-is (the caller
+ * re-encrypts them in place). A value that looks encrypted but fails to
+ * decrypt (e.g. its key version was rotated away) is used verbatim so it is
+ * never double-encrypted; SMTP auth will fail loudly instead of silently.
+ */
+function readStoredSmtpPass(stored: string): { pass: string; isLegacyPlaintext: boolean } {
+  if (stored === '') {
+    return { pass: '', isLegacyPlaintext: false };
+  }
+  if (!isEncryptedSecretFormat(stored)) {
+    return { pass: stored, isLegacyPlaintext: true };
+  }
+  try {
+    return { pass: decryptPat(stored), isLegacyPlaintext: false };
+  } catch (err) {
+    logger.warn({ err }, 'Stored smtp_pass looks encrypted but failed to decrypt; using the stored value as-is');
+    return { pass: stored, isLegacyPlaintext: false };
+  }
+}
+
+/**
  * Initialize SMTP config from admin_settings table.
  */
 export async function initEmailService(): Promise<void> {
@@ -195,17 +221,34 @@ export async function initEmailService(): Promise<void> {
     }
 
     if (Object.keys(settings).length > 0) {
+      const storedPass = settings['smtp_pass'];
+      const passResult = storedPass !== undefined ? readStoredSmtpPass(storedPass) : null;
       updateSmtpConfig({
         host: settings['smtp_host'] ?? _config.host,
         port: settings['smtp_port'] ? parseInt(settings['smtp_port'], 10) : _config.port,
         secure: settings['smtp_secure'] === 'true',
         user: settings['smtp_user'] ?? _config.user,
-        pass: settings['smtp_pass'] ?? _config.pass,
+        pass: passResult ? passResult.pass : _config.pass,
         from: settings['smtp_from'] ?? _config.from,
         // DB value is authoritative when present (issue #743) — otherwise an
         // SMTP_ENABLED=true env bootstrap could never be disabled via the UI.
         enabled: settings['smtp_enabled'] !== undefined ? settings['smtp_enabled'] === 'true' : _config.enabled,
       });
+
+      // issue #738 — migrate legacy plaintext rows to encrypted-at-rest so
+      // existing deployments converge without the admin re-saving settings.
+      if (passResult?.isLegacyPlaintext) {
+        try {
+          await query(
+            `UPDATE admin_settings SET setting_value = $1, updated_at = NOW()
+             WHERE setting_key = 'smtp_pass'`,
+            [encryptPat(passResult.pass)],
+          );
+          logger.info('Re-encrypted legacy plaintext smtp_pass in admin_settings');
+        } catch (err) {
+          logger.warn({ err }, 'Failed to re-encrypt legacy plaintext smtp_pass in admin_settings');
+        }
+      }
     }
   } catch (err) {
     logger.warn({ err }, 'Failed to load SMTP settings from admin_settings');

--- a/backend/src/core/utils/crypto.test.ts
+++ b/backend/src/core/utils/crypto.test.ts
@@ -1,5 +1,34 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { encryptPat, decryptPat, reEncryptPat, getEncryptionKeys, getLatestEncryptionKey } from './crypto.js';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { randomBytes, createCipheriv } from 'crypto';
+import {
+  encryptPat,
+  decryptPat,
+  reEncryptPat,
+  getEncryptionKeys,
+  getLatestEncryptionKey,
+  isEncryptedSecretFormat,
+  isValidEncryptionKey,
+} from './crypto.js';
+
+/**
+ * Reproduces the pre-#738 encryption path: AES key = first 32 *chars* of the
+ * passphrase as UTF-8 (no KDF). Used to create fixtures representing data
+ * already at rest, so back-compat is proven against the real old algorithm.
+ */
+function encryptWithLegacyDerivation(
+  plaintext: string,
+  passphrase: string,
+  version: number | null,
+): string {
+  const key = Buffer.from(passphrase.slice(0, 32), 'utf-8');
+  const iv = randomBytes(16);
+  const cipher = createCipheriv('aes-256-gcm', key, iv, { authTagLength: 16 });
+  let encrypted = cipher.update(plaintext, 'utf-8', 'hex');
+  encrypted += cipher.final('hex');
+  const authTag = cipher.getAuthTag().toString('hex');
+  const body = `${iv.toString('hex')}:${authTag}:${encrypted}`;
+  return version === null ? body : `v${version}:${body}`;
+}
 
 describe('PAT encryption', () => {
   it('should encrypt and decrypt a PAT', () => {
@@ -25,11 +54,13 @@ describe('PAT encryption', () => {
     expect(() => decryptPat('invalid')).toThrow();
   });
 
-  it('should produce versioned format (v0:iv:authTag:ciphertext)', () => {
+  it('should produce HKDF-versioned format (h0:iv:authTag:ciphertext)', () => {
+    // 'h' prefix = HKDF-SHA256 key derivation (#738); the legacy 'v' prefix
+    // marks pre-HKDF (truncation-derived) ciphertexts and is decrypt-only.
     const encrypted = encryptPat('test-pat');
     const parts = encrypted.split(':');
     expect(parts).toHaveLength(4);
-    expect(parts[0]).toMatch(/^v\d+$/);
+    expect(parts[0]).toMatch(/^h\d+$/);
   });
 });
 
@@ -64,7 +95,7 @@ describe('PAT encryption key versioning', () => {
   it('should encrypt with versioned format', () => {
     process.env.PAT_ENCRYPTION_KEY_V1 = 'versioned-key-one-at-least-32-chars!!';
     const encrypted = encryptPat('my-secret-pat');
-    expect(encrypted).toMatch(/^v1:/);
+    expect(encrypted).toMatch(/^h1:/);
   });
 
   it('should decrypt versioned format', () => {
@@ -72,20 +103,6 @@ describe('PAT encryption key versioning', () => {
     const encrypted = encryptPat('my-secret-pat');
     const decrypted = decryptPat(encrypted);
     expect(decrypted).toBe('my-secret-pat');
-  });
-
-  it('should support decrypting legacy (unversioned) format', () => {
-    // Legacy format: just iv:authTag:ciphertext (no version prefix)
-    // First encrypt with the current key (version 0)
-    // Simulate legacy format by removing version prefix
-    const encrypted = encryptPat('legacy-pat');
-    // The new format is v0:iv:authTag:ciphertext
-    // Legacy would be iv:authTag:ciphertext
-    const parts = encrypted.split(':');
-    expect(parts[0]).toBe('v0'); // Current default is v0
-    const legacyFormat = parts.slice(1).join(':');
-    const decrypted = decryptPat(legacyFormat);
-    expect(decrypted).toBe('legacy-pat');
   });
 
   it('should support JSON-based PAT_ENCRYPTION_KEYS', () => {
@@ -106,7 +123,7 @@ describe('PAT encryption key versioning', () => {
       { version: 2, key: 'json-key-version-two-32-chars-long!!' },
     ]);
     const encrypted = encryptPat('json-pat');
-    expect(encrypted).toMatch(/^v2:/);
+    expect(encrypted).toMatch(/^h2:/);
     expect(decryptPat(encrypted)).toBe('json-pat');
   });
 
@@ -114,12 +131,180 @@ describe('PAT encryption key versioning', () => {
     // First encrypt with v1
     process.env.PAT_ENCRYPTION_KEY_V1 = 'versioned-key-one-at-least-32-chars!!';
     const encrypted = encryptPat('old-pat');
-    expect(encrypted).toMatch(/^v1:/);
+    expect(encrypted).toMatch(/^h1:/);
 
     // Now add v2 and verify v1 data can still be decrypted
     process.env.PAT_ENCRYPTION_KEY_V2 = 'versioned-key-two-at-least-32-chars!!';
     const decrypted = decryptPat(encrypted);
     expect(decrypted).toBe('old-pat');
+  });
+});
+
+// issue #738 — data already at rest was encrypted with a key derived by
+// truncating the passphrase to its first 32 chars. The HKDF migration must
+// keep every one of those ciphertexts decryptable.
+describe('pre-HKDF ciphertext back-compat (#738)', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    delete process.env.PAT_ENCRYPTION_KEY_V1;
+    process.env.PAT_ENCRYPTION_KEY = originalEnv.PAT_ENCRYPTION_KEY;
+  });
+
+  it('decrypts v{N}-format data encrypted with the old truncation derivation', () => {
+    process.env.PAT_ENCRYPTION_KEY_V1 = 'versioned-key-one-at-least-32-chars!!';
+    const legacy = encryptWithLegacyDerivation(
+      'old-at-rest-pat',
+      process.env.PAT_ENCRYPTION_KEY_V1,
+      1,
+    );
+    expect(decryptPat(legacy)).toBe('old-at-rest-pat');
+  });
+
+  it('decrypts unversioned (iv:authTag:ct) data encrypted with the old derivation', () => {
+    const legacy = encryptWithLegacyDerivation('really-old-pat', process.env.PAT_ENCRYPTION_KEY!, null);
+    expect(decryptPat(legacy)).toBe('really-old-pat');
+  });
+
+  it('decrypts v0-format data encrypted with the old derivation of PAT_ENCRYPTION_KEY', () => {
+    const legacy = encryptWithLegacyDerivation('old-v0-pat', process.env.PAT_ENCRYPTION_KEY!, 0);
+    expect(decryptPat(legacy)).toBe('old-v0-pat');
+  });
+
+  it('reEncryptPat upgrades old-derivation data to the HKDF format even at the same key version', () => {
+    const legacy = encryptWithLegacyDerivation('upgrade-me', process.env.PAT_ENCRYPTION_KEY!, 0);
+    const upgraded = reEncryptPat(legacy);
+    expect(upgraded).not.toBeNull();
+    expect(upgraded).toMatch(/^h0:/);
+    expect(decryptPat(upgraded!)).toBe('upgrade-me');
+  });
+});
+
+// issue #738 — keys are now derived via HKDF-SHA256 over the FULL passphrase
+// bytes instead of `Buffer.from(key.slice(0, 32), 'utf-8')`.
+describe('HKDF key derivation (#738)', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    delete process.env.PAT_ENCRYPTION_KEY_V1;
+    process.env.PAT_ENCRYPTION_KEY = originalEnv.PAT_ENCRYPTION_KEY;
+  });
+
+  it('round-trips with multi-byte chars in the first 32 chars (old path threw "Invalid key length")', () => {
+    const multiByteKey = '🔑🔑🔑🔑-multibyte-passphrase-with-32-bytes!';
+    // Sanity: the old truncation derivation cannot produce a 32-byte AES key here.
+    expect(Buffer.from(multiByteKey.slice(0, 32), 'utf-8').length).not.toBe(32);
+
+    process.env.PAT_ENCRYPTION_KEY_V1 = multiByteKey;
+    const encrypted = encryptPat('multi-byte-pat');
+    expect(encrypted).toMatch(/^h1:/);
+    expect(decryptPat(encrypted)).toBe('multi-byte-pat');
+  });
+
+  it('uses the full passphrase — keys sharing the first 32 chars are distinct', () => {
+    const sharedPrefix = 'A'.repeat(32);
+    process.env.PAT_ENCRYPTION_KEY_V1 = `${sharedPrefix}-tail-one`;
+    const encrypted = encryptPat('full-passphrase-pat');
+    expect(decryptPat(encrypted)).toBe('full-passphrase-pat');
+
+    // The old derivation truncated to 32 chars, so these two keys collided.
+    process.env.PAT_ENCRYPTION_KEY_V1 = `${sharedPrefix}-tail-two`;
+    expect(() => decryptPat(encrypted)).toThrow();
+  });
+
+  it('accepts a key that is >= 32 bytes but < 32 chars (byte-based validation)', () => {
+    const key = 'パスワードパスワードパスワー'; // 14 chars, 42 UTF-8 bytes
+    expect(key.length).toBeLessThan(32);
+    expect(Buffer.byteLength(key, 'utf-8')).toBeGreaterThanOrEqual(32);
+
+    process.env.PAT_ENCRYPTION_KEY_V1 = key;
+    const keys = getEncryptionKeys();
+    expect(keys.some((k) => k.version === 1)).toBe(true);
+    expect(decryptPat(encryptPat('cjk-key-pat'))).toBe('cjk-key-pat');
+  });
+
+  it('rejects keys shorter than 32 bytes', () => {
+    process.env.PAT_ENCRYPTION_KEY_V1 = 'only-31-ascii-chars-aaaaaaaaaa!'; // 31 bytes
+    const keys = getEncryptionKeys();
+    expect(keys.some((k) => k.version === 1)).toBe(false);
+  });
+});
+
+// issue #738 — startup validation must measure UTF-8 bytes, not UTF-16 chars,
+// so that what passes boot is exactly what the crypto module accepts.
+describe('isValidEncryptionKey (#738)', () => {
+  it('accepts 32 ASCII chars (32 bytes) — existing deployments keep working', () => {
+    expect(isValidEncryptionKey('a'.repeat(32))).toBe(true);
+  });
+
+  it('rejects 31 ASCII chars', () => {
+    expect(isValidEncryptionKey('a'.repeat(31))).toBe(false);
+  });
+
+  it('measures bytes, not chars: 11 three-byte chars (33 bytes) pass', () => {
+    expect(isValidEncryptionKey('あ'.repeat(11))).toBe(true);
+  });
+
+  it('rejects the empty string', () => {
+    expect(isValidEncryptionKey('')).toBe(false);
+  });
+});
+
+// issue #738 — used to tell encrypted-at-rest secrets apart from legacy
+// plaintext values (e.g. smtp_pass rows written before encryption landed).
+describe('isEncryptedSecretFormat (#738)', () => {
+  it('matches current encryptPat output', () => {
+    expect(isEncryptedSecretFormat(encryptPat('some-secret'))).toBe(true);
+  });
+
+  it('matches pre-HKDF v{N}-format ciphertexts', () => {
+    const legacy = encryptWithLegacyDerivation('s', process.env.PAT_ENCRYPTION_KEY!, 0);
+    expect(isEncryptedSecretFormat(legacy)).toBe(true);
+  });
+
+  it('matches legacy unversioned (iv:authTag:ct) ciphertexts', () => {
+    const legacy = encryptWithLegacyDerivation('s', process.env.PAT_ENCRYPTION_KEY!, null);
+    expect(isEncryptedSecretFormat(legacy)).toBe(true);
+  });
+
+  it('does not match plaintext passwords', () => {
+    expect(isEncryptedSecretFormat('hunter2')).toBe(false);
+    expect(isEncryptedSecretFormat('pass:with:colons')).toBe(false);
+    expect(isEncryptedSecretFormat('a:b:c:d')).toBe(false);
+    expect(isEncryptedSecretFormat('')).toBe(false);
+    expect(isEncryptedSecretFormat('••••••••')).toBe(false);
+  });
+});
+
+// issue #738 — a malformed PAT_ENCRYPTION_KEYS used to be swallowed silently,
+// leaving the operator unaware their rotation keys were being ignored.
+describe('PAT_ENCRYPTION_KEYS parse warning (#738)', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    delete process.env.PAT_ENCRYPTION_KEYS;
+    process.env.PAT_ENCRYPTION_KEY = originalEnv.PAT_ENCRYPTION_KEY;
+    vi.doUnmock('./logger.js');
+    vi.resetModules();
+  });
+
+  it('logs a warning once when PAT_ENCRYPTION_KEYS is invalid JSON', async () => {
+    vi.resetModules();
+    const warn = vi.fn();
+    vi.doMock('./logger.js', () => ({
+      logger: { warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    }));
+
+    process.env.PAT_ENCRYPTION_KEYS = '{not-valid-json';
+    const fresh = await import('./crypto.js');
+
+    // Falls back to the other key sources...
+    const keys = fresh.getEncryptionKeys();
+    expect(keys.some((k) => k.version === 0)).toBe(true);
+    // ...but tells the operator about it (once per process, not per call).
+    expect(warn).toHaveBeenCalledTimes(1);
+    fresh.getEncryptionKeys();
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -142,7 +327,7 @@ describe('reEncryptPat', () => {
   it('should re-encrypt with newer key version', () => {
     // Encrypt with v0 (legacy)
     const encrypted = encryptPat('rotate-me');
-    expect(encrypted).toMatch(/^v0:/);
+    expect(encrypted).toMatch(/^h0:/);
 
     // Add v1 key
     process.env.PAT_ENCRYPTION_KEY_V1 = 'versioned-key-one-at-least-32-chars!!';
@@ -150,24 +335,22 @@ describe('reEncryptPat', () => {
     // Re-encrypt
     const reEncrypted = reEncryptPat(encrypted);
     expect(reEncrypted).not.toBeNull();
-    expect(reEncrypted).toMatch(/^v1:/);
+    expect(reEncrypted).toMatch(/^h1:/);
 
     // Verify data is preserved
     expect(decryptPat(reEncrypted!)).toBe('rotate-me');
   });
 
   it('should re-encrypt legacy (unversioned) format', () => {
-    // Create legacy format manually
-    const encrypted = encryptPat('legacy');
-    const parts = encrypted.split(':');
-    const legacyFormat = parts.slice(1).join(':');
+    // Old-derivation, unversioned data at rest
+    const legacyFormat = encryptWithLegacyDerivation('legacy', process.env.PAT_ENCRYPTION_KEY!, null);
 
     // Add v1 key
     process.env.PAT_ENCRYPTION_KEY_V1 = 'versioned-key-one-at-least-32-chars!!';
 
     const reEncrypted = reEncryptPat(legacyFormat);
     expect(reEncrypted).not.toBeNull();
-    expect(reEncrypted).toMatch(/^v1:/);
+    expect(reEncrypted).toMatch(/^h1:/);
     expect(decryptPat(reEncrypted!)).toBe('legacy');
   });
 });

--- a/backend/src/core/utils/crypto.test.ts
+++ b/backend/src/core/utils/crypto.test.ts
@@ -274,6 +274,15 @@ describe('isEncryptedSecretFormat (#738)', () => {
     expect(isEncryptedSecretFormat('')).toBe(false);
     expect(isEncryptedSecretFormat('••••••••')).toBe(false);
   });
+
+  it('limitation (pinned): rejects the ciphertext of the EMPTY string', () => {
+    // `encryptPat('')` yields `h{N}:iv:tag:` with an empty ciphertext
+    // segment, which this predicate rejects. Unreachable today — callers
+    // persist empty secrets as `''` — but pinned so a future caller does
+    // not rely on it to recognise an encrypted-empty secret (it would be
+    // treated as plaintext and double-encrypted). See crypto.ts.
+    expect(isEncryptedSecretFormat(encryptPat(''))).toBe(false);
+  });
 });
 
 // issue #738 — a malformed PAT_ENCRYPTION_KEYS used to be swallowed silently,

--- a/backend/src/core/utils/crypto.ts
+++ b/backend/src/core/utils/crypto.ts
@@ -254,6 +254,13 @@ function isHexOfLength(value: string | undefined, length: number): boolean {
  * `smtp_pass` in `admin_settings`). A plaintext secret can only collide by
  * containing colon-separated lowercase-hex groups of the exact IV / auth-tag
  * sizes, which is implausible for a human- or generator-chosen password.
+ *
+ * Limitation: rejects the output of `encryptPat('')` — an empty plaintext
+ * yields an EMPTY ciphertext segment (`h{N}:iv:tag:`), and every segment
+ * here must be non-empty hex. Unreachable today (callers persist empty
+ * secrets as `''` instead of encrypting them), but a future caller must not
+ * rely on this predicate to recognise an encrypted-empty secret — it would
+ * be misclassified as plaintext and double-encrypted.
  */
 export function isEncryptedSecretFormat(value: string): boolean {
   const parts = value.split(':');

--- a/backend/src/core/utils/crypto.ts
+++ b/backend/src/core/utils/crypto.ts
@@ -1,8 +1,16 @@
-import { randomBytes, createCipheriv, createDecipheriv } from 'crypto';
+import { randomBytes, createCipheriv, createDecipheriv, hkdfSync } from 'crypto';
+import { logger } from './logger.js';
 
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 16;
 const AUTH_TAG_LENGTH = 16;
+const KEY_LENGTH = 32; // AES-256 requires exactly 32 key bytes
+const MIN_KEY_BYTES = 32;
+
+// Fixed, non-secret HKDF context parameters (issue #738). Domain-separation
+// only — the secrecy of the derived key comes entirely from the passphrase.
+const HKDF_SALT = Buffer.from('compendiq-pat-encryption', 'utf-8');
+const HKDF_INFO = Buffer.from('aes-256-gcm', 'utf-8');
 
 /**
  * Versioned encryption key support for zero-downtime key rotation.
@@ -11,12 +19,56 @@ const AUTH_TAG_LENGTH = 16;
  * 1. PAT_ENCRYPTION_KEYS - JSON array of { version, key } objects
  * 2. PAT_ENCRYPTION_KEY_V1, PAT_ENCRYPTION_KEY_V2, etc.
  * 3. PAT_ENCRYPTION_KEY - legacy single key (treated as version 0)
+ *
+ * Ciphertext formats (issue #738 introduced the `h` prefix):
+ * - `h{N}:iv:authTag:ciphertext` — current. AES key = HKDF-SHA256 over the
+ *   FULL passphrase bytes of key version N. Used for all new encryptions.
+ * - `v{N}:iv:authTag:ciphertext` — pre-HKDF. AES key = first 32 *chars* of
+ *   the passphrase as UTF-8 (no KDF). Decrypt-only, kept for data at rest.
+ * - `iv:authTag:ciphertext` — legacy unversioned; same truncation derivation
+ *   with key version 0. Decrypt-only.
  */
 
 interface VersionedKey {
   version: number;
+  /** HKDF-SHA256-derived key (32 bytes) — used for all new encryptions. */
   key: Buffer;
+  /**
+   * Pre-#738 truncation-derived key, used only to decrypt `v{N}`/unversioned
+   * data already at rest. `null` when the first 32 chars of the passphrase
+   * are not exactly 32 UTF-8 bytes — such a key could never have encrypted
+   * anything (createCipheriv would have thrown "Invalid key length").
+   */
+  legacyKey: Buffer | null;
 }
+
+/**
+ * True when the key has at least 32 bytes of UTF-8 key material. Measured in
+ * BYTES, not UTF-16 chars (issue #738): for ASCII keys this is identical to
+ * the historical `length >= 32` check, but multi-byte passphrases are judged
+ * by what actually feeds the KDF.
+ */
+export function isValidEncryptionKey(key: string): boolean {
+  return Buffer.byteLength(key, 'utf-8') >= MIN_KEY_BYTES;
+}
+
+/** Current derivation (#738): HKDF-SHA256 over the full passphrase bytes. */
+function deriveKey(passphrase: string): Buffer {
+  return Buffer.from(hkdfSync('sha256', Buffer.from(passphrase, 'utf-8'), HKDF_SALT, HKDF_INFO, KEY_LENGTH));
+}
+
+/** Pre-#738 derivation: first 32 chars as UTF-8 (only valid when that is exactly 32 bytes). */
+function deriveLegacyKey(passphrase: string): Buffer | null {
+  const key = Buffer.from(passphrase.slice(0, 32), 'utf-8');
+  return key.length === KEY_LENGTH ? key : null;
+}
+
+function toVersionedKey(version: number, passphrase: string): VersionedKey {
+  return { version, key: deriveKey(passphrase), legacyKey: deriveLegacyKey(passphrase) };
+}
+
+// Warn once per process, not on every encrypt/decrypt call.
+let warnedInvalidKeysJson = false;
 
 /**
  * Returns all configured encryption keys sorted by version (highest first).
@@ -30,36 +82,44 @@ export function getEncryptionKeys(): VersionedKey[] {
     try {
       const parsed = JSON.parse(keysJson) as Array<{ version: number; key: string }>;
       for (const entry of parsed) {
-        if (entry.key && entry.key.length >= 32) {
-          keys.push({ version: entry.version, key: Buffer.from(entry.key.slice(0, 32), 'utf-8') });
+        if (entry.key && isValidEncryptionKey(entry.key)) {
+          keys.push(toVersionedKey(entry.version, entry.key));
         }
       }
-    } catch {
-      // Invalid JSON, fall through to other sources
+    } catch (err) {
+      // Invalid JSON, fall through to other sources — but tell the operator
+      // their rotation keys are being ignored (issue #738).
+      if (!warnedInvalidKeysJson) {
+        warnedInvalidKeysJson = true;
+        logger.warn(
+          { err },
+          'PAT_ENCRYPTION_KEYS is not valid JSON — ignoring it and falling back to PAT_ENCRYPTION_KEY / PAT_ENCRYPTION_KEY_V{n}',
+        );
+      }
     }
   }
 
   // Source 2: Numbered env vars PAT_ENCRYPTION_KEY_V1, _V2, etc.
   for (let v = 1; v <= 10; v++) {
     const envKey = process.env[`PAT_ENCRYPTION_KEY_V${v}`];
-    if (envKey && envKey.length >= 32) {
+    if (envKey && isValidEncryptionKey(envKey)) {
       // Only add if not already present from JSON source
       if (!keys.some((k) => k.version === v)) {
-        keys.push({ version: v, key: Buffer.from(envKey.slice(0, 32), 'utf-8') });
+        keys.push(toVersionedKey(v, envKey));
       }
     }
   }
 
   // Source 3: Legacy single key (version 0)
   const legacyKey = process.env.PAT_ENCRYPTION_KEY;
-  if (legacyKey && legacyKey.length >= 32) {
+  if (legacyKey && isValidEncryptionKey(legacyKey)) {
     if (!keys.some((k) => k.version === 0)) {
-      keys.push({ version: 0, key: Buffer.from(legacyKey.slice(0, 32), 'utf-8') });
+      keys.push(toVersionedKey(0, legacyKey));
     }
   }
 
   if (keys.length === 0) {
-    throw new Error('No PAT encryption key configured. Set PAT_ENCRYPTION_KEY (>= 32 chars).');
+    throw new Error('No PAT encryption key configured. Set PAT_ENCRYPTION_KEY (>= 32 bytes).');
   }
 
   // Sort by version descending (latest first)
@@ -91,7 +151,8 @@ function getEncryptionKeyByVersion(version: number): VersionedKey {
 
 /**
  * Encrypts a PAT using the latest key version.
- * Format: v{version}:iv:authTag:ciphertext (all hex except version prefix)
+ * Format: h{version}:iv:authTag:ciphertext (all hex except version prefix;
+ * `h` = HKDF-SHA256 key derivation, see module doc).
  */
 export function encryptPat(plaintext: string): string {
   const { version, key } = getLatestEncryptionKey();
@@ -102,32 +163,36 @@ export function encryptPat(plaintext: string): string {
   encrypted += cipher.final('hex');
   const authTag = cipher.getAuthTag();
 
-  return `v${version}:${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
+  return `h${version}:${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
 }
 
 /**
- * Decrypts a PAT. Supports both versioned and legacy (unversioned) formats.
+ * Decrypts a PAT. Supports all historical formats:
  *
- * Versioned format: v{N}:iv:authTag:ciphertext
- * Legacy format: iv:authTag:ciphertext (uses version 0 / PAT_ENCRYPTION_KEY)
+ * - `h{N}:iv:authTag:ciphertext` — HKDF-derived key (current)
+ * - `v{N}:iv:authTag:ciphertext` — pre-HKDF truncation-derived key
+ * - `iv:authTag:ciphertext`      — legacy unversioned (version 0, truncation)
  */
 export function decryptPat(encrypted: string): string {
   const parts = encrypted.split(':');
 
   let version: number;
+  let useLegacyDerivation: boolean;
   let ivHex: string;
   let authTagHex: string;
   let ciphertext: string;
 
-  if (parts[0]?.startsWith('v') && parts.length === 4) {
-    // Versioned format: v{N}:iv:authTag:ciphertext
+  if (parts.length === 4 && /^[hv]\d+$/.test(parts[0]!)) {
+    // Versioned format: h{N}|v{N}:iv:authTag:ciphertext
     version = parseInt(parts[0]!.slice(1), 10);
+    useLegacyDerivation = parts[0]!.startsWith('v');
     ivHex = parts[1]!;
     authTagHex = parts[2]!;
     ciphertext = parts[3]!;
   } else if (parts.length === 3) {
-    // Legacy format: iv:authTag:ciphertext (version 0)
+    // Legacy format: iv:authTag:ciphertext (version 0, truncation derivation)
     version = 0;
+    useLegacyDerivation = true;
     ivHex = parts[0]!;
     authTagHex = parts[1]!;
     ciphertext = parts[2]!;
@@ -139,7 +204,13 @@ export function decryptPat(encrypted: string): string {
     throw new Error('Invalid encrypted PAT format');
   }
 
-  const { key } = getEncryptionKeyByVersion(version);
+  const versionedKey = getEncryptionKeyByVersion(version);
+  const key = useLegacyDerivation ? versionedKey.legacyKey : versionedKey.key;
+  if (!key) {
+    throw new Error(
+      `Encryption key version ${version} cannot decrypt pre-HKDF data: the first 32 chars of the passphrase are not exactly 32 UTF-8 bytes`,
+    );
+  }
   const iv = Buffer.from(ivHex, 'hex');
   const authTag = Buffer.from(authTagHex, 'hex');
   const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
@@ -151,22 +222,55 @@ export function decryptPat(encrypted: string): string {
 }
 
 /**
- * Re-encrypts a PAT with the latest key version.
- * Returns the new encrypted string, or null if already using the latest version.
+ * Re-encrypts a PAT with the latest key version and the current (HKDF) key
+ * derivation. Returns the new encrypted string, or null if the input already
+ * uses both. Pre-HKDF (`v{N}`/unversioned) data is always upgraded, even when
+ * its key version is already the latest.
  */
 export function reEncryptPat(encrypted: string): string | null {
   const latest = getLatestEncryptionKey();
   const parts = encrypted.split(':');
 
-  // Check if already using latest version
-  if (parts[0]?.startsWith('v') && parts.length === 4) {
-    const currentVersion = parseInt(parts[0]!.slice(1), 10);
-    if (currentVersion === latest.version) {
-      return null; // Already up to date
-    }
+  // Already using the latest key version AND the HKDF derivation
+  if (parts.length === 4 && parts[0] === `h${latest.version}`) {
+    return null; // Already up to date
   }
 
   // Decrypt with current key, re-encrypt with latest
   const plaintext = decryptPat(encrypted);
   return encryptPat(plaintext);
+}
+
+const HEX_RE = /^[0-9a-f]+$/;
+
+function isHexOfLength(value: string | undefined, length: number): boolean {
+  return value !== undefined && value.length === length && HEX_RE.test(value);
+}
+
+/**
+ * True when `value` is structurally a ciphertext produced by `encryptPat()`
+ * (any historical format). Used to tell encrypted-at-rest secrets apart from
+ * legacy plaintext values stored before encryption landed (issue #738, e.g.
+ * `smtp_pass` in `admin_settings`). A plaintext secret can only collide by
+ * containing colon-separated lowercase-hex groups of the exact IV / auth-tag
+ * sizes, which is implausible for a human- or generator-chosen password.
+ */
+export function isEncryptedSecretFormat(value: string): boolean {
+  const parts = value.split(':');
+  if (parts.length === 4) {
+    return (
+      /^[hv]\d+$/.test(parts[0]!) &&
+      isHexOfLength(parts[1], IV_LENGTH * 2) &&
+      isHexOfLength(parts[2], AUTH_TAG_LENGTH * 2) &&
+      HEX_RE.test(parts[3]!)
+    );
+  }
+  if (parts.length === 3) {
+    return (
+      isHexOfLength(parts[0], IV_LENGTH * 2) &&
+      isHexOfLength(parts[1], AUTH_TAG_LENGTH * 2) &&
+      HEX_RE.test(parts[2]!)
+    );
+  }
+  return false;
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,7 @@ import {
 import { initLlmQueue } from './domains/llm/services/llm-queue.js';
 import { initRateLimiter } from './domains/confluence/services/confluence-rate-limiter.js';
 import { initEmailService, closeEmailService } from './core/services/email-service.js';
+import { isValidEncryptionKey } from './core/utils/crypto.js';
 
 const PORT = parseInt(process.env.BACKEND_PORT ?? '3051', 10);
 const HOST = process.env.NODE_ENV === 'production' ? '0.0.0.0' : '127.0.0.1';
@@ -29,8 +30,11 @@ async function start() {
     if (jwtSecret.length < 32 || jwtSecret.startsWith('change-me')) {
       throw new Error('JWT_SECRET must be at least 32 chars and not default in production');
     }
-    if (patKey.length < 32 || patKey.startsWith('change-me')) {
-      throw new Error('PAT_ENCRYPTION_KEY must be at least 32 chars and not default in production');
+    // issue #738 — validate UTF-8 BYTE length (matches what the crypto module
+    // accepts), not UTF-16 char length. Identical to the old check for ASCII
+    // keys, but no longer lets a multi-byte key pass boot only to fail later.
+    if (!isValidEncryptionKey(patKey) || patKey.startsWith('change-me')) {
+      throw new Error('PAT_ENCRYPTION_KEY must be at least 32 bytes (UTF-8) and not default in production');
     }
   }
 

--- a/backend/src/routes/foundation/admin-rotate-encryption-key.integration.test.ts
+++ b/backend/src/routes/foundation/admin-rotate-encryption-key.integration.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import sensible from '@fastify/sensible';
+
+// admin.ts imports the cluster-wide LLM queue setters (Redis cache-bus).
+// They are not under test here — keep Redis out of this suite.
+vi.mock('../../domains/llm/services/llm-queue.js', () => ({
+  setLlmConcurrencyClusterWide: vi.fn().mockResolvedValue(undefined),
+  setLlmMaxQueueDepthClusterWide: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../test-db-helper.js';
+import { query } from '../../core/db/postgres.js';
+import { encryptPat, decryptPat } from '../../core/utils/crypto.js';
+import { adminRoutes } from './admin.js';
+
+/**
+ * Real-DB integration test for POST /api/admin/rotate-encryption-key.
+ *
+ * #762 review follow-up: the rotation sweep must cover
+ * `admin_settings.smtp_pass` (a versioned ciphertext since #738), not just
+ * `user_settings.confluence_pat`. Otherwise the documented rotation
+ * procedure — rotate, then remove the old key — leaves smtp_pass
+ * undecryptable and SMTP auth fails silently.
+ */
+
+const dbAvailable = await isDbAvailable();
+
+describe.skipIf(!dbAvailable)(
+  'POST /api/admin/rotate-encryption-key — admin_settings.smtp_pass sweep (#762 review follow-up)',
+  () => {
+    let app: FastifyInstance;
+    let adminId = '';
+
+    beforeAll(async () => {
+      await setupTestDb();
+      app = Fastify({ logger: false });
+      await app.register(sensible);
+      // Stub auth at the decorator boundary (per repo test rules); the
+      // userId is a real seeded admin row so the audit_log FK holds.
+      app.decorate(
+        'requireAdmin',
+        async (request: { userId: string; username: string; userRole: string }) => {
+          request.userId = adminId;
+          request.username = 'rotate_admin';
+          request.userRole = 'admin';
+        },
+      );
+      await app.register(adminRoutes, { prefix: '/api' });
+      await app.ready();
+    });
+
+    afterAll(async () => {
+      await app.close();
+      await teardownTestDb();
+    });
+
+    beforeEach(async () => {
+      await truncateAllTables();
+      const r = await query<{ id: string }>(
+        `INSERT INTO users (username, password_hash, role)
+         VALUES ('rotate_admin', 'fakehash', 'admin') RETURNING id`,
+      );
+      adminId = r.rows[0]!.id;
+    });
+
+    afterEach(() => {
+      delete process.env.PAT_ENCRYPTION_KEY_V1;
+    });
+
+    async function seedSmtpPass(value: string): Promise<void> {
+      await query(
+        `INSERT INTO admin_settings (setting_key, setting_value, updated_at)
+         VALUES ('smtp_pass', $1, NOW())`,
+        [value],
+      );
+    }
+
+    async function readSmtpPass(): Promise<string | null> {
+      const r = await query<{ setting_value: string }>(
+        `SELECT setting_value FROM admin_settings WHERE setting_key = 'smtp_pass'`,
+      );
+      return r.rows[0]?.setting_value ?? null;
+    }
+
+    it('re-encrypts smtp_pass alongside PATs so it stays decryptable after the old key is removed', async () => {
+      // Both secrets at rest under key version 0 (PAT_ENCRYPTION_KEY).
+      await seedSmtpPass(encryptPat('smtp-secret'));
+      await query(
+        `INSERT INTO user_settings (user_id, confluence_pat) VALUES ($1, $2)`,
+        [adminId, encryptPat('pat-secret')],
+      );
+
+      // Operator rotates: introduce key version 1.
+      process.env.PAT_ENCRYPTION_KEY_V1 = 'versioned-key-one-at-least-32-chars!!';
+
+      const res = await app.inject({ method: 'POST', url: '/api/admin/rotate-encryption-key' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ rotated: 2, skipped: 0, errors: 0, total: 2 });
+
+      // smtp_pass now lives under the NEW key — removing v0 cannot strand it.
+      const smtp = await readSmtpPass();
+      expect(smtp).toMatch(/^h1:/);
+      expect(decryptPat(smtp!)).toBe('smtp-secret');
+
+      // The PAT sweep still works as before.
+      const pat = (
+        await query<{ confluence_pat: string }>(
+          `SELECT confluence_pat FROM user_settings WHERE user_id = $1`,
+          [adminId],
+        )
+      ).rows[0]!.confluence_pat;
+      expect(pat).toMatch(/^h1:/);
+      expect(decryptPat(pat)).toBe('pat-secret');
+    });
+
+    it('encrypts a legacy plaintext smtp_pass during the sweep', async () => {
+      await seedSmtpPass('plain-old-secret');
+      process.env.PAT_ENCRYPTION_KEY_V1 = 'versioned-key-one-at-least-32-chars!!';
+
+      const res = await app.inject({ method: 'POST', url: '/api/admin/rotate-encryption-key' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ rotated: 1, skipped: 0, errors: 0, total: 1 });
+
+      const smtp = await readSmtpPass();
+      expect(smtp).toMatch(/^h1:/);
+      expect(decryptPat(smtp!)).toBe('plain-old-secret');
+    });
+
+    it('skips an smtp_pass already on the latest key, leaving the row byte-identical', async () => {
+      const current = encryptPat('already-current');
+      await seedSmtpPass(current);
+
+      const res = await app.inject({ method: 'POST', url: '/api/admin/rotate-encryption-key' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ rotated: 0, skipped: 1, errors: 0, total: 1 });
+      expect(await readSmtpPass()).toBe(current);
+    });
+
+    it('ignores an empty smtp_pass row (cleared password is not a secret)', async () => {
+      await seedSmtpPass('');
+
+      const res = await app.inject({ method: 'POST', url: '/api/admin/rotate-encryption-key' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ rotated: 0, skipped: 0, errors: 0, total: 0 });
+      expect(await readSmtpPass()).toBe('');
+    });
+  },
+);

--- a/backend/src/routes/foundation/admin.test.ts
+++ b/backend/src/routes/foundation/admin.test.ts
@@ -4,8 +4,11 @@ import sensible from '@fastify/sensible';
 import { ZodError } from 'zod';
 import { adminRoutes } from './admin.js';
 
-// Mock external dependencies
-vi.mock('../../core/utils/crypto.js', () => ({
+// Mock external dependencies. Passthrough keeps the real encryptPat/decryptPat
+// (used by PUT /admin/smtp to encrypt smtp_pass at rest, #738) while stubbing
+// the key-rotation entry point.
+vi.mock('../../core/utils/crypto.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../core/utils/crypto.js')>()),
   reEncryptPat: vi.fn().mockReturnValue(null),
 }));
 
@@ -77,6 +80,7 @@ vi.mock('../../domains/llm/services/llm-queue.js', () => ({
 
 import nodemailer from 'nodemailer';
 import { listErrors, resolveError, getErrorSummary } from '../../core/services/error-tracker.js';
+import { decryptPat, isEncryptedSecretFormat } from '../../core/utils/crypto.js';
 import { query as mockQuery } from '../../core/db/postgres.js';
 import { _resetStreamCapCache } from '../../core/services/sse-stream-limiter.js';
 import { _resetCache as _resetRateLimitsCache } from '../../core/services/rate-limit-service.js';
@@ -922,7 +926,63 @@ describe('Admin routes', () => {
       const persistedKeys = upsert?.[1][0] as string[];
       const persistedValues = upsert?.[1][1] as string[];
       expect(persistedKeys).toContain('smtp_pass');
-      expect(persistedValues[persistedKeys.indexOf('smtp_pass')]).toBe('brand-new-password');
+      // issue #738 — smtp_pass is now encrypted at rest, so the persisted
+      // value is a versioned ciphertext that decrypts to the real password,
+      // never the plaintext itself.
+      const stored = persistedValues[persistedKeys.indexOf('smtp_pass')];
+      expect(stored).not.toBe('brand-new-password');
+      expect(isEncryptedSecretFormat(stored)).toBe(true);
+      expect(decryptPat(stored)).toBe('brand-new-password');
+    });
+  });
+
+  // ========================
+  // SMTP settings — smtp_pass encrypted at rest (issue #738)
+  // ========================
+  describe('PUT /api/admin/smtp - smtp_pass encrypted at rest (#738)', () => {
+    const findAdminSettingsUpsert = () => {
+      const calls = (mockQuery as ReturnType<typeof vi.fn>).mock.calls as Array<[string, unknown[]]>;
+      return calls.find(([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO admin_settings'));
+    };
+
+    it('persists smtp_pass encrypted, never plaintext', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/smtp',
+        payload: { host: 'smtp.test.local', pass: 'super-secret-smtp', enabled: true },
+      });
+      expect(response.statusCode).toBe(200);
+
+      const upsert = findAdminSettingsUpsert();
+      expect(upsert).toBeDefined();
+      const [, params] = upsert!;
+      const keys = params[0] as string[];
+      const values = params[1] as string[];
+      const stored = values[keys.indexOf('smtp_pass')];
+
+      expect(stored).not.toBe('super-secret-smtp');
+      expect(stored).toMatch(/^h\d+:/); // versioned encryptPat format
+      expect(decryptPat(stored)).toBe('super-secret-smtp');
+    });
+
+    it('persists an empty smtp_pass as an empty string so admins can clear it', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/admin/smtp',
+        payload: { pass: '' },
+      });
+      expect(response.statusCode).toBe(200);
+
+      const upsert = findAdminSettingsUpsert();
+      expect(upsert).toBeDefined();
+      const [, params] = upsert!;
+      const keys = params[0] as string[];
+      const values = params[1] as string[];
+      expect(values[keys.indexOf('smtp_pass')]).toBe('');
     });
   });
 });

--- a/backend/src/routes/foundation/admin.test.ts
+++ b/backend/src/routes/foundation/admin.test.ts
@@ -80,7 +80,7 @@ vi.mock('../../domains/llm/services/llm-queue.js', () => ({
 
 import nodemailer from 'nodemailer';
 import { listErrors, resolveError, getErrorSummary } from '../../core/services/error-tracker.js';
-import { decryptPat, isEncryptedSecretFormat } from '../../core/utils/crypto.js';
+import { decryptPat, isEncryptedSecretFormat, reEncryptPat } from '../../core/utils/crypto.js';
 import { query as mockQuery } from '../../core/db/postgres.js';
 import { _resetStreamCapCache } from '../../core/services/sse-stream-limiter.js';
 import { _resetCache as _resetRateLimitsCache } from '../../core/services/rate-limit-service.js';
@@ -983,6 +983,111 @@ describe('Admin routes', () => {
       const keys = params[0] as string[];
       const values = params[1] as string[];
       expect(values[keys.indexOf('smtp_pass')]).toBe('');
+    });
+  });
+
+  // ========================
+  // Encryption-key rotation must sweep admin_settings.smtp_pass too —
+  // otherwise the documented procedure (rotate, remove old key) strands the
+  // ciphertext and SMTP auth fails silently (#762 review follow-up).
+  // ========================
+  describe('POST /api/admin/rotate-encryption-key - admin_settings.smtp_pass sweep (#762 review)', () => {
+    const mockedReEncryptPat = reEncryptPat as ReturnType<typeof vi.fn>;
+    // Structurally valid h0 ciphertext (passes the real isEncryptedSecretFormat).
+    const storedCipher = `h0:${'a'.repeat(32)}:${'b'.repeat(32)}:cc`;
+
+    const mockRotationQueries = (smtpValue: string | undefined, updateRowCount = 1) => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockImplementation(async (sql: string) => {
+        if (typeof sql === 'string' && sql.includes('FROM user_settings')) {
+          return { rows: [], rowCount: 0 };
+        }
+        if (typeof sql === 'string' && sql.trimStart().startsWith('SELECT') && sql.includes(`'smtp_pass'`)) {
+          return smtpValue === undefined
+            ? { rows: [], rowCount: 0 }
+            : { rows: [{ setting_value: smtpValue }], rowCount: 1 };
+        }
+        return { rows: [], rowCount: updateRowCount };
+      });
+    };
+
+    const findSmtpPassUpdate = () => {
+      const calls = (mockQuery as ReturnType<typeof vi.fn>).mock.calls as Array<[string, unknown[]]>;
+      return calls.find(([sql]) =>
+        typeof sql === 'string' && sql.includes('UPDATE admin_settings') && sql.includes(`'smtp_pass'`),
+      );
+    };
+
+    it('re-encrypts smtp_pass with the latest key, conditional on the value read, and reports it as rotated', async () => {
+      mockRotationQueries(storedCipher);
+      mockedReEncryptPat.mockReturnValueOnce('h1:new-cipher');
+
+      const response = await app.inject({ method: 'POST', url: '/api/admin/rotate-encryption-key' });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toMatchObject({ rotated: 1, skipped: 0, errors: 0, total: 1 });
+
+      const update = findSmtpPassUpdate();
+      expect(update).toBeDefined();
+      const [sql, params] = update!;
+      // Lost-update guard: a concurrent PUT /admin/smtp must never be
+      // clobbered with a re-encryption of the OLD password.
+      expect(sql).toContain('setting_value = $2');
+      expect(params).toEqual(['h1:new-cipher', storedCipher]);
+    });
+
+    it('counts smtp_pass as skipped when already on the latest key (reEncryptPat → null)', async () => {
+      mockRotationQueries(storedCipher);
+      mockedReEncryptPat.mockReturnValueOnce(null);
+
+      const response = await app.inject({ method: 'POST', url: '/api/admin/rotate-encryption-key' });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toMatchObject({ rotated: 0, skipped: 1, errors: 0, total: 1 });
+      expect(findSmtpPassUpdate()).toBeUndefined();
+    });
+
+    it('counts smtp_pass as skipped when the conditional UPDATE matches 0 rows (concurrent change)', async () => {
+      mockRotationQueries(storedCipher, 0);
+      mockedReEncryptPat.mockReturnValueOnce('h1:new-cipher');
+
+      const response = await app.inject({ method: 'POST', url: '/api/admin/rotate-encryption-key' });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toMatchObject({ rotated: 0, skipped: 1, errors: 0, total: 1 });
+    });
+
+    it('encrypts a legacy plaintext smtp_pass outright during the sweep', async () => {
+      mockRotationQueries('plain-old-secret');
+
+      const response = await app.inject({ method: 'POST', url: '/api/admin/rotate-encryption-key' });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toMatchObject({ rotated: 1, skipped: 0, errors: 0, total: 1 });
+
+      const update = findSmtpPassUpdate();
+      expect(update).toBeDefined();
+      const [sql, params] = update!;
+      expect(sql).toContain('setting_value = $2');
+      expect((params as string[])[1]).toBe('plain-old-secret');
+      expect((params as string[])[0]).toMatch(/^h\d+:/);
+      expect(decryptPat((params as string[])[0]!)).toBe('plain-old-secret');
+    });
+
+    it('reports an error when smtp_pass re-encryption throws, without failing the request', async () => {
+      mockRotationQueries(storedCipher);
+      mockedReEncryptPat.mockImplementationOnce(() => {
+        throw new Error('key version 0 not found');
+      });
+
+      const response = await app.inject({ method: 'POST', url: '/api/admin/rotate-encryption-key' });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toMatchObject({ rotated: 0, skipped: 0, errors: 1, total: 1 });
+    });
+
+    it('does not count an absent or empty smtp_pass row', async () => {
+      mockRotationQueries(undefined);
+      const absent = await app.inject({ method: 'POST', url: '/api/admin/rotate-encryption-key' });
+      expect(JSON.parse(absent.body)).toMatchObject({ rotated: 0, skipped: 0, errors: 0, total: 0 });
+
+      mockRotationQueries('');
+      const empty = await app.inject({ method: 'POST', url: '/api/admin/rotate-encryption-key' });
+      expect(JSON.parse(empty.body)).toMatchObject({ rotated: 0, skipped: 0, errors: 0, total: 0 });
     });
   });
 });

--- a/backend/src/routes/foundation/admin.ts
+++ b/backend/src/routes/foundation/admin.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { query } from '../../core/db/postgres.js';
-import { encryptPat, reEncryptPat } from '../../core/utils/crypto.js';
+import { encryptPat, isEncryptedSecretFormat, reEncryptPat } from '../../core/utils/crypto.js';
 import { getAuditLog, logAuditEvent } from '../../core/services/audit-service.js';
 import { listErrors, resolveError, getErrorSummary } from '../../core/services/error-tracker.js';
 import { logger } from '../../core/utils/logger.js';
@@ -57,7 +57,8 @@ export async function adminRoutes(fastify: FastifyInstance) {
   // All admin routes require admin role
   fastify.addHook('onRequest', fastify.requireAdmin);
 
-  // POST /api/admin/rotate-encryption-key - re-encrypt all PATs with the latest key
+  // POST /api/admin/rotate-encryption-key - re-encrypt all PATs and
+  // admin_settings secrets (smtp_pass) with the latest key
   fastify.post('/admin/rotate-encryption-key', ADMIN_RATE_LIMIT, async (request) => {
     const userId = request.userId;
 
@@ -71,6 +72,7 @@ export async function adminRoutes(fastify: FastifyInstance) {
     let rotated = 0;
     let skipped = 0;
     let errors = 0;
+    let total = result.rows.length;
 
     for (const row of result.rows) {
       try {
@@ -90,12 +92,56 @@ export async function adminRoutes(fastify: FastifyInstance) {
       }
     }
 
+    // issue #738 / #762 review follow-up — admin_settings.smtp_pass is a
+    // versioned ciphertext too. Sweeping only user_settings would strand it
+    // on the old key once the operator follows the documented procedure
+    // (rotate, then remove the old key) → silent SMTP auth failures.
+    // NOTE: llm_providers.api_key and webhook secret_enc have the same
+    // pre-existing gap — tracked as a follow-up, deliberately not widened
+    // into this sweep here.
+    const smtpRow = await query<{ setting_value: string }>(
+      `SELECT setting_value FROM admin_settings WHERE setting_key = 'smtp_pass'`,
+    );
+    const storedSmtpPass = smtpRow.rows[0]?.setting_value;
+    if (storedSmtpPass) {
+      total++;
+      try {
+        // Legacy plaintext rows (pre-#738) are encrypted outright; ciphertexts
+        // are upgraded only when their key version / derivation is stale.
+        const reEncrypted = isEncryptedSecretFormat(storedSmtpPass)
+          ? reEncryptPat(storedSmtpPass)
+          : encryptPat(storedSmtpPass);
+        if (reEncrypted) {
+          // Conditional on the exact value read so a concurrent
+          // PUT /admin/smtp is never clobbered with a re-encryption of the
+          // OLD password (lost-update guard).
+          const updated = await query(
+            `UPDATE admin_settings SET setting_value = $1, updated_at = NOW()
+             WHERE setting_key = 'smtp_pass' AND setting_value = $2`,
+            [reEncrypted, storedSmtpPass],
+          );
+          if ((updated.rowCount ?? 0) > 0) {
+            rotated++;
+          } else {
+            // Concurrently replaced — PUT /admin/smtp already wrote the new
+            // value encrypted with the latest key.
+            skipped++;
+          }
+        } else {
+          skipped++; // Already using latest key + derivation
+        }
+      } catch (err) {
+        errors++;
+        logger.error({ err }, 'Failed to re-encrypt smtp_pass in admin_settings');
+      }
+    }
+
     await logAuditEvent(
       userId,
       'ENCRYPTION_KEY_ROTATED',
       'system',
       undefined,
-      { rotated, skipped, errors, totalPats: result.rows.length },
+      { rotated, skipped, errors, totalPats: result.rows.length, total },
       request,
     );
 
@@ -106,7 +152,7 @@ export async function adminRoutes(fastify: FastifyInstance) {
       rotated,
       skipped,
       errors,
-      total: result.rows.length,
+      total,
     };
   });
 

--- a/backend/src/routes/foundation/admin.ts
+++ b/backend/src/routes/foundation/admin.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { query } from '../../core/db/postgres.js';
-import { reEncryptPat } from '../../core/utils/crypto.js';
+import { encryptPat, reEncryptPat } from '../../core/utils/crypto.js';
 import { getAuditLog, logAuditEvent } from '../../core/services/audit-service.js';
 import { listErrors, resolveError, getErrorSummary } from '../../core/services/error-tracker.js';
 import { logger } from '../../core/utils/logger.js';
@@ -536,7 +536,13 @@ export async function adminRoutes(fastify: FastifyInstance) {
     if (body.port !== undefined) entries.push({ key: 'smtp_port', value: String(body.port) });
     if (body.secure !== undefined) entries.push({ key: 'smtp_secure', value: String(body.secure) });
     if (body.user !== undefined) entries.push({ key: 'smtp_user', value: body.user });
-    if (body.pass !== undefined) entries.push({ key: 'smtp_pass', value: body.pass });
+    // issue #738 — encrypt at rest with the versioned PAT helpers. The masked
+    // sentinel was already stripped from `body` above (#743), so any defined
+    // value here is a real update. An empty string clears the password and is
+    // stored as-is (it is not a secret).
+    if (body.pass !== undefined) {
+      entries.push({ key: 'smtp_pass', value: body.pass ? encryptPat(body.pass) : '' });
+    }
     if (body.from !== undefined) entries.push({ key: 'smtp_from', value: body.from });
     if (body.enabled !== undefined) entries.push({ key: 'smtp_enabled', value: String(body.enabled) });
 

--- a/docs/architecture/06-data-model.md
+++ b/docs/architecture/06-data-model.md
@@ -279,7 +279,11 @@ erDiagram
   `backend/src/domains/llm/services/embedding-service.ts` (`enqueueReembedAll`).
 - **Encryption at rest.** `user_settings.confluence_pat` is stored as a
   ciphertext blob (AES-256-GCM, key from `PAT_ENCRYPTION_KEY`). Never
-  log or expose it to the frontend.
+  log or expose it to the frontend. The AES key is derived via HKDF-SHA256
+  over the full passphrase (#738); pre-HKDF ciphertexts (`v{N}:` /
+  unversioned) remain decryptable. The `smtp_pass` row in `admin_settings`
+  uses the same versioned helpers — legacy plaintext rows are detected on
+  startup and re-encrypted in place.
 - **`admin_settings`** is a key-value bag used for server-wide config
   that must survive restarts and be editable at runtime — notably the
   `license_key` (populated by the EE plugin) and the `embedding_dimensions`


### PR DESCRIPTION
## Root cause (issue #738)

1. **`smtp_pass` stored in plaintext** — `PUT /api/admin/smtp` upserted the raw password into `admin_settings`, and `initEmailService` read it back as plaintext. A DB dump / backup leak yielded working SMTP credentials, inconsistent with the project's own PAT-encryption mandate.
2. **AES key derived by char-truncation, no KDF** — `crypto.ts` derived the key as `Buffer.from(key.slice(0, 32), 'utf-8')`. `slice` counts UTF-16 code units, so a multi-byte passphrase produced a ≠32-byte buffer: it passed the startup guard (`.length >= 32` chars) but crashed with "Invalid key length" on first encrypt. Chars beyond 32 were silently ignored (prefix-equal keys collided), and a malformed `PAT_ENCRYPTION_KEYS` JSON was swallowed silently.

## Fix

- **HKDF-SHA256 derivation** (`backend/src/core/utils/crypto.ts`): AES-256-GCM keys are now `HKDF-SHA256(full passphrase bytes, fixed salt/info, 32)`. New ciphertexts carry an `h{N}:` prefix.
- **`smtp_pass` encrypted at rest**: `PUT /admin/smtp` encrypts via the versioned `encryptPat()` before upserting (empty string still clears the password and is stored as-is). `initEmailService` decrypts on read.
- **Startup guard** (`backend/src/index.ts`): validates `PAT_ENCRYPTION_KEY` by **UTF-8 byte length** (`isValidEncryptionKey`), so what passes boot is exactly what the crypto module accepts. Identical semantics for ASCII keys (32 chars = 32 bytes).
- **Observability**: a malformed `PAT_ENCRYPTION_KEYS` now logs a warning (once per process) instead of being silently ignored.

## Backward compatibility

- **Old ciphertexts keep decrypting.** `decryptPat()` supports all three formats: `h{N}:` (HKDF, new), `v{N}:` (pre-HKDF truncation-derived) and unversioned `iv:tag:ct` (truncation, version 0). Each `VersionedKey` keeps both the HKDF key and the legacy truncated key (decrypt-only). Regression tests encrypt fixtures with the *real old algorithm* (re-implemented in the test) and decrypt them through the new code.
- **`reEncryptPat()` upgrades derivation**: pre-HKDF data is re-encrypted to `h{N}` on key rotation even when the key version is already latest.
- **Legacy plaintext `smtp_pass` rows**: `initEmailService` detects values that aren't in the encrypted format (strict hex/structure check via `isEncryptedSecretFormat`) and uses them as the live password, then **re-encrypts them in place** so existing deployments converge without re-saving settings. A value that *looks* encrypted but fails decryption (rotated-away key) is used verbatim and never double-encrypted.
- **Key acceptance is byte-based** everywhere (`>= 32` UTF-8 bytes): unchanged for ASCII keys; multi-byte passphrases now work instead of crashing at runtime.
- Note: ciphertexts written *after* this change (`h{N}:`) are not readable by older backends — relevant only for rollback.
- CLAUDE.md's documented contract (PATs AES-256-GCM with `PAT_ENCRYPTION_KEY`, never plaintext) is unchanged; only the internal key derivation is hardened. `.env.example` and `docs/architecture/06-data-model.md` updated accordingly.

## Overlap with #759

Overlaps PR #759 — merge that first, then rebase this branch; conflicts are confined to the SMTP persist/read hunks (the inline mask-sentinel guard in `admin.ts` and the `pass:`/`enabled:` lines in `initEmailService`). This PR deliberately does **not** re-fix the mask-sentinel bug.

## Test evidence

TDD: 22 new/updated assertions failed on the dev base, all green after the fix.

- `src/core/utils/crypto.test.ts` — 33 tests: pre-HKDF back-compat fixtures (v{N} + unversioned), HKDF full-passphrase/multi-byte behavior, byte-based key validation, `isEncryptedSecretFormat`, once-per-process JSON warning, re-encrypt/rotation.
- `src/core/services/email-service.test.ts` — 8 tests: encrypted round-trip via `initEmailService`, legacy-plaintext read + in-place re-encryption, fails-decryption used-as-is (no double encryption), empty-password handling.
- `src/routes/foundation/admin.test.ts` — 46 tests: `PUT /admin/smtp` persists ciphertext (`h{N}:`, decrypts back to the original), empty-string clear path.
- Full regression slice: `src/core/utils` + `src/core/services` + `src/routes/foundation` → **59 files, 1044 passed / 2 skipped**. `npm run lint -w backend` and `npm run typecheck -w backend` clean.

## Review follow-up (adversarial review on this PR)

- **Key rotation now covers `admin_settings.smtp_pass`** — `POST /admin/rotate-encryption-key` previously re-encrypted only `user_settings.confluence_pat`, so the documented procedure (rotate, then remove the old key) stranded the smtp_pass ciphertext: `readStoredSmtpPass` fell back to using it verbatim as the password → silent SMTP auth failures. The sweep now encrypts legacy plaintext rows outright, upgrades stale-version / pre-HKDF ciphertexts, and reports the row in the existing `rotated`/`skipped`/`errors`/`total` response counts.
- **Defense in depth: re-encrypt-on-read** — `initEmailService` now upgrades a stored smtp_pass that decrypts under a non-latest key version or the pre-HKDF derivation (not just legacy plaintext), so the value converges onto the latest key even if the rotation endpoint is never called.
- **Lost-update guard on all write-backs** — every smtp_pass write-back (legacy upgrade + re-encrypt-on-read + rotation sweep) is conditional on the exact value read (`WHERE setting_key = 'smtp_pass' AND setting_value = $2`), so a concurrent `PUT /admin/smtp` during pod startup or rotation can never be overwritten with a re-encryption of the OLD password.
- **`isEncryptedSecretFormat` limitation documented + pinned** — it rejects `encryptPat('')` output (empty ciphertext segment). Unreachable today (empty secrets are persisted as `''`), but documented in `crypto.ts` and pinned by a test so a future caller doesn't double-encrypt an encrypted-empty secret.

**Follow-up candidate (pre-existing, out of scope here):** the same rotation gap exists for `llm_providers.api_key` and webhook `secret_enc` — neither is swept by `POST /admin/rotate-encryption-key`. Should be fixed in a dedicated PR (the sweep helper introduced here can be generalised).

**Test evidence (follow-up):** TDD — 13 new assertions failed before the fix, all green after. New real-Postgres integration suites: `admin-rotate-encryption-key.integration.test.ts` (rotation leaves smtp_pass decryptable under the new key, plaintext sweep, skip-when-current, empty-row ignore) and `email-service.integration.test.ts` (in-place upgrades + concurrent-PUT lost-update guard exercised against the real `admin_settings` schema). Targeted suites: crypto 33 ✓, email-service unit 10 ✓ + integration 3 ✓, admin routes 53 ✓ + rotation integration 4 ✓. Full slice `src/core/utils` + `src/core/services` + `src/routes/foundation`: **61 files, 1060 passed / 2 skipped**. `npm run lint -w backend` and `npm run typecheck -w backend` clean.

Fixes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)

