### PR TITLE
fix(searxng): add trusted_proxies to limiter.toml

### DIFF
--- a/docker/searxng/limiter.toml
+++ b/docker/searxng/limiter.toml
@@ -1,6 +1,14 @@
 [botdetection]
 ipv4_prefix = 32
 ipv6_prefix = 48
+# Trusted proxies for bot detection — allows SearXNG to run without a reverse
+# proxy by trusting the Docker internal network (e.g. mcp-docs calls SearXNG
+# directly via Docker DNS at http://searxng:8080).
+trusted_proxies = [
+  '127.0.0.0/8',
+  '::1',
+  '172.18.0.0/16',
+]
 
 [botdetection.ip_limit]
 filter_link_local = false


### PR DESCRIPTION
## Problem

The SearXNG container crashes on startup with the error:

```
ERROR:searx.botdetection: X-Forwarded-For nor X-Real-IP header is set!
```

This happens because the `mcp-docs` container calls SearXNG directly via Docker DNS (`http://searxng:8080`) without a reverse proxy in between. SearXNG's bot detection middleware expects these headers from a reverse proxy and shuts down when they are missing.

## Fix

Added `trusted_proxies` to `docker/searxng/limiter.toml` with the Docker internal network range (`172.18.0.0/16`). This tells SearXNG to trust requests coming from other containers on the same Docker network, eliminating the need for a reverse proxy in this deployment pattern.

The fix was verified by restarting the container on the production server (`docker-v001.kt.lunet.ch`) and confirming it stays healthy and responds to search queries from `mcp-docs`.

## Changed files

- `docker/searxng/limiter.toml` — added `trusted_proxies` section under `[botdetection]`