### PR TITLE
fix(sidebar): stable tree view text weight (no faux-bold)

### DIFF
--- a/frontend/src/font-rendering.test.ts
+++ b/frontend/src/font-rendering.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { extractBlock } from './test-utils';
 
 /**
  * Regression tests for stable text weight during async font load (#767).
@@ -18,22 +19,6 @@ import { resolve } from 'path';
  */
 
 const css = readFileSync(resolve(__dirname, 'index.css'), 'utf-8');
-
-function extractBlock(source: string, openingLine: string): string {
-  const startIndex = source.indexOf(openingLine);
-  if (startIndex === -1) return '';
-  const braceStart = source.indexOf('{', startIndex);
-  if (braceStart === -1) return '';
-  let depth = 0;
-  for (let i = braceStart; i < source.length; i++) {
-    if (source[i] === '{') depth++;
-    else if (source[i] === '}') {
-      depth--;
-      if (depth === 0) return source.slice(braceStart, i + 1);
-    }
-  }
-  return '';
-}
 
 describe('font-synthesis guard against faux-bold during font swap (#767)', () => {
   const bodyBlock = extractBlock(css, '\nbody {');

--- a/frontend/src/font-rendering.test.ts
+++ b/frontend/src/font-rendering.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression tests for stable text weight during async font load (#767).
+ *
+ * The brand fonts are self-hosted variable fonts loaded async via @fontsource
+ * (font-display: swap). During the swap window the browser renders system
+ * fallbacks and — unless told otherwise — may synthesize a faux-bold, which
+ * made random sidebar tree titles flash heavier between loads.
+ *
+ * `font-synthesis: style` on body disables weight (and small-caps) synthesis
+ * app-wide while keeping style synthesis: the app uses the `italic` utility
+ * and the editor's Italic mark, but ships no italic cut of IBM Plex Sans, so
+ * italics depend on oblique synthesis. Full `font-synthesis: none` would
+ * silently un-italicize them — guard against that too.
+ */
+
+const css = readFileSync(resolve(__dirname, 'index.css'), 'utf-8');
+
+function extractBlock(source: string, openingLine: string): string {
+  const startIndex = source.indexOf(openingLine);
+  if (startIndex === -1) return '';
+  const braceStart = source.indexOf('{', startIndex);
+  if (braceStart === -1) return '';
+  let depth = 0;
+  for (let i = braceStart; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(braceStart, i + 1);
+    }
+  }
+  return '';
+}
+
+describe('font-synthesis guard against faux-bold during font swap (#767)', () => {
+  const bodyBlock = extractBlock(css, '\nbody {');
+
+  it('body disables weight synthesis via the font-synthesis shorthand', () => {
+    expect(bodyBlock).toContain('font-synthesis: style;');
+  });
+
+  it('does not fully disable synthesis (italics rely on oblique synthesis)', () => {
+    expect(css).not.toContain('font-synthesis: none');
+    expect(css).not.toContain('font-synthesis-style: none');
+  });
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -47,6 +47,15 @@ body {
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
   font-feature-settings: "liga" 1, "kern" 1;
+  /* #767: the variable fonts above load async (@fontsource, font-display:
+     swap). During the swap window the browser renders system fallbacks and
+     may synthesize faux-bold glyphs, making random sidebar/tree text flash
+     heavier between loads. `style` allows only italic synthesis (we ship no
+     italic cut of IBM Plex Sans, so the `italic` utility and the editor's
+     Italic mark rely on oblique synthesis) while disabling weight and
+     small-caps synthesis. Shorthand over `font-synthesis-weight: none` for
+     wider browser support (Safari 9+/Firefox 34+ vs 16.4+/111+). */
+  font-synthesis: style;
 }
 
 /* Headings share the body's sans stack (IBM Plex Sans Variable) so the UI

--- a/frontend/src/neumorphic-themes.test.ts
+++ b/frontend/src/neumorphic-themes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { extractBlock } from './test-utils';
 import {
   THEMES,
   THEME_IDS,
@@ -26,22 +27,6 @@ import {
 
 const cssPath = resolve(__dirname, 'index.css');
 const css = readFileSync(cssPath, 'utf-8');
-
-function extractBlock(source: string, openingLine: string): string {
-  const startIndex = source.indexOf(openingLine);
-  if (startIndex === -1) return '';
-  const braceStart = source.indexOf('{', startIndex);
-  if (braceStart === -1) return '';
-  let depth = 0;
-  for (let i = braceStart; i < source.length; i++) {
-    if (source[i] === '{') depth++;
-    else if (source[i] === '}') {
-      depth--;
-      if (depth === 0) return source.slice(braceStart, i + 1);
-    }
-  }
-  return '';
-}
 
 const themeBlock = extractBlock(css, '@theme {');
 const honeyLinenBlock = extractBlock(css, '[data-theme="honey-linen"] {');

--- a/frontend/src/shared/components/layout/DndLocalSpaceTree.test.tsx
+++ b/frontend/src/shared/components/layout/DndLocalSpaceTree.test.tsx
@@ -140,4 +140,31 @@ describe('DndLocalSpaceTree', () => {
     const active = document.querySelector('[data-active="true"]');
     expect(active?.getAttribute('data-page-id')).toBe('p2-c1');
   });
+
+  // #767: tree titles intermittently rendered faux-bold (synthesized weight
+  // during variable-font load / compositing re-rasterization). The weight is
+  // now pinned per-state on the title span so it can never float: exactly one
+  // of font-normal / font-medium, never both (Tailwind class order between the
+  // two utilities is unspecified, so conditional classes are mandatory).
+  it('pins font-normal on inactive titles and font-medium on the active title (#767)', () => {
+    renderTree({ activePageId: 'p1' });
+
+    const activeTitle = screen.getByText('Page One');
+    expect(activeTitle.className).toContain('font-medium');
+    expect(activeTitle.className).not.toContain('font-normal');
+
+    const inactiveTitle = screen.getByText('Page Two');
+    expect(inactiveTitle.className).toContain('font-normal');
+    expect(inactiveTitle.className).not.toContain('font-medium');
+  });
+
+  it('pins font-normal on every title when no page is active (#767)', () => {
+    renderTree({ activePageId: undefined });
+
+    for (const title of ['Page One', 'Page Two']) {
+      const span = screen.getByText(title);
+      expect(span.className).toContain('font-normal');
+      expect(span.className).not.toContain('font-medium');
+    }
+  });
 });

--- a/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
+++ b/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
@@ -97,7 +97,12 @@ const DndSortableTreeNode = memo(function DndSortableTreeNode({
           <span className="w-[20px] shrink-0" />
         )}
         <FileText size={15} className={cn('shrink-0', isActive ? 'text-action/80' : 'text-muted-foreground/70')} />
-        <span className="truncate text-sm">{node.page.title}</span>
+        {/* #767: pin the weight explicitly (conditional, never both classes)
+            so titles can't inherit or synthesize a heavier weight while the
+            variable font loads or the row sits on a composited layer. */}
+        <span className={cn('truncate text-sm', isActive ? 'font-medium' : 'font-normal')}>
+          {node.page.title}
+        </span>
       </div>
 
       {hasChildren && isExpanded && (

--- a/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
@@ -274,6 +274,36 @@ describe('SidebarTreeView', () => {
     expect(row.className).toContain('text-action-foreground');
   });
 
+  // #767: tree titles intermittently rendered faux-bold (synthesized weight
+  // during variable-font load / compositing re-rasterization). The weight is
+  // now pinned per-state on the title span so it can never float: exactly one
+  // of font-normal / font-medium, never both (Tailwind class order between the
+  // two utilities is unspecified, so conditional classes are mandatory).
+  it('pins font-normal on inactive tree titles and font-medium on the active title (#767)', () => {
+    // OPS has no homepage, so the full tree (incl. "Getting Started") renders.
+    useUiStore.setState({ treeSidebarCollapsed: false, treeSidebarSpaceKey: 'OPS' });
+    render(<SidebarTreeView />, { wrapper: createWrapper('/pages/root-2') });
+
+    const activeTitle = screen.getByText('API Reference');
+    expect(activeTitle.className).toContain('font-medium');
+    expect(activeTitle.className).not.toContain('font-normal');
+
+    const inactiveTitle = screen.getByText('Getting Started');
+    expect(inactiveTitle.className).toContain('font-normal');
+    expect(inactiveTitle.className).not.toContain('font-medium');
+  });
+
+  it('pins font-normal on every title when no page is active (#767)', () => {
+    useUiStore.setState({ treeSidebarCollapsed: false, treeSidebarSpaceKey: 'OPS' });
+    render(<SidebarTreeView />, { wrapper: createWrapper('/') });
+
+    for (const title of ['Getting Started', 'API Reference']) {
+      const span = screen.getByText(title);
+      expect(span.className).toContain('font-normal');
+      expect(span.className).not.toContain('font-medium');
+    }
+  });
+
   it('shows collapsed state with expand toggle and nav icons when treeSidebarCollapsed is true', () => {
     useUiStore.setState({ treeSidebarCollapsed: true });
     render(<SidebarTreeView />, { wrapper: createWrapper() });

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -156,7 +156,12 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
           <span className="w-[20px] shrink-0" />
         )}
         <FileText size={15} className={cn('shrink-0', isActive ? 'text-action-foreground/80' : 'text-muted-foreground/70')} />
-        <span className="truncate text-sm">{node.page.title}</span>
+        {/* #767: pin the weight explicitly (conditional, never both classes)
+            so titles can't inherit or synthesize a heavier weight while the
+            variable font loads or the row sits on a composited layer. */}
+        <span className={cn('truncate text-sm', isActive ? 'font-medium' : 'font-normal')}>
+          {node.page.title}
+        </span>
       </div>
 
       {hasChildren && isExpanded && (

--- a/frontend/src/test-utils.ts
+++ b/frontend/src/test-utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared test-only helpers. Not imported by application code.
+ */
+
+/**
+ * Extract a balanced `{ ... }` block from `source`, starting at the first
+ * occurrence of `openingLine` (e.g. `'@theme {'` or `'\nbody {'`).
+ *
+ * Throws when the anchor (or its opening brace) is missing so anchor drift
+ * in index.css fails loudly instead of silently matching an empty string.
+ * Returns `''` only for an unterminated (unbalanced) block.
+ */
+export function extractBlock(source: string, openingLine: string): string {
+  const startIndex = source.indexOf(openingLine);
+  if (startIndex === -1) {
+    throw new Error(`extractBlock: anchor not found: ${JSON.stringify(openingLine)}`);
+  }
+  const braceStart = source.indexOf('{', startIndex);
+  if (braceStart === -1) {
+    throw new Error(
+      `extractBlock: no opening brace after anchor: ${JSON.stringify(openingLine)}`,
+    );
+  }
+  let depth = 0;
+  for (let i = braceStart; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(braceStart, i + 1);
+    }
+  }
+  return '';
+}


### PR DESCRIPTION
## Summary

Sidebar tree page titles intermittently rendered faux-bold — a few rows, varying between loads (#767). This applies a layered rendering-level fix: disable bold synthesis app-wide during the variable-font swap window, and pin an explicit per-state font weight on the tree title spans in both render paths.

## Root cause analysis

The fix targets **hypothesis 1 (synthesized bold during variable-font load)** as the primary cause: `IBM Plex Sans Variable` is self-hosted via @fontsource (`font-display: swap`, loaded async from `index.css`), and `font-synthesis` was never disabled — so rows painted during the swap window could get synthetically emboldened fallback glyphs. That matches the intermittent, few-rows-per-load symptom exactly.

The fix is **layered** because hypothesis 2 (compositing-layer antialiasing flips from the Motion width animation / `scale-[1.01]` / `active:scale-[0.98]`) is also plausible and cheap to harden against: pinning `font-normal` / `font-medium` explicitly on the title spans guarantees a single computed weight per state regardless of inheritance, load timing, or re-rasterization. (Audit note: `will-change: transform` only exists on `nm-card-interactive`, which tree rows don't use, and `nm-pill-active` carries no transform — so no residual-transform cleanup was needed.)

## Changes

- **`frontend/src/index.css`** — `body` now sets `font-synthesis: style`: weight (and small-caps) synthesis disabled app-wide, style synthesis kept. Full `font-synthesis: none` was considered and rejected: the app *does* use italics (`italic` utility in VersionHistory/TagEditor/macro views, TipTap Italic mark, figure/table captions) but only the `wght` cut of IBM Plex Sans ships — italics depend on oblique synthesis, and `none` would silently un-italicize them. The shorthand also has far wider support than the `font-synthesis-weight: none` longhand (Safari 9+/Firefox 34+/Chrome 97+ vs Safari 16.4+/Firefox 111+).
- **`SidebarTreeView.tsx`** / **`DndLocalSpaceTree.tsx`** — the title `<span>` now carries a conditional weight: `font-medium` when active, `font-normal` otherwise. Conditional (never both classes) so Tailwind utility order can't decide the winner; the active row's existing row-level `font-medium` is preserved.
- Font preloading was evaluated and skipped: the @fontsource woff2 URLs are hashed by Vite and not statically addressable from `index.html`, so a preload would require build plumbing — not low-risk, and `font-synthesis: style` already makes the swap window weight-stable.

## Test plan

- `SidebarTreeView.test.tsx` — new assertions: active title span carries `font-medium` (not `font-normal`), inactive titles carry `font-normal` (not `font-medium`); all-inactive case covered.
- `DndLocalSpaceTree.test.tsx` — same pair of assertions for the local-space (dnd) render path.
- `font-rendering.test.ts` (new) — CSS regression test: `body` contains `font-synthesis: style;`, and `font-synthesis: none` / `font-synthesis-style: none` never appear (guards the italics dependency).
- Verified: targeted vitest run (3 files, 82 tests passed), `npm run lint -w frontend`, `npm run typecheck -w frontend` all clean.

Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)