### PR TITLE
fix(editor): keep selection highlighted during AI Improve, place popover below bubble menu

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2502,3 +2502,25 @@ pre:hover .code-copy-btn {
   background-color: rgba(255, 130, 0, 0.6);
   border-radius: 2px;
 }
+
+/* ============================================
+   AI Improve — selection decoration (#764)
+   Keeps the captured passage visibly marked while the bubble menu's Improve
+   popover holds focus (a blurred editor stops painting its native selection).
+   Applied via a ProseMirror inline decoration — never a document mark. Honey
+   primary at low alpha reads as a highlight on both Graphite Honey (dark) and
+   Honey Linen (light) without hurting text contrast.
+   ============================================ */
+.ai-improve-selection {
+  background-color: color-mix(in srgb, var(--color-primary) 30%, transparent);
+  border-radius: 2px;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+@media (forced-colors: active) {
+  .ai-improve-selection {
+    background-color: Highlight;
+    color: HighlightText;
+  }
+}

--- a/frontend/src/shared/components/article/EditorBubbleMenu.test.tsx
+++ b/frontend/src/shared/components/article/EditorBubbleMenu.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../../lib/sse', () => ({
 }));
 
 import { BubbleMenuContent, selectionShouldShow } from './EditorBubbleMenu';
+import { IMPROVE_DECORATION_CLASS } from './improve-decoration';
 
 function gen(chunks: Array<Record<string, unknown>>) {
   return (async function* () {
@@ -217,6 +218,104 @@ describe('BubbleMenuContent — try-again replays the chosen action', () => {
     await waitFor(() => expect(streamSSE).toHaveBeenCalledTimes(2));
     const [, secondBody] = streamSSE.mock.calls[1]!;
     expect((secondBody as { instruction: string }).instruction).toContain('more concise');
+  });
+});
+
+describe('BubbleMenuContent — selection decoration lifecycle (#764)', () => {
+  beforeEach(() => streamSSE.mockReset());
+
+  const decorated = (editor: EditorType) =>
+    editor.view.dom.querySelector(`.${IMPROVE_DECORATION_CLASS}`);
+
+  it('decorates the captured range while the Improve popover is open, without mutating the doc', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    expect(decorated(editor)).toBeNull();
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+
+    const el = decorated(editor);
+    expect(el).not.toBeNull();
+    expect(el!.textContent).toBe('Hello');
+    // The highlight is a view decoration, not a mark — document unchanged.
+    expect(editor.getHTML()).toBe('<p>Hello world</p>');
+  });
+
+  it('clears the decoration when the popover closes via Escape', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    expect(decorated(editor)).not.toBeNull();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => expect(decorated(editor)).toBeNull());
+    expect(editor.getHTML()).toBe('<p>Hello world</p>');
+  });
+
+  it('clears the decoration on Discard', async () => {
+    streamSSE.mockReturnValue(gen([{ content: 'Howdy' }]));
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    fireEvent.click(await screen.findByText('Improve writing'));
+    await waitFor(() => expect(screen.getByTestId('bubble-ai-preview')).toHaveTextContent('Howdy'));
+    expect(decorated(editor)).not.toBeNull();
+
+    fireEvent.click(screen.getByTitle('Discard'));
+
+    await waitFor(() => expect(decorated(editor)).toBeNull());
+    expect(editor.getHTML()).toBe('<p>Hello world</p>'); // discarded, untouched
+  });
+
+  it('clears the decoration after Replace', async () => {
+    streamSSE.mockReturnValue(gen([{ content: 'Howdy' }]));
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    fireEvent.click(await screen.findByText('Improve writing'));
+    await waitFor(() => expect(screen.getByTestId('bubble-ai-preview')).toHaveTextContent('Howdy'));
+
+    fireEvent.click(screen.getByTitle('Replace selection'));
+
+    await waitFor(() => expect(editor.getHTML()).toContain('Howdy world'));
+    expect(decorated(editor)).toBeNull();
+  });
+
+  it('clears the decoration after Insert below', async () => {
+    streamSSE.mockReturnValue(gen([{ content: 'Extra detail' }]));
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 12 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    fireEvent.click(await screen.findByText('Make longer'));
+    await waitFor(() => expect(screen.getByTestId('bubble-ai-preview')).toHaveTextContent('Extra detail'));
+
+    fireEvent.click(screen.getByTitle('Insert below selection'));
+
+    await waitFor(() => expect(editor.getHTML()).toContain('Extra detail'));
+    expect(decorated(editor)).toBeNull();
+  });
+});
+
+describe('BubbleMenuContent — AI popover placement (#764)', () => {
+  beforeEach(() => streamSSE.mockReset());
+
+  it('opens below the selection anchor (side bottom, align start)', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+
+    const popover = await screen.findByTestId('bubble-ai-popover');
+    // Radix reflects the resolved placement as data attributes. `bottom` +
+    // the selection-rect virtual anchor stacks the popover under the bubble
+    // menu (which floats above the selection) instead of over the text.
+    await waitFor(() => expect(popover).toHaveAttribute('data-side', 'bottom'));
+    expect(popover).toHaveAttribute('data-align', 'start');
   });
 });
 

--- a/frontend/src/shared/components/article/EditorBubbleMenu.test.tsx
+++ b/frontend/src/shared/components/article/EditorBubbleMenu.test.tsx
@@ -40,9 +40,12 @@ beforeAll(() => {
 function Harness({
   content,
   onReady,
+  scrollable,
 }: {
   content: string;
   onReady: (editor: EditorType) => void;
+  /** Wrap the editor in an overflow container (mimics AppLayout's `data-scroll-container`). */
+  scrollable?: boolean;
 }) {
   const editor = useEditor({
     extensions: [StarterKit, Highlight.configure({ multicolor: true })],
@@ -55,17 +58,25 @@ function Harness({
   }, [editor, onReady]);
 
   if (!editor) return null;
-  return (
+  const body = (
     <>
       <EditorContent editor={editor} />
       <BubbleMenuContent editor={editor} />
     </>
   );
+  return scrollable
+    ? <div data-testid="scroll-container" style={{ overflow: 'auto' }}>{body}</div>
+    : body;
 }
 
-async function mountEditor(content: string): Promise<EditorType> {
+async function mountEditor(
+  content: string,
+  opts?: { scrollable?: boolean },
+): Promise<EditorType> {
   let editor: EditorType | null = null;
-  render(<Harness content={content} onReady={(e) => { editor = e; }} />);
+  render(
+    <Harness content={content} onReady={(e) => { editor = e; }} scrollable={opts?.scrollable} />,
+  );
   await waitFor(() => expect(editor).not.toBeNull());
   return editor!;
 }
@@ -298,6 +309,60 @@ describe('BubbleMenuContent — selection decoration lifecycle (#764)', () => {
 
     await waitFor(() => expect(editor.getHTML()).toContain('Extra detail'));
     expect(decorated(editor)).toBeNull();
+  });
+
+  it('keeps the decoration and Replace range glued to the passage after an unrelated doc change', async () => {
+    streamSSE.mockReturnValue(gen([{ content: 'Howdy' }]));
+    const editor = await mountEditor('<p>Intro</p><p>Hello world</p>');
+    // "Hello" in the second paragraph (p1 spans 0..7, p2 text starts at 8).
+    act(() => { editor.commands.setTextSelection({ from: 8, to: 13 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    fireEvent.click(await screen.findByText('Improve writing'));
+    await waitFor(() => expect(screen.getByTestId('bubble-ai-preview')).toHaveTextContent('Howdy'));
+
+    // Unrelated edit earlier in the document while the popover is open —
+    // shifts every later position by 4.
+    act(() => { editor.view.dispatch(editor.state.tr.insertText('XYZ ', 1)); });
+
+    // (a) the decoration set is remapped, so the highlight stays on "Hello".
+    const el = decorated(editor);
+    expect(el).not.toBeNull();
+    expect(el!.textContent).toBe('Hello');
+
+    // (b) Replace acts on the remapped range, not the stale offsets captured
+    // when the popover opened (those now point into "XYZ Intro").
+    fireEvent.click(screen.getByTitle('Replace selection'));
+    await waitFor(() => {
+      const html = editor.getHTML();
+      expect(html).toContain('<p>XYZ Intro</p>');
+      expect(html).toContain('Howdy world');
+      expect(html).not.toContain('Hello');
+    });
+  });
+});
+
+describe('BubbleMenuContent — AI popover scroll tracking (#764)', () => {
+  beforeEach(() => streamSSE.mockReset());
+
+  it('attaches a scroll listener to the article scroll container via the virtual anchor', async () => {
+    const editor = await mountEditor('<p>Hello world</p>', { scrollable: true });
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    const container = screen.getByTestId('scroll-container');
+    const addListener = vi.spyOn(container, 'addEventListener');
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    await screen.findByTestId('bubble-ai-popover');
+
+    // The popover is portalled to <body>, so the article's scroll container
+    // is reachable only through the virtual reference's `contextElement`.
+    // Floating UI's autoUpdate must derive a scroll listener from it —
+    // without `contextElement` no reference-side listeners attach and the
+    // popover would stay put while the decorated text scrolls away.
+    await waitFor(() => {
+      expect(addListener.mock.calls.some(([type]) => type === 'scroll')).toBe(true);
+    });
   });
 });
 

--- a/frontend/src/shared/components/article/EditorBubbleMenu.tsx
+++ b/frontend/src/shared/components/article/EditorBubbleMenu.tsx
@@ -143,21 +143,26 @@ export function BubbleMenuContent({
 
   // #764 — register the non-destructive selection-decoration plugin for the
   // life of the menu. It stays inert (empty DecorationSet) until `openAi`
-  // dispatches the captured range.
+  // dispatches the captured range. TipTap guards `unregisterPlugin` against a
+  // destroyed editor internally, but not `registerPlugin` — hence the check.
   useEffect(() => {
+    if (editor.isDestroyed) return;
     editor.registerPlugin(createImproveDecorationPlugin());
     return () => { editor.unregisterPlugin(improveDecorationKey); };
   }, [editor]);
+
+  // Latest-ref so the stable virtual-anchor object below always measures the
+  // current editor. Assigned in an effect rather than during render for
+  // concurrent-rendering safety.
+  const editorRef = useRef(editor);
+  useEffect(() => { editorRef.current = editor; }, [editor]);
 
   // #764 — Radix virtual anchor that measures the captured selection rect, so
   // the AI popover positions relative to the SELECTION rather than the Improve
   // trigger. The bubble menu floats above the selection, so `side="bottom"`
   // from the trigger would land the popover exactly on top of the selected
   // text; anchored to the selection rect instead, the stack reads predictably
-  // top-to-bottom as bubble menu → decorated selection → popover. Measured
-  // lazily on every Floating UI update so scrolling stays tracked.
-  const editorRef = useRef(editor);
-  editorRef.current = editor;
+  // top-to-bottom as bubble menu → decorated selection → popover.
   const selectionAnchorRef = useRef({
     getBoundingClientRect: (): DOMRect => {
       const range = rangeRef.current;
@@ -171,6 +176,15 @@ export function BubbleMenuContent({
       }
       const zero = { top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0, x: 0, y: 0 };
       return { ...zero, toJSON: () => zero } as DOMRect;
+    },
+    // Floating UI's `autoUpdate` unwraps virtual references via
+    // `contextElement` to derive scroll/move listeners. The popover is
+    // portalled to <body> while the article scrolls in an inner container, so
+    // without this the popover would stay put as the decorated text scrolls
+    // away. Extra properties pass through Radix's `Measurable` untouched.
+    get contextElement(): HTMLElement | undefined {
+      const e = editorRef.current;
+      return e.isDestroyed ? undefined : e.view.dom;
     },
   });
 
@@ -229,16 +243,29 @@ export function BubbleMenuContent({
     return () => document.removeEventListener('keydown', handler);
   }, [editor, openAi]);
 
+  // #764 — the decoration set is remapped through every transaction (see
+  // improve-decoration.ts), while `rangeRef` keeps the offsets captured when
+  // the popover opened. Read the live range from the decoration so actions
+  // track the passage even if the document changed while the popover was
+  // open; fall back to the captured range when no decoration exists.
+  const currentRange = useCallback((): { from: number; to: number } | null => {
+    if (!editor.isDestroyed) {
+      const deco = improveDecorationKey.getState(editor.state)?.find()[0];
+      if (deco) return { from: deco.from, to: deco.to };
+    }
+    return rangeRef.current;
+  }, [editor]);
+
   const runAction = useCallback(
     (action: QuickAction, freeFormText: string) => {
-      const range = rangeRef.current;
+      const range = currentRange();
       if (!range) return;
       const text = editor.state.doc.textBetween(range.from, range.to, '\n');
       if (!text.trim()) return;
       lastRunRef.current = { action, freeForm: freeFormText };
       void stream.run(text, action.type, buildInstruction(action, freeFormText));
     },
-    [editor, stream],
+    [editor, stream, currentRange],
   );
 
   // "Try again" replays the last action with its captured free-form text,
@@ -250,15 +277,15 @@ export function BubbleMenuContent({
   }, [runAction, freeForm]);
 
   const replaceSelection = useCallback(() => {
-    const range = rangeRef.current;
+    const range = currentRange();
     if (!range || !stream.output) return;
     const { inline } = buildImproveHtml(stream.output);
     editor.chain().focus().insertContentAt({ from: range.from, to: range.to }, inline).run();
     closeAi();
-  }, [editor, stream.output, closeAi]);
+  }, [editor, stream.output, closeAi, currentRange]);
 
   const insertBelow = useCallback(() => {
-    const range = rangeRef.current;
+    const range = currentRange();
     if (!range || !stream.output) return;
     const { html } = buildImproveHtml(stream.output);
     // Insert block HTML at the end of the selection so the original passage is
@@ -270,7 +297,7 @@ export function BubbleMenuContent({
     // than constraining selections to block boundaries.
     editor.chain().focus().insertContentAt(range.to, html).run();
     closeAi();
-  }, [editor, stream.output, closeAi]);
+  }, [editor, stream.output, closeAi, currentRange]);
 
   const isStreaming = stream.status === 'streaming';
   const hasResult = stream.output.length > 0;
@@ -335,9 +362,6 @@ export function BubbleMenuContent({
       <div role="separator" aria-orientation="vertical" className="mx-0.5 h-5 w-px bg-border" />
 
       <Popover.Root open={aiOpen} onOpenChange={(o) => (o ? openAi() : closeAi())}>
-        {/* #764 — virtual anchor on the captured selection rect (see
-            selectionAnchorRef above); renders no DOM node of its own. */}
-        <Popover.Anchor virtualRef={selectionAnchorRef} />
         <Popover.Trigger asChild>
           <button
             type="button"
@@ -355,6 +379,14 @@ export function BubbleMenuContent({
             <span>Improve</span>
           </button>
         </Popover.Trigger>
+        {/* #764 — virtual anchor on the captured selection rect (see
+            selectionAnchorRef above); renders no DOM node of its own.
+            MUST come after Popover.Trigger: on the first render Radix's
+            `hasCustomAnchor` is still false, so the Trigger wraps itself in
+            its own popper Anchor whose mount effect would otherwise run last
+            and permanently override the virtual anchor with the trigger
+            button (nothing re-asserts the virtual anchor afterwards). */}
+        <Popover.Anchor virtualRef={selectionAnchorRef} />
         <Popover.Portal>
           <Popover.Content
             // #764 — anchored to the selection rect (virtual anchor above):

--- a/frontend/src/shared/components/article/EditorBubbleMenu.tsx
+++ b/frontend/src/shared/components/article/EditorBubbleMenu.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { BubbleMenu } from '@tiptap/react/menus';
 import { useEditorState } from '@tiptap/react';
+import { posToDOMRect } from '@tiptap/core';
 import * as Popover from '@radix-ui/react-popover';
 import type { Editor as EditorType } from '@tiptap/react';
 import {
@@ -12,6 +13,12 @@ import { cn } from '../../lib/cn';
 import { SanitizedHtml } from '../SanitizedHtml';
 import { useImproveStream } from './use-improve-stream';
 import { buildImproveHtml } from './improve-markdown';
+import {
+  createImproveDecorationPlugin,
+  improveDecorationKey,
+  setImproveDecoration,
+  clearImproveDecoration,
+} from './improve-decoration';
 
 /**
  * #708 — Notion-style selection bubble menu for the article editor (edit mode
@@ -134,6 +141,39 @@ export function BubbleMenuContent({
   const lastRunRef = useRef<{ action: QuickAction; freeForm: string } | null>(null);
   const stream = useImproveStream();
 
+  // #764 — register the non-destructive selection-decoration plugin for the
+  // life of the menu. It stays inert (empty DecorationSet) until `openAi`
+  // dispatches the captured range.
+  useEffect(() => {
+    editor.registerPlugin(createImproveDecorationPlugin());
+    return () => { editor.unregisterPlugin(improveDecorationKey); };
+  }, [editor]);
+
+  // #764 — Radix virtual anchor that measures the captured selection rect, so
+  // the AI popover positions relative to the SELECTION rather than the Improve
+  // trigger. The bubble menu floats above the selection, so `side="bottom"`
+  // from the trigger would land the popover exactly on top of the selected
+  // text; anchored to the selection rect instead, the stack reads predictably
+  // top-to-bottom as bubble menu → decorated selection → popover. Measured
+  // lazily on every Floating UI update so scrolling stays tracked.
+  const editorRef = useRef(editor);
+  editorRef.current = editor;
+  const selectionAnchorRef = useRef({
+    getBoundingClientRect: (): DOMRect => {
+      const range = rangeRef.current;
+      const e = editorRef.current;
+      if (range && !e.isDestroyed) {
+        try {
+          return posToDOMRect(e.view, range.from, range.to);
+        } catch {
+          // jsdom / detached view — fall through to the zero rect below.
+        }
+      }
+      const zero = { top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0, x: 0, y: 0 };
+      return { ...zero, toJSON: () => zero } as DOMRect;
+    },
+  });
+
   // Subscribe to active marks so the formatting buttons re-render their
   // active/pressed state on selection and toggle changes (mirrors EditorToolbar).
   const active = useEditorState({
@@ -157,6 +197,10 @@ export function BubbleMenuContent({
     const { from, to } = editor.state.selection;
     if (from === to) return;
     rangeRef.current = { from, to };
+    // #764 — the AI input is about to steal focus, which blurs the editor and
+    // hides the native selection highlight. Decorate the captured range so the
+    // passage stays visibly marked (no document mutation).
+    setImproveDecoration(editor, { from, to });
     setFreeForm('');
     stream.reset();
     setAi(true);
@@ -165,10 +209,11 @@ export function BubbleMenuContent({
   const closeAi = useCallback(() => {
     stream.abort();
     stream.reset();
+    clearImproveDecoration(editor);
     setAi(false);
     rangeRef.current = null;
     lastRunRef.current = null;
-  }, [stream, setAi]);
+  }, [editor, stream, setAi]);
 
   // Cmd/Ctrl+J opens the AI popover on the current selection (#708 optional
   // keyboard trigger).
@@ -290,6 +335,9 @@ export function BubbleMenuContent({
       <div role="separator" aria-orientation="vertical" className="mx-0.5 h-5 w-px bg-border" />
 
       <Popover.Root open={aiOpen} onOpenChange={(o) => (o ? openAi() : closeAi())}>
+        {/* #764 — virtual anchor on the captured selection rect (see
+            selectionAnchorRef above); renders no DOM node of its own. */}
+        <Popover.Anchor virtualRef={selectionAnchorRef} />
         <Popover.Trigger asChild>
           <button
             type="button"
@@ -309,9 +357,13 @@ export function BubbleMenuContent({
         </Popover.Trigger>
         <Popover.Portal>
           <Popover.Content
+            // #764 — anchored to the selection rect (virtual anchor above):
+            // `side="bottom"` opens BELOW the selection, i.e. under the bubble
+            // menu (which floats above it) without covering the decorated text.
             align="start"
             side="bottom"
-            sideOffset={6}
+            sideOffset={8}
+            collisionPadding={12}
             data-testid="bubble-ai-popover"
             // Keep focus inside; closing is explicit (Discard / Escape).
             onOpenAutoFocus={(e) => { if (hasResult || isStreaming) e.preventDefault(); }}

--- a/frontend/src/shared/components/article/improve-decoration.ts
+++ b/frontend/src/shared/components/article/improve-decoration.ts
@@ -1,0 +1,72 @@
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Decoration, DecorationSet } from '@tiptap/pm/view';
+import type { Editor as EditorType } from '@tiptap/react';
+
+/**
+ * #764 — Non-destructive selection highlight for the bubble menu's AI Improve
+ * flow. When the Improve popover opens, its input steals focus and the blurred
+ * editor stops painting the native selection, so the user loses sight of the
+ * passage being improved (the logical range survives in the menu's `rangeRef`).
+ * This plugin re-marks that captured range with a ProseMirror inline
+ * decoration — a pure view overlay that never touches the document, preserving
+ * #716's "document is never mutated until accept" guarantee. Styled by
+ * `.ai-improve-selection` in `frontend/src/index.css` (theme tokens, works in
+ * both Graphite Honey and Honey Linen).
+ */
+
+/** Class applied to the decorated range; styled in `frontend/src/index.css`. */
+export const IMPROVE_DECORATION_CLASS = 'ai-improve-selection';
+
+export const improveDecorationKey = new PluginKey<DecorationSet>('aiImproveSelection');
+
+interface ImproveDecorationMeta {
+  /** Decorate this range (replaces any existing decoration). */
+  range?: { from: number; to: number };
+  /** Remove the decoration. */
+  clear?: true;
+}
+
+export function createImproveDecorationPlugin(): Plugin<DecorationSet> {
+  return new Plugin<DecorationSet>({
+    key: improveDecorationKey,
+    state: {
+      init: () => DecorationSet.empty,
+      apply(tr, set) {
+        const meta = tr.getMeta(improveDecorationKey) as ImproveDecorationMeta | undefined;
+        if (meta?.clear) return DecorationSet.empty;
+        if (meta?.range) {
+          return DecorationSet.create(tr.doc, [
+            Decoration.inline(meta.range.from, meta.range.to, { class: IMPROVE_DECORATION_CLASS }),
+          ]);
+        }
+        // Map through unrelated document changes so the highlight stays glued
+        // to the original passage.
+        return set.map(tr.mapping, tr.doc);
+      },
+    },
+    props: {
+      decorations(state) {
+        return improveDecorationKey.getState(state);
+      },
+    },
+  });
+}
+
+/** Highlight `range` while the Improve popover is open. */
+export function setImproveDecoration(
+  editor: EditorType,
+  range: { from: number; to: number },
+): void {
+  if (editor.isDestroyed) return;
+  editor.view.dispatch(
+    editor.state.tr.setMeta(improveDecorationKey, { range } satisfies ImproveDecorationMeta),
+  );
+}
+
+/** Remove the highlight (Replace / Insert below / Discard / Escape / close). */
+export function clearImproveDecoration(editor: EditorType): void {
+  if (editor.isDestroyed) return;
+  editor.view.dispatch(
+    editor.state.tr.setMeta(improveDecorationKey, { clear: true } satisfies ImproveDecorationMeta),
+  );
+}


### PR DESCRIPTION
## Summary

Follow-up to #716 (Notion-style selection bubble menu). Fixes the two UX problems from #764 in the AI **Improve** flow of `EditorBubbleMenu`: the selected passage lost its visible highlight the moment the Improve popover opened, and the generation/preview popover opened directly on top of the selected text.

## Root cause

1. **Lost highlight** — the AI input autofocuses when the popover opens, which blurs the editor. A blurred ProseMirror/contenteditable stops painting the native selection, so the highlight visually vanished even though the logical range survived in `rangeRef`. Nothing re-marked the text.
2. **Popover over the selection** — the bubble menu is anchored *above* the selection (`placement: 'top'`), while the popover opened `side="bottom"` from the Improve trigger inside the bubble — i.e. directly below the bubble, which is exactly where the selected text sits.

## Changes

- **New `improve-decoration.ts`** — a ProseMirror plugin holding a `DecorationSet`. `openAi` dispatches the captured `rangeRef` range as a `Decoration.inline`; it is cleared on Replace / Insert below / Discard / Escape / popover close. Decorations are pure view overlays, so the document is **never mutated** until accept (preserves #716's guarantee). The set maps through unrelated transactions so it stays glued to the passage. Registered/unregistered by `BubbleMenuContent` for its mount lifetime (inert in view mode).
- **`index.css`** — `.ai-improve-selection` styled with `color-mix(in srgb, var(--color-primary) 30%, transparent)` (honey token, identical in both Graphite Honey and Honey Linen, keeps text contrast), `box-decoration-break: clone` for multi-line ranges, and a `forced-colors: active` fallback (`Highlight`/`HighlightText`).
- **Popover anchoring** — added a Radix `Popover.Anchor` with a `virtualRef` that measures the captured selection rect live via `posToDOMRect` (tracks scrolling through Floating UI's autoUpdate). With `side="bottom"` + `align="start"` + `sideOffset={8}` + `collisionPadding={12}`, the popover now opens **below the selection**, so the vertical stack reads: bubble menu → decorated selection → popover. Replace / Insert below / Try again / Discard behavior is unchanged; Escape still closes via Radix and now also clears the decoration. Animations remain behind `motion-safe:`.

## Test plan

Extended `EditorBubbleMenu.test.tsx` (jsdom + Testing Library, SSE mocked at the network boundary):

- open Improve → `.ai-improve-selection` present in the editor DOM over exactly the captured text, `editor.getHTML()` unchanged (decoration, not a mark)
- Escape / Discard → decoration cleared, document untouched
- Replace / Insert below → edit applied to the captured range and decoration cleared
- popover placement → resolved `data-side="bottom"` / `data-align="start"` on the content

```
Test Files  1 passed (1)
     Tests  20 passed (20)
```

Also ran `Editor.test.tsx`, `use-improve-stream.test.ts`, `improve-markdown.test.ts` (53 passed); `npm run lint -w frontend` and `npm run typecheck -w frontend` are clean.

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)