### PR TITLE
fix(llm): preserve Confluence row/column layouts (and triage labels) through AI Improve

### DIFF
--- a/backend/src/core/services/content-converter.test.ts
+++ b/backend/src/core/services/content-converter.test.ts
@@ -5,6 +5,8 @@ import {
   htmlToMarkdown,
   markdownToHtml,
   htmlToText,
+  protectMedia,
+  restoreMedia,
 } from './content-converter.js';
 import {
   SIMPLE_PAGE,
@@ -187,7 +189,7 @@ describe('content-converter', () => {
       expect(html).toContain('Embedded widget');
     });
 
-    it('drops the labels macro and never leaks "[Confluence macro: labels]" (#348)', () => {
+    it('converts the labels macro to a placeholder and never leaks "[Confluence macro: labels]" (#348, #765)', () => {
       const xhtml = `<p>Before</p>
         <ac:structured-macro ac:name="labels" ac:schema-version="1">
           <ac:parameter ac:name="showLabels">true</ac:parameter>
@@ -197,6 +199,10 @@ describe('content-converter', () => {
       expect(html).not.toContain('[Confluence macro: labels]');
       expect(html).not.toContain('confluence-macro-unknown');
       expect(html).not.toContain('ac:structured-macro');
+      // #765: kept as a placeholder (was: dropped) so write-back does not
+      // delete the widget from the Confluence page body.
+      expect(html).toContain('class="confluence-labels-macro"');
+      expect(html).toContain('data-showlabels="true"');
       expect(html).toContain('Before');
       expect(html).toContain('After');
     });
@@ -775,7 +781,7 @@ describe('content-converter', () => {
       expect(md).not.toContain('confluence-attachments-macro');
     });
 
-    it('converts section/column to markdown preserving column content', () => {
+    it('converts section/column to markdown with boundary tokens around editable content (#765)', () => {
       const html = confluenceToHtml(SECTION_COLUMN_PAGE);
       const md = htmlToMarkdown(html);
       expect(md).toContain('Left column content');
@@ -783,6 +789,26 @@ describe('content-converter', () => {
       expect(md).not.toMatch(/<div[^>]*>/);
       expect(md).not.toContain('confluence-section');
       expect(md).not.toContain('confluence-column');
+      // #765: wrappers are no longer dropped — boundary tokens carry them.
+      expect(md).toContain('[[[SECTION]]]');
+      expect(md).toContain('[[[COLUMN width=30%]]]');
+      expect(md).toContain('[[[COLUMN width=70%]]]');
+      expect(md).toContain('[[[/COLUMN]]]');
+      expect(md).toContain('[[[/SECTION]]]');
+    });
+
+    it('converts modern layout divs to markdown with boundary tokens (#765)', () => {
+      const html = confluenceToHtml(LAYOUT_TWO_EQUAL_PAGE);
+      const md = htmlToMarkdown(html);
+      expect(md).toContain('[[[LAYOUT]]]');
+      expect(md).toContain('[[[LAYOUT-SECTION two_equal]]]');
+      expect(md).toContain('[[[LAYOUT-CELL]]]');
+      expect(md).toContain('[[[/LAYOUT-CELL]]]');
+      expect(md).toContain('[[[/LAYOUT-SECTION]]]');
+      expect(md).toContain('[[[/LAYOUT]]]');
+      expect(md).toContain('Left column content');
+      expect(md).toContain('Right column content');
+      expect(md).not.toMatch(/<div[^>]*>/);
     });
 
     it('produces clean markdown for LLM consumption from complex page', () => {
@@ -1143,5 +1169,192 @@ describe('content-converter: index block stripping (#13)', () => {
     const html = '<div class="figure-index">figures</div><p>Content</p>';
     const result = confluenceToHtml(html);
     expect(result).toContain('figure-index');
+  });
+});
+
+// ==========================================================================
+// #765 — layout / section / column preservation through the AI Improve
+// markdown round-trip, exercised over the FULL Improve path:
+//   protectMedia → htmlToMarkdown → (LLM edit) → markdownToHtml →
+//   restoreMedia → htmlToConfluence
+// ==========================================================================
+
+describe('content-converter: #765 layout preservation through AI Improve round-trip', () => {
+  /** Run the full Improve pipeline, optionally editing the markdown like an LLM would. */
+  async function improveRoundTrip(
+    storageXhtml: string,
+    editMarkdown: (md: string) => string = (md) => md,
+  ): Promise<{ md: string; html: string; xhtml: string }> {
+    const bodyHtml = confluenceToHtml(storageXhtml);
+    const { html: protectedHtml, media } = protectMedia(bodyHtml);
+    const md = editMarkdown(htmlToMarkdown(protectedHtml));
+    const html = restoreMedia(await markdownToHtml(md), media);
+    return { md, html, xhtml: htmlToConfluence(html) };
+  }
+
+  it('preserves a two-column (two_equal) layout end to end', async () => {
+    const { html, xhtml } = await improveRoundTrip(LAYOUT_TWO_EQUAL_PAGE);
+    expect(html).toContain('class="confluence-layout"');
+    expect(html).toContain('data-layout-type="two_equal"');
+    expect((html.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(2);
+    expect(xhtml).toContain('<ac:layout>');
+    expect(xhtml).toContain('ac:type="two_equal"');
+    expect((xhtml.match(/<ac:layout-cell>/g) ?? []).length).toBe(2);
+    expect(xhtml).toContain('Left column content');
+    expect(xhtml).toContain('Right column content');
+    expect(xhtml).not.toContain('[[[');
+  });
+
+  it('preserves a three-column (three_equal) layout end to end', async () => {
+    const { xhtml } = await improveRoundTrip(LAYOUT_THREE_EQUAL_PAGE);
+    expect(xhtml).toContain('ac:type="three_equal"');
+    expect((xhtml.match(/<ac:layout-cell>/g) ?? []).length).toBe(3);
+    expect(xhtml).toContain('Column one');
+    expect(xhtml).toContain('Column two');
+    expect(xhtml).toContain('Column three');
+  });
+
+  it('preserves stacked layout sections with distinct types', async () => {
+    const { xhtml } = await improveRoundTrip(LAYOUT_STACKED_SECTIONS_PAGE);
+    expect(xhtml).toContain('ac:type="single"');
+    expect(xhtml).toContain('ac:type="two_equal"');
+    expect(xhtml).toContain('ac:type="three_equal"');
+    expect((xhtml.match(/<ac:layout>/g) ?? []).length).toBe(1);
+    expect(xhtml).toContain('Welcome to the guide.');
+    expect(xhtml).toContain('Feature C');
+  });
+
+  it('preserves legacy section/column with border and width parameters', async () => {
+    const { xhtml } = await improveRoundTrip(SECTION_BORDER_PAGE);
+    expect(xhtml).toContain('ac:name="section"');
+    expect(xhtml).toContain('<ac:parameter ac:name="border">true</ac:parameter>');
+    expect((xhtml.match(/ac:name="column"/g) ?? []).length).toBe(2);
+    expect(xhtml).toContain('Column A');
+    expect(xhtml).toContain('Column B');
+
+    const widths = await improveRoundTrip(SECTION_COLUMN_PAGE);
+    expect(widths.xhtml).toContain('<ac:parameter ac:name="width">30%</ac:parameter>');
+    expect(widths.xhtml).toContain('<ac:parameter ac:name="width">70%</ac:parameter>');
+  });
+
+  it('keeps prose inside cells editable — an LLM-style text edit survives with the layout', async () => {
+    const { md, xhtml } = await improveRoundTrip(LAYOUT_TWO_EQUAL_PAGE, (markdown) =>
+      markdown.replace('Left column content', 'Left column content, now much clearer.'),
+    );
+    // The prose was exposed as plain markdown (NOT hidden in an opaque token).
+    expect(md).toContain('Left column content');
+    expect(xhtml).toContain('Left column content, now much clearer.');
+    expect(xhtml).toContain('ac:type="two_equal"');
+    expect((xhtml.match(/<ac:layout-cell>/g) ?? []).length).toBe(2);
+  });
+
+  it('preserves rich nested content (lists, code, tables) inside layout cells', async () => {
+    const { xhtml } = await improveRoundTrip(LAYOUT_NESTED_CONTENT_PAGE);
+    expect(xhtml).toContain('<ac:layout>');
+    expect(xhtml).toContain('ac:type="two_equal"');
+    expect(xhtml).toContain('ac:name="code"');
+    expect(xhtml).toContain('echo "hello"');
+    expect(xhtml).toContain('<li>Item 1</li>');
+    expect(xhtml).toContain('<td>Name</td>');
+    // Panels are still lossy through the markdown boundary (blockquote form —
+    // pre-existing, unrelated to #765) but their text stays inside the cell.
+    expect(xhtml).toContain('Important note');
+  });
+
+  it('protects media inside layout cells via tokens and restores it in place', async () => {
+    const storage = `<ac:layout><ac:layout-section ac:type="two_equal"><ac:layout-cell><p>Intro</p><ac:image><ri:attachment ri:filename="photo.png"></ri:attachment></ac:image></ac:layout-cell><ac:layout-cell><p>Other</p></ac:layout-cell></ac:layout-section></ac:layout>`;
+    const bodyHtml = confluenceToHtml(storage, '42');
+    const { html: protectedHtml, media } = protectMedia(bodyHtml);
+    expect(media).toHaveLength(1);
+    const md = htmlToMarkdown(protectedHtml);
+    // The media token sits INSIDE the cell boundary tokens.
+    expect(md.indexOf('[[[LAYOUT-CELL]]]')).toBeLessThan(md.indexOf('CQ\\_MEDIA\\_PLACEHOLDER\\_0'));
+    const html = restoreMedia(await markdownToHtml(md), media);
+    const xhtml = htmlToConfluence(html);
+    expect(xhtml).toContain('ri:filename="photo.png"');
+    // Image is still inside the first layout cell.
+    const firstCell = xhtml.slice(xhtml.indexOf('<ac:layout-cell>'), xhtml.indexOf('</ac:layout-cell>'));
+    expect(firstCell).toContain('ri:filename="photo.png"');
+  });
+
+  describe('drop-guard', () => {
+    it('flattens gracefully when the LLM drops a closing token (unbalanced)', async () => {
+      const bodyHtml = confluenceToHtml(LAYOUT_TWO_EQUAL_PAGE);
+      const md = htmlToMarkdown(bodyHtml).replace('[[[/LAYOUT-CELL]]]', '');
+      const html = await markdownToHtml(md);
+      expect(html).not.toContain('[[[');
+      expect(html).not.toContain('confluence-layout');
+      expect(html).toContain('Left column content');
+      expect(html).toContain('Right column content');
+      // The flattened HTML still converts to valid (layout-free) storage.
+      const xhtml = htmlToConfluence(html);
+      expect(xhtml).not.toContain('ac:layout');
+      expect(xhtml).not.toContain('[[[');
+    });
+
+    it('flattens gracefully when the LLM reorders tokens into invalid nesting', async () => {
+      // LAYOUT-CELL outside any LAYOUT-SECTION — balanced but invalid.
+      const md = '[[[LAYOUT-CELL]]]\n\nOrphan prose\n\n[[[/LAYOUT-CELL]]]';
+      const html = await markdownToHtml(md);
+      expect(html).not.toContain('[[[');
+      expect(html).not.toContain('confluence-layout');
+      expect(html).toContain('Orphan prose');
+    });
+
+    it('rebuilds even when the LLM merges token lines without blank lines', async () => {
+      const md =
+        '[[[LAYOUT]]]\n[[[LAYOUT-SECTION two_equal]]]\n[[[LAYOUT-CELL]]]\nLeft prose\n[[[/LAYOUT-CELL]]]\n[[[LAYOUT-CELL]]]\nRight prose\n[[[/LAYOUT-CELL]]]\n[[[/LAYOUT-SECTION]]]\n[[[/LAYOUT]]]';
+      const html = await markdownToHtml(md);
+      expect(html).toContain('data-layout-type="two_equal"');
+      expect((html.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(2);
+      expect(html).toContain('Left prose');
+      expect(html).not.toContain('[[[');
+    });
+
+    it('strips case-mangled token remnants instead of leaking them into the page', async () => {
+      const md = '[[[layout]]]\n\n[[[layout-section two_equal]]]\n\nProse survives\n\n[[[/layout-section]]]\n\n[[[/layout]]]';
+      const html = await markdownToHtml(md);
+      expect(html).not.toContain('[[[');
+      expect(html).not.toContain('confluence-layout');
+      expect(html).toContain('Prose survives');
+    });
+
+    it('leaves ordinary bracketed prose untouched', async () => {
+      const md = 'See [the docs](https://example.com) and \\[citation\\] plus [[wiki-style]] links.';
+      const html = await markdownToHtml(md);
+      expect(html).toContain('the docs');
+      expect(html).toContain('[citation]');
+      expect(html).toContain('[[wiki-style]]');
+    });
+
+    it('falls back to single for an invalid layout-section type', async () => {
+      const md = '[[[LAYOUT]]]\n\n[[[LAYOUT-SECTION <script>alert(1)</script>]]]\n\n[[[LAYOUT-CELL]]]\n\nX\n\n[[[/LAYOUT-CELL]]]\n\n[[[/LAYOUT-SECTION]]]\n\n[[[/LAYOUT]]]';
+      const html = await markdownToHtml(md);
+      // Injected attrs never reach the output; type falls back to single.
+      expect(html).not.toContain('script');
+      expect(html).toContain('data-layout-type="single"');
+    });
+  });
+
+  describe('labels macro (#765 triage fix)', () => {
+    const LABELS_PAGE = `<p>Before</p><ac:structured-macro ac:name="labels" ac:schema-version="1"><ac:parameter ac:name="showLabels">true</ac:parameter></ac:structured-macro><p>After</p>`;
+
+    it('round-trips the in-body labels macro at the Confluence⇄HTML boundary', () => {
+      const html = confluenceToHtml(LABELS_PAGE);
+      expect(html).toContain('class="confluence-labels-macro"');
+      const xhtml = htmlToConfluence(html);
+      expect(xhtml).toContain('ac:name="labels"');
+      expect(xhtml).toContain('<ac:parameter ac:name="showLabels">true</ac:parameter>');
+      expect(xhtml).not.toContain('confluence-labels-macro');
+    });
+
+    it('survives the full Improve path via opaque media protection', async () => {
+      const { md, xhtml } = await improveRoundTrip(LABELS_PAGE);
+      // Atomic placeholder — protected as an opaque token, not boundary tokens.
+      expect(md).toContain('CQ\\_MEDIA\\_PLACEHOLDER\\_0');
+      expect(xhtml).toContain('ac:name="labels"');
+      expect(xhtml).toContain('Before');
+      expect(xhtml).toContain('After');
+    });
   });
 });

--- a/backend/src/core/services/content-converter.test.ts
+++ b/backend/src/core/services/content-converter.test.ts
@@ -781,9 +781,9 @@ describe('content-converter', () => {
       expect(md).not.toContain('confluence-attachments-macro');
     });
 
-    it('converts section/column to markdown with boundary tokens around editable content (#765)', () => {
+    it('converts section/column to markdown with boundary tokens when layoutTokens is set (#765)', () => {
       const html = confluenceToHtml(SECTION_COLUMN_PAGE);
-      const md = htmlToMarkdown(html);
+      const md = htmlToMarkdown(html, { layoutTokens: true });
       expect(md).toContain('Left column content');
       expect(md).toContain('Right column content');
       expect(md).not.toMatch(/<div[^>]*>/);
@@ -797,9 +797,9 @@ describe('content-converter', () => {
       expect(md).toContain('[[[/SECTION]]]');
     });
 
-    it('converts modern layout divs to markdown with boundary tokens (#765)', () => {
+    it('converts modern layout divs to markdown with boundary tokens when layoutTokens is set (#765)', () => {
       const html = confluenceToHtml(LAYOUT_TWO_EQUAL_PAGE);
-      const md = htmlToMarkdown(html);
+      const md = htmlToMarkdown(html, { layoutTokens: true });
       expect(md).toContain('[[[LAYOUT]]]');
       expect(md).toContain('[[[LAYOUT-SECTION two_equal]]]');
       expect(md).toContain('[[[LAYOUT-CELL]]]');
@@ -809,6 +809,30 @@ describe('content-converter', () => {
       expect(md).toContain('Left column content');
       expect(md).toContain('Right column content');
       expect(md).not.toMatch(/<div[^>]*>/);
+    });
+
+    it('does NOT emit boundary tokens by default — non-Improve flows keep the flattened output (#765 review)', () => {
+      // Default call shape used by quality-worker, auto-tagger, llm-diagram,
+      // version-tracker, subpage-context, and pages-import: no options.
+      const layoutMd = htmlToMarkdown(confluenceToHtml(LAYOUT_TWO_EQUAL_PAGE));
+      expect(layoutMd).not.toContain('[[[');
+      expect(layoutMd).toContain('Left column content');
+      expect(layoutMd).toContain('Right column content');
+      expect(layoutMd).not.toMatch(/<div[^>]*>/);
+
+      const sectionMd = htmlToMarkdown(confluenceToHtml(SECTION_COLUMN_PAGE));
+      expect(sectionMd).not.toContain('[[[');
+      expect(sectionMd).toContain('Left column content');
+      expect(sectionMd).toContain('Right column content');
+      expect(sectionMd).not.toMatch(/<div[^>]*>/);
+      expect(sectionMd).not.toContain('confluence-section');
+      expect(sectionMd).not.toContain('confluence-column');
+    });
+
+    it('does NOT emit boundary tokens when layoutTokens is explicitly false (#765 review)', () => {
+      const md = htmlToMarkdown(confluenceToHtml(LAYOUT_TWO_EQUAL_PAGE), { layoutTokens: false });
+      expect(md).not.toContain('[[[');
+      expect(md).toContain('Left column content');
     });
 
     it('produces clean markdown for LLM consumption from complex page', () => {
@@ -1187,7 +1211,8 @@ describe('content-converter: #765 layout preservation through AI Improve round-t
   ): Promise<{ md: string; html: string; xhtml: string }> {
     const bodyHtml = confluenceToHtml(storageXhtml);
     const { html: protectedHtml, media } = protectMedia(bodyHtml);
-    const md = editMarkdown(htmlToMarkdown(protectedHtml));
+    // layoutTokens: true mirrors the Improve route's main-page conversion.
+    const md = editMarkdown(htmlToMarkdown(protectedHtml, { layoutTokens: true }));
     const html = restoreMedia(await markdownToHtml(md), media);
     return { md, html, xhtml: htmlToConfluence(html) };
   }
@@ -1266,7 +1291,7 @@ describe('content-converter: #765 layout preservation through AI Improve round-t
     const bodyHtml = confluenceToHtml(storage, '42');
     const { html: protectedHtml, media } = protectMedia(bodyHtml);
     expect(media).toHaveLength(1);
-    const md = htmlToMarkdown(protectedHtml);
+    const md = htmlToMarkdown(protectedHtml, { layoutTokens: true });
     // The media token sits INSIDE the cell boundary tokens.
     expect(md.indexOf('[[[LAYOUT-CELL]]]')).toBeLessThan(md.indexOf('CQ\\_MEDIA\\_PLACEHOLDER\\_0'));
     const html = restoreMedia(await markdownToHtml(md), media);
@@ -1280,7 +1305,7 @@ describe('content-converter: #765 layout preservation through AI Improve round-t
   describe('drop-guard', () => {
     it('flattens gracefully when the LLM drops a closing token (unbalanced)', async () => {
       const bodyHtml = confluenceToHtml(LAYOUT_TWO_EQUAL_PAGE);
-      const md = htmlToMarkdown(bodyHtml).replace('[[[/LAYOUT-CELL]]]', '');
+      const md = htmlToMarkdown(bodyHtml, { layoutTokens: true }).replace('[[[/LAYOUT-CELL]]]', '');
       const html = await markdownToHtml(md);
       expect(html).not.toContain('[[[');
       expect(html).not.toContain('confluence-layout');
@@ -1355,6 +1380,141 @@ describe('content-converter: #765 layout preservation through AI Improve round-t
       expect(xhtml).toContain('ac:name="labels"');
       expect(xhtml).toContain('Before');
       expect(xhtml).toContain('After');
+    });
+  });
+
+  // #765 review follow-up: legacy section/column wrappers nested inside
+  // markdown-constrained containers must be opaque-frozen (pre-#765
+  // behavior), never boundary-tokenized — token normalization would rip the
+  // token line out of the construct (e.g. split a GFM table row).
+  describe('legacy section/column nested in constrained containers (#765 review)', () => {
+    const SECTION_MACRO =
+      '<ac:structured-macro ac:name="section"><ac:rich-text-body>' +
+      '<ac:structured-macro ac:name="column"><ac:rich-text-body><p>Nested cell prose</p></ac:rich-text-body></ac:structured-macro>' +
+      '</ac:rich-text-body></ac:structured-macro>';
+
+    it('protectMedia freezes a nested section but not a top-level one', () => {
+      const html = confluenceToHtml(
+        `<table><tbody><tr><th>H1</th><th>H2</th></tr><tr><td>${SECTION_MACRO}</td><td><p>other</p></td></tr></tbody></table>${SECTION_MACRO}`,
+      );
+      const { html: protectedHtml, media } = protectMedia(html);
+      // Only the in-table section is frozen (whole, including its column).
+      expect(media).toHaveLength(1);
+      expect(media[0]!.html).toContain('class="confluence-section"');
+      expect(media[0]!.html).toContain('Nested cell prose');
+      // The top-level section stays in the DOM for boundary tokens.
+      expect(protectedHtml).toContain('class="confluence-section"');
+    });
+
+    it('a legacy section inside a table cell round-trips without corrupting the table', async () => {
+      // Note: plain-text sibling cell — turndown's GFM rule cannot flatten
+      // block content (<p>) inside cells, a pre-existing quirk unrelated to
+      // the frozen wrapper under test here.
+      const storage = `<table><tbody><tr><th>H1</th><th>H2</th></tr><tr><td>${SECTION_MACRO}</td><td>other</td></tr></tbody></table>`;
+      const { md, html, xhtml } = await improveRoundTrip(storage);
+
+      // The wrapper traveled as an opaque token, not boundary tokens.
+      expect(md).toContain('CQ\\_MEDIA\\_PLACEHOLDER\\_0');
+      expect(md).not.toContain('[[[');
+
+      // Table is intact: two rows, no cells leaked as literal `| … |` text.
+      expect((html.match(/<tr>/g) ?? []).length).toBe(2);
+      expect((html.match(/<td>/g) ?? []).length).toBe(2);
+      expect(html).not.toMatch(/<p>[^<]*\|/);
+
+      // Section macro restored inside the cell, no token leakage.
+      expect(xhtml).toContain('ac:name="section"');
+      expect(xhtml).toContain('ac:name="column"');
+      expect(xhtml).toContain('Nested cell prose');
+      expect(xhtml).toContain('other');
+      expect(xhtml).not.toContain('[[[');
+      const td = xhtml.slice(xhtml.indexOf('<td>'), xhtml.indexOf('</td>'));
+      expect(td).toContain('ac:name="section"');
+    });
+
+    it('a legacy section inside a list item round-trips without corrupting the list', async () => {
+      const storage = `<ul><li><p>Item with layout</p>${SECTION_MACRO}</li><li><p>Plain item</p></li></ul>`;
+      const { md, html, xhtml } = await improveRoundTrip(storage);
+
+      expect(md).toContain('CQ\\_MEDIA\\_PLACEHOLDER\\_0');
+      expect(md).not.toContain('[[[');
+
+      // Both list items survive; the section stays inside the first.
+      expect((html.match(/<li>/g) ?? []).length).toBe(2);
+      expect(xhtml).toContain('ac:name="section"');
+      expect(xhtml).toContain('Nested cell prose');
+      expect(xhtml).toContain('Plain item');
+      expect(xhtml).not.toContain('[[[');
+    });
+
+    it('a legacy section inside a panel is frozen, not tokenized — survives verbatim', async () => {
+      const storage = `<ac:structured-macro ac:name="info"><ac:rich-text-body><p>Panel intro</p>${SECTION_MACRO}</ac:rich-text-body></ac:structured-macro>`;
+      const { md, xhtml } = await improveRoundTrip(storage);
+
+      expect(md).toContain('CQ\\_MEDIA\\_PLACEHOLDER\\_0');
+      expect(md).not.toContain('[[[');
+
+      // (Panels degrade to blockquotes through markdown — pre-existing, and
+      // the frozen section may land after the quote, exactly like pre-#765.)
+      // What matters: the section is never flattened and tokens never leak.
+      expect(xhtml).toContain('ac:name="section"');
+      expect(xhtml).toContain('Nested cell prose');
+      expect(xhtml).toContain('Panel intro');
+      expect(xhtml).not.toContain('[[[');
+    });
+  });
+
+  // #765 review follow-up: literal token text inside <pre>/<code> is data —
+  // never rebuilt into layout divs, never stripped by the backstop.
+  describe('literal token text inside code blocks (#765 review)', () => {
+    it('a fenced code block containing [[[LAYOUT]]] literal text survives markdownToHtml unchanged', async () => {
+      const md = 'Token docs:\n\n```\n[[[LAYOUT]]]\nliteral token text\n[[[/LAYOUT]]]\n```\n';
+      const html = await markdownToHtml(md);
+      expect(html).toContain('[[[LAYOUT]]]');
+      expect(html).toContain('[[[/LAYOUT]]]');
+      expect(html).toContain('literal token text');
+      expect(html).not.toContain('confluence-layout');
+      expect(html).toMatch(/<pre><code>\[\[\[LAYOUT\]\]\]\nliteral token text\n\[\[\[\/LAYOUT\]\]\]/);
+    });
+
+    it('inline code containing a token literal survives markdownToHtml unchanged', async () => {
+      const md = 'Use `[[[LAYOUT]]]` to open a layout.';
+      const html = await markdownToHtml(md);
+      expect(html).toContain('<code>[[[LAYOUT]]]</code>');
+      expect(html).not.toContain('confluence-layout');
+    });
+
+    it('a stray token inside a code block does not poison validation of real tokens', async () => {
+      const md = [
+        '[[[LAYOUT]]]', '',
+        '[[[LAYOUT-SECTION two_equal]]]', '',
+        '[[[LAYOUT-CELL]]]', '',
+        'Cell prose with docs:', '',
+        '```',
+        '[[[LAYOUT-CELL]]]', // unbalanced INSIDE code — must be ignored
+        '```', '',
+        '[[[/LAYOUT-CELL]]]', '',
+        '[[[LAYOUT-CELL]]]', '',
+        'Second cell', '',
+        '[[[/LAYOUT-CELL]]]', '',
+        '[[[/LAYOUT-SECTION]]]', '',
+        '[[[/LAYOUT]]]',
+      ].join('\n');
+      const html = await markdownToHtml(md);
+      // Real tokens rebuilt…
+      expect(html).toContain('data-layout-type="two_equal"');
+      expect((html.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(2);
+      // …while the code literal is untouched.
+      expect(html).toMatch(/<code>\[\[\[LAYOUT-CELL\]\]\]/);
+    });
+
+    it('a code macro containing token literals survives the full Improve round-trip', async () => {
+      const storage =
+        '<p>Docs page</p><ac:structured-macro ac:name="code"><ac:plain-text-body>' +
+        '<![CDATA[[[[LAYOUT]]] opens a layout]]></ac:plain-text-body></ac:structured-macro>';
+      const { xhtml } = await improveRoundTrip(storage);
+      expect(xhtml).toContain('ac:name="code"');
+      expect(xhtml).toContain('[[[LAYOUT]]] opens a layout');
     });
   });
 });

--- a/backend/src/core/services/content-converter.ts
+++ b/backend/src/core/services/content-converter.ts
@@ -442,14 +442,25 @@ export function confluenceToHtml(storageXhtml: string, pageId?: string, spaceKey
     layout.replaceWith(div);
   }
 
-  // Drop labels macro (#348). Labels are page metadata fetched via
-  // expand=metadata.labels — never parse them out of the body. The macro is
-  // a rendering placeholder with no body, so dropping it (rather than
-  // round-tripping) is safe; htmlToConfluence's "labels" output is currently
-  // unused.
+  // Labels macro (#348 → #765). Label *metadata* still comes exclusively from
+  // expand=metadata.labels — never parse label names out of the body. But the
+  // macro itself must round-trip: #348 dropped it outright, which was safe
+  // when nothing pushed bodies back to Confluence. Now that AI-Improve apply
+  // and editor saves DO push the converted body back, dropping the macro here
+  // would permanently delete the in-body labels widget from the Confluence
+  // page on the first write-back (#765). Keep it as a placeholder instead,
+  // mirroring the toc/children pattern.
+  const labelsParamNames = ['max', 'spaces', 'excludedLabels', 'showLabels'];
   for (const macro of byTag(doc, 'ac:structured-macro')) {
     if (getMacroName(macro) !== 'labels') continue;
-    macro.remove();
+    const div = doc.createElement('div');
+    div.className = 'confluence-labels-macro';
+    for (const paramName of labelsParamNames) {
+      const val = getParamValue(macro, paramName);
+      if (val !== null && val !== undefined) div.setAttribute(`data-${paramName.toLowerCase()}`, val);
+    }
+    div.textContent = '[Labels]';
+    macro.replaceWith(div);
   }
 
   // Remove remaining unknown macros - preserve as data attributes
@@ -655,6 +666,29 @@ export function htmlToConfluence(html: string): string {
       param.setAttribute('ac:name', 'old');
       param.textContent = old;
       macro.appendChild(param);
+    }
+    div.replaceWith(macro);
+  }
+
+  // Convert labels macro placeholders back to ac:structured-macro[name=labels]
+  // (#765) so write-back doesn't delete the widget from the Confluence page.
+  for (const div of doc.querySelectorAll('div.confluence-labels-macro')) {
+    const macro = doc.createElement('ac:structured-macro');
+    macro.setAttribute('ac:name', 'labels');
+    const labelsReverseParams: Record<string, string> = {
+      'max': 'max',
+      'spaces': 'spaces',
+      'excludedlabels': 'excludedLabels',
+      'showlabels': 'showLabels',
+    };
+    for (const [dataAttr, paramName] of Object.entries(labelsReverseParams)) {
+      const val = div.getAttribute(`data-${dataAttr}`);
+      if (val !== null) {
+        const p = doc.createElement('ac:parameter');
+        p.setAttribute('ac:name', paramName);
+        p.textContent = val;
+        macro.appendChild(p);
+      }
     }
     div.replaceWith(macro);
   }
@@ -871,13 +905,18 @@ function pathBasename(urlString: string): string {
 export interface ProtectedMedia { token: string; html: string; }
 
 const MEDIA_TOKEN_PREFIX = 'CQ_MEDIA_PLACEHOLDER_';
+// #765: legacy section/column wrappers are NO LONGER opaque-protected here.
+// #723 froze them whole (token swap), which preserved them but made the prose
+// inside uneditable by the LLM. They now round-trip via layout boundary
+// tokens in htmlToMarkdown/markdownToHtml (see LAYOUT_TOKEN_* below) so the
+// inner content stays improvable. The labels macro placeholder IS opaque —
+// it is atomic (no prose inside) so the token pattern fits it exactly.
 const MEDIA_SELECTOR = [
   'img',
   'div.confluence-drawio',
   'div.confluence-mermaid',
   'div.mermaid',
-  'div.confluence-section',
-  'div.confluence-column',
+  'div.confluence-labels-macro',
 ].join(',');
 
 /**
@@ -989,18 +1028,70 @@ export function htmlToMarkdown(html: string): string {
     },
   });
 
-  // Custom rule for section containers — render content inline
+  // #765: layout containers — emit boundary tokens as standalone lines so the
+  // wrapper structure survives the markdown round-trip while the prose inside
+  // stays editable by the LLM. markdownToHtml() rebuilds the divs from the
+  // tokens (with a drop-guard if the LLM mangled them).
+  turndownService.addRule('confluenceLayout', {
+    filter: (node) =>
+      node.nodeName === 'DIV' && node.classList.contains('confluence-layout'),
+    replacement: (content) => `\n\n[[[LAYOUT]]]\n\n${content.trim()}\n\n[[[/LAYOUT]]]\n\n`,
+  });
+
+  turndownService.addRule('confluenceLayoutSection', {
+    filter: (node) =>
+      node.nodeName === 'DIV' && node.classList.contains('confluence-layout-section'),
+    replacement: (content, node) => {
+      const raw = (node as HTMLElement).getAttribute('data-layout-type') ?? 'single';
+      // Confluence layout types are lowercase identifiers (single, two_equal,
+      // three_with_sidebars, …) — anything else would break the token line.
+      const layoutType = /^[a-z_]+$/.test(raw) ? raw : 'single';
+      return `\n\n[[[LAYOUT-SECTION ${layoutType}]]]\n\n${content.trim()}\n\n[[[/LAYOUT-SECTION]]]\n\n`;
+    },
+  });
+
+  turndownService.addRule('confluenceLayoutCell', {
+    filter: (node) =>
+      node.nodeName === 'DIV' && node.classList.contains('confluence-layout-cell'),
+    replacement: (content) => `\n\n[[[LAYOUT-CELL]]]\n\n${content.trim()}\n\n[[[/LAYOUT-CELL]]]\n\n`,
+  });
+
+  // #765: legacy section/column containers — same boundary-token treatment
+  // (previously these dropped the wrapper and emitted only trimmed content).
   turndownService.addRule('confluenceSection', {
     filter: (node) =>
       node.nodeName === 'DIV' && node.classList.contains('confluence-section'),
-    replacement: (content) => `\n${content.trim()}\n\n`,
+    replacement: (content, node) => {
+      const border = (node as HTMLElement).getAttribute('data-border');
+      const attrs = border === 'true' || border === 'false' ? ` border=${border}` : '';
+      return `\n\n[[[SECTION${attrs}]]]\n\n${content.trim()}\n\n[[[/SECTION]]]\n\n`;
+    },
   });
 
-  // Custom rule for column containers — separate with divider
   turndownService.addRule('confluenceColumn', {
     filter: (node) =>
       node.nodeName === 'DIV' && node.classList.contains('confluence-column'),
-    replacement: (content) => `\n${content.trim()}\n`,
+    replacement: (content, node) => {
+      const el = node as HTMLElement;
+      // Prefer data-cell-width; fall back to the inline flex style (mirrors
+      // htmlToConfluence). Only token-safe width values are carried.
+      let width = el.getAttribute('data-cell-width');
+      if (!width) {
+        const m = (el.getAttribute('style') ?? '').match(/flex:\s*0\s+0\s+(\S+)/);
+        if (m) width = m[1] ?? null;
+      }
+      const attrs = width && /^[\d.]+(%|px|em|rem)?$/.test(width) ? ` width=${width}` : '';
+      return `\n\n[[[COLUMN${attrs}]]]\n\n${content.trim()}\n\n[[[/COLUMN]]]\n\n`;
+    },
+  });
+
+  // Custom rule for the labels macro placeholder (#765). Only reached by
+  // non-Improve flows (quality/auto-tag/diagram context) — the Improve path
+  // opaque-protects the div via protectMedia before turndown runs.
+  turndownService.addRule('confluenceLabels', {
+    filter: (node) =>
+      node.nodeName === 'DIV' && node.classList.contains('confluence-labels-macro'),
+    replacement: () => '\n[Labels]\n\n',
   });
 
   // Custom rule for children macro placeholder
@@ -1041,11 +1132,143 @@ export function htmlToMarkdown(html: string): string {
   return turndownService.turndown(html);
 }
 
+// ---------------------------------------------------------------------------
+// #765: Confluence layout boundary tokens.
+//
+// Row/column structure (modern `ac:layout` grids and legacy section/column
+// macros) has no Markdown representation, so the AI-Improve round-trip
+// (htmlToMarkdown → LLM → markdownToHtml) used to flatten it. Unlike media
+// (#723's opaque CQ_MEDIA_PLACEHOLDER swap), layout cells contain prose the
+// LLM must still be able to edit — so htmlToMarkdown emits BOUNDARY tokens as
+// standalone lines around the (still editable) cell content:
+//
+//   [[[LAYOUT]]] … [[[/LAYOUT]]]
+//   [[[LAYOUT-SECTION two_equal]]] … [[[/LAYOUT-SECTION]]]
+//   [[[LAYOUT-CELL]]] … [[[/LAYOUT-CELL]]]
+//   [[[SECTION border=true]]] … [[[/SECTION]]]    (legacy ac:section macro)
+//   [[[COLUMN width=50%]]] … [[[/COLUMN]]]        (legacy ac:column macro)
+//
+// markdownToHtml() rebuilds the corresponding div.confluence-* wrappers from
+// the tokens, which htmlToConfluence then maps losslessly back to ac:layout*
+// / section / column. Drop-guard: if the LLM mangled the tokens (unbalanced
+// or invalid nesting), ALL tokens are stripped instead — content degrades to
+// the pre-#765 flattened form, but the page is never corrupted and raw
+// [[[…]]] text never reaches the saved page.
+// ---------------------------------------------------------------------------
+
+// Longest-first so LAYOUT never shadows LAYOUT-SECTION / LAYOUT-CELL.
+const LAYOUT_TOKEN_KINDS = 'LAYOUT-SECTION|LAYOUT-CELL|LAYOUT|SECTION|COLUMN';
+const LAYOUT_TOKEN_BARE = String.raw`\[\[\[\/?(?:${LAYOUT_TOKEN_KINDS})(?:[ \t][^\]\n]*)?\]\]\]`;
+const LAYOUT_TOKEN_CAPTURE = String.raw`\[\[\[(\/?)(${LAYOUT_TOKEN_KINDS})((?:[ \t][^\]\n]*)?)\]\]\]`;
+
+interface LayoutToken { isClose: boolean; kind: string; attrs: string; }
+
+// Fresh instance per use — global regexes are stateful via lastIndex.
+function layoutTokenRegex(): RegExp {
+  // Paragraph-wrapped form first so the lone wrapping <p> is consumed too.
+  return new RegExp(`<p>\\s*${LAYOUT_TOKEN_CAPTURE}\\s*</p>|${LAYOUT_TOKEN_CAPTURE}`, 'g');
+}
+
+function parseLayoutToken(m: RegExpMatchArray): LayoutToken {
+  return {
+    isClose: (m[1] ?? m[4]) === '/',
+    kind: (m[2] ?? m[5])!,
+    attrs: (m[3] ?? m[6] ?? '').trim(),
+  };
+}
+
+/**
+ * Where each token kind may open, mirroring what htmlToConfluence can emit as
+ * valid Confluence storage (ac:layout-section only directly inside ac:layout,
+ * ac:layout-cell only inside a section, legacy column only inside a legacy
+ * section, layouts only at top level). Anything else means the LLM rearranged
+ * the tokens — flatten instead of risking invalid storage format.
+ */
+function layoutOpenAllowed(kind: string, stack: string[]): boolean {
+  const top = stack[stack.length - 1];
+  switch (kind) {
+    case 'LAYOUT': return stack.length === 0;
+    case 'LAYOUT-SECTION': return top === 'LAYOUT';
+    case 'LAYOUT-CELL': return top === 'LAYOUT-SECTION';
+    case 'SECTION': return top === undefined || top === 'LAYOUT-CELL' || top === 'COLUMN';
+    case 'COLUMN': return top === 'SECTION';
+    default: return false;
+  }
+}
+
+function layoutOpenTag(kind: string, attrs: string): string {
+  switch (kind) {
+    case 'LAYOUT':
+      return '<div class="confluence-layout">';
+    case 'LAYOUT-SECTION': {
+      const layoutType = /^[a-z_]+$/.test(attrs) ? attrs : 'single';
+      return `<div class="confluence-layout-section" data-layout-type="${layoutType}">`;
+    }
+    case 'LAYOUT-CELL':
+      return '<div class="confluence-layout-cell">';
+    case 'SECTION': {
+      const m = attrs.match(/^border=(true|false)$/);
+      return m ? `<div class="confluence-section" data-border="${m[1]}">` : '<div class="confluence-section">';
+    }
+    case 'COLUMN': {
+      const m = attrs.match(/^width=([\d.]+(?:%|px|em|rem)?)$/);
+      if (!m) return '<div class="confluence-column">';
+      const width = m[1]!;
+      // Same safe-width rule as confluenceToHtml: only digits + unit get a style.
+      const style = /^\d+(%|px|em|rem)$/.test(width) ? ` style="flex: 0 0 ${width}"` : '';
+      return `<div class="confluence-column" data-cell-width="${width}"${style}>`;
+    }
+    // Unreachable: kinds are constrained by LAYOUT_TOKEN_KINDS in the regex.
+    default:
+      return '<div>';
+  }
+}
+
+/**
+ * Rebuild div.confluence-layout* / -section / -column wrappers from boundary
+ * tokens in marked's HTML output. All-or-nothing: the token sequence is
+ * validated for balance + nesting first, so a single mangled token can never
+ * produce unbalanced divs — instead every token is stripped (graceful
+ * flatten) while the prose is kept.
+ */
+function rebuildLayoutStructure(html: string): string {
+  const tokens = [...html.matchAll(layoutTokenRegex())].map(parseLayoutToken);
+  if (tokens.length === 0) return html;
+
+  let valid = true;
+  const stack: string[] = [];
+  for (const t of tokens) {
+    if (!t.isClose) {
+      if (!layoutOpenAllowed(t.kind, stack)) { valid = false; break; }
+      stack.push(t.kind);
+    } else if (stack.pop() !== t.kind) {
+      valid = false;
+      break;
+    }
+  }
+  if (stack.length > 0) valid = false;
+
+  let i = 0;
+  return html.replace(layoutTokenRegex(), () => {
+    const t = tokens[i++]!;
+    if (!valid) return ''; // drop-guard: strip the token, keep the prose
+    return t.isClose ? '</div>' : layoutOpenTag(t.kind, t.attrs);
+  });
+}
+
 /**
  * Converts Markdown to HTML (for LLM output -> editor).
  */
 export async function markdownToHtml(markdown: string): Promise<string> {
-  let html = await marked(markdown) as string;
+  // #765: force every layout boundary token onto its own paragraph so marked
+  // wraps it in a lone <p>, even when the LLM merged adjacent token lines or
+  // pulled a token into surrounding prose.
+  const normalized = markdown.replace(
+    new RegExp(`[ \\t]*(${LAYOUT_TOKEN_BARE})[ \\t]*`, 'g'),
+    '\n\n$1\n\n',
+  );
+
+  let html = await marked(normalized) as string;
 
   // #723: rebuild draw.io wrappers from ```drawio fences.
   // marked emits: <pre><code class="language-drawio">NAME\n</code></pre>
@@ -1055,6 +1278,17 @@ export async function markdownToHtml(markdown: string): Promise<string> {
       const safe = String(name).trim();
       return `<div class="confluence-drawio" data-diagram-name="${safe.replace(/"/g, '&quot;')}"></div>`;
     },
+  );
+
+  // #765: rebuild layout/section/column wrappers from boundary tokens.
+  html = rebuildLayoutStructure(html);
+
+  // #765 drop-guard backstop: strip any token-shaped remnant that failed
+  // structural matching (e.g. the LLM lower-cased a marker) — raw [[[…]]]
+  // text must never reach the saved page.
+  html = html.replace(
+    new RegExp(`<p>\\s*${LAYOUT_TOKEN_BARE}\\s*</p>|${LAYOUT_TOKEN_BARE}`, 'gi'),
+    '',
   );
 
   return html;

--- a/backend/src/core/services/content-converter.ts
+++ b/backend/src/core/services/content-converter.ts
@@ -905,12 +905,13 @@ function pathBasename(urlString: string): string {
 export interface ProtectedMedia { token: string; html: string; }
 
 const MEDIA_TOKEN_PREFIX = 'CQ_MEDIA_PLACEHOLDER_';
-// #765: legacy section/column wrappers are NO LONGER opaque-protected here.
-// #723 froze them whole (token swap), which preserved them but made the prose
-// inside uneditable by the LLM. They now round-trip via layout boundary
-// tokens in htmlToMarkdown/markdownToHtml (see LAYOUT_TOKEN_* below) so the
-// inner content stays improvable. The labels macro placeholder IS opaque —
-// it is atomic (no prose inside) so the token pattern fits it exactly.
+// #765: legacy section/column wrappers are NO LONGER opaque-protected here
+// (with one exception — see below). #723 froze them whole (token swap), which
+// preserved them but made the prose inside uneditable by the LLM. They now
+// round-trip via layout boundary tokens in htmlToMarkdown/markdownToHtml (see
+// LAYOUT_TOKEN_* below) so the inner content stays improvable. The labels
+// macro placeholder IS opaque — it is atomic (no prose inside) so the token
+// pattern fits it exactly.
 const MEDIA_SELECTOR = [
   'img',
   'div.confluence-drawio',
@@ -918,6 +919,26 @@ const MEDIA_SELECTOR = [
   'div.mermaid',
   'div.confluence-labels-macro',
 ].join(',');
+
+// #765 review follow-up: legacy section/column wrappers nested inside
+// markdown-constrained containers (table cells, list items, blockquotes,
+// panels — which turndown renders as blockquotes) CANNOT use boundary tokens.
+// markdownToHtml's token normalization forces every token onto its own
+// paragraph, which rips it out of the containing construct (e.g. splits a GFM
+// table row, emptying the table and leaking cells as literal `| … |` text).
+// These nested wrappers keep the pre-#765 opaque freeze; boundary tokens are
+// used only for non-nested legacy sections/columns.
+const LEGACY_WRAPPER_SELECTOR = 'div.confluence-section, div.confluence-column';
+const CONSTRAINED_ANCESTOR_SELECTOR =
+  'td, th, li, blockquote, div.panel-info, div.panel-warning, div.panel-note, div.panel-tip';
+
+function isLegacyWrapper(el: Element): boolean {
+  return el.classList.contains('confluence-section') || el.classList.contains('confluence-column');
+}
+
+function isFrozenLegacyWrapper(el: Element): boolean {
+  return isLegacyWrapper(el) && el.parentElement?.closest(CONSTRAINED_ANCESTOR_SELECTOR) != null;
+}
 
 /**
  * #723: Replace rich/media nodes with opaque text tokens before the lossy
@@ -930,9 +951,22 @@ export function protectMedia(html: string): { html: string; media: ProtectedMedi
   const doc = dom.window.document;
   const media: ProtectedMedia[] = [];
   // Outermost-first: a div.confluence-drawio contains an <img>; protect the
-  // wrapper and skip its descendants.
-  const nodes = Array.from(doc.body.querySelectorAll(MEDIA_SELECTOR))
-    .filter((n) => !n.parentElement?.closest('div.confluence-drawio, div.confluence-mermaid, div.mermaid'));
+  // wrapper and skip its descendants. Same for frozen legacy section/column
+  // wrappers (#765 review), which may contain media or further nested columns.
+  const nodes = Array.from(doc.body.querySelectorAll(`${MEDIA_SELECTOR},${LEGACY_WRAPPER_SELECTOR}`))
+    .filter((n) => {
+      // Legacy section/column wrappers freeze ONLY when nested inside a
+      // markdown-constrained container; elsewhere they use boundary tokens.
+      if (isLegacyWrapper(n) && !isFrozenLegacyWrapper(n)) return false;
+      if (n.parentElement?.closest('div.confluence-drawio, div.confluence-mermaid, div.mermaid')) return false;
+      // Skip descendants of a frozen wrapper — it is protected whole. If the
+      // nearest wrapper ancestor is not frozen, no farther one can be either
+      // (frozenness propagates downward: a frozen ancestor's constrained
+      // container is an ancestor of every nested wrapper too).
+      const wrapperAncestor = n.parentElement?.closest(LEGACY_WRAPPER_SELECTOR);
+      if (wrapperAncestor && isFrozenLegacyWrapper(wrapperAncestor)) return false;
+      return true;
+    });
   for (const node of nodes) {
     const token = `${MEDIA_TOKEN_PREFIX}${media.length}`;
     media.push({ token, html: (node as Element).outerHTML });
@@ -999,10 +1033,26 @@ export function restoreMedia(html: string, media: ProtectedMedia[]): string {
   });
 }
 
+export interface HtmlToMarkdownOptions {
+  /**
+   * #765: emit [[[LAYOUT…]]] / [[[SECTION…]]] / [[[COLUMN…]]] boundary tokens
+   * around layout containers so markdownToHtml() can rebuild them after the
+   * AI-Improve round-trip. ONLY the Improve route's main-page conversion sets
+   * this — every other flow (quality scoring, auto-tagging, diagram context,
+   * version-compare summaries, sub-page context, imports) keeps the default
+   * flattened output so raw tokens never leak into prompts or user-visible
+   * text. Sub-page context in particular must stay token-free: truncated
+   * sub-page token sequences can be echoed by the model into the parent
+   * page's output and build layout that never existed on the parent.
+   */
+  layoutTokens?: boolean;
+}
+
 /**
  * Converts HTML to Markdown (for LLM consumption).
  */
-export function htmlToMarkdown(html: string): string {
+export function htmlToMarkdown(html: string, options?: HtmlToMarkdownOptions): string {
+  const layoutTokens = options?.layoutTokens === true;
   const turndownService = new TurndownService({
     headingStyle: 'atx',
     codeBlockStyle: 'fenced',
@@ -1028,62 +1078,83 @@ export function htmlToMarkdown(html: string): string {
     },
   });
 
-  // #765: layout containers — emit boundary tokens as standalone lines so the
-  // wrapper structure survives the markdown round-trip while the prose inside
-  // stays editable by the LLM. markdownToHtml() rebuilds the divs from the
-  // tokens (with a drop-guard if the LLM mangled them).
-  turndownService.addRule('confluenceLayout', {
-    filter: (node) =>
-      node.nodeName === 'DIV' && node.classList.contains('confluence-layout'),
-    replacement: (content) => `\n\n[[[LAYOUT]]]\n\n${content.trim()}\n\n[[[/LAYOUT]]]\n\n`,
-  });
+  if (layoutTokens) {
+    // #765: layout containers — emit boundary tokens as standalone lines so the
+    // wrapper structure survives the markdown round-trip while the prose inside
+    // stays editable by the LLM. markdownToHtml() rebuilds the divs from the
+    // tokens (with a drop-guard if the LLM mangled them). Opt-in: ONLY the
+    // AI-Improve main-page conversion sets `layoutTokens` (see
+    // HtmlToMarkdownOptions) — everywhere else the rules below flatten instead.
+    turndownService.addRule('confluenceLayout', {
+      filter: (node) =>
+        node.nodeName === 'DIV' && node.classList.contains('confluence-layout'),
+      replacement: (content) => `\n\n[[[LAYOUT]]]\n\n${content.trim()}\n\n[[[/LAYOUT]]]\n\n`,
+    });
 
-  turndownService.addRule('confluenceLayoutSection', {
-    filter: (node) =>
-      node.nodeName === 'DIV' && node.classList.contains('confluence-layout-section'),
-    replacement: (content, node) => {
-      const raw = (node as HTMLElement).getAttribute('data-layout-type') ?? 'single';
-      // Confluence layout types are lowercase identifiers (single, two_equal,
-      // three_with_sidebars, …) — anything else would break the token line.
-      const layoutType = /^[a-z_]+$/.test(raw) ? raw : 'single';
-      return `\n\n[[[LAYOUT-SECTION ${layoutType}]]]\n\n${content.trim()}\n\n[[[/LAYOUT-SECTION]]]\n\n`;
-    },
-  });
+    turndownService.addRule('confluenceLayoutSection', {
+      filter: (node) =>
+        node.nodeName === 'DIV' && node.classList.contains('confluence-layout-section'),
+      replacement: (content, node) => {
+        const raw = (node as HTMLElement).getAttribute('data-layout-type') ?? 'single';
+        // Confluence layout types are lowercase identifiers (single, two_equal,
+        // three_with_sidebars, …) — anything else would break the token line.
+        const layoutType = /^[a-z_]+$/.test(raw) ? raw : 'single';
+        return `\n\n[[[LAYOUT-SECTION ${layoutType}]]]\n\n${content.trim()}\n\n[[[/LAYOUT-SECTION]]]\n\n`;
+      },
+    });
 
-  turndownService.addRule('confluenceLayoutCell', {
-    filter: (node) =>
-      node.nodeName === 'DIV' && node.classList.contains('confluence-layout-cell'),
-    replacement: (content) => `\n\n[[[LAYOUT-CELL]]]\n\n${content.trim()}\n\n[[[/LAYOUT-CELL]]]\n\n`,
-  });
+    turndownService.addRule('confluenceLayoutCell', {
+      filter: (node) =>
+        node.nodeName === 'DIV' && node.classList.contains('confluence-layout-cell'),
+      replacement: (content) => `\n\n[[[LAYOUT-CELL]]]\n\n${content.trim()}\n\n[[[/LAYOUT-CELL]]]\n\n`,
+    });
 
-  // #765: legacy section/column containers — same boundary-token treatment
-  // (previously these dropped the wrapper and emitted only trimmed content).
-  turndownService.addRule('confluenceSection', {
-    filter: (node) =>
-      node.nodeName === 'DIV' && node.classList.contains('confluence-section'),
-    replacement: (content, node) => {
-      const border = (node as HTMLElement).getAttribute('data-border');
-      const attrs = border === 'true' || border === 'false' ? ` border=${border}` : '';
-      return `\n\n[[[SECTION${attrs}]]]\n\n${content.trim()}\n\n[[[/SECTION]]]\n\n`;
-    },
-  });
+    // #765: legacy section/column containers — same boundary-token treatment.
+    // (When nested inside a constrained container these never reach turndown:
+    // protectMedia froze them opaquely first.)
+    turndownService.addRule('confluenceSection', {
+      filter: (node) =>
+        node.nodeName === 'DIV' && node.classList.contains('confluence-section'),
+      replacement: (content, node) => {
+        const border = (node as HTMLElement).getAttribute('data-border');
+        const attrs = border === 'true' || border === 'false' ? ` border=${border}` : '';
+        return `\n\n[[[SECTION${attrs}]]]\n\n${content.trim()}\n\n[[[/SECTION]]]\n\n`;
+      },
+    });
 
-  turndownService.addRule('confluenceColumn', {
-    filter: (node) =>
-      node.nodeName === 'DIV' && node.classList.contains('confluence-column'),
-    replacement: (content, node) => {
-      const el = node as HTMLElement;
-      // Prefer data-cell-width; fall back to the inline flex style (mirrors
-      // htmlToConfluence). Only token-safe width values are carried.
-      let width = el.getAttribute('data-cell-width');
-      if (!width) {
-        const m = (el.getAttribute('style') ?? '').match(/flex:\s*0\s+0\s+(\S+)/);
-        if (m) width = m[1] ?? null;
-      }
-      const attrs = width && /^[\d.]+(%|px|em|rem)?$/.test(width) ? ` width=${width}` : '';
-      return `\n\n[[[COLUMN${attrs}]]]\n\n${content.trim()}\n\n[[[/COLUMN]]]\n\n`;
-    },
-  });
+    turndownService.addRule('confluenceColumn', {
+      filter: (node) =>
+        node.nodeName === 'DIV' && node.classList.contains('confluence-column'),
+      replacement: (content, node) => {
+        const el = node as HTMLElement;
+        // Prefer data-cell-width; fall back to the inline flex style (mirrors
+        // htmlToConfluence). Only token-safe width values are carried.
+        let width = el.getAttribute('data-cell-width');
+        if (!width) {
+          const m = (el.getAttribute('style') ?? '').match(/flex:\s*0\s+0\s+(\S+)/);
+          if (m) width = m[1] ?? null;
+        }
+        const attrs = width && /^[\d.]+(%|px|em|rem)?$/.test(width) ? ` width=${width}` : '';
+        return `\n\n[[[COLUMN${attrs}]]]\n\n${content.trim()}\n\n[[[/COLUMN]]]\n\n`;
+      },
+    });
+  } else {
+    // Default (all non-Improve flows): pre-#765 flattened output — wrapper
+    // structure is dropped, only the inner content survives. Modern
+    // div.confluence-layout* wrappers need no rule: turndown's default DIV
+    // handling already passes their content through.
+    turndownService.addRule('confluenceSection', {
+      filter: (node) =>
+        node.nodeName === 'DIV' && node.classList.contains('confluence-section'),
+      replacement: (content) => `\n${content.trim()}\n\n`,
+    });
+
+    turndownService.addRule('confluenceColumn', {
+      filter: (node) =>
+        node.nodeName === 'DIV' && node.classList.contains('confluence-column'),
+      replacement: (content) => `\n${content.trim()}\n`,
+    });
+  }
 
   // Custom rule for the labels macro placeholder (#765). Only reached by
   // non-Improve flows (quality/auto-tag/diagram context) — the Improve path
@@ -1139,8 +1210,10 @@ export function htmlToMarkdown(html: string): string {
 // macros) has no Markdown representation, so the AI-Improve round-trip
 // (htmlToMarkdown → LLM → markdownToHtml) used to flatten it. Unlike media
 // (#723's opaque CQ_MEDIA_PLACEHOLDER swap), layout cells contain prose the
-// LLM must still be able to edit — so htmlToMarkdown emits BOUNDARY tokens as
-// standalone lines around the (still editable) cell content:
+// LLM must still be able to edit — so htmlToMarkdown, when called with
+// `{ layoutTokens: true }` (Improve main-page conversion ONLY), emits
+// BOUNDARY tokens as standalone lines around the (still editable) cell
+// content:
 //
 //   [[[LAYOUT]]] … [[[/LAYOUT]]]
 //   [[[LAYOUT-SECTION two_equal]]] … [[[/LAYOUT-SECTION]]]
@@ -1256,16 +1329,51 @@ function rebuildLayoutStructure(html: string): string {
   });
 }
 
+// #765 review follow-up: literal token text inside code is DATA, not
+// structure (e.g. documentation about the token syntax itself). Rebuilding
+// or stripping it would mutate code content, and a stray token-shaped string
+// in a code block could poison the all-or-nothing validation for the real
+// tokens. Both the markdown normalization and the HTML rebuild/backstop
+// therefore skip code regions.
+
+// Markdown code constructs: fenced blocks (``` / ~~~, unterminated fences run
+// to end-of-input, matching marked) and inline code spans.
+const MARKDOWN_CODE_SEGMENT =
+  /(```[\s\S]*?(?:```|$)|~~~[\s\S]*?(?:~~~|$)|``[^`][\s\S]*?``|`[^`\n]*`)/g;
+
+/** Apply `transform` to every part of `markdown` that is NOT a code construct. */
+function transformOutsideMarkdownCode(markdown: string, transform: (segment: string) => string): string {
+  // split() with a capturing group keeps the separators at odd indexes.
+  return markdown
+    .split(MARKDOWN_CODE_SEGMENT)
+    .map((segment, i) => (i % 2 === 1 ? segment : transform(segment)))
+    .join('');
+}
+
+/** Apply `transform` to every part of `html` outside <pre>/<code> elements. */
+function transformOutsideHtmlCode(html: string, transform: (segment: string) => string): string {
+  const regions: string[] = [];
+  // <pre> first so a whole <pre><code>…</code></pre> block masks as one unit.
+  // NUL-delimited placeholders cannot collide with marked's HTML output.
+  const masked = html.replace(/<pre[\s>][\s\S]*?<\/pre\s*>|<code[\s>][\s\S]*?<\/code\s*>/gi, (m) => {
+    regions.push(m);
+    return `\u0000CQ_CODE_REGION_${regions.length - 1}\u0000`;
+  });
+  // eslint-disable-next-line no-control-regex -- NUL delimiter is intentional: it cannot occur in marked HTML output
+  return transform(masked).replace(/\u0000CQ_CODE_REGION_(\d+)\u0000/g, (m, i) => regions[Number(i)] ?? m);
+}
+
 /**
  * Converts Markdown to HTML (for LLM output -> editor).
  */
 export async function markdownToHtml(markdown: string): Promise<string> {
   // #765: force every layout boundary token onto its own paragraph so marked
   // wraps it in a lone <p>, even when the LLM merged adjacent token lines or
-  // pulled a token into surrounding prose.
-  const normalized = markdown.replace(
-    new RegExp(`[ \\t]*(${LAYOUT_TOKEN_BARE})[ \\t]*`, 'g'),
-    '\n\n$1\n\n',
+  // pulled a token into surrounding prose. Code constructs are skipped —
+  // literal token text in a fenced block must survive verbatim.
+  const tokenLine = new RegExp(`[ \\t]*(${LAYOUT_TOKEN_BARE})[ \\t]*`, 'g');
+  const normalized = transformOutsideMarkdownCode(markdown, (segment) =>
+    segment.replace(tokenLine, '\n\n$1\n\n'),
   );
 
   let html = await marked(normalized) as string;
@@ -1280,16 +1388,19 @@ export async function markdownToHtml(markdown: string): Promise<string> {
     },
   );
 
-  // #765: rebuild layout/section/column wrappers from boundary tokens.
-  html = rebuildLayoutStructure(html);
+  html = transformOutsideHtmlCode(html, (segment) => {
+    // #765: rebuild layout/section/column wrappers from boundary tokens.
+    let out = rebuildLayoutStructure(segment);
 
-  // #765 drop-guard backstop: strip any token-shaped remnant that failed
-  // structural matching (e.g. the LLM lower-cased a marker) — raw [[[…]]]
-  // text must never reach the saved page.
-  html = html.replace(
-    new RegExp(`<p>\\s*${LAYOUT_TOKEN_BARE}\\s*</p>|${LAYOUT_TOKEN_BARE}`, 'gi'),
-    '',
-  );
+    // #765 drop-guard backstop: strip any token-shaped remnant that failed
+    // structural matching (e.g. the LLM lower-cased a marker) — raw [[[…]]]
+    // text must never reach the saved page.
+    out = out.replace(
+      new RegExp(`<p>\\s*${LAYOUT_TOKEN_BARE}\\s*</p>|${LAYOUT_TOKEN_BARE}`, 'gi'),
+      '',
+    );
+    return out;
+  });
 
   return html;
 }

--- a/backend/src/domains/confluence/services/subpage-context.test.ts
+++ b/backend/src/domains/confluence/services/subpage-context.test.ts
@@ -204,6 +204,32 @@ describe('subpage-context', () => {
       // Should include parent + at most 1-2 child pages within 600 chars
       expect(result.pageCount).toBeLessThanOrEqual(3);
     });
+
+    it('never requests layout boundary tokens — sub-page context stays flattened (#765 review)', async () => {
+      // Truncated sub-page token sequences could be echoed by the model into
+      // the parent page's output, so neither the parent nor any sub-page
+      // conversion may opt in to layoutTokens here.
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          { confluence_id: 'child-1', title: 'Child 1', body_html: '<div class="confluence-layout"><p>Sub</p></div>' },
+        ],
+      });
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await assembleSubPageContext(
+        'user-1',
+        'parent-1',
+        '<div class="confluence-layout"><p>Parent</p></div>',
+        'Parent',
+      );
+
+      const { htmlToMarkdown } = await import('../../../core/services/content-converter.js');
+      const calls = vi.mocked(htmlToMarkdown).mock.calls;
+      expect(calls.length).toBeGreaterThanOrEqual(2); // parent + sub-page
+      for (const call of calls) {
+        expect(call[1]).toBeUndefined();
+      }
+    });
   });
 
   describe('getMultiPagePromptSuffix', () => {

--- a/backend/src/domains/llm/services/prompts.ts
+++ b/backend/src/domains/llm/services/prompts.ts
@@ -13,6 +13,11 @@ export interface ChatMessage {
 
 export const LANGUAGE_PRESERVATION_INSTRUCTION = `IMPORTANT: Keep the text in its ORIGINAL language. If the text is in German, respond in German. If in English, respond in English. Never translate — only improve the text while preserving its language.`;
 
+// #765: appended to improve prompts when the markdown contains layout
+// boundary tokens or media placeholders, so the LLM keeps the page structure
+// intact. markdownToHtml() has a drop-guard for when it still mangles them.
+export const STRUCTURE_PRESERVATION_INSTRUCTION = `The text contains structural placeholder tokens: standalone lines like [[[LAYOUT]]], [[[LAYOUT-SECTION two_equal]]], [[[LAYOUT-CELL]]], [[[SECTION]]], [[[COLUMN width=50%]]] and their matching closing forms ([[[/LAYOUT]]], [[[/LAYOUT-SECTION]]], …), plus opaque CQ_MEDIA_PLACEHOLDER_N tokens. These mark page structure that must survive your edit. Keep every token EXACTLY as written, each on its own line, in the same order and nesting. Improve only the prose between them. Never delete, rename, reorder, or merge tokens.`;
+
 const SYSTEM_PROMPTS = {
   improve_grammar: `You are a technical writing assistant. Improve the grammar, spelling, and punctuation of the following article while preserving its meaning and structure. Return the improved text in Markdown format. Only output the improved text, no explanations. ${LANGUAGE_PRESERVATION_INSTRUCTION}`,
 

--- a/backend/src/routes/llm/_helpers.ts
+++ b/backend/src/routes/llm/_helpers.ts
@@ -44,7 +44,7 @@ export async function assembleContextIfNeeded(
   pageId: string | undefined,
   content: string,
   includeSubPages?: boolean,
-  opts?: { protectMedia?: boolean },
+  opts?: { protectMedia?: boolean; layoutTokens?: boolean },
 ): Promise<{ markdown: string; multiPageSuffix: string }> {
   if (includeSubPages && pageId) {
     const pageResult = await query<{ title: string }>(
@@ -62,7 +62,11 @@ export async function assembleContextIfNeeded(
 
   const html = opts?.protectMedia ? protectMedia(content).html : content;
   return {
-    markdown: htmlToMarkdown(html),
+    // #765: layout boundary tokens are opt-in — only the Improve route's
+    // main-page conversion requests them. The sub-page branch above never
+    // emits tokens (truncated sub-page token sequences could be echoed by
+    // the model into the parent page's output).
+    markdown: htmlToMarkdown(html, { layoutTokens: opts?.layoutTokens === true }),
     multiPageSuffix: '',
   };
 }

--- a/backend/src/routes/llm/apply-improvement-media.test.ts
+++ b/backend/src/routes/llm/apply-improvement-media.test.ts
@@ -205,3 +205,122 @@ describe('POST /api/llm/improvements/apply — drop-guard with REAL restoreMedia
     expect(savedHtml.split('/api/attachments/42/q.png').length - 1).toBe(1);
   });
 });
+
+describe('POST /api/llm/improvements/apply — layout boundary tokens with REAL markdownToHtml (#765)', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+    app.decorate('authenticate', async () => {});
+    app.decorate('requireAdmin', async () => {});
+    app.decorate('redis', {});
+    app.decorateRequest('userId', '');
+    app.addHook('onRequest', async (request) => {
+      request.userId = 'user-123';
+      request.userCan = async () => true;
+    });
+    await app.register(llmConversationRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const layoutBodyHtml =
+    '<div class="confluence-layout"><div class="confluence-layout-section" data-layout-type="two_equal">' +
+    '<div class="confluence-layout-cell"><p>Left column content</p></div>' +
+    '<div class="confluence-layout-cell"><p>Right column content</p></div>' +
+    '</div></div>';
+
+  function mockPageWith(bodyHtml: string): void {
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT id, version, title, space_key, source, confluence_id')) {
+        return Promise.resolve({
+          rows: [{
+            id: 42, version: 5, title: 'My Article', space_key: 'OPS',
+            source: 'standalone', confluence_id: null, body_html: bodyHtml,
+            created_by_user_id: 'user-123', visibility: 'private',
+          }],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+  }
+
+  function captureUpdatedBodyHtml(): string {
+    const updateCall = (mockQuery.mock.calls as unknown[][]).find(
+      (args) => typeof args[0] === 'string' && (args[0] as string).includes('UPDATE pages'),
+    );
+    expect(updateCall).toBeDefined();
+    return (updateCall as unknown[])[1]![2] as string;
+  }
+
+  it('rebuilds the layout when the LLM kept the boundary tokens and edited the prose', async () => {
+    mockPageWith(layoutBodyHtml);
+
+    const improvedMarkdown = [
+      '[[[LAYOUT]]]', '',
+      '[[[LAYOUT-SECTION two_equal]]]', '',
+      '[[[LAYOUT-CELL]]]', '',
+      'Left column content, improved by the model.', '',
+      '[[[/LAYOUT-CELL]]]', '',
+      '[[[LAYOUT-CELL]]]', '',
+      'Right column content stays.', '',
+      '[[[/LAYOUT-CELL]]]', '',
+      '[[[/LAYOUT-SECTION]]]', '',
+      '[[[/LAYOUT]]]',
+    ].join('\n');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/improvements/apply',
+      payload: { pageId: '42', improvedMarkdown, version: 5, title: 'My Article' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const savedHtml = captureUpdatedBodyHtml();
+    expect(savedHtml).toContain('class="confluence-layout"');
+    expect(savedHtml).toContain('data-layout-type="two_equal"');
+    expect((savedHtml.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(2);
+    expect(savedHtml).toContain('Left column content, improved by the model.');
+    expect(savedHtml).not.toContain('[[[');
+  });
+
+  it('drop-guard: mangled tokens flatten gracefully — no raw [[[…]]] and no unbalanced divs', async () => {
+    mockPageWith(layoutBodyHtml);
+
+    // The LLM dropped one closing token and lower-cased another.
+    const improvedMarkdown = [
+      '[[[LAYOUT]]]', '',
+      '[[[LAYOUT-SECTION two_equal]]]', '',
+      '[[[LAYOUT-CELL]]]', '',
+      'Left prose survives.', '',
+      '[[[/layout-cell]]]', '',
+      '[[[LAYOUT-CELL]]]', '',
+      'Right prose survives.', '',
+      '[[[/LAYOUT-SECTION]]]', '',
+      '[[[/LAYOUT]]]',
+    ].join('\n');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/improvements/apply',
+      payload: { pageId: '42', improvedMarkdown, version: 5, title: 'My Article' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const savedHtml = captureUpdatedBodyHtml();
+    expect(savedHtml).not.toContain('[[[');
+    expect(savedHtml).not.toContain('confluence-layout');
+    expect(savedHtml).toContain('Left prose survives.');
+    expect(savedHtml).toContain('Right prose survives.');
+    // No dangling open/close divs.
+    expect((savedHtml.match(/<div/g) ?? []).length).toBe((savedHtml.match(/<\/div>/g) ?? []).length);
+  });
+});

--- a/backend/src/routes/llm/improve-instruction.test.ts
+++ b/backend/src/routes/llm/improve-instruction.test.ts
@@ -93,6 +93,8 @@ vi.mock('../../core/utils/sanitize-llm-input.js', () => ({
 }));
 
 import { llmImproveRoutes } from './llm-improve.js';
+import { STRUCTURE_PRESERVATION_INSTRUCTION } from '../../domains/llm/services/prompts.js';
+import { htmlToMarkdown } from '../../core/services/content-converter.js';
 
 describe('POST /api/llm/improve - instruction field', () => {
   let app: ReturnType<typeof Fastify>;
@@ -263,5 +265,83 @@ describe('POST /api/llm/improve - instruction field', () => {
     const messages = callArgs[2];
     const systemMessage = messages.find((m: { role: string }) => m.role === 'system');
     expect(systemMessage.content).not.toContain('ADDITIONAL USER INSTRUCTIONS');
+  });
+});
+
+describe('POST /api/llm/improve - structure preservation instruction (#765)', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.decorate('authenticate', async () => {});
+    app.decorate('requireAdmin', async () => {});
+    app.decorate('redis', {});
+    app.decorateRequest('userId', '');
+    app.addHook('onRequest', async (request) => {
+      request.userId = 'test-user-123';
+      request.userCan = async () => true;
+    });
+
+    await app.register(llmImproveRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCachedResponse.mockResolvedValue(null);
+  });
+
+  async function injectImprove(content: string): Promise<string> {
+    async function* mockGenerator() {
+      yield { content: 'Improved text', done: true };
+    }
+    mockProviderStreamChat.mockReturnValue(mockGenerator());
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/improve',
+      payload: { content, type: 'grammar', model: 'llama3' },
+    });
+    expect(response.statusCode).toBe(200);
+
+    expect(mockProviderStreamChat).toHaveBeenCalledTimes(1);
+    const messages = mockProviderStreamChat.mock.calls[0]![2];
+    return messages.find((m: { role: string }) => m.role === 'system').content as string;
+  }
+
+  it('appends STRUCTURE_PRESERVATION_INSTRUCTION when the markdown carries layout boundary tokens', async () => {
+    // htmlToMarkdown is mocked as a passthrough, so token-bearing content
+    // stands in for the real layoutTokens conversion output.
+    const systemPrompt = await injectImprove(
+      '[[[LAYOUT]]]\n\n[[[LAYOUT-CELL]]]\n\nProse\n\n[[[/LAYOUT-CELL]]]\n\n[[[/LAYOUT]]]',
+    );
+    expect(systemPrompt).toContain(STRUCTURE_PRESERVATION_INSTRUCTION);
+  });
+
+  it('appends STRUCTURE_PRESERVATION_INSTRUCTION when the markdown carries media placeholders', async () => {
+    const systemPrompt = await injectImprove('Some prose with CQ_MEDIA_PLACEHOLDER_0 inside.');
+    expect(systemPrompt).toContain(STRUCTURE_PRESERVATION_INSTRUCTION);
+  });
+
+  it('keeps the system prompt clean when no tokens are present', async () => {
+    const systemPrompt = await injectImprove('<p>Plain text without any structural tokens</p>');
+    expect(systemPrompt).not.toContain(STRUCTURE_PRESERVATION_INSTRUCTION);
+    // Not even a fragment of the instruction leaks in.
+    expect(systemPrompt).not.toContain('structural placeholder tokens');
+  });
+
+  it('requests layout boundary tokens for the main-page conversion (#765 review)', async () => {
+    await injectImprove('<p>Whatever</p>');
+    // The Improve route is the ONLY caller allowed to set layoutTokens.
+    expect(vi.mocked(htmlToMarkdown)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ layoutTokens: true }),
+    );
   });
 });

--- a/backend/src/routes/llm/llm-improve.ts
+++ b/backend/src/routes/llm/llm-improve.ts
@@ -49,7 +49,9 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
       throw fastify.httpErrors.badRequest(`Content too large (max ${MAX_INPUT_LENGTH} characters)`);
     }
 
-    const { markdown, multiPageSuffix } = await assembleContextIfNeeded(userId, body.pageId, content, includeSubPages, { protectMedia: true });
+    // #765: layoutTokens applies only to the main-page conversion — the
+    // sub-page branch inside assembleContextIfNeeded never emits tokens.
+    const { markdown, multiPageSuffix } = await assembleContextIfNeeded(userId, body.pageId, content, includeSubPages, { protectMedia: true, layoutTokens: true });
 
     // Sanitize before sending to LLM
     const { sanitized, warnings } = sanitizeLlmInput(markdown);

--- a/backend/src/routes/llm/llm-improve.ts
+++ b/backend/src/routes/llm/llm-improve.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { query } from '../../core/db/postgres.js';
-import { SystemPromptKey } from '../../domains/llm/services/prompts.js';
+import { SystemPromptKey, STRUCTURE_PRESERVATION_INSTRUCTION } from '../../domains/llm/services/prompts.js';
 import { resolveUsecase } from '../../domains/llm/services/llm-provider-resolver.js';
 import { streamChat } from '../../domains/llm/services/openai-compatible-client.js';
 import { LlmCache, buildLlmCacheKey } from '../../domains/llm/services/llm-cache.js';
@@ -86,6 +86,12 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
     }
 
     let systemPrompt = await resolveSystemPrompt(userId, `improve_${type}` as SystemPromptKey) + multiPageSuffix;
+    // #765: when the markdown carries layout boundary tokens or media
+    // placeholders, instruct the model to keep them verbatim. (Deterministic
+    // per content, so it composes safely with the cache key below.)
+    if (/\[\[\[|CQ\\?_MEDIA\\?_PLACEHOLDER/.test(markdown)) {
+      systemPrompt += `\n\n${STRUCTURE_PRESERVATION_INSTRUCTION}`;
+    }
     if (sanitizedInstruction) {
       systemPrompt += `\n\nADDITIONAL USER INSTRUCTIONS:\n${sanitizedInstruction}`;
     }

--- a/docs/architecture/11-content-pipeline.md
+++ b/docs/architecture/11-content-pipeline.md
@@ -58,8 +58,8 @@ Custom turndown rules handle Confluence-specific macros:
 | `ac:structured-macro[excerpt-include]` | `<div class="confluence-include-macro" data-macro-name="excerpt-include">[Excerpt: …]</div>` | `[Excerpt: …]` placeholder |
 | `ac:structured-macro[toc]`           | `<div class="confluence-toc" data-maxlevel="…">[Table of Contents]</div>` | `[Table of Contents]` placeholder |
 | `ac:structured-macro[labels]`        | `<div class="confluence-labels-macro" data-showlabels="…">[Labels]</div>` (#765; was dropped per #348) | `[Labels]` placeholder; opaque-protected on Improve |
-| `ac:layout` / `ac:layout-section` / `ac:layout-cell` | `div.confluence-layout` / `div.confluence-layout-section[data-layout-type]` / `div.confluence-layout-cell` | `[[[LAYOUT]]]` / `[[[LAYOUT-SECTION type]]]` / `[[[LAYOUT-CELL]]]` boundary tokens (#765) |
-| `ac:structured-macro[section]` / `[column]` (legacy) | `div.confluence-section[data-border]` / `div.confluence-column[data-cell-width]` | `[[[SECTION border=…]]]` / `[[[COLUMN width=…]]]` boundary tokens (#765) |
+| `ac:layout` / `ac:layout-section` / `ac:layout-cell` | `div.confluence-layout` / `div.confluence-layout-section[data-layout-type]` / `div.confluence-layout-cell` | flattened content (default); `[[[LAYOUT]]]` / `[[[LAYOUT-SECTION type]]]` / `[[[LAYOUT-CELL]]]` boundary tokens with `{ layoutTokens: true }` (#765, Improve only) |
+| `ac:structured-macro[section]` / `[column]` (legacy) | `div.confluence-section[data-border]` / `div.confluence-column[data-cell-width]` | flattened content (default); `[[[SECTION border=…]]]` / `[[[COLUMN width=…]]]` boundary tokens with `{ layoutTokens: true }` (#765, Improve only) |
 
 ### Round-trip notes (issue #300)
 
@@ -143,7 +143,11 @@ verbatim. The replacement map is returned alongside the protected HTML; the
 index is document order, making it deterministic. (#765: legacy
 `div.confluence-section` / `div.confluence-column` were removed from this
 selector — opaque protection froze the prose inside them; they now use
-layout boundary tokens instead so the LLM can still edit the content.)
+layout boundary tokens instead so the LLM can still edit the content.
+Exception: a legacy section/column nested inside a `td`, `th`, `li`,
+`blockquote`, or panel div **stays opaque-frozen** — a boundary token line
+inside such a construct would be ripped out of it by the token
+normalization, e.g. splitting a GFM table row.)
 
 `assembleContextIfNeeded` in `_helpers.ts` applies `protectMedia` when the
 caller passes `opts.protectMedia = true` (set by `llmImproveRoutes`).
@@ -183,7 +187,8 @@ round-trip used to flatten them to a single column. They cannot use the
 opaque `protectMedia` tokens because — unlike media — layout cells contain
 **prose the LLM must still be able to improve**.
 
-Instead, `htmlToMarkdown()` emits **boundary tokens** as standalone lines
+Instead, `htmlToMarkdown()` — **only when called with
+`{ layoutTokens: true }`** — emits **boundary tokens** as standalone lines
 around the (still fully editable) cell content:
 
 ```text
@@ -199,11 +204,24 @@ around the (still fully editable) cell content:
 [[[COLUMN width=50%]]]    … [[[/COLUMN]]]    ← legacy ac:column macro
 ```
 
+`layoutTokens` is set solely by the Improve route's main-page conversion
+(`assembleContextIfNeeded` in `routes/llm/_helpers.ts`). Every other
+`htmlToMarkdown` caller — quality scoring, auto-tagging, diagram context,
+version-compare summaries, sub-page context, page imports — keeps the
+default flattened output, so raw `[[[…]]]` tokens never leak into prompts
+or user-visible text. Sub-page context in particular must stay token-free
+even within the Improve flow: a truncated sub-page token sequence could be
+echoed by the model into the parent page's output and build layout that
+never existed on the parent. Legacy sections/columns nested inside
+markdown-constrained containers (`td`/`th`/`li`/`blockquote`/panels) never
+emit tokens either — they stay opaque-frozen via `protectMedia` (see above).
+
 Tokens carry the structural attributes (`data-layout-type`, `data-border`,
 `data-cell-width`). `markdownToHtml()` then:
 
 1. normalizes the Markdown so every token sits in its own paragraph (in case
-   the LLM merged adjacent token lines);
+   the LLM merged adjacent token lines), skipping fenced/inline code so
+   literal token text in code is never touched;
 2. validates the whole token sequence for **balance and nesting** (a
    `LAYOUT-SECTION` may only open directly inside a `LAYOUT`, a `COLUMN`
    only inside a `SECTION`, …);
@@ -215,6 +233,11 @@ Tokens carry the structural attributes (`data-layout-type`, `data-border`,
    case-changed), ALL tokens are stripped instead — the content degrades to
    the old flattened form, but the page is never corrupted and raw
    `[[[…]]]` text never reaches the saved page.
+
+Steps 2–4 operate only **outside `<pre>`/`<code>` elements**: literal token
+text inside code blocks (e.g. documentation about the token syntax) is
+data, never rebuilt into layout divs, never stripped, and never able to
+poison the balance validation of the real tokens.
 
 `/llm/improve` appends `STRUCTURE_PRESERVATION_INSTRUCTION` (from
 `prompts.ts`) to the system prompt whenever the markdown contains boundary

--- a/docs/architecture/11-content-pipeline.md
+++ b/docs/architecture/11-content-pipeline.md
@@ -57,7 +57,9 @@ Custom turndown rules handle Confluence-specific macros:
 | `ac:structured-macro[include]`       | `<div class="confluence-include-macro" data-page-title="…">[Include: …]</div>` | `[Include: …]` placeholder |
 | `ac:structured-macro[excerpt-include]` | `<div class="confluence-include-macro" data-macro-name="excerpt-include">[Excerpt: …]</div>` | `[Excerpt: …]` placeholder |
 | `ac:structured-macro[toc]`           | `<div class="confluence-toc" data-maxlevel="…">[Table of Contents]</div>` | `[Table of Contents]` placeholder |
-| `ac:structured-macro[labels]`        | dropped on import (page metadata, no body)                   | — (not rendered)              |
+| `ac:structured-macro[labels]`        | `<div class="confluence-labels-macro" data-showlabels="…">[Labels]</div>` (#765; was dropped per #348) | `[Labels]` placeholder; opaque-protected on Improve |
+| `ac:layout` / `ac:layout-section` / `ac:layout-cell` | `div.confluence-layout` / `div.confluence-layout-section[data-layout-type]` / `div.confluence-layout-cell` | `[[[LAYOUT]]]` / `[[[LAYOUT-SECTION type]]]` / `[[[LAYOUT-CELL]]]` boundary tokens (#765) |
+| `ac:structured-macro[section]` / `[column]` (legacy) | `div.confluence-section[data-border]` / `div.confluence-column[data-cell-width]` | `[[[SECTION border=…]]]` / `[[[COLUMN width=…]]]` boundary tokens (#765) |
 
 ### Round-trip notes (issue #300)
 
@@ -126,18 +128,22 @@ flowchart LR
 
 The `/llm/improve` → Accept round-trip runs `body_html` through
 `htmlToMarkdown()` before the LLM and `markdownToHtml()` after — a lossy
-path that discards `<img>` attributes, draw.io wrappers, and layout
-structure. Two safeguards prevent media from being destroyed:
+path that would discard `<img>` attributes, draw.io wrappers, and layout
+structure. Two safeguards prevent media from being destroyed (layout
+structure has its own mechanism — see the next section):
 
 ### Placeholder protection (Improve request)
 
 `protectMedia(html)` (exported from `content-converter.ts`) replaces every
 `img`, `div.confluence-drawio`, `div.confluence-mermaid`, `div.mermaid`,
-`div.confluence-section`, and `div.confluence-column` with an opaque token
+and `div.confluence-labels-macro` with an opaque token
 `CQ_MEDIA_PLACEHOLDER_<N>` before `htmlToMarkdown()`. Tokens use only
 `[A-Z_0-9]` so they survive turndown, `sanitizeLlmInput`, and the LLM
 verbatim. The replacement map is returned alongside the protected HTML; the
-index is document order, making it deterministic.
+index is document order, making it deterministic. (#765: legacy
+`div.confluence-section` / `div.confluence-column` were removed from this
+selector — opaque protection froze the prose inside them; they now use
+layout boundary tokens instead so the LLM can still edit the content.)
 
 `assembleContextIfNeeded` in `_helpers.ts` applies `protectMedia` when the
 caller passes `opts.protectMedia = true` (set by `llmImproveRoutes`).
@@ -168,6 +174,61 @@ non-Improve callers (copy/paste, export) also round-trip draw.io losslessly.
 | Custom rule | HTML form | Markdown form |
 |-------------|-----------|---------------|
 | `confluenceDrawio` | `<div class="confluence-drawio" data-diagram-name="…">` | ` ```drawio\nNAME\n``` ` |
+
+## AI Improve layout preservation — boundary tokens (#765)
+
+Confluence row/column layouts (modern `ac:layout` grids and the legacy
+`section` / `column` macros) have no Markdown representation, so the Improve
+round-trip used to flatten them to a single column. They cannot use the
+opaque `protectMedia` tokens because — unlike media — layout cells contain
+**prose the LLM must still be able to improve**.
+
+Instead, `htmlToMarkdown()` emits **boundary tokens** as standalone lines
+around the (still fully editable) cell content:
+
+```text
+[[[LAYOUT]]]
+[[[LAYOUT-SECTION two_equal]]]
+[[[LAYOUT-CELL]]]
+…normal editable Markdown…
+[[[/LAYOUT-CELL]]]
+[[[/LAYOUT-SECTION]]]
+[[[/LAYOUT]]]
+
+[[[SECTION border=true]]] … [[[/SECTION]]]   ← legacy ac:section macro
+[[[COLUMN width=50%]]]    … [[[/COLUMN]]]    ← legacy ac:column macro
+```
+
+Tokens carry the structural attributes (`data-layout-type`, `data-border`,
+`data-cell-width`). `markdownToHtml()` then:
+
+1. normalizes the Markdown so every token sits in its own paragraph (in case
+   the LLM merged adjacent token lines);
+2. validates the whole token sequence for **balance and nesting** (a
+   `LAYOUT-SECTION` may only open directly inside a `LAYOUT`, a `COLUMN`
+   only inside a `SECTION`, …);
+3. if valid, converts the token paragraphs back into the
+   `div.confluence-layout*` / `div.confluence-section` /
+   `div.confluence-column` wrappers (which `htmlToConfluence()` already maps
+   losslessly to `ac:layout*` / `section` / `column`);
+4. **drop-guard:** if the LLM mangled the tokens (unbalanced, reordered,
+   case-changed), ALL tokens are stripped instead — the content degrades to
+   the old flattened form, but the page is never corrupted and raw
+   `[[[…]]]` text never reaches the saved page.
+
+`/llm/improve` appends `STRUCTURE_PRESERVATION_INSTRUCTION` (from
+`prompts.ts`) to the system prompt whenever the markdown contains boundary
+or media tokens, instructing the model to keep them verbatim.
+
+The in-body **labels macro** is the opposite case: it is atomic (no editable
+prose), so since #765 it is kept as a
+`<div class="confluence-labels-macro">` placeholder on sync-in (it was
+previously dropped per #348, which silently deleted the widget from the
+Confluence page on any write-back) and opaque-protected through Improve via
+`protectMedia`. Page-label *metadata* (`pages.labels`) is unaffected by
+Improve: the apply handler never touches the column and the Confluence
+`updatePage` call sends only title+body, which does not modify labels
+server-side.
 
 ## Attachments
 


### PR DESCRIPTION
## Summary

AI Improve flattened Confluence row/column layouts to a single column and (per triage) deleted the in-body labels macro from the Confluence page on apply. This PR makes layout structure survive the full Improve round-trip (`protectMedia → htmlToMarkdown → LLM → markdownToHtml → restoreMedia → htmlToConfluence`) while keeping the prose inside cells fully editable by the LLM, and fixes the genuinely-broken half of the labels symptom.

## Root cause

The Confluence⇄HTML boundary was already lossless (`ac:layout*` ⇄ `div.confluence-layout*`, `section`/`column` macros ⇄ `div.confluence-section`/`-column`), but the Markdown boundary was not:

- `htmlToMarkdown()` had **no turndown rule** for the modern `confluence-layout` / `confluence-layout-section[data-layout-type]` / `confluence-layout-cell` divs (default block handling flattened them), and the legacy `confluence-section` / `confluence-column` rules emitted only trimmed content (wrapper dropped).
- `markdownToHtml()` never rebuilt any layout divs.

So by the time `htmlToConfluence()` ran on the LLM output, no layout divs remained and the `ac:layout` structure was permanently gone.

## Mechanism chosen: layout boundary tokens

Media/draw.io use **opaque** placeholder swaps (#723) because they are atomic. Layout cells are not — they contain prose the LLM must still be able to improve. So instead of freezing the subtree, `htmlToMarkdown()` now emits **boundary tokens as standalone lines** around the (still editable) Markdown content:

```
[[[LAYOUT]]]
[[[LAYOUT-SECTION two_equal]]]
[[[LAYOUT-CELL]]]
…normal editable Markdown…
[[[/LAYOUT-CELL]]]
[[[/LAYOUT-SECTION]]]
[[[/LAYOUT]]]

[[[SECTION border=true]]] … [[[/SECTION]]]   ← legacy ac:section
[[[COLUMN width=50%]]]    … [[[/COLUMN]]]    ← legacy ac:column
```

`markdownToHtml()` then (1) normalizes the Markdown so every token gets its own paragraph even if the LLM merged token lines, (2) validates the whole token sequence for **balance and nesting** (`LAYOUT-SECTION` only directly inside `LAYOUT`, `COLUMN` only inside `SECTION`, …), (3) rebuilds the `div.confluence-*` wrappers which `htmlToConfluence()` already maps back losslessly.

**Drop-guard (all-or-nothing):** if the LLM mangled the tokens — unbalanced, reordered into invalid nesting, case-changed — every token is stripped instead. Content degrades to the pre-fix flattened form (prose kept), but the page can never get unbalanced divs or invalid `ac:layout` nesting, and raw `[[[…]]]` text never reaches the saved page (a final case-insensitive backstop strips mangled remnants). This was chosen over partial recovery for predictability: the failure mode equals today's behavior, never something worse.

Consequence: legacy `div.confluence-section`/`-column` were **removed from the `protectMedia` selector** — #723 froze them whole, which preserved them but made their prose uneditable; they now round-trip via boundary tokens like the modern layouts.

`/llm/improve` additionally appends a `STRUCTURE_PRESERVATION_INSTRUCTION` to the system prompt whenever the markdown carries boundary/media tokens, so well-behaved models keep them verbatim (the drop-guard covers the rest).

## Labels triage findings

The issue asked to confirm whether a real loss path exists for the two kinds of "labels":

1. **Page-metadata labels (`pages.labels`) — NOT lost.** The apply handler's resolve `SELECT` doesn't read the column, but its `UPDATE` never touches it either, so the local value persists. The Confluence push (`client.updatePage`) sends only `type/title/version/body.storage` — the Confluence REST API does not modify labels on a content PUT (labels are managed via the separate `/label` endpoints). Next sync re-pulls the unchanged labels. No fix needed; no code path clears them.
2. **In-body labels macro — REAL loss, fixed.** #348 dropped `ac:structured-macro[name=labels]` at sync-in, which was safe when nothing pushed bodies back. Now that AI-Improve apply (and editor saves) push `htmlToConfluence(body_html)` to Confluence, the macro was **permanently deleted from the Confluence page body on the first write-back**. Fixed by keeping it as a `div.confluence-labels-macro` placeholder (params `max`/`spaces`/`excludedLabels`/`showLabels` round-tripped, toc-style), rebuilding the macro in `htmlToConfluence()`, and opaque-protecting it through Improve via `protectMedia` (it is atomic — no prose inside — so the #723 token pattern fits exactly). The label *metadata* is still sourced exclusively from `expand=metadata.labels`, preserving #348's intent.

If a reporter still sees metadata labels vanish in the UI after Improve, that would be a separate (frontend/sync) repro we could not construct from the backend code paths.

## Changes

- `backend/src/core/services/content-converter.ts` — boundary-token turndown rules (modern + legacy layouts), token grammar + stack-validated rebuild + drop-guard in `markdownToHtml()`, labels-macro placeholder (forward + reverse), `MEDIA_SELECTOR` update.
- `backend/src/domains/llm/services/prompts.ts` — `STRUCTURE_PRESERVATION_INSTRUCTION`.
- `backend/src/routes/llm/llm-improve.ts` — append the instruction when tokens are present (deterministic per content, cache-key safe).
- `backend/src/core/services/content-converter.test.ts`, `backend/src/routes/llm/apply-improvement-media.test.ts` — see test plan.
- `docs/architecture/11-content-pipeline.md` — new "AI Improve layout preservation — boundary tokens (#765)" section, macro-table + `protectMedia` selector updates (Mandatory Rule 6).

## Test plan

All tests run against the real converter (pure utility, no mocks), plus the real route with the real `markdownToHtml`/`protectMedia`/`restoreMedia` (only DB/auth/externals mocked, per repo testing rules):

- Full Improve path (`protectMedia → htmlToMarkdown → markdownToHtml → restoreMedia → htmlToConfluence`) for: two-column `two_equal` (with `data-layout-type` + cell count), three-column `three_equal`, stacked sections (`single`+`two_equal`+`three_equal`), legacy section/column with `border` and `%` widths.
- LLM-style prose edit between the two conversion halves survives with structure intact (proves cell content is editable, not frozen).
- Rich nested content (lists, code macro, tables) inside cells; media `<img>` inside a cell is token-protected and restored in place inside the cell.
- Drop-guard: dropped closing token → graceful flatten (no `[[[`, no layout divs, balanced output); balanced-but-invalid nesting → flatten; merged token lines without blank lines → still rebuilt; case-mangled tokens → stripped by backstop; ordinary bracketed prose untouched; injected section type falls back to `single`.
- Labels macro: Confluence⇄HTML round-trip with params, full Improve path survival, updated #348 test (placeholder instead of drop, still no unknown-macro leak).
- Apply route (`POST /llm/improvements/apply`): kept tokens + edited prose → rebuilt layout in saved `body_html`; mangled tokens → no raw `[[[…]]]`, balanced divs.

```
Test Files  8 passed (8)
     Tests  183 passed (183)
```
`npm run lint -w backend` and `npm run typecheck -w backend` clean.

Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)