### PR TITLE
fix(pages): no local/Confluence divergence on delete; treat trashed as deleted in reconciliation

### DIFF
--- a/backend/src/domains/confluence/services/sync-embedding.test.ts
+++ b/backend/src/domains/confluence/services/sync-embedding.test.ts
@@ -90,9 +90,13 @@ describe('syncUser auto-embedding', () => {
       // 2. getUserAccessibleSpaces is mocked (returns ['DEV'])
       // 3. last_synced (no previous sync -> full sync)
       .mockResolvedValueOnce({ rows: [{ last_synced: null }] })
-      // 4. detectDeletedPages: existing pages (none → no deletion candidates)
+      // 4. detectDeletedPages: revival cross-check UPDATE (none revived)
       .mockResolvedValueOnce({ rows: [] })
-      // 5. update space sync timestamp
+      // 5. detectDeletedPages: existing pages (none → no deletion candidates)
+      .mockResolvedValueOnce({ rows: [] })
+      // 6. purgeDeletedPages: candidate SELECT (none expired)
+      .mockResolvedValueOnce({ rows: [] })
+      // 7. update space sync timestamp
       .mockResolvedValueOnce({ rows: [] });
 
     mocks.getAllPagesInSpace.mockResolvedValueOnce([]);
@@ -263,11 +267,13 @@ describe('syncPage attachment cache invalidation', () => {
     }
 
     mocks.query
-      // 6. detectDeletedPages: existing page ids (none → no deletion candidates)
+      // 6. detectDeletedPages: revival cross-check UPDATE (none revived)
       .mockResolvedValueOnce({ rows: [] })
-      // 7. purgeDeletedPages: DELETE old soft-deleted (none)
-      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
-      // 8. update space last_synced
+      // 7. detectDeletedPages: existing page ids (none → no deletion candidates)
+      .mockResolvedValueOnce({ rows: [] })
+      // 8. purgeDeletedPages: candidate SELECT (none expired)
+      .mockResolvedValueOnce({ rows: [] })
+      // 9. update space last_synced
       .mockResolvedValueOnce({ rows: [] });
 
     mocks.getAllPagesInSpace.mockResolvedValueOnce([mockPage]);
@@ -349,12 +355,17 @@ describe('incremental sync with missing attachments', () => {
       rows: opts.cachedPages ?? [],
     });
 
-    // detectDeletedPages now runs on incremental syncs too (#706): existing
-    // page ids in the space (none → no deletion candidates).
+    // detectDeletedPages now runs on incremental syncs too (#706):
+    // revival cross-check UPDATE (none revived), then existing page ids in
+    // the space (none → no deletion candidates).
+    mocks.query.mockResolvedValueOnce({ rows: [] });
     mocks.query.mockResolvedValueOnce({ rows: [] });
     mocks.getAllPageIds.mockResolvedValueOnce(
       new Set((opts.modifiedPages ?? []).map((p) => p.id)),
     );
+
+    // purgeDeletedPages: candidate SELECT (none expired)
+    mocks.query.mockResolvedValueOnce({ rows: [] });
 
     // update space last_synced
     mocks.query.mockResolvedValueOnce({ rows: [] });
@@ -427,9 +438,13 @@ describe('incremental sync with missing attachments', () => {
       // 2. getUserAccessibleSpaces is mocked (returns ['DEV'])
       // 3. spaces.last_synced -> null -> full sync
       .mockResolvedValueOnce({ rows: [{ last_synced: null }] })
-      // 4. detectDeletedPages: existing page ids (none → no deletion candidates)
+      // 4. detectDeletedPages: revival cross-check UPDATE (none revived)
       .mockResolvedValueOnce({ rows: [] })
-      // 5. update space last_synced
+      // 5. detectDeletedPages: existing page ids (none → no deletion candidates)
+      .mockResolvedValueOnce({ rows: [] })
+      // 6. purgeDeletedPages: candidate SELECT (none expired)
+      .mockResolvedValueOnce({ rows: [] })
+      // 7. update space last_synced
       .mockResolvedValueOnce({ rows: [] });
 
     mocks.getAllPagesInSpace.mockResolvedValueOnce([]);

--- a/backend/src/domains/confluence/services/sync-service-delete-reconcile.integration.test.ts
+++ b/backend/src/domains/confluence/services/sync-service-delete-reconcile.integration.test.ts
@@ -33,18 +33,23 @@ const dbAvailable = await isDbAvailable();
 /**
  * Minimal ConfluenceClient stub for the reconciler. `getAllPageIds` returns the
  * authoritative live set for the space; `getPage` resolves for ids the caller
- * configures as "still present" and rejects with a 404 ConfluenceError for ids
- * configured as "gone". Any id not in either set rejects with the supplied error
- * (used to exercise the "inconclusive — do not delete" branch with a 403/5xx).
+ * configures as "still present" (200 `status: 'current'`), resolves with
+ * `status: 'trashed'` for ids configured as trashed (#766 — DC's DELETE trashes
+ * rather than purges, and some DC versions still serve trashed content on a
+ * direct GET), and rejects with a 404 ConfluenceError for ids configured as
+ * "gone". Any id not in those sets rejects with the supplied error (used to
+ * exercise the "inconclusive — do not delete" branch with a 403/5xx).
  */
 function makeClient(opts: {
   liveIds: string[];
   presentForGetPage?: string[];
+  trashedForGetPage?: string[];
   goneForGetPage?: string[];
   getPageError?: (id: string) => Error;
   failListing?: boolean;
 }) {
   const present = new Set(opts.presentForGetPage ?? []);
+  const trashed = new Set(opts.trashedForGetPage ?? []);
   const gone = new Set(opts.goneForGetPage ?? []);
   const getPageCalls: string[] = [];
   return {
@@ -56,10 +61,11 @@ function makeClient(opts: {
     async getPage(id: string): Promise<unknown> {
       getPageCalls.push(id);
       if (gone.has(id)) throw new ConfluenceError('Resource not found', 404);
-      if (present.has(id)) return { id };
+      if (trashed.has(id)) return { id, status: 'trashed' };
+      if (present.has(id)) return { id, status: 'current' };
       if (opts.getPageError) throw opts.getPageError(id);
       // Default: treat as present so an unconfigured id is never deleted.
-      return { id };
+      return { id, status: 'current' };
     },
   };
 }
@@ -113,6 +119,28 @@ describe.skipIf(!dbAvailable)('sync-service deletion reconciliation (#706)', () 
     expect(counts.pagesDeleted).toBe(1);
     // The reconciler only confirms candidates absent from the live set.
     expect(client.getPageCalls).toEqual(['gone-1']);
+  });
+
+  it('soft-deletes a page Confluence reports as trashed (200, not 404) — #766', async () => {
+    // Confluence DC's DELETE on a current page moves it to the space trash; on
+    // some DC versions a direct GET then answers 200 {status:'trashed'} rather
+    // than 404. The reconciler must treat that as deleted, otherwise pages
+    // removed via Compendiq's own Delete button are never converged.
+    await insertPage('keep-2', 'DEV');
+    await insertPage('trashed-1', 'DEV');
+
+    const client = makeClient({
+      liveIds: ['keep-2'], // trashed content is absent from the live listing
+      trashedForGetPage: ['trashed-1'], // direct GET answers 200 {status:'trashed'}
+    });
+    const counts = { pagesCreated: 0, pagesUpdated: 0, pagesDeleted: 0 };
+
+    await detectDeletedPages(client as never, 'DEV', counts);
+
+    expect(await getDeletedAt('trashed-1')).not.toBeNull();
+    expect(await getDeletedAt('keep-2')).toBeNull();
+    expect(counts.pagesDeleted).toBe(1);
+    expect(client.getPageCalls).toEqual(['trashed-1']);
   });
 
   it('does NOT delete a page absent from this view but still present remotely (shared-space safety)', async () => {

--- a/backend/src/domains/confluence/services/sync-service-delete-reconcile.integration.test.ts
+++ b/backend/src/domains/confluence/services/sync-service-delete-reconcile.integration.test.ts
@@ -1,5 +1,10 @@
 /**
- * Integration tests for deletion reconciliation (#706).
+ * Integration tests for deletion reconciliation (#706) and its #766 follow-ups:
+ * the revival cross-check (a page live upstream again — e.g. restored from the
+ * Confluence trash — gets its local soft-delete cleared, guarded by a grace
+ * window so an in-flight delete-route intent is never resurrected) and the
+ * purge upstream gone-confirmation (purge is irreversible, so candidates are
+ * re-confirmed 404/trashed before the local hard-delete).
  *
  * `detectDeletedPages` soft-deletes local rows for pages that were removed in
  * Confluence. These tests exercise the real PostgreSQL `pages` table via
@@ -24,7 +29,7 @@ import { query } from '../../../core/db/postgres.js';
 import { ConfluenceError } from './confluence-client.js';
 
 const { __internal } = await import('./sync-service.js');
-const { detectDeletedPages } = __internal;
+const { detectDeletedPages, purgeDeletedPages } = __internal;
 
 const dbAvailable = await isDbAvailable();
 
@@ -87,6 +92,19 @@ async function getDeletedAt(confluenceId: string): Promise<Date | null> {
     [confluenceId],
   );
   return res.rows[0]?.deleted_at ?? null;
+}
+
+/** Backdate a row's soft-delete by `seconds` (0 = soft-deleted right now). */
+async function softDelete(confluenceId: string, seconds = 0): Promise<void> {
+  await query(
+    'UPDATE pages SET deleted_at = NOW() - make_interval(secs => $2) WHERE confluence_id = $1',
+    [confluenceId, seconds],
+  );
+}
+
+async function rowExists(confluenceId: string): Promise<boolean> {
+  const res = await query('SELECT 1 FROM pages WHERE confluence_id = $1', [confluenceId]);
+  return (res.rowCount ?? 0) > 0;
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -260,5 +278,163 @@ describe.skipIf(!dbAvailable)('sync-service deletion reconciliation (#706)', () 
 
     expect(client.getPageCalls).toHaveLength(200);
     expect(counts.pagesDeleted).toBe(200);
+  });
+
+  // ── revival cross-check (#766 review) ────────────────────────────────────
+
+  it('revives a soft-deleted page that is live in Confluence again (trash restore)', async () => {
+    // A trash-restore creates no new version, so the incremental upsert never
+    // re-upserts the page — the cross-check against the live listing is the only
+    // path that converges it. The row was soft-deleted in an earlier cycle, so
+    // `deleted_at` is comfortably older than the revival grace window.
+    await insertPage('restored-1', 'DEV');
+    await softDelete('restored-1', 60 * 60); // soft-deleted an hour ago
+
+    const client = makeClient({ liveIds: ['restored-1'] });
+    const counts = { pagesCreated: 0, pagesUpdated: 0, pagesDeleted: 0 };
+
+    await detectDeletedPages(client as never, 'DEV', counts);
+
+    expect(await getDeletedAt('restored-1')).toBeNull();
+    // A revived page is in the live listing, so it is never a deletion candidate.
+    expect(client.getPageCalls).toEqual([]);
+    expect(counts.pagesDeleted).toBe(0);
+  });
+
+  it('does NOT revive a row soft-deleted within the grace window (in-flight delete intent)', async () => {
+    // Interleaving guard: the delete routes record their delete INTENT as a
+    // soft-delete BEFORE calling Confluence — until that upstream DELETE lands,
+    // the page is still in the live listing. A reconciliation running in that
+    // window must NOT resurrect the row mid-delete; the grace window (deleted_at
+    // must be older than REVIVAL_GRACE_SECONDS) keeps the intent untouched.
+    await insertPage('mid-delete', 'DEV');
+    await softDelete('mid-delete', 0); // intent recorded "just now" by a delete route
+
+    const client = makeClient({ liveIds: ['mid-delete'] }); // upstream delete not landed yet
+    const counts = { pagesCreated: 0, pagesUpdated: 0, pagesDeleted: 0 };
+
+    await detectDeletedPages(client as never, 'DEV', counts);
+
+    // Still hidden: the in-flight delete proceeds undisturbed.
+    expect(await getDeletedAt('mid-delete')).not.toBeNull();
+    expect(client.getPageCalls).toEqual([]);
+    expect(counts.pagesDeleted).toBe(0);
+  });
+
+  it('does not revive soft-deleted rows absent from the live listing (still deleted)', async () => {
+    await insertPage('still-gone', 'DEV');
+    await softDelete('still-gone', 60 * 60);
+
+    const client = makeClient({ liveIds: [] });
+    const counts = { pagesCreated: 0, pagesUpdated: 0, pagesDeleted: 0 };
+
+    await detectDeletedPages(client as never, 'DEV', counts);
+
+    expect(await getDeletedAt('still-gone')).not.toBeNull();
+    expect(client.getPageCalls).toEqual([]);
+  });
+
+  it('revival is space-scoped: a live id in another space does not revive rows elsewhere', async () => {
+    await insertPage('other-space', 'OTHER');
+    await softDelete('other-space', 60 * 60);
+
+    const client = makeClient({ liveIds: ['other-space'] });
+    const counts = { pagesCreated: 0, pagesUpdated: 0, pagesDeleted: 0 };
+
+    await detectDeletedPages(client as never, 'DEV', counts);
+
+    expect(await getDeletedAt('other-space')).not.toBeNull();
+  });
+});
+
+// ── purge upstream confirmation (#766 review) ───────────────────────────────
+
+describe.skipIf(!dbAvailable)('purgeDeletedPages upstream gone-confirmation (#766 review)', () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+  beforeEach(async () => {
+    await truncateAllTables();
+  });
+
+  const THIRTY_ONE_DAYS = 31 * 24 * 60 * 60;
+
+  it('purges a 30-day-old soft-deleted row once upstream confirms gone (404)', async () => {
+    await insertPage('purge-404', 'DEV');
+    await softDelete('purge-404', THIRTY_ONE_DAYS);
+
+    const client = makeClient({ liveIds: [], goneForGetPage: ['purge-404'] });
+    await purgeDeletedPages(client as never, 'DEV');
+
+    expect(await rowExists('purge-404')).toBe(false);
+    expect(client.getPageCalls).toEqual(['purge-404']);
+  });
+
+  it('purges when upstream still serves the page as trashed (200 trashed)', async () => {
+    await insertPage('purge-trashed', 'DEV');
+    await softDelete('purge-trashed', THIRTY_ONE_DAYS);
+
+    const client = makeClient({ liveIds: [], trashedForGetPage: ['purge-trashed'] });
+    await purgeDeletedPages(client as never, 'DEV');
+
+    expect(await rowExists('purge-trashed')).toBe(false);
+  });
+
+  it('does NOT purge a row whose page is current upstream (diverged — left for reconciliation)', async () => {
+    // E.g. restored from the trash but hidden from this principal's listing, so
+    // the revival cross-check never saw it. Purge is irreversible, so a live
+    // upstream answer must veto the local hard-delete.
+    await insertPage('purge-current', 'DEV');
+    await softDelete('purge-current', THIRTY_ONE_DAYS);
+
+    const client = makeClient({ liveIds: [], presentForGetPage: ['purge-current'] });
+    await purgeDeletedPages(client as never, 'DEV');
+
+    expect(await rowExists('purge-current')).toBe(true);
+    expect(await getDeletedAt('purge-current')).not.toBeNull(); // stays soft-deleted
+  });
+
+  it('does NOT purge on an inconclusive confirmation (403/5xx) — deferred to a later cycle', async () => {
+    await insertPage('purge-403', 'DEV');
+    await softDelete('purge-403', THIRTY_ONE_DAYS);
+
+    const client = makeClient({
+      liveIds: [],
+      getPageError: () => new ConfluenceError('Insufficient permissions', 403),
+    });
+    await purgeDeletedPages(client as never, 'DEV');
+
+    expect(await rowExists('purge-403')).toBe(true);
+  });
+
+  it('leaves rows younger than 30 days untouched (no confirmation fetch)', async () => {
+    await insertPage('purge-young', 'DEV');
+    await softDelete('purge-young', 24 * 60 * 60); // 1 day
+
+    const client = makeClient({ liveIds: [], goneForGetPage: ['purge-young'] });
+    await purgeDeletedPages(client as never, 'DEV');
+
+    expect(await rowExists('purge-young')).toBe(true);
+    expect(client.getPageCalls).toEqual([]);
+  });
+
+  it('purges only the confirmed-gone subset of a mixed candidate batch', async () => {
+    await insertPage('mix-gone', 'DEV');
+    await insertPage('mix-live', 'DEV');
+    await softDelete('mix-gone', THIRTY_ONE_DAYS);
+    await softDelete('mix-live', THIRTY_ONE_DAYS);
+
+    const client = makeClient({
+      liveIds: [],
+      goneForGetPage: ['mix-gone'],
+      presentForGetPage: ['mix-live'],
+    });
+    await purgeDeletedPages(client as never, 'DEV');
+
+    expect(await rowExists('mix-gone')).toBe(false);
+    expect(await rowExists('mix-live')).toBe(true);
   });
 });

--- a/backend/src/domains/confluence/services/sync-service.test.ts
+++ b/backend/src/domains/confluence/services/sync-service.test.ts
@@ -522,11 +522,14 @@ describe('sync-service', () => {
   });
 
   describe('purgeDeletedPages', () => {
-    it('runs DELETE for pages with deleted_at older than 30 days', async () => {
+    it('runs DELETE for confirmed-gone pages with deleted_at older than 30 days', async () => {
       // Configure the shared mock client instance for a minimal sync
       mockConfluenceClientInstance.getAllSpaces.mockResolvedValue([{ key: 'TEST', name: 'Test Space', homepage: null }]);
       mockConfluenceClientInstance.getAllPagesInSpace.mockResolvedValue([]);
       mockConfluenceClientInstance.getModifiedPages.mockResolvedValue([]);
+      // Purge re-confirms each candidate is still gone upstream before the
+      // irreversible local delete (#766 review) — answer 404 (genuinely gone).
+      mockConfluenceClientInstance.getPage.mockRejectedValue(new ConfluenceError('Resource not found', 404));
 
       vi.mocked(getUserAccessibleSpaces).mockResolvedValue(['TEST']);
       mockRedisSet.mockResolvedValue('OK');
@@ -549,17 +552,27 @@ describe('sync-service', () => {
         if (sqlStr.includes('COUNT(DISTINCT principal_id)')) {
           return { rows: [{ count: '1' }], rowCount: 1, command: '', oid: 0, fields: [] } as QueryResult;
         }
+        // purgeDeletedPages: candidate SELECT (>30-day soft-deleted rows)
+        if (sqlStr.includes('SELECT id, confluence_id FROM pages') && sqlStr.includes('deleted_at <')) {
+          return {
+            rows: [{ id: 11, confluence_id: 'purged-1' }],
+            rowCount: 1, command: '', oid: 0, fields: [],
+          } as QueryResult;
+        }
         if (sqlStr.includes('SELECT confluence_id FROM pages')) {
           return emptyResult as QueryResult;
         }
         if (sqlStr.includes('DELETE FROM pages') && sqlStr.includes('deleted_at <')) {
-          return { rows: [], rowCount: 0, command: 'DELETE', oid: 0, fields: [] } as QueryResult;
+          return { rows: [{ confluence_id: 'purged-1' }], rowCount: 1, command: 'DELETE', oid: 0, fields: [] } as QueryResult;
         }
         if (sqlStr.includes('UPDATE spaces SET last_synced')) return emptyResult as QueryResult;
         return emptyResult as QueryResult;
       });
 
       await syncUser('user-1');
+
+      // The candidate was re-confirmed gone upstream before the DELETE.
+      expect(mockConfluenceClientInstance.getPage).toHaveBeenCalledWith('purged-1');
 
       const queryCalls = vi.mocked(query).mock.calls;
       const purgeCall = queryCalls.find(
@@ -568,13 +581,15 @@ describe('sync-service', () => {
           && call[0].includes("deleted_at < NOW() - INTERVAL '30 days'"),
       );
       expect(purgeCall).toBeDefined();
-      expect(purgeCall![1]).toEqual(['TEST']);
+      expect(purgeCall![1]).toEqual([[11]]);
     });
 
     it('calls cleanPageAttachments and clearPageFailures for each purged page', async () => {
       mockConfluenceClientInstance.getAllSpaces.mockResolvedValue([{ key: 'TEST', name: 'Test Space', homepage: null }]);
       mockConfluenceClientInstance.getAllPagesInSpace.mockResolvedValue([]);
       mockConfluenceClientInstance.getModifiedPages.mockResolvedValue([]);
+      // Both candidates confirm gone upstream (404) so both are purged.
+      mockConfluenceClientInstance.getPage.mockRejectedValue(new ConfluenceError('Resource not found', 404));
 
       vi.mocked(getUserAccessibleSpaces).mockResolvedValue(['TEST']);
       mockRedisSet.mockResolvedValue('OK');
@@ -596,6 +611,13 @@ describe('sync-service', () => {
         }
         if (sqlStr.includes('COUNT(DISTINCT principal_id)')) {
           return { rows: [{ count: '1' }], rowCount: 1, command: '', oid: 0, fields: [] } as QueryResult;
+        }
+        // purgeDeletedPages: candidate SELECT (>30-day soft-deleted rows)
+        if (sqlStr.includes('SELECT id, confluence_id FROM pages') && sqlStr.includes('deleted_at <')) {
+          return {
+            rows: [{ id: 21, confluence_id: 'purged-1' }, { id: 22, confluence_id: 'purged-2' }],
+            rowCount: 2, command: '', oid: 0, fields: [],
+          } as QueryResult;
         }
         if (sqlStr.includes('SELECT confluence_id FROM pages')) {
           return emptyResult as QueryResult;

--- a/backend/src/domains/confluence/services/sync-service.ts
+++ b/backend/src/domains/confluence/services/sync-service.ts
@@ -60,6 +60,32 @@ const SYNC_STATUS_TTL = 86_400; // 24 h
 const MAX_DELETION_CONFIRMATIONS = 200;
 
 /**
+ * Grace window (seconds) before deletion reconciliation may REVIVE a locally
+ * soft-deleted row whose page is present in the live Confluence listing again
+ * (#766 review).
+ *
+ * Why revival exists: a page restored from the Confluence trash does NOT get a
+ * new version (`lastmodified` is unchanged), so the incremental sync's
+ * `lastmodified >=` CQL window never re-upserts it — without this cross-check
+ * the local row would stay hidden until `purgeDeletedPages` hard-deletes it
+ * (with all local enrichment) at 30 days. The upsert path only revives a row
+ * when the page is modified upstream or a full sync (≥24h-stale `last_synced`)
+ * happens to run.
+ *
+ * Why the grace window exists: the delete routes record their delete INTENT as
+ * a soft-delete BEFORE calling Confluence (#766) — until that upstream DELETE
+ * lands, the page is still in the live listing, so a reconciliation running
+ * concurrently would see "soft-deleted locally but live upstream" and revive a
+ * row that is mid-delete. Reviving only rows whose `deleted_at` is older than
+ * this window keeps the in-flight intent untouched: the route's
+ * Confluence call is bounded by the client's HTTP timeouts (30–120s), far
+ * below this window. A genuine trash-restore is unaffected — its row was
+ * soft-deleted in an earlier reconciliation cycle, so `deleted_at` is already
+ * older than the window by the time an admin restores the page.
+ */
+const REVIVAL_GRACE_SECONDS = 15 * 60;
+
+/**
  * Per-space dedupe window for deletion reconciliation (#706).
  *
  * Reconciliation is invoked once per (user × space) per sync cycle: a space
@@ -365,10 +391,13 @@ async function syncSpace(
   // id list from Confluence (the incremental `pages` list only holds *modified*
   // pages, so it can't be used to infer deletions) and confirms each candidate is
   // genuinely gone before soft-deleting, which makes it safe in shared spaces.
+  // It also revives soft-deleted rows that are live upstream again (e.g. restored
+  // from the Confluence trash — see the revival cross-check, #766 review).
   await detectDeletedPages(client, spaceKey, counts);
 
-  // Purge pages that have been soft-deleted for more than 30 days
-  await purgeDeletedPages(spaceKey);
+  // Purge pages that have been soft-deleted for more than 30 days, re-confirming
+  // each is still gone upstream first (purge is irreversible — #766 review).
+  await purgeDeletedPages(client, spaceKey);
 
   // Update space sync timestamp (shared table)
   await query(
@@ -1277,7 +1306,10 @@ async function syncMissingAttachments(
 
 /**
  * Reconcile pages that were deleted in Confluence by soft-deleting their local
- * rows (#706).
+ * rows (#706), and REVIVE soft-deleted rows whose page is live upstream again
+ * (#766 review — e.g. restored from the Confluence trash; restore creates no
+ * new version, so only this cross-check converges it — the sync upsert revives
+ * a row only when the page is also modified upstream or a full sync runs).
  *
  * Runs on every sync (incremental and full). The authoritative live id set comes
  * from a dedicated lightweight listing (`getAllPageIds`) rather than the modified-
@@ -1324,6 +1356,33 @@ async function detectDeletedPages(
       'Skipping deletion reconciliation: failed to list live Confluence page ids',
     );
     return;
+  }
+
+  // Revival cross-check (#766 review): clear `deleted_at` for soft-deleted rows
+  // whose page is back in the live listing — the page was restored from the
+  // Confluence trash (or the earlier soft-delete was otherwise stale). The
+  // incremental-sync upsert can NOT do this: a trash-restore creates no new
+  // version, so the page never matches the `lastmodified >=` CQL window and is
+  // never re-upserted; without this cross-check the hidden row would sit out
+  // the 30-day clock and be hard-purged with all its local enrichment. The
+  // grace window keeps an in-flight delete-route INTENT (soft-deleted seconds
+  // ago, upstream DELETE not landed yet, page therefore still listed) from
+  // being resurrected mid-delete — see `REVIVAL_GRACE_SECONDS`.
+  const revived = await query<{ confluence_id: string }>(
+    `UPDATE pages
+        SET deleted_at = NULL
+      WHERE space_key = $1
+        AND deleted_at IS NOT NULL
+        AND deleted_at < NOW() - make_interval(secs => $2)
+        AND confluence_id = ANY($3::text[])
+      RETURNING confluence_id`,
+    [spaceKey, REVIVAL_GRACE_SECONDS, [...liveIds]],
+  );
+  if (revived.rows.length > 0) {
+    logger.info(
+      { spaceKey, revived: revived.rows.map((r) => r.confluence_id) },
+      'Revived soft-deleted pages that are live in Confluence again (e.g. restored from trash)',
+    );
   }
 
   // Local non-deleted rows for this space.
@@ -1400,14 +1459,74 @@ async function detectDeletedPages(
 /**
  * Permanently remove pages that were soft-deleted more than 30 days ago.
  * page_embeddings are removed by CASCADE on the pages table FK.
+ *
+ * Purge is the point of no return — it irreversibly destroys the local row and
+ * every piece of local enrichment hanging off it (embeddings, version history
+ * via FK cascade). So before deleting, each candidate is RE-CONFIRMED gone
+ * upstream with a direct `GET /content/{id}` (#766 review):
+ *   - 404 or 200 `status: 'trashed'` → confirmed gone, purge proceeds;
+ *   - 200 `status: 'current'`        → the page exists upstream (e.g. restored
+ *     from the trash but hidden from this principal's listing, so the revival
+ *     cross-check never saw it) — do NOT purge; the row stays soft-deleted for
+ *     reconciliation to sort out;
+ *   - anything else (403/5xx/network) → inconclusive — defer to a later cycle.
+ * Rows without a `confluence_id` have no upstream to consult; for them the
+ * 30-day local-trash window remains the only authority.
+ *
+ * Confirmation fetches are bounded per run: at most `MAX_DELETION_CONFIRMATIONS`
+ * candidates (oldest first) are processed each cycle; a larger backlog converges
+ * over subsequent cycles.
  */
-async function purgeDeletedPages(spaceKey: string): Promise<void> {
-  const result = await query<{ confluence_id: string }>(
-    `DELETE FROM pages WHERE space_key = $1 AND deleted_at < NOW() - INTERVAL '30 days' RETURNING confluence_id`,
-    [spaceKey],
+async function purgeDeletedPages(client: ConfluenceClient, spaceKey: string): Promise<void> {
+  const candidates = await query<{ id: number; confluence_id: string | null }>(
+    `SELECT id, confluence_id FROM pages
+      WHERE space_key = $1 AND deleted_at < NOW() - INTERVAL '30 days'
+      ORDER BY deleted_at
+      LIMIT $2`,
+    [spaceKey, MAX_DELETION_CONFIRMATIONS],
+  );
+  if (candidates.rows.length === 0) return;
+
+  const confirmedIds: number[] = [];
+  for (const row of candidates.rows) {
+    if (row.confluence_id === null) {
+      confirmedIds.push(row.id);
+      continue;
+    }
+    try {
+      const remote = await client.getPage(row.confluence_id);
+      if (remote.status === 'trashed') {
+        confirmedIds.push(row.id);
+      } else {
+        logger.warn(
+          { spaceKey, confluenceId: row.confluence_id },
+          'Purge candidate still exists upstream (200 current) — skipping permanent delete',
+        );
+      }
+    } catch (err) {
+      if (err instanceof ConfluenceError && err.statusCode === 404) {
+        confirmedIds.push(row.id);
+      } else {
+        logger.debug(
+          { spaceKey, confluenceId: row.confluence_id, status: err instanceof ConfluenceError ? err.statusCode : 'unknown' },
+          'Purge candidate not confirmed gone upstream — deferring to a later cycle',
+        );
+      }
+    }
+  }
+  if (confirmedIds.length === 0) return;
+
+  // Re-assert the 30-day precondition inside the DELETE: a row revived between
+  // the SELECT and here has `deleted_at = NULL` and falls out of the predicate.
+  const result = await query<{ confluence_id: string | null }>(
+    `DELETE FROM pages
+      WHERE id = ANY($1::int[]) AND deleted_at < NOW() - INTERVAL '30 days'
+      RETURNING confluence_id`,
+    [confirmedIds],
   );
   if (result.rowCount && result.rowCount > 0) {
     for (const { confluence_id } of result.rows) {
+      if (!confluence_id) continue;
       await cleanPageAttachments('', confluence_id);
       await clearPageFailures(confluence_id);
     }
@@ -1712,13 +1831,14 @@ export const __internal = {
   // snapshot writer just to reach this branch via syncUser.
   applyConflictPolicyForExistingPage,
   // Exposed for the #706 deletion-reconciliation integration tests so the
-  // live-id listing + per-candidate 404 confirmation can be exercised against
-  // a real Postgres (real `pages` rows, real soft-delete + count tracking)
-  // with only the ConfluenceClient stubbed.
+  // live-id listing + per-candidate 404 confirmation + revival cross-check
+  // can be exercised against a real Postgres (real `pages` rows, real
+  // soft-delete + count tracking) with only the ConfluenceClient stubbed.
   detectDeletedPages,
   // Exposed for the #766 delete-atomicity integration tests: after a
   // post-upstream local failure the row is left soft-deleted, and the test
-  // proves the standard sync lifecycle (30-day purge) converges it fully
-  // without driving an entire syncSpace run.
+  // proves the standard sync lifecycle (30-day purge, with its upstream
+  // gone-confirmation) converges it fully without driving an entire
+  // syncSpace run.
   purgeDeletedPages,
 };

--- a/backend/src/domains/confluence/services/sync-service.ts
+++ b/backend/src/domains/confluence/services/sync-service.ts
@@ -1287,10 +1287,13 @@ async function syncMissingAttachments(
  * Shared-space correctness: rather than gating on "exactly one user owns the space"
  * (which meant shared-space deletions were never reconciled), each candidate — a
  * local page missing from this principal's listing — is confirmed genuinely gone via
- * a direct `GET /content/{id}` that returns 404 before we soft-delete it. A page that
- * still exists but is merely hidden from this principal answers 200/403, not 404, so
- * one user's restricted view can no longer nuke pages others can still see. The number
- * of confirmation fetches per run is capped (`MAX_DELETION_CONFIRMATIONS`).
+ * a direct `GET /content/{id}` before we soft-delete it: a 404 **or** a 200 with
+ * `status: 'trashed'` (#766 — Confluence DC's DELETE trashes rather than purges, and
+ * some DC versions still serve trashed content on a direct GET) counts as gone. A page
+ * that still exists but is merely hidden from this principal answers 200 `current`
+ * or 403, so one user's restricted view can no longer nuke pages others can still
+ * see. The number of confirmation fetches per run is capped
+ * (`MAX_DELETION_CONFIRMATIONS`).
  *
  * Per-cycle fan-out: this runs once per (user × space). A shared space would
  * otherwise re-run the listing + confirmation fetches once per user each cycle, so
@@ -1350,12 +1353,28 @@ async function detectDeletedPages(
   }
 
   for (const confluenceId of candidates) {
-    // Confirm the page is genuinely gone (404) before soft-deleting. Any other
-    // outcome means "still there / not visible to me" — leave it untouched.
+    // Confirm the page is genuinely gone before soft-deleting. Two outcomes
+    // count as "gone" (#706, #766):
+    //   - 404: the content no longer exists for this DC (purged, or the DC
+    //     version hides trashed content from a plain GET);
+    //   - 200 with `status: 'trashed'`: Confluence DC's DELETE on a current
+    //     page moves it to the space trash rather than purging it, and some
+    //     DC versions still serve that trashed content on a direct GET. A
+    //     trashed page is already absent from the live listing (only `current`
+    //     content is listed), so a trashed answer here means the page was
+    //     deleted — not restricted from this principal. Without this branch,
+    //     pages deleted via Compendiq's own Delete button (which trashes
+    //     upstream) would never be reconciled (#766).
+    // Any other outcome means "still there / not visible to me" — leave it
+    // untouched. The local soft-delete mirrors the trash's recoverability:
+    // the row survives (hidden) for 30 days before `purgeDeletedPages`.
     try {
-      await client.getPage(confluenceId);
-      // 200: page still exists for this principal — not deleted.
-      continue;
+      const remote = await client.getPage(confluenceId);
+      if (remote.status !== 'trashed') {
+        // 200 current: page still exists for this principal — not deleted.
+        continue;
+      }
+      // 200 trashed: fall through to the soft-delete below.
     } catch (err) {
       if (!(err instanceof ConfluenceError && err.statusCode === 404)) {
         // 403/401/5xx/network: inconclusive — do not delete.
@@ -1697,4 +1716,9 @@ export const __internal = {
   // a real Postgres (real `pages` rows, real soft-delete + count tracking)
   // with only the ConfluenceClient stubbed.
   detectDeletedPages,
+  // Exposed for the #766 delete-atomicity integration tests: after a
+  // post-upstream local failure the row is left soft-deleted, and the test
+  // proves the standard sync lifecycle (30-day purge) converges it fully
+  // without driving an entire syncSpace run.
+  purgeDeletedPages,
 };

--- a/backend/src/routes/knowledge/bulk-pages.test.ts
+++ b/backend/src/routes/knowledge/bulk-pages.test.ts
@@ -88,9 +88,19 @@ vi.mock('../../core/services/rbac-service.js', () => ({
 }));
 
 const mockQueryFn = vi.fn();
+// Transaction client returned by getPool().connect() — since #766 the bulk
+// delete route finishes local cleanup in a BEGIN…COMMIT on a dedicated client.
+const mockTxQueryFn = vi.fn();
+const mockTxRelease = vi.fn();
 vi.mock('../../core/db/postgres.js', () => ({
   query: (...args: unknown[]) => mockQueryFn(...args),
-  getPool: vi.fn().mockReturnValue({}),
+  getPool: vi.fn().mockReturnValue({
+    connect: () =>
+      Promise.resolve({
+        query: (...args: unknown[]) => mockTxQueryFn(...args),
+        release: (...args: unknown[]) => mockTxRelease(...args),
+      }),
+  }),
   runMigrations: vi.fn(),
   closePool: vi.fn(),
 }));
@@ -153,6 +163,7 @@ describe('Bulk Pages Routes (Parallelized)', () => {
       ],
       rowCount: 2,
     });
+    mockTxQueryFn.mockResolvedValue({ rows: [], rowCount: 0 });
   });
 
   describe('POST /api/pages/bulk/delete', () => {
@@ -254,21 +265,23 @@ describe('Bulk Pages Routes (Parallelized)', () => {
 
       expect(response.statusCode).toBe(200);
 
-      // Verify pages DELETE uses ANY($1) (no user_id in shared table)
-      // and pinned_pages DELETE uses ANY($2) (user_id=$1, page_id=ANY($2))
-      const cachedPageDelete = mockQueryFn.mock.calls.find(
+      // Verify both batch DELETEs use ANY(…) and run inside the #766 cleanup
+      // transaction (dedicated client, BEGIN…COMMIT).
+      const cachedPageDelete = mockTxQueryFn.mock.calls.find(
         (call: unknown[]) => typeof call[0] === 'string' &&
           (call[0] as string).includes('DELETE FROM pages'),
       );
       expect(cachedPageDelete).toBeDefined();
-      expect(cachedPageDelete![0]).toContain('ANY($1)');
+      expect(cachedPageDelete![0]).toContain('ANY($1::int[])');
 
-      const pinnedDelete = mockQueryFn.mock.calls.find(
+      const pinnedDelete = mockTxQueryFn.mock.calls.find(
         (call: unknown[]) => typeof call[0] === 'string' &&
           (call[0] as string).includes('DELETE FROM pinned_pages'),
       );
       expect(pinnedDelete).toBeDefined();
-      expect(pinnedDelete![0]).toContain('page_id = ANY($2');
+      expect(pinnedDelete![0]).toContain('page_id = ANY($1::int[])');
+      expect(mockTxQueryFn).toHaveBeenCalledWith('BEGIN');
+      expect(mockTxQueryFn).toHaveBeenCalledWith('COMMIT');
     });
 
     it('should call cleanPageAttachments for each deleted page', async () => {
@@ -315,8 +328,8 @@ describe('Bulk Pages Routes (Parallelized)', () => {
       );
       expect(softDelete).toBeDefined();
 
-      // Confluence page should be hard-deleted
-      const hardDelete = mockQueryFn.mock.calls.find(
+      // Confluence page should be hard-deleted (inside the #766 cleanup transaction)
+      const hardDelete = mockTxQueryFn.mock.calls.find(
         (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('DELETE FROM pages'),
       );
       expect(hardDelete).toBeDefined();
@@ -353,6 +366,14 @@ describe('Bulk Pages Routes (Parallelized)', () => {
       expect(body.failed).toBe(1);
       expect(body.errors).toHaveLength(1);
       expect(body.errors[0]).toContain('Confluence error');
+
+      // #766: the delete intent recorded before the upstream calls is rolled
+      // back for the failed page (id 2) so it stays fully live locally.
+      const intentRestore = mockQueryFn.mock.calls.find(
+        (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('UPDATE pages SET deleted_at = NULL'),
+      );
+      expect(intentRestore).toBeDefined();
+      expect(intentRestore![1]).toEqual([[2]]);
     });
 
     it('treats a 404 Confluence rejection as success and removes the row locally (#706)', async () => {
@@ -390,12 +411,13 @@ describe('Bulk Pages Routes (Parallelized)', () => {
       expect(body.failed).toBe(0);
       expect(body.errors).toHaveLength(0);
 
-      // The already-gone page is included in the batch row removal + attachment cleanup.
-      const pageDelete = mockQueryFn.mock.calls.find(
-        (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('DELETE FROM pages WHERE confluence_id = ANY'),
+      // The already-gone page is included in the batch row removal + attachment
+      // cleanup (the row delete runs inside the #766 cleanup transaction).
+      const pageDelete = mockTxQueryFn.mock.calls.find(
+        (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('DELETE FROM pages WHERE id = ANY'),
       );
       expect(pageDelete).toBeDefined();
-      expect(pageDelete![1]).toEqual([['page-1', 'page-2']]);
+      expect(pageDelete![1]).toEqual([[1, 2]]);
       expect(cleanPageAttachments).toHaveBeenCalledWith('test-user-id', 'page-2');
     });
   });

--- a/backend/src/routes/knowledge/pages-crud-delete-atomicity.integration.test.ts
+++ b/backend/src/routes/knowledge/pages-crud-delete-atomicity.integration.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Integration tests for delete atomicity (#766) — `DELETE /api/pages/:id` and
+ * `POST /api/pages/bulk/delete` against a REAL PostgreSQL.
+ *
+ * #766 production bug: the route called Confluence first and ran several
+ * separate local statements afterwards with no transaction, so any
+ * post-upstream failure stranded a live local row whose Confluence
+ * counterpart was already gone — and nothing ever converged it. The fixed
+ * ordering is:
+ *
+ *   1. record the delete intent locally (soft-delete, single atomic UPDATE);
+ *   2. call Confluence (irreversible);
+ *   3. upstream success/404 → finish hard cleanup in ONE transaction;
+ *   4. upstream failure (non-404) → clear the soft-delete (neither side changed).
+ *
+ * These tests drive the real route against real rows. Only the Confluence
+ * client (external HTTP boundary, via `getClientForUser`) and infrastructure
+ * side-channels (Redis cache, audit log, webhook hook, attachment filesystem)
+ * are stubbed. A post-upstream DB failure is simulated with a real BEFORE
+ * DELETE trigger on `pages` — the database itself rejects the hard delete,
+ * exactly like a mid-flight connection/constraint failure would.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+import { ZodError } from 'zod';
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../test-db-helper.js';
+import { query } from '../../core/db/postgres.js';
+import { ConfluenceError } from '../../domains/confluence/services/confluence-client.js';
+
+// --- Boundary mocks (everything else is real) ---
+
+vi.mock('../../core/services/redis-cache.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../core/services/redis-cache.js')>()),
+  RedisCache: class MockRedisCache {
+    get = vi.fn().mockResolvedValue(null);
+    set = vi.fn().mockResolvedValue(undefined);
+    invalidate = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('../../core/services/audit-service.js', () => ({
+  logAuditEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../core/services/webhook-emit-hook.js', () => ({
+  emitWebhookEvent: vi.fn(),
+}));
+
+// Attachment cleanup touches the filesystem — out of scope here.
+vi.mock('../../domains/confluence/services/attachment-handler.js', () => ({
+  cleanPageAttachments: vi.fn().mockResolvedValue(undefined),
+  syncDrawioAttachments: vi.fn().mockResolvedValue(undefined),
+  syncImageAttachments: vi.fn().mockResolvedValue(undefined),
+  getMissingAttachments: vi.fn().mockResolvedValue([]),
+  writeAttachmentCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../domains/llm/services/embedding-service.js', () => ({
+  processDirtyPages: vi.fn().mockResolvedValue(undefined),
+  isProcessingUser: vi.fn().mockReturnValue(false),
+  computePageRelationships: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('../../domains/knowledge/services/quality-worker.js', () => ({
+  triggerQualityBatch: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetUserAccessibleSpaces = vi.fn();
+vi.mock('../../core/services/rbac-service.js', () => ({
+  getUserAccessibleSpaces: (...args: unknown[]) => mockGetUserAccessibleSpaces(...args),
+  invalidateRbacCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Stub ONLY the Confluence client factory; keep the rest of sync-service real
+// so `__internal.purgeDeletedPages` exercises the genuine convergence path.
+const mockGetClientForUser = vi.fn();
+vi.mock('../../domains/confluence/services/sync-service.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../domains/confluence/services/sync-service.js')>();
+  return {
+    ...actual,
+    getClientForUser: (...args: unknown[]) => mockGetClientForUser(...args),
+  };
+});
+
+const { __internal } = await import('../../domains/confluence/services/sync-service.js');
+const { purgeDeletedPages } = __internal;
+
+const dbAvailable = await isDbAvailable();
+
+// --- Fixtures ---
+
+let userId: string;
+
+async function insertPage(confluenceId: string, spaceKey = 'DEV'): Promise<number> {
+  const res = await query<{ id: number }>(
+    `INSERT INTO pages (confluence_id, source, space_key, title, body_text,
+                         body_storage, body_html, inherit_perms)
+     VALUES ($1, 'confluence', $2, $3, 'text', '', '', TRUE)
+     RETURNING id`,
+    [confluenceId, spaceKey, `Page ${confluenceId}`],
+  );
+  return res.rows[0]!.id;
+}
+
+async function insertPin(pageId: number): Promise<void> {
+  await query('INSERT INTO pinned_pages (user_id, page_id) VALUES ($1, $2)', [userId, pageId]);
+}
+
+async function getRow(confluenceId: string): Promise<{ id: number; deleted_at: Date | null } | null> {
+  const res = await query<{ id: number; deleted_at: Date | null }>(
+    'SELECT id, deleted_at FROM pages WHERE confluence_id = $1',
+    [confluenceId],
+  );
+  return res.rows[0] ?? null;
+}
+
+/** Count of rows a user-facing query would still surface (all list/tree/search
+ *  queries filter `deleted_at IS NULL`). */
+async function liveCount(confluenceId: string): Promise<number> {
+  const res = await query<{ n: string }>(
+    'SELECT COUNT(*) AS n FROM pages WHERE confluence_id = $1 AND deleted_at IS NULL',
+    [confluenceId],
+  );
+  return parseInt(res.rows[0]!.n, 10);
+}
+
+/** Simulate a DB-side failure of the hard delete with a real trigger. */
+async function blockPageDeletes(): Promise<void> {
+  await query(`
+    CREATE OR REPLACE FUNCTION test_block_page_delete() RETURNS trigger AS $$
+    BEGIN RAISE EXCEPTION 'simulated post-upstream DB failure'; END
+    $$ LANGUAGE plpgsql;
+  `);
+  await query(`
+    CREATE TRIGGER test_block_page_delete
+    BEFORE DELETE ON pages FOR EACH ROW
+    EXECUTE FUNCTION test_block_page_delete();
+  `);
+}
+
+async function unblockPageDeletes(): Promise<void> {
+  await query('DROP TRIGGER IF EXISTS test_block_page_delete ON pages');
+  await query('DROP FUNCTION IF EXISTS test_block_page_delete()');
+}
+
+// --- Tests ---
+
+describe.skipIf(!dbAvailable)('delete atomicity — no local/Confluence divergence (#766)', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    await setupTestDb();
+
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+    app.setErrorHandler((error: Error & { statusCode?: number }, _request, reply) => {
+      if (error instanceof ZodError) {
+        return reply.status(400).send({ error: 'Validation failed' });
+      }
+      return reply.status(error.statusCode ?? 500).send({ error: error.message });
+    });
+    app.decorate('authenticate', async (request: { userId: string }) => {
+      request.userId = userId;
+    });
+    app.decorate('requireAdmin', async (request: { userId: string }) => {
+      request.userId = userId;
+    });
+    app.decorate('redis', {});
+    const { pagesCrudRoutes } = await import('./pages-crud.js');
+    await app.register(pagesCrudRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await unblockPageDeletes(); // safety: never leak the trigger across tests
+    await truncateAllTables();
+    const res = await query<{ id: string }>(
+      "INSERT INTO users (username, email, password_hash, role) VALUES ('del_user', 'del@test', 'x', 'user') RETURNING id",
+    );
+    userId = res.rows[0]!.id;
+    mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
+  });
+
+  // ── single delete ─────────────────────────────────────────────────────────
+
+  it('hard-deletes the row and pins when the Confluence delete succeeds', async () => {
+    const pageId = await insertPage('conf-ok');
+    await insertPin(pageId);
+    mockGetClientForUser.mockResolvedValue({ deletePage: vi.fn().mockResolvedValue(undefined) });
+
+    const response = await app.inject({ method: 'DELETE', url: '/api/pages/conf-ok' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().message).toBe('Page deleted');
+    expect(await getRow('conf-ok')).toBeNull();
+    const pins = await query('SELECT 1 FROM pinned_pages WHERE page_id = $1', [pageId]);
+    expect(pins.rowCount).toBe(0);
+  });
+
+  it('(b) leaves the article fully intact when the Confluence delete fails — intent rolled back, neither side changed', async () => {
+    await insertPage('conf-5xx');
+    const deletePage = vi.fn().mockRejectedValue(new ConfluenceError('Confluence API error: HTTP 503', 503));
+    mockGetClientForUser.mockResolvedValue({ deletePage });
+
+    const response = await app.inject({ method: 'DELETE', url: '/api/pages/conf-5xx' });
+
+    expect(response.statusCode).toBeGreaterThanOrEqual(400);
+    expect(deletePage).toHaveBeenCalledWith('conf-5xx');
+    // The row survives AND is still live (the #766 delete intent was cleared).
+    const row = await getRow('conf-5xx');
+    expect(row).not.toBeNull();
+    expect(row!.deleted_at).toBeNull();
+    expect(await liveCount('conf-5xx')).toBe(1);
+  });
+
+  it('(d) #719 regression: a 404 from Confluence still completes the local removal', async () => {
+    const pageId = await insertPage('conf-404');
+    await insertPin(pageId);
+    mockGetClientForUser.mockResolvedValue({
+      deletePage: vi.fn().mockRejectedValue(new ConfluenceError('Resource not found', 404)),
+    });
+
+    const response = await app.inject({ method: 'DELETE', url: '/api/pages/conf-404' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().message).toBe('Page was already removed in Confluence — removed locally');
+    expect(await getRow('conf-404')).toBeNull();
+  });
+
+  it('(a) upstream delete succeeds but the local hard-delete fails → article is hidden (soft-deleted), never a live orphan; sync purge converges it', async () => {
+    await insertPage('conf-strand');
+    mockGetClientForUser.mockResolvedValue({ deletePage: vi.fn().mockResolvedValue(undefined) });
+
+    await blockPageDeletes();
+    try {
+      const response = await app.inject({ method: 'DELETE', url: '/api/pages/conf-strand' });
+
+      // The user-visible outcome (gone on both sides) is achieved — no error.
+      expect(response.statusCode).toBe(200);
+
+      // Pre-#766 behaviour left this row LIVE (deleted_at NULL) forever. Now it
+      // must be soft-deleted: invisible to every user-facing query.
+      const row = await getRow('conf-strand');
+      expect(row).not.toBeNull();
+      expect(row!.deleted_at).not.toBeNull();
+      expect(await liveCount('conf-strand')).toBe(0);
+    } finally {
+      await unblockPageDeletes();
+    }
+
+    // Convergence: the standard sync lifecycle purges soft-deleted rows after
+    // 30 days — prove the leftover row is fully removed by the real purge path.
+    await query("UPDATE pages SET deleted_at = NOW() - INTERVAL '31 days' WHERE confluence_id = 'conf-strand'");
+    await purgeDeletedPages('DEV');
+    expect(await getRow('conf-strand')).toBeNull();
+  });
+
+  // ── bulk delete ───────────────────────────────────────────────────────────
+
+  it('bulk: success + 404 are removed, a 5xx page stays fully live (intent rolled back per page)', async () => {
+    await insertPage('bulk-ok');
+    await insertPage('bulk-5xx');
+    await insertPage('bulk-404');
+    const deletePage = vi.fn().mockImplementation((id: string) => {
+      if (id === 'bulk-5xx') return Promise.reject(new ConfluenceError('Confluence API error: HTTP 503', 503));
+      if (id === 'bulk-404') return Promise.reject(new ConfluenceError('Resource not found', 404));
+      return Promise.resolve(undefined);
+    });
+    mockGetClientForUser.mockResolvedValue({ deletePage });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/bulk/delete',
+      payload: { ids: ['bulk-ok', 'bulk-5xx', 'bulk-404'] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.succeeded).toBe(2);
+    expect(body.failed).toBe(1);
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0]).toContain('bulk-5xx');
+
+    // Upstream-deleted pages are hard-removed locally (one transaction).
+    expect(await getRow('bulk-ok')).toBeNull();
+    expect(await getRow('bulk-404')).toBeNull();
+    // The upstream-failed page is fully live — soft-delete intent rolled back.
+    const survivor = await getRow('bulk-5xx');
+    expect(survivor).not.toBeNull();
+    expect(survivor!.deleted_at).toBeNull();
+    expect(await liveCount('bulk-5xx')).toBe(1);
+  });
+
+  it('bulk (a): upstream deletes succeed but local cleanup fails → rows hidden (soft-deleted), never live orphans', async () => {
+    await insertPage('bulk-strand-1');
+    await insertPage('bulk-strand-2');
+    mockGetClientForUser.mockResolvedValue({ deletePage: vi.fn().mockResolvedValue(undefined) });
+
+    await blockPageDeletes();
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/bulk/delete',
+        payload: { ids: ['bulk-strand-1', 'bulk-strand-2'] },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.succeeded).toBe(2);
+      expect(body.failed).toBe(0);
+
+      for (const cid of ['bulk-strand-1', 'bulk-strand-2']) {
+        const row = await getRow(cid);
+        expect(row).not.toBeNull();
+        expect(row!.deleted_at).not.toBeNull();
+        expect(await liveCount(cid)).toBe(0);
+      }
+    } finally {
+      await unblockPageDeletes();
+    }
+  });
+});

--- a/backend/src/routes/knowledge/pages-crud-delete-atomicity.integration.test.ts
+++ b/backend/src/routes/knowledge/pages-crud-delete-atomicity.integration.test.ts
@@ -262,8 +262,15 @@ describe.skipIf(!dbAvailable)('delete atomicity — no local/Confluence divergen
 
     // Convergence: the standard sync lifecycle purges soft-deleted rows after
     // 30 days — prove the leftover row is fully removed by the real purge path.
+    // Purge re-confirms the page is gone upstream before the irreversible local
+    // delete (#766 review); here the upstream GET answers 404 (page trashed and
+    // hidden / purged), so the purge proceeds.
     await query("UPDATE pages SET deleted_at = NOW() - INTERVAL '31 days' WHERE confluence_id = 'conf-strand'");
-    await purgeDeletedPages('DEV');
+    const purgeClient = {
+      getPage: vi.fn().mockRejectedValue(new ConfluenceError('Resource not found', 404)),
+    };
+    await purgeDeletedPages(purgeClient as never, 'DEV');
+    expect(purgeClient.getPage).toHaveBeenCalledWith('conf-strand');
     expect(await getRow('conf-strand')).toBeNull();
   });
 

--- a/backend/src/routes/knowledge/pages-crud-delete-rbac.test.ts
+++ b/backend/src/routes/knowledge/pages-crud-delete-rbac.test.ts
@@ -50,9 +50,19 @@ vi.mock('../../core/services/rbac-service.js', () => ({
 }));
 
 const mockQueryFn = vi.fn();
+// Transaction client returned by getPool().connect() — since #766 the delete
+// route finishes local cleanup in a BEGIN…COMMIT on a dedicated client.
+const mockTxQueryFn = vi.fn();
+const mockTxRelease = vi.fn();
 vi.mock('../../core/db/postgres.js', () => ({
   query: (...args: unknown[]) => mockQueryFn(...args),
-  getPool: vi.fn().mockReturnValue({}),
+  getPool: vi.fn().mockReturnValue({
+    connect: () =>
+      Promise.resolve({
+        query: (...args: unknown[]) => mockTxQueryFn(...args),
+        release: (...args: unknown[]) => mockTxRelease(...args),
+      }),
+  }),
   runMigrations: vi.fn(),
   closePool: vi.fn(),
 }));
@@ -97,6 +107,7 @@ describe('DELETE /api/pages/:id RBAC space access checks', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+    mockTxQueryFn.mockResolvedValue({ rows: [], rowCount: 0 });
   });
 
   it('returns 403 when Confluence page is in a space the user cannot access, and deletePage is not called', async () => {
@@ -275,14 +286,17 @@ describe('DELETE /api/pages/:id RBAC space access checks', () => {
     expect(mockDeletePage).toHaveBeenCalledWith('page-100');
 
     // Local cleanup must still run: the page row, pins and attachments are removed.
-    const pageDelete = mockQueryFn.mock.calls.find(
+    // Since #766 the hard cleanup runs inside one transaction on a dedicated client.
+    const pageDelete = mockTxQueryFn.mock.calls.find(
       (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('DELETE FROM pages WHERE id = $1'),
     );
     expect(pageDelete).toBeDefined();
-    const pinDelete = mockQueryFn.mock.calls.find(
+    const pinDelete = mockTxQueryFn.mock.calls.find(
       (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('DELETE FROM pinned_pages'),
     );
     expect(pinDelete).toBeDefined();
+    expect(mockTxQueryFn).toHaveBeenCalledWith('BEGIN');
+    expect(mockTxQueryFn).toHaveBeenCalledWith('COMMIT');
     expect(cleanPageAttachments).toHaveBeenCalledWith(TEST_USER, 'page-100');
   });
 
@@ -305,6 +319,10 @@ describe('DELETE /api/pages/:id RBAC space access checks', () => {
           }],
         });
       }
+      // The #766 delete-intent soft-delete reports it updated the row.
+      if (typeof sql === 'string' && sql.includes('UPDATE pages SET deleted_at = NOW()')) {
+        return Promise.resolve({ rows: [{ id: 10 }], rowCount: 1 });
+      }
       return Promise.resolve({ rows: [], rowCount: 0 });
     });
 
@@ -319,10 +337,87 @@ describe('DELETE /api/pages/:id RBAC space access checks', () => {
 
     // Critical: the local row must NOT be deleted when the remote delete failed
     // for any reason other than 404 — otherwise we silently lose the page.
-    const pageDelete = mockQueryFn.mock.calls.find(
+    const pageDelete = mockTxQueryFn.mock.calls.find(
       (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('DELETE FROM pages WHERE id = $1'),
     );
     expect(pageDelete).toBeUndefined();
     expect(cleanPageAttachments).not.toHaveBeenCalled();
+
+    // #766: the delete intent recorded before the upstream call is rolled back,
+    // so the article stays fully live — neither side changed.
+    const intentRestore = mockQueryFn.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('UPDATE pages SET deleted_at = NULL'),
+    );
+    expect(intentRestore).toBeDefined();
+    expect(intentRestore![1]).toEqual([10]);
+  });
+
+  // ── #766: delete intent ordering + post-upstream failure containment ───────
+
+  it('records the local delete intent (soft-delete) BEFORE calling Confluence', async () => {
+    const mockDeletePage = vi.fn().mockResolvedValue(undefined);
+    mockGetClientForUser.mockResolvedValue({ deletePage: mockDeletePage });
+
+    let intentOrder = -1;
+    let callIndex = 0;
+    mockQueryFn.mockImplementation((sql: string) => {
+      callIndex++;
+      if (typeof sql === 'string' && sql.includes('id, source, created_by_user_id')) {
+        return Promise.resolve({
+          rows: [{ id: 10, source: 'confluence', created_by_user_id: null, confluence_id: 'page-100', space_key: 'DEV' }],
+        });
+      }
+      if (typeof sql === 'string' && sql.includes('UPDATE pages SET deleted_at = NOW()')) {
+        intentOrder = callIndex;
+        // The upstream call must not have happened yet at this point.
+        expect(mockDeletePage).not.toHaveBeenCalled();
+        return Promise.resolve({ rows: [{ id: 10 }], rowCount: 1 });
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+
+    const response = await app.inject({ method: 'DELETE', url: '/api/pages/page-100' });
+
+    expect(response.statusCode).toBe(200);
+    expect(intentOrder).toBeGreaterThan(0); // the intent soft-delete actually ran
+    expect(mockDeletePage).toHaveBeenCalledWith('page-100');
+  });
+
+  it('leaves the row soft-deleted (hidden, NOT live) when local cleanup fails after a successful upstream delete', async () => {
+    const mockDeletePage = vi.fn().mockResolvedValue(undefined);
+    mockGetClientForUser.mockResolvedValue({ deletePage: mockDeletePage });
+
+    mockQueryFn.mockImplementation((sql: string) => {
+      if (typeof sql === 'string' && sql.includes('id, source, created_by_user_id')) {
+        return Promise.resolve({
+          rows: [{ id: 10, source: 'confluence', created_by_user_id: null, confluence_id: 'page-100', space_key: 'DEV' }],
+        });
+      }
+      if (typeof sql === 'string' && sql.includes('UPDATE pages SET deleted_at = NOW()')) {
+        return Promise.resolve({ rows: [{ id: 10 }], rowCount: 1 });
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+    // The hard-cleanup transaction blows up on the page row delete.
+    mockTxQueryFn.mockImplementation((sql: string) => {
+      if (typeof sql === 'string' && sql.includes('DELETE FROM pages')) {
+        return Promise.reject(new Error('connection terminated'));
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+
+    const response = await app.inject({ method: 'DELETE', url: '/api/pages/page-100' });
+
+    // The user-visible outcome (page gone on both sides) is achieved — the row is
+    // soft-deleted (hidden) and sync purges it later; the request succeeds.
+    expect(response.statusCode).toBe(200);
+    expect(mockTxQueryFn).toHaveBeenCalledWith('ROLLBACK');
+
+    // Crucially the delete intent is NOT rolled back — the row must stay hidden,
+    // never resurface as a live orphan (#766).
+    const intentRestore = mockQueryFn.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('UPDATE pages SET deleted_at = NULL'),
+    );
+    expect(intentRestore).toBeUndefined();
   });
 });

--- a/backend/src/routes/knowledge/pages-crud-webhooks.test.ts
+++ b/backend/src/routes/knowledge/pages-crud-webhooks.test.ts
@@ -61,9 +61,18 @@ vi.mock('../../core/services/webhook-emit-hook.js', () => ({
 }));
 
 const mockQueryFn = vi.fn();
+// Transaction client returned by getPool().connect() — since #766 the delete
+// route finishes local cleanup in a BEGIN…COMMIT on a dedicated client.
+const mockTxQueryFn = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
 vi.mock('../../core/db/postgres.js', () => ({
   query: (...args: unknown[]) => mockQueryFn(...args),
-  getPool: vi.fn().mockReturnValue({}),
+  getPool: vi.fn().mockReturnValue({
+    connect: () =>
+      Promise.resolve({
+        query: (...args: unknown[]) => mockTxQueryFn(...args),
+        release: vi.fn(),
+      }),
+  }),
   runMigrations: vi.fn(),
   closePool: vi.fn(),
 }));

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -1398,9 +1398,13 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     //   4. on upstream failure (non-404), clear the soft-delete so NEITHER side
     //      changed.
     // A crash between 1 and 2 leaves a hidden row for a page that still exists
-    // upstream — the sync upsert (`ON CONFLICT … DO UPDATE … deleted_at = NULL`)
-    // restores it. A failure after 2 leaves at worst a hidden soft-deleted row
-    // that `purgeDeletedPages` converges — never the live orphan from #766.
+    // upstream — deletion reconciliation revives it: the page is still in the
+    // live listing, and once the soft-delete is older than the revival grace
+    // window the cross-check in `detectDeletedPages` clears `deleted_at`. (The
+    // sync upsert also restores it, but only if the page is modified upstream
+    // or a full sync runs — incremental sync never re-upserts an unmodified
+    // page.) A failure after 2 leaves at worst a hidden soft-deleted row that
+    // `purgeDeletedPages` converges — never the live orphan from #766.
     const intent = await query<{ id: number }>(
       'UPDATE pages SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL RETURNING id',
       [existingPage.id],
@@ -1431,11 +1435,13 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
             await query('UPDATE pages SET deleted_at = NULL WHERE id = $1', [existingPage.id]);
           } catch (restoreErr) {
             // Worst case: the page stays hidden although it still exists in
-            // Confluence. The sync upsert clears `deleted_at` for pages that
-            // still exist upstream, so this self-heals on the next sync cycle.
+            // Confluence. Deletion reconciliation revives soft-deleted rows
+            // whose page is still in the live listing (once the soft-delete is
+            // older than the revival grace window), so this self-heals within
+            // a couple of sync cycles.
             logger.error(
               { pageId: existingPage.id, err: restoreErr instanceof Error ? restoreErr.message : String(restoreErr) },
-              'Failed to clear delete intent after Confluence delete failure — sync will restore the page',
+              'Failed to clear delete intent after Confluence delete failure — sync reconciliation will revive the page',
             );
           }
         }
@@ -1827,11 +1833,13 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
             await query('UPDATE pages SET deleted_at = NULL WHERE id = ANY($1::int[])', [restoreIds]);
           } catch (restoreErr) {
             // Worst case: pages stay hidden although they still exist upstream.
-            // The sync upsert clears `deleted_at` for pages that still exist in
-            // Confluence, so this self-heals on the next sync cycle.
+            // Deletion reconciliation revives soft-deleted rows whose pages are
+            // still in the live listing (once the soft-delete is older than the
+            // revival grace window), so this self-heals within a couple of
+            // sync cycles.
             logger.error(
               { pageIds: restoreIds, err: restoreErr instanceof Error ? restoreErr.message : String(restoreErr) },
-              'Failed to clear bulk delete intent after Confluence failures — sync will restore the pages',
+              'Failed to clear bulk delete intent after Confluence failures — sync reconciliation will revive the pages',
             );
           }
         }

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -1388,6 +1388,25 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       throw fastify.httpErrors.badRequest('Confluence not configured');
     }
 
+    // #766: record the delete intent locally FIRST (soft-delete), so a failure at
+    // any later step can never leave a user-visible local article whose Confluence
+    // counterpart is already gone. Ordering:
+    //   1. soft-delete the row (single atomic UPDATE — hides it from every
+    //      list/tree/search query, all of which filter `deleted_at IS NULL`);
+    //   2. propagate the delete to Confluence (irreversible upstream side-effect);
+    //   3. on upstream success/404, finish hard local cleanup in ONE transaction;
+    //   4. on upstream failure (non-404), clear the soft-delete so NEITHER side
+    //      changed.
+    // A crash between 1 and 2 leaves a hidden row for a page that still exists
+    // upstream — the sync upsert (`ON CONFLICT … DO UPDATE … deleted_at = NULL`)
+    // restores it. A failure after 2 leaves at worst a hidden soft-deleted row
+    // that `purgeDeletedPages` converges — never the live orphan from #766.
+    const intent = await query<{ id: number }>(
+      'UPDATE pages SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL RETURNING id',
+      [existingPage.id],
+    );
+    const intentRecordedHere = (intent.rowCount ?? 0) > 0;
+
     // Propagate the delete to Confluence. A 404 means the page is already gone
     // remotely — the desired end state is already true, so we treat it as success
     // and fall through to local cleanup rather than leaving an orphaned, undeletable
@@ -1404,15 +1423,63 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
           'Confluence page already deleted remotely (404) — cleaning up locally',
         );
       } else {
+        // Upstream genuinely failed: roll back the delete intent so neither side
+        // changed. Only clear a soft-delete WE set — a row that was already
+        // soft-deleted (e.g. by sync reconciliation) must stay that way.
+        if (intentRecordedHere) {
+          try {
+            await query('UPDATE pages SET deleted_at = NULL WHERE id = $1', [existingPage.id]);
+          } catch (restoreErr) {
+            // Worst case: the page stays hidden although it still exists in
+            // Confluence. The sync upsert clears `deleted_at` for pages that
+            // still exist upstream, so this self-heals on the next sync cycle.
+            logger.error(
+              { pageId: existingPage.id, err: restoreErr instanceof Error ? restoreErr.message : String(restoreErr) },
+              'Failed to clear delete intent after Confluence delete failure — sync will restore the page',
+            );
+          }
+        }
         throw err;
       }
     }
 
-    // Clean up local data (page_embeddings cascade-deleted via FK)
-    await query('DELETE FROM pinned_pages WHERE user_id = $1 AND page_id = $2', [userId, existingPage.id]);
-    await query('DELETE FROM pages WHERE id = $1', [existingPage.id]);
+    // Upstream is gone (deleted now, or already 404). Finish the local cleanup in
+    // ONE transaction on a dedicated client — pool.query() draws a random
+    // connection per call, so separate statements would not be atomic
+    // (page_embeddings/page_versions cascade-delete via FK; pinned_pages also
+    // cascades, deleted explicitly for clarity).
+    const txClient = await getPool().connect();
+    try {
+      await txClient.query('BEGIN');
+      await txClient.query('DELETE FROM pinned_pages WHERE page_id = $1', [existingPage.id]);
+      await txClient.query('DELETE FROM pages WHERE id = $1', [existingPage.id]);
+      await txClient.query('COMMIT');
+    } catch (cleanupErr) {
+      await txClient.query('ROLLBACK').catch(() => undefined);
+      // The upstream delete already happened and cannot be rolled back. The row
+      // stays soft-deleted (hidden everywhere) and `purgeDeletedPages` removes it
+      // within the standard 30-day window, so the stores never diverge visibly.
+      // The user-visible outcome (page gone on both sides) is achieved — log
+      // loudly instead of failing the request.
+      logger.error(
+        { pageId: existingPage.id, confluenceId: existingPage.confluence_id, err: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr) },
+        'Local cleanup failed after successful Confluence delete — row left soft-deleted for sync to purge',
+      );
+    } finally {
+      txClient.release();
+    }
+
+    // Attachment files live on the filesystem and cannot participate in the DB
+    // transaction — best-effort, never fatal (same pattern as unsyncSpace).
     if (existingPage.confluence_id) {
-      await cleanPageAttachments(userId, existingPage.confluence_id);
+      try {
+        await cleanPageAttachments(userId, existingPage.confluence_id);
+      } catch (attachErr) {
+        logger.warn(
+          { pageId: existingPage.id, confluenceId: existingPage.confluence_id, err: attachErr instanceof Error ? attachErr.message : String(attachErr) },
+          'Attachment cleanup failed after page delete (orphaned files only — DB is consistent)',
+        );
+      }
     }
 
     // Invalidate cache
@@ -1706,12 +1773,24 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
           errors.push(`Page ${p.confluence_id ?? p.id}: Confluence not configured`);
         });
       } else {
+        // #766: record the delete intent locally FIRST (soft-delete) for every
+        // candidate, mirroring the single-delete route: a failure after the
+        // upstream deletes can then never strand a user-visible local article.
+        // Only rows whose soft-delete WE set are restored on upstream failure.
+        const confluenceNumericIds = confluencePages.map((p) => p.id);
+        const intent = await query<{ id: number }>(
+          'UPDATE pages SET deleted_at = NOW() WHERE id = ANY($1::int[]) AND deleted_at IS NULL RETURNING id',
+          [confluenceNumericIds],
+        );
+        const intentRecordedHere = new Set(intent.rows.map((r) => r.id));
+
         const deleteResults = await Promise.allSettled(
           confluencePages.map((p) => bulkLimit(() => client.deletePage(p.confluence_id!))),
         );
 
         const deletedConfluenceIds: string[] = [];
         const deletedConfluenceNumericIds: number[] = [];
+        const failedNumericIds: number[] = [];
         for (let i = 0; i < deleteResults.length; i++) {
           const result = deleteResults[i]!;
           // A 404 rejection means the page is already gone in Confluence — the
@@ -1733,18 +1812,52 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
             confluenceSucceeded++;
           } else {
             failed++;
+            failedNumericIds.push(confluencePages[i]!.id);
             errors.push(
               `Page ${confluencePages[i]!.confluence_id}: ${result.reason instanceof Error ? result.reason.message : 'Unknown error'}`,
             );
           }
         }
 
-        // Batch cleanup: page_embeddings cascade-deleted via FK
+        // Upstream genuinely failed for these (non-404): roll back the delete
+        // intent so neither side changed for them.
+        const restoreIds = failedNumericIds.filter((id) => intentRecordedHere.has(id));
+        if (restoreIds.length > 0) {
+          try {
+            await query('UPDATE pages SET deleted_at = NULL WHERE id = ANY($1::int[])', [restoreIds]);
+          } catch (restoreErr) {
+            // Worst case: pages stay hidden although they still exist upstream.
+            // The sync upsert clears `deleted_at` for pages that still exist in
+            // Confluence, so this self-heals on the next sync cycle.
+            logger.error(
+              { pageIds: restoreIds, err: restoreErr instanceof Error ? restoreErr.message : String(restoreErr) },
+              'Failed to clear bulk delete intent after Confluence failures — sync will restore the pages',
+            );
+          }
+        }
+
+        // Upstream is gone for these. Finish the local cleanup in ONE transaction
+        // (page_embeddings/page_versions cascade-delete via FK; pinned_pages also
+        // cascades, deleted explicitly for clarity).
         if (deletedConfluenceNumericIds.length > 0) {
-          await Promise.all([
-            query('DELETE FROM pinned_pages WHERE user_id = $1 AND page_id = ANY($2::int[])', [userId, deletedConfluenceNumericIds]),
-            query('DELETE FROM pages WHERE confluence_id = ANY($1)', [deletedConfluenceIds]),
-          ]);
+          const txClient = await getPool().connect();
+          try {
+            await txClient.query('BEGIN');
+            await txClient.query('DELETE FROM pinned_pages WHERE page_id = ANY($1::int[])', [deletedConfluenceNumericIds]);
+            await txClient.query('DELETE FROM pages WHERE id = ANY($1::int[])', [deletedConfluenceNumericIds]);
+            await txClient.query('COMMIT');
+          } catch (cleanupErr) {
+            await txClient.query('ROLLBACK').catch(() => undefined);
+            // Upstream deletes already happened — the rows stay soft-deleted
+            // (hidden) and `purgeDeletedPages` converges them; never a live orphan.
+            logger.error(
+              { pageIds: deletedConfluenceNumericIds, err: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr) },
+              'Bulk local cleanup failed after successful Confluence deletes — rows left soft-deleted for sync to purge',
+            );
+          } finally {
+            txClient.release();
+          }
+          // Filesystem attachment cleanup cannot join the DB transaction — best-effort.
           await Promise.allSettled(deletedConfluenceIds.map((id) => bulkLimit(() => cleanPageAttachments(userId, id))));
           // Confluence bulk delete is always a hard delete (Confluence API + local row removal).
           for (const pageId of deletedConfluenceNumericIds) {

--- a/backend/src/routes/knowledge/pinned-pages.test.ts
+++ b/backend/src/routes/knowledge/pinned-pages.test.ts
@@ -79,9 +79,18 @@ vi.mock('../../core/services/rbac-service.js', () => ({
 }));
 
 const mockQueryFn = vi.fn();
+// Transaction client returned by getPool().connect() — since #766 the delete
+// routes finish local cleanup in a BEGIN…COMMIT on a dedicated client.
+const mockTxQueryFn = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
 vi.mock('../../core/db/postgres.js', () => ({
   query: (...args: unknown[]) => mockQueryFn(...args),
-  getPool: vi.fn().mockReturnValue({}),
+  getPool: vi.fn().mockReturnValue({
+    connect: () =>
+      Promise.resolve({
+        query: (...args: unknown[]) => mockTxQueryFn(...args),
+        release: vi.fn(),
+      }),
+  }),
   runMigrations: vi.fn(),
   closePool: vi.fn(),
 }));
@@ -520,10 +529,8 @@ describe('Pinned Pages API', () => {
         rows: [{ id: 42, source: 'confluence', created_by_user_id: null, confluence_id: 'page-1' }],
         rowCount: 1,
       });
-      // pinned_pages delete
-      mockQueryFn.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-      // pages delete (page_embeddings cascade-deleted via FK)
-      mockQueryFn.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+      // #766 delete-intent soft-delete (UPDATE … RETURNING id)
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ id: 42 }], rowCount: 1 });
 
       const response = await app.inject({
         method: 'DELETE',
@@ -531,20 +538,22 @@ describe('Pinned Pages API', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      // Second query (after page lookup) should be pinned_pages cleanup
-      expect(mockQueryFn.mock.calls[1][0]).toContain('DELETE FROM pinned_pages');
-      expect(mockQueryFn.mock.calls[1][1]).toEqual(['test-user-id', 42]);
+      // Since #766 the hard cleanup (pins + page row) runs inside one
+      // transaction on a dedicated pool client.
+      const pinnedDeleteCall = mockTxQueryFn.mock.calls.find(
+        (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('DELETE FROM pinned_pages'),
+      );
+      expect(pinnedDeleteCall).toBeDefined();
+      expect(pinnedDeleteCall![1]).toEqual([42]);
     });
 
     it('should delete pinned_pages row when bulk-deleting pages', async () => {
-      // Bulk delete uses batched queries: ownership check, then parallel cleanup (pinned_pages, pages)
-      // page_embeddings are cascade-deleted via FK on pages
-      // batch ownership check via RBAC space access (route selects id, source, confluence_id, space_key)
+      // Bulk delete: ownership check, #766 delete-intent soft-delete, then the
+      // batched cleanup (pinned_pages, pages) inside one transaction.
+      // page_embeddings are cascade-deleted via FK on pages.
       mockQueryFn.mockResolvedValueOnce({ rows: [{ id: 42, source: 'confluence', confluence_id: 'page-1', space_key: 'DEV' }], rowCount: 1 });
-      // batched pinned_pages delete via ANY($2)
-      mockQueryFn.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-      // batched pages delete via ANY($1)
-      mockQueryFn.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+      // #766 delete-intent soft-delete (UPDATE … RETURNING id)
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ id: 42 }], rowCount: 1 });
 
       const response = await app.inject({
         method: 'POST',
@@ -556,14 +565,13 @@ describe('Pinned Pages API', () => {
       const body = JSON.parse(response.body);
       expect(body.succeeded).toBe(1);
 
-      // After the ownership check (index 0), the Confluence client.deletePage is
-      // called (mocked), then the batch cleanup queries run in parallel.
-      // Find the pinned_pages DELETE among the subsequent queries.
-      const pinnedDeleteCall = mockQueryFn.mock.calls.find(
+      // After the ownership check, the Confluence client.deletePage is called
+      // (mocked), then the batch cleanup runs inside the #766 transaction.
+      const pinnedDeleteCall = mockTxQueryFn.mock.calls.find(
         (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('DELETE FROM pinned_pages'),
       );
       expect(pinnedDeleteCall).toBeDefined();
-      expect(pinnedDeleteCall![1]).toEqual(['test-user-id', [42]]);
+      expect(pinnedDeleteCall![1]).toEqual([[42]]);
     });
   });
 });

--- a/docs/architecture/08-flow-sync.md
+++ b/docs/architecture/08-flow-sync.md
@@ -59,11 +59,11 @@ sequenceDiagram
         loop per candidate (local row absent from liveIds)
             S->>CL: getPage(confluenceId) — confirm gone
             CL->>CF: GET /rest/api/content/{id}
-            alt 404 (genuinely deleted)
-                CF-->>S: 404
+            alt 404 or 200 status:"trashed" (deleted — #766)
+                CF-->>S: 404 / 200 trashed
                 S->>DB: UPDATE pages SET deleted_at = NOW()
-            else 200 / 403 (still there / not visible to this principal)
-                CF-->>S: 200 / 403
+            else 200 current / 403 (still there / not visible to this principal)
+                CF-->>S: 200 current / 403
                 Note over S: leave row in place (shared-space safe)
             end
         end
@@ -123,18 +123,25 @@ surface within a normal sync cycle rather than lingering until a rare full run.
   modified-pages list can't be used for this — it only holds pages that changed.
 - **Shared-space safety.** A page absent from one principal's listing is *not*
   assumed deleted (it may simply be restricted from that user). Each candidate is
-  confirmed gone via a direct `GET /content/{id}` → **404** before its row is
-  soft-deleted; a `200`/`403` leaves the row untouched, so one user's restricted
-  view can no longer nuke pages others can still see. The number of confirmation
-  fetches per run is capped (`MAX_DELETION_CONFIRMATIONS`); a larger candidate set
-  is deferred to a later run (the whole run defers — zero soft-deletes that cycle).
-- **Trash vs. purge.** Confluence DC move-to-trash does **not** make a page 404 —
-  `GET /content/{id}` still returns `200` with `status: "trashed"`. So a page sitting
-  in the Confluence trash is treated as *still present* and is **not** reconciled;
-  reconciliation fires only once the page is hard-purged (then the id is gone from
-  `getAllPageIds` *and* the confirmation fetch returns 404). This is intentional —
-  it mirrors Confluence's own "deleted means purged" semantics and avoids removing a
-  page a Confluence admin could still restore from the trash.
+  confirmed gone via a direct `GET /content/{id}` — a **404** *or* a **200 with
+  `status: "trashed"`** — before its row is soft-deleted; a `200` (`current`) / `403`
+  leaves the row untouched, so one user's restricted view can no longer nuke pages
+  others can still see. The number of confirmation fetches per run is capped
+  (`MAX_DELETION_CONFIRMATIONS`); a larger candidate set is deferred to a later run
+  (the whole run defers — zero soft-deletes that cycle).
+- **Trash counts as deleted (#766).** Confluence DC's `DELETE /rest/api/content/{id}`
+  on a current page moves it to the space **Trash** rather than purging it, and —
+  depending on the DC version — `GET /content/{id}` may still answer `200` with
+  `status: "trashed"` instead of 404. #719 originally treated such a page as *still
+  present*, which meant pages deleted via Compendiq's **own Delete button** (which
+  trashes upstream) were never reconciled if a post-delete local failure left a row
+  behind. Reconciliation now treats `trashed` as gone: trashed content is already
+  absent from the live listing (only `current` content is listed), so a trashed
+  confirmation can only mean "deleted", never "restricted from this principal".
+  Restorability is preserved on the Compendiq side: the local row is *soft*-deleted
+  and survives (hidden) for 30 days before `purgeDeletedPages` — mirroring the
+  Confluence trash's own recoverability — and a page restored from the Confluence
+  trash is revived locally by the sync upsert (`deleted_at = NULL`).
 - **Per-cycle fan-out.** Reconciliation is invoked once per (user × space); a shared
   space would otherwise repeat the listing + confirmation fetches per user each cycle.
   A best-effort Redis `SET NX EX` guard (`sync:reconcile:{spaceKey}`) lets the first
@@ -150,6 +157,34 @@ The same 404-tolerance applies to **user-initiated delete** (`DELETE /api/pages/
 and the bulk path): if Confluence answers 404 the remote page is already gone, so
 local cleanup proceeds and the delete succeeds instead of failing with
 "Resource not found". Any non-404 error still surfaces (no silent data loss).
+
+### User-initiated delete ordering (#766)
+
+The delete routes used to call Confluence first and then run several separate
+local statements with no transaction — any post-upstream failure stranded a
+**live** local row whose Confluence counterpart was already gone, and nothing
+converged it. The routes now order the work so the two stores can never diverge
+visibly:
+
+1. **Record the delete intent locally first** — soft-delete the row
+   (`deleted_at = NOW()`, one atomic UPDATE). Every user-facing query filters
+   `deleted_at IS NULL`, so the article disappears immediately.
+2. **Call Confluence** (`DELETE /rest/api/content/{id}` — irreversible; trashes
+   the page upstream).
+3. **On upstream success or 404** — finish the hard local cleanup
+   (`pinned_pages` + `pages`; embeddings/versions cascade via FK) inside **one**
+   `BEGIN…COMMIT` on a dedicated pool client. Attachment files are cleaned
+   best-effort after commit (filesystem can't join the transaction).
+4. **On upstream failure (non-404)** — clear the soft-delete (only if this
+   request set it) and surface the error: **neither side changed**.
+
+Failure containment: a crash between 1 and 2 leaves a hidden row for a page
+that still exists upstream — the sync upsert (`deleted_at = NULL`) restores it.
+A local failure after a successful upstream delete leaves at worst a hidden
+soft-deleted row that `purgeDeletedPages` removes within the standard 30-day
+window — never a live orphan. The bulk path applies the same shape per batch
+(intent for all candidates up front, per-page restore for upstream failures,
+one cleanup transaction for the upstream-deleted set).
 
 ## Version history backfill (#722/#724)
 

--- a/docs/architecture/08-flow-sync.md
+++ b/docs/architecture/08-flow-sync.md
@@ -55,6 +55,8 @@ sequenceDiagram
         CL->>CF: GET /rest/api/content?spaceKey=… (ids only, no expand)
         CF-->>CL: authoritative live id set
         CL-->>S: liveIds
+        S->>DB: UPDATE pages SET deleted_at = NULL<br/>WHERE deleted_at older than grace window AND id ∈ liveIds
+        Note over S,DB: revival cross-check (#766) — a trash-restored page is live again<br/>but never re-upserted by incremental sync (no new version);<br/>grace window protects in-flight delete intents
         S->>DB: SELECT confluence_id FROM pages WHERE space_key=… AND deleted_at IS NULL
         loop per candidate (local row absent from liveIds)
             S->>CL: getPage(confluenceId) — confirm gone
@@ -141,7 +143,22 @@ surface within a normal sync cycle rather than lingering until a rare full run.
   Restorability is preserved on the Compendiq side: the local row is *soft*-deleted
   and survives (hidden) for 30 days before `purgeDeletedPages` — mirroring the
   Confluence trash's own recoverability — and a page restored from the Confluence
-  trash is revived locally by the sync upsert (`deleted_at = NULL`).
+  trash is revived locally by the reconciliation revival cross-check (below).
+- **Revival cross-check (#766 review).** Restoring a page from the Confluence trash
+  creates **no new version** (`lastmodified` is unchanged), so the incremental
+  sync's `lastmodified >=` CQL window never re-upserts it — the upsert path
+  (`deleted_at = NULL` on `ON CONFLICT … DO UPDATE`) revives a row only when the
+  page is *also modified upstream* or a full sync (≥24h-stale `last_synced`) runs.
+  `detectDeletedPages` therefore cross-checks the already-fetched live id listing
+  against locally soft-deleted rows for the space and clears `deleted_at` for
+  matches, so a trash-restore converges within one reconciliation cycle.
+  **Grace window**: the delete routes record their delete *intent* as a soft-delete
+  *before* calling Confluence — until that upstream DELETE lands, the page is still
+  in the live listing, and a concurrent reconciliation would otherwise resurrect a
+  row that is mid-delete. Only rows whose `deleted_at` is older than
+  `REVIVAL_GRACE_SECONDS` (15 min — far above the Confluence client's 30–120s HTTP
+  timeouts) are revived; a genuine trash-restore is unaffected because its row was
+  soft-deleted in an earlier cycle, so the grace has long elapsed.
 - **Per-cycle fan-out.** Reconciliation is invoked once per (user × space); a shared
   space would otherwise repeat the listing + confirmation fetches per user each cycle.
   A best-effort Redis `SET NX EX` guard (`sync:reconcile:{spaceKey}`) lets the first
@@ -150,8 +167,17 @@ surface within a normal sync cycle rather than lingering until a rare full run.
   every principal, so whoever reaches the space first reconciles it.
 - **Soft delete + purge.** Reconciled rows are soft-deleted (`deleted_at`), then
   hard-purged after 30 days by `purgeDeletedPages`. A subsequent re-appearance in
-  Confluence revives the row: `syncPage`'s upsert `ON CONFLICT … DO UPDATE` (and the
-  version-mismatch update path) both set `deleted_at = NULL`.
+  Confluence revives the row via the reconciliation revival cross-check above;
+  `syncPage`'s upsert `ON CONFLICT … DO UPDATE` (and the version-mismatch update
+  path) also set `deleted_at = NULL`, but only fire when the page is modified
+  upstream or a full sync runs. **Purge re-confirms before the point of no
+  return (#766 review)**: purge irreversibly destroys the row and all local
+  enrichment (embeddings, version history via FK cascade), so each candidate is
+  re-confirmed gone upstream (`GET /content/{id}` → 404 or `status: "trashed"`)
+  first. A `200 current` answer skips the purge (the page exists upstream — left
+  for reconciliation); an inconclusive answer (403/5xx/network) defers to a later
+  cycle. Confirmations are capped at `MAX_DELETION_CONFIRMATIONS` per run, oldest
+  first; a larger backlog converges over subsequent cycles.
 
 The same 404-tolerance applies to **user-initiated delete** (`DELETE /api/pages/:id`
 and the bulk path): if Confluence answers 404 the remote page is already gone, so
@@ -179,7 +205,9 @@ visibly:
    request set it) and surface the error: **neither side changed**.
 
 Failure containment: a crash between 1 and 2 leaves a hidden row for a page
-that still exists upstream — the sync upsert (`deleted_at = NULL`) restores it.
+that still exists upstream — the reconciliation revival cross-check restores it
+once the soft-delete is older than the grace window (the sync upsert would also
+restore it, but only if the page is modified upstream or a full sync runs).
 A local failure after a successful upstream delete leaves at worst a hidden
 soft-deleted row that `purgeDeletedPages` removes within the standard 30-day
 window — never a live orphan. The bulk path applies the same shape per batch


### PR DESCRIPTION
## Summary

Production follow-up to #706 / PR #719: deleting a Confluence-backed article via Compendiq's **Delete** button removed the page in Confluence but the local article survived and stayed visible — the inverse divergence of the case #719 closed. This PR makes the delete ordering safe (a successful upstream delete can never leave a user-visible local article) and closes the reconciliation blind spot so any leftover row converges within a sync cycle.

## Root cause

1. **Non-atomic delete ordering.** `DELETE /api/pages/:id` (and `POST /api/pages/bulk/delete`) called `client.deletePage()` **first**, then ran several separate local statements (`DELETE FROM pinned_pages`, `DELETE FROM pages`, `cleanPageAttachments`) with no transaction. Any post-upstream failure (DB blip, pool timeout, attachment-cleanup throw) stranded a **live** local row whose Confluence counterpart was already gone — and nothing ever converged it.
2. **Reconciliation blind spot for `trashed`.** Confluence DC's `DELETE /rest/api/content/{id}` on a current page moves it to the space **Trash** (`status: 'trashed'`), not a 404 purge. #719's `detectDeletedPages` only soft-deleted a candidate when the confirmation `GET /content/{id}` returned **404** — a trashed page can answer `200 {status:'trashed'}` (DC-version dependent), so the safety net never fired for Compendiq's own deletes. (The `status` field is a top-level member of every content response — no `expand`/query change needed in `confluence-client.ts`.)

## New ordering / transaction design

Single and bulk delete now follow intent-first ordering:

1. **Record the delete intent locally first** — soft-delete (`deleted_at = NOW()`, one atomic `UPDATE … RETURNING`). Every user-facing query (list/tree/search/get) filters `deleted_at IS NULL`, so the article disappears immediately.
2. **Call Confluence** (irreversible upstream side-effect).
3. **Upstream success or 404** → finish hard local cleanup (`pinned_pages` + `pages`; embeddings/versions cascade via FK) inside **one `BEGIN…COMMIT` on a dedicated pool client** (same pattern as `unsyncSpace` / draft-publish). Attachment files are cleaned best-effort **after** commit (the filesystem can't join the transaction).
4. **Upstream failure (non-404)** → clear the soft-delete (only if this request set it) and surface the error — **neither side changed**.

Failure containment:
- Crash between 1↔2: hidden row for a page that still exists upstream → the sync upsert (`ON CONFLICT … SET deleted_at = NULL`) restores it.
- Local failure after a successful upstream delete: at worst a hidden soft-deleted row that `purgeDeletedPages` removes within the standard 30-day window — **never a live orphan**. The request still succeeds (the user-visible outcome is achieved) and the failure is logged at error level.
- Bulk applies the same shape per batch: intent for all candidates up front, per-page intent restore for upstream failures, one cleanup transaction for the upstream-deleted set.

Reconciliation: `detectDeletedPages` now counts a `200` confirmation with `status: 'trashed'` as gone, in addition to `404`. Trashed content is already absent from the live listing (only `current` content is listed), so a trashed answer can only mean "deleted", never "restricted from this principal" — shared-space safety from #719 is preserved (200 `current` / 403 still spare the row). The local soft-delete + 30-day purge mirrors the Confluence trash's own recoverability, and a page restored from the trash is revived locally by the sync upsert.

## Changes

- `backend/src/routes/knowledge/pages-crud.ts` — intent-first ordering + single cleanup transaction for both `DELETE /api/pages/:id` and `POST /api/pages/bulk/delete`; intent rollback on upstream failure; best-effort attachment cleanup.
- `backend/src/domains/confluence/services/sync-service.ts` — `detectDeletedPages` treats `status: 'trashed'` as deleted; `purgeDeletedPages` exposed via `__internal` for the convergence test.
- `docs/architecture/08-flow-sync.md` — reconciliation alt-branch updated, "Trash counts as deleted (#766)" rationale (reverses #719's deliberate trash-is-present stance), new "User-initiated delete ordering (#766)" section.
- Mocked route suites (`pages-crud-delete-rbac`, `bulk-pages`, `pinned-pages`, `pages-crud-webhooks`) updated to the new tx-client contract.

## Test plan

New `pages-crud-delete-atomicity.integration.test.ts` (real Postgres; only the Confluence client + infra side-channels stubbed; post-upstream DB failure simulated with a **real `BEFORE DELETE` trigger** on `pages`):

- (a) upstream delete succeeds, local hard-delete fails → row is soft-deleted (hidden, `liveCount = 0`), request succeeds; backdating `deleted_at` and running the real `purgeDeletedPages` converges it fully. Same for the bulk path.
- (b) upstream delete fails (503) → article fully intact and **live** (`deleted_at IS NULL`) — intent rolled back, neither side changed. Bulk: per-page (success + 404 removed, 503 page fully live).
- (c) trashed-but-not-404 page → `detectDeletedPages` soft-deletes it (new case in `sync-service-delete-reconcile.integration.test.ts`); current/403/listing-failure/cap behaviors unchanged.
- (d) #719 regression: 404 tolerated → local cleanup proceeds with the special message (kept in both mocked and real-DB suites).

Evidence: targeted suites all green — `pages-crud-delete-atomicity.integration` 6/6, `sync-service-delete-reconcile.integration` 9/9, full `routes/knowledge` 635/635, sync-service suites 139/139; `lint` and `typecheck` clean.

Closes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)