### PR TITLE
fix(versions): distinguish errors/skipped backfill from empty version history

### DIFF
--- a/backend/src/routes/knowledge/pages-versions.backfill-status.integration.test.ts
+++ b/backend/src/routes/knowledge/pages-versions.backfill-status.integration.test.ts
@@ -145,6 +145,32 @@ describe.skipIf(!dbAvailable)('GET /api/pages/:id/versions — backfillStatus (#
     expect(body.versions[0]).toMatchObject({ versionNumber: 4, isCurrent: true });
   });
 
+  it('"failed" with a credentials-specific detail: corrupt stored PAT → decryption throws, Confluence never contacted (#763 follow-up)', async () => {
+    const pageId = await seedConfluencePage('c-763-badpat', 2);
+    // A stored PAT that is not a valid ciphertext (e.g. written before a
+    // PAT_ENCRYPTION_KEY rotation) makes decryptPat() throw inside
+    // getClientForUser — client construction fails before any HTTP call.
+    await query(
+      `INSERT INTO user_settings (user_id, confluence_url, confluence_pat)
+       VALUES ($1, 'https://confluence.example.com', 'not-a-valid-ciphertext')`,
+      [userId],
+    );
+    const spy = vi
+      .spyOn(ConfluenceClient.prototype, 'getPageVersions')
+      .mockRejectedValue(new Error('must not be called'));
+
+    const r = await app.inject({ method: 'GET', url: `/api/pages/${pageId}/versions` });
+
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBe('failed');
+    expect(body.backfillDetail).toMatch(/credentials could not be used/i);
+    expect(body.backfillDetail).not.toMatch(/Importing historical versions from Confluence failed/);
+    expect(body.versions).toHaveLength(1);
+    expect(body.versions[0]).toMatchObject({ versionNumber: 2, isCurrent: true });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   it('standalone page: backfillStatus is omitted entirely', async () => {
     const res = await query<{ id: number }>(
       `INSERT INTO pages (space_key, title, body_html, body_text, version, source, visibility, created_by_user_id, embedding_dirty, embedding_status)

--- a/backend/src/routes/knowledge/pages-versions.backfill-status.integration.test.ts
+++ b/backend/src/routes/knowledge/pages-versions.backfill-status.integration.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import sensible from '@fastify/sensible';
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../test-db-helper.js';
+import { query } from '../../core/db/postgres.js';
+import { encryptPat } from '../../core/utils/crypto.js';
+import { ConfluenceClient } from '../../domains/confluence/services/confluence-client.js';
+import { pagesVersionRoutes } from './pages-versions.js';
+
+/**
+ * Real-DB integration tests for the #763 `backfillStatus` contract on
+ * GET /api/pages/:id/versions.
+ *
+ * Only the Confluence HTTP boundary is mocked (vi.spyOn on the client
+ * method); credentials, RBAC, page resolution, and the version-snapshot
+ * writes all run against the real test Postgres. This proves end-to-end:
+ *   - `ok`   → backfill ran and page_versions rows were actually written;
+ *   - `skipped_no_credentials` → no user_settings row → import never ran,
+ *     but the synthetic current row is still returned (the list is never
+ *     empty for a resolvable page);
+ *   - `failed` → Confluence error is surfaced, current row still returned;
+ *   - standalone pages → no backfillStatus at all.
+ */
+
+const dbAvailable = await isDbAvailable();
+
+describe.skipIf(!dbAvailable)('GET /api/pages/:id/versions — backfillStatus (#763, real DB)', () => {
+  let app: FastifyInstance;
+  let userId = '';
+
+  beforeAll(async () => {
+    await setupTestDb();
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+    // Stub auth at the decorator boundary (per repo test rules); userId is a
+    // real seeded row so FKs and RBAC lookups resolve against the real DB.
+    app.decorate('authenticate', async (request: { userId: string }) => {
+      request.userId = userId;
+    });
+    app.decorate('redis', {} as never);
+    app.decorateRequest('userId', '');
+    await app.register(pagesVersionRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables();
+    // Admin role → getUserAccessibleSpaces grants every known space, so the
+    // seeded page's space is accessible without wiring role assignments.
+    const u = await query<{ id: string }>(
+      `INSERT INTO users (username, password_hash, role)
+       VALUES ('versions_763_admin', 'fakehash', 'admin') RETURNING id`,
+    );
+    userId = u.rows[0]!.id;
+    await query(`INSERT INTO spaces (space_key, space_name) VALUES ('DEV', 'Dev space')`);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function seedConfluencePage(confluenceId: string, version: number): Promise<number> {
+    const res = await query<{ id: number }>(
+      `INSERT INTO pages (confluence_id, space_key, title, body_html, body_text, version, source, last_modified_at, embedding_dirty, embedding_status)
+       VALUES ($1, 'DEV', 'Page 763', '<p>live</p>', 'live', $2, 'confluence', NOW(), FALSE, 'not_embedded')
+       RETURNING id`,
+      [confluenceId, version],
+    );
+    return res.rows[0]!.id;
+  }
+
+  async function seedCredentials(): Promise<void> {
+    await query(
+      `INSERT INTO user_settings (user_id, confluence_url, confluence_pat)
+       VALUES ($1, 'https://confluence.example.com', $2)`,
+      [userId, encryptPat('test-pat-763')],
+    );
+  }
+
+  it('"ok": backfill runs against the (mocked) Confluence boundary and persists rows', async () => {
+    const pageId = await seedConfluencePage('c-763-ok', 2);
+    await seedCredentials();
+    vi.spyOn(ConfluenceClient.prototype, 'getPageVersions').mockResolvedValue([
+      { number: 1, when: '2026-01-01T00:00:00Z', author: 'alice', message: 'first draft', minorEdit: false },
+    ]);
+
+    const r = await app.inject({ method: 'GET', url: `/api/pages/${pageId}/versions` });
+
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBe('ok');
+    expect(body.backfillDetail).toBeUndefined();
+    // Current live row (v2) + the backfilled historical row (v1).
+    expect(body.versions.map((v: { versionNumber: number }) => v.versionNumber)).toEqual([2, 1]);
+    expect(body.versions[1]).toMatchObject({ author: 'alice', message: 'first draft', isCurrent: false });
+    // The import actually wrote to the real DB.
+    const db = await query(
+      'SELECT version_number FROM page_versions WHERE page_id = $1',
+      [pageId],
+    );
+    expect(db.rows).toHaveLength(1);
+  });
+
+  it('"skipped_no_credentials": no user_settings row → import never runs, current row still returned', async () => {
+    const pageId = await seedConfluencePage('c-763-skip', 3);
+    const spy = vi
+      .spyOn(ConfluenceClient.prototype, 'getPageVersions')
+      .mockRejectedValue(new Error('must not be called'));
+
+    const r = await app.inject({ method: 'GET', url: `/api/pages/${pageId}/versions` });
+
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBe('skipped_no_credentials');
+    expect(body.backfillDetail).toMatch(/Settings/);
+    expect(body.versions).toHaveLength(1);
+    expect(body.versions[0]).toMatchObject({ versionNumber: 3, isCurrent: true });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('"failed": Confluence error during backfill → status surfaced, current row still returned', async () => {
+    const pageId = await seedConfluencePage('c-763-fail', 4);
+    await seedCredentials();
+    vi.spyOn(ConfluenceClient.prototype, 'getPageVersions').mockRejectedValue(
+      new Error('Confluence unreachable'),
+    );
+
+    const r = await app.inject({ method: 'GET', url: `/api/pages/${pageId}/versions` });
+
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBe('failed');
+    expect(body.backfillDetail).toMatch(/incomplete/i);
+    expect(body.versions).toHaveLength(1);
+    expect(body.versions[0]).toMatchObject({ versionNumber: 4, isCurrent: true });
+  });
+
+  it('standalone page: backfillStatus is omitted entirely', async () => {
+    const res = await query<{ id: number }>(
+      `INSERT INTO pages (space_key, title, body_html, body_text, version, source, visibility, created_by_user_id, embedding_dirty, embedding_status)
+       VALUES (NULL, 'Local page', '<p>x</p>', 'x', 1, 'standalone', 'shared', $1, FALSE, 'not_embedded')
+       RETURNING id`,
+      [userId],
+    );
+    const pageId = res.rows[0]!.id;
+
+    const r = await app.inject({ method: 'GET', url: `/api/pages/${pageId}/versions` });
+
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBeUndefined();
+    expect(body.backfillDetail).toBeUndefined();
+    expect(body.versions[0]).toMatchObject({ versionNumber: 1, isCurrent: true });
+  });
+});

--- a/backend/src/routes/knowledge/pages-versions.test.ts
+++ b/backend/src/routes/knowledge/pages-versions.test.ts
@@ -351,6 +351,28 @@ describe('GET /api/pages/:id/versions', () => {
     const body = r.json();
     expect(body.backfillStatus).toBe('failed');
     expect(body.backfillDetail).toMatch(/incomplete/i);
+    // Confluence WAS contacted here — the detail blames the import, not the
+    // stored credentials (distinct from the client-construction failure below).
+    expect(body.backfillDetail).toMatch(/Importing historical versions from Confluence failed/);
+    expect(body.backfillDetail).not.toMatch(/credentials could not be used/i);
+    expect(body.versions).toHaveLength(1);
+    expect(body.versions[0]).toMatchObject({ versionNumber: 5, isCurrent: true });
+  });
+
+  it('reports "failed" with a credentials-specific detail when client construction throws — Confluence never contacted (#763 follow-up)', async () => {
+    mockResolvedPage({ id: 7, confluence_id: 'page-1', space_key: 'DEV', version: 5 });
+    // e.g. PAT decryption failure after a PAT_ENCRYPTION_KEY change.
+    mockGetClientForUser.mockRejectedValue(new Error('Invalid encrypted PAT format'));
+    mockGetVersionHistory.mockResolvedValue([]);
+
+    const r = await app.inject({ method: 'GET', url: '/api/pages/page-1/versions' });
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBe('failed');
+    expect(body.backfillDetail).toMatch(/credentials could not be used/i);
+    expect(body.backfillDetail).not.toMatch(/Importing historical versions from Confluence failed/);
+    // The import itself never ran.
+    expect(mockBackfillVersionHistory).not.toHaveBeenCalled();
     expect(body.versions).toHaveLength(1);
     expect(body.versions[0]).toMatchObject({ versionNumber: 5, isCurrent: true });
   });

--- a/backend/src/routes/knowledge/pages-versions.test.ts
+++ b/backend/src/routes/knowledge/pages-versions.test.ts
@@ -307,6 +307,65 @@ describe('GET /api/pages/:id/versions', () => {
     const r = await app.inject({ method: 'GET', url: '/api/pages/page-1/versions' });
     expect(r.statusCode).toBe(200);
   });
+
+  // ── #763: backfillStatus — distinguish "complete" / "never ran" / "failed" ──
+
+  it('reports backfillStatus "ok" when the backfill ran (#763)', async () => {
+    mockResolvedPage({ id: 7, confluence_id: 'page-1', space_key: 'DEV', version: 5 });
+    mockGetClientForUser.mockResolvedValue({});
+    mockBackfillVersionHistory.mockResolvedValue({ imported: 2 });
+    mockGetVersionHistory.mockResolvedValue([]);
+
+    const r = await app.inject({ method: 'GET', url: '/api/pages/page-1/versions' });
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBe('ok');
+    expect(body.backfillDetail).toBeUndefined();
+  });
+
+  it('reports "skipped_no_credentials" AND still returns the current row when the user has no PAT (#763)', async () => {
+    mockResolvedPage({ id: 7, confluence_id: 'page-1', space_key: 'DEV', version: 5 });
+    mockGetClientForUser.mockResolvedValue(null); // no stored Confluence credentials
+    mockGetVersionHistory.mockResolvedValue([]);
+
+    const r = await app.inject({ method: 'GET', url: '/api/pages/page-1/versions' });
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBe('skipped_no_credentials');
+    expect(body.backfillDetail).toMatch(/Settings/);
+    // The synthetic current row is still returned — the list is never empty
+    // for a resolvable page.
+    expect(body.versions).toHaveLength(1);
+    expect(body.versions[0]).toMatchObject({ versionNumber: 5, isCurrent: true });
+    expect(mockBackfillVersionHistory).not.toHaveBeenCalled();
+  });
+
+  it('reports "failed" AND still returns the current row when the backfill throws (#763)', async () => {
+    mockResolvedPage({ id: 7, confluence_id: 'page-1', space_key: 'DEV', version: 5 });
+    mockGetClientForUser.mockResolvedValue({});
+    mockBackfillVersionHistory.mockRejectedValue(new Error('Confluence down'));
+    mockGetVersionHistory.mockResolvedValue([]);
+
+    const r = await app.inject({ method: 'GET', url: '/api/pages/page-1/versions' });
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBe('failed');
+    expect(body.backfillDetail).toMatch(/incomplete/i);
+    expect(body.versions).toHaveLength(1);
+    expect(body.versions[0]).toMatchObject({ versionNumber: 5, isCurrent: true });
+  });
+
+  it('omits backfillStatus for standalone pages — no Confluence backfill applies (#763)', async () => {
+    mockResolvedPage({ id: 11, source: 'standalone', visibility: 'shared', created_by_user_id: TEST_USER, version: 1 });
+    mockGetVersionHistory.mockResolvedValue([]);
+
+    const r = await app.inject({ method: 'GET', url: '/api/pages/11/versions' });
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBeUndefined();
+    expect(body.backfillDetail).toBeUndefined();
+    expect(mockGetClientForUser).not.toHaveBeenCalled();
+  });
 });
 
 // =============================================================================

--- a/backend/src/routes/knowledge/pages-versions.ts
+++ b/backend/src/routes/knowledge/pages-versions.ts
@@ -113,21 +113,32 @@ export async function pagesVersionRoutes(fastify: FastifyInstance) {
     let backfillStatus: VersionBackfillStatus | undefined;
     let backfillDetail: string | undefined;
     if (ctx.confluenceId) {
+      // Two distinct failure paths: constructing the client (stored-credential
+      // lookup / PAT decryption) throwing means Confluence was never contacted,
+      // so the detail points at the stored credentials rather than the import.
+      let client: Awaited<ReturnType<typeof getClientForUser>> = null;
       try {
-        const client = await getClientForUser(userId);
-        if (client) {
-          await backfillVersionHistory(ctx.id, ctx.confluenceId, client);
-          backfillStatus = 'ok';
-        } else {
-          backfillStatus = 'skipped_no_credentials';
-          backfillDetail =
-            'No Confluence credentials are configured for your account, so historical versions could not be imported. Add your Confluence URL and PAT in Settings → Confluence.';
-        }
+        client = await getClientForUser(userId);
       } catch (err) {
         backfillStatus = 'failed';
         backfillDetail =
-          'Importing historical versions from Confluence failed — the list below may be incomplete.';
-        request.log.warn({ err, pageId: id }, '#722: version backfill failed (Confluence unavailable)');
+          'Your stored Confluence credentials could not be used, so historical versions were not imported — the list below may be incomplete. Re-save your PAT in Settings → Confluence.';
+        request.log.warn({ err, pageId: id }, '#763: version backfill skipped (Confluence client construction failed)');
+      }
+      if (client) {
+        try {
+          await backfillVersionHistory(ctx.id, ctx.confluenceId, client);
+          backfillStatus = 'ok';
+        } catch (err) {
+          backfillStatus = 'failed';
+          backfillDetail =
+            'Importing historical versions from Confluence failed — the list below may be incomplete.';
+          request.log.warn({ err, pageId: id }, '#722: version backfill failed (Confluence unavailable)');
+        }
+      } else if (backfillStatus === undefined) {
+        backfillStatus = 'skipped_no_credentials';
+        backfillDetail =
+          'No Confluence credentials are configured for your account, so historical versions could not be imported. Add your Confluence URL and PAT in Settings → Confluence.';
       }
     }
 

--- a/backend/src/routes/knowledge/pages-versions.ts
+++ b/backend/src/routes/knowledge/pages-versions.ts
@@ -21,6 +21,7 @@ import {
   RestoreVersionSchema,
   PageVersionsResponseSchema,
   PageVersionDetailSchema,
+  type VersionBackfillStatus,
 } from '@compendiq/contracts';
 import { z } from 'zod';
 
@@ -105,12 +106,28 @@ export async function pagesVersionRoutes(fastify: FastifyInstance) {
     if (!ctx) return PageVersionsResponseSchema.parse({ versions: [], pageId: id });
 
     // #722: Best-effort backfill of Confluence version list on dialog open.
+    // #763: the outcome is surfaced as `backfillStatus` so the UI can tell
+    // "history is complete" from "historical import never ran / failed"
+    // instead of silently rendering an incomplete list. Stays undefined for
+    // standalone pages, where no Confluence backfill applies.
+    let backfillStatus: VersionBackfillStatus | undefined;
+    let backfillDetail: string | undefined;
     if (ctx.confluenceId) {
       try {
         const client = await getClientForUser(userId);
-        if (client) await backfillVersionHistory(ctx.id, ctx.confluenceId, client);
+        if (client) {
+          await backfillVersionHistory(ctx.id, ctx.confluenceId, client);
+          backfillStatus = 'ok';
+        } else {
+          backfillStatus = 'skipped_no_credentials';
+          backfillDetail =
+            'No Confluence credentials are configured for your account, so historical versions could not be imported. Add your Confluence URL and PAT in Settings → Confluence.';
+        }
       } catch (err) {
-        request.log.warn({ err, pageId: id }, '#722: version backfill skipped (Confluence unavailable)');
+        backfillStatus = 'failed';
+        backfillDetail =
+          'Importing historical versions from Confluence failed — the list below may be incomplete.';
+        request.log.warn({ err, pageId: id }, '#722: version backfill failed (Confluence unavailable)');
       }
     }
 
@@ -160,6 +177,8 @@ export async function pagesVersionRoutes(fastify: FastifyInstance) {
         })),
       ],
       pageId: id,
+      backfillStatus,
+      backfillDetail,
     });
   });
 

--- a/docs/architecture/08-flow-sync.md
+++ b/docs/architecture/08-flow-sync.md
@@ -168,6 +168,9 @@ backfill outcome as `backfillStatus` (`ok` | `skipped_no_credentials` | `failed`
 plus a human-readable `backfillDetail`) so the UI can distinguish a complete
 history from one whose Confluence import never ran (viewer has no stored PAT —
 backfill uses the *viewing user's* credentials via `getClientForUser`) or failed.
+For `failed`, the `backfillDetail` wording further distinguishes a client-construction
+failure (stored credentials unusable, e.g. PAT decryption error — Confluence was
+never contacted) from a failed Confluence import call.
 The field is omitted for standalone pages, where no Confluence backfill applies.
 
 The `edited_at` column holds the real Confluence edit timestamp; the existing

--- a/docs/architecture/08-flow-sync.md
+++ b/docs/architecture/08-flow-sync.md
@@ -162,8 +162,13 @@ dialog, `GET /api/pages/:id/versions` calls `backfillVersionHistory` which hits
 COALESCE). The historical body (`body_html`) for each old version is fetched even
 more lazily — only when a user previews or compares that specific version
 (`GET /api/pages/:id/versions/:version` triggers `getHistoricalBody` when
-`body_html IS NULL`). Both calls are best-effort: failures are logged and swallowed
-so the dialog still opens.
+`body_html IS NULL`). Both calls are best-effort: failures never fail the request,
+so the dialog still opens. Since #763 the list endpoint additionally reports the
+backfill outcome as `backfillStatus` (`ok` | `skipped_no_credentials` | `failed`,
+plus a human-readable `backfillDetail`) so the UI can distinguish a complete
+history from one whose Confluence import never ran (viewer has no stored PAT —
+backfill uses the *viewing user's* credentials via `getClientForUser`) or failed.
+The field is omitted for standalone pages, where no Confluence backfill applies.
 
 The `edited_at` column holds the real Confluence edit timestamp; the existing
 `synced_at` column records when Compendiq last ingested the row. The frontend

--- a/frontend/src/features/pages/VersionHistory.test.tsx
+++ b/frontend/src/features/pages/VersionHistory.test.tsx
@@ -156,6 +156,137 @@ describe('VersionHistory', () => {
     });
   });
 
+  it('empty-state copy describes lazy-on-open import, not sync (#763 regression)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ versions: [], pageId: 'page-1' }),
+        { headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(
+      <VersionHistory pageId="page-1" model="qwen3.5" />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(screen.getByText('History'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/No version history available/)).toBeInTheDocument();
+    });
+    // The stale post-#728 copy must be gone — backfill is lazy-on-open, syncing cannot help.
+    expect(screen.queryByText(/saved during sync/i)).not.toBeInTheDocument();
+    // The new copy explains the lazy import and the PAT requirement.
+    expect(screen.getByText(/imported\s+from Confluence when this dialog opens/i)).toBeInTheDocument();
+    expect(screen.getByText(/Confluence PAT/i)).toBeInTheDocument();
+  });
+
+  it('renders the error branch (with reason + retry) instead of the empty state on a failed request (#763)', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'Access denied to this space' }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValue(mockVersionsResponse());
+
+    render(
+      <VersionHistory pageId="page-1" model="qwen3.5" />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(screen.getByText('History'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load version history.')).toBeInTheDocument();
+    });
+    // The backend reason is surfaced, and the error is NOT masked as "no data".
+    expect(screen.getByText(/Access denied to this space \(HTTP 403\)/)).toBeInTheDocument();
+    expect(screen.queryByText(/No version history available/)).not.toBeInTheDocument();
+
+    // Retry refetches and renders the list.
+    fireEvent.click(screen.getByText('Retry'));
+    await waitFor(() => {
+      expect(screen.getByText('v3')).toBeInTheDocument();
+    });
+    expect(fetchSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows the no-credentials hint alongside the list when backfillStatus is skipped_no_credentials (#763)', async () => {
+    const base = JSON.parse(await mockVersionsResponse().text());
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ ...base, backfillStatus: 'skipped_no_credentials' }),
+        { headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(
+      <VersionHistory pageId="page-1" model="qwen3.5" />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(screen.getByText('History'));
+
+    await waitFor(() => {
+      expect(screen.getByText('v3')).toBeInTheDocument();
+    });
+    // The list still renders, with a hint pointing the user at Settings → Confluence.
+    expect(screen.getByText(/no Confluence credentials/i)).toBeInTheDocument();
+    expect(screen.getByText(/Settings → Confluence/)).toBeInTheDocument();
+  });
+
+  it('prefers the server-provided backfillDetail and shows a failed-import hint (#763)', async () => {
+    const base = JSON.parse(await mockVersionsResponse().text());
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ...base,
+          backfillStatus: 'failed',
+          backfillDetail: 'Importing historical versions from Confluence failed — the list below may be incomplete.',
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(
+      <VersionHistory pageId="page-1" model="qwen3.5" />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(screen.getByText('History'));
+
+    await waitFor(() => {
+      expect(screen.getByText('v3')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/may be incomplete/i)).toBeInTheDocument();
+  });
+
+  it('shows no backfill hint when backfillStatus is ok (#763)', async () => {
+    const base = JSON.parse(await mockVersionsResponse().text());
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ ...base, backfillStatus: 'ok' }),
+        { headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(
+      <VersionHistory pageId="page-1" model="qwen3.5" />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(screen.getByText('History'));
+
+    await waitFor(() => {
+      expect(screen.getByText('v3')).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/could not be imported/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/may be incomplete/i)).not.toBeInTheDocument();
+  });
+
   it('shows loading state in dialog', async () => {
     vi.spyOn(globalThis, 'fetch').mockReturnValue(
       new Promise(() => {}),

--- a/frontend/src/features/pages/VersionHistory.test.tsx
+++ b/frontend/src/features/pages/VersionHistory.test.tsx
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { VersionHistory } from './VersionHistory';
 import { useAuthStore } from '../../stores/auth-store';
 
-function createWrapper() {
-  const queryClient = new QueryClient({
+function createWrapper(externalQueryClient?: QueryClient) {
+  const queryClient = externalQueryClient ?? new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return function Wrapper({ children }: { children: React.ReactNode }) {
@@ -212,6 +212,50 @@ describe('VersionHistory', () => {
       expect(screen.getByText('v3')).toBeInTheDocument();
     });
     expect(fetchSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('keeps the loaded list and shows an inline notice when a background refetch fails (#763 review follow-up)', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockVersionsResponse())
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'upstream hiccup' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValue(mockVersionsResponse());
+
+    render(
+      <VersionHistory pageId="page-1" model="qwen3.5" />,
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    fireEvent.click(screen.getByText('History'));
+    await waitFor(() => expect(screen.getByText('v3')).toBeInTheDocument());
+
+    // Simulate a background refetch that fails — same path as the
+    // invalidateQueries after a restore or a window-focus refetch.
+    await act(async () => {
+      await queryClient.refetchQueries({ queryKey: ['pages', 'page-1', 'versions'], exact: true });
+    });
+
+    // The observer notifies asynchronously after refetchQueries resolves.
+    await waitFor(() => {
+      expect(screen.getByText(/Could not refresh version history/)).toBeInTheDocument();
+    });
+    // The loaded list survives; the full-panel error does NOT replace it.
+    expect(screen.getByText('v3')).toBeInTheDocument();
+    expect(screen.queryByText('Failed to load version history.')).not.toBeInTheDocument();
+
+    // The inline Retry recovers and clears the notice.
+    fireEvent.click(screen.getByText('Retry'));
+    await waitFor(() => {
+      expect(screen.queryByText(/Could not refresh version history/)).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('v3')).toBeInTheDocument();
   });
 
   it('shows the no-credentials hint alongside the list when backfillStatus is skipped_no_credentials (#763)', async () => {

--- a/frontend/src/features/pages/VersionHistory.tsx
+++ b/frontend/src/features/pages/VersionHistory.tsx
@@ -1,14 +1,14 @@
 import { useState, useEffect, type ReactNode } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { AnimatePresence, m } from 'framer-motion';
-import { History, Eye, GitCompare, Sparkles, Loader2, X, RotateCcw } from 'lucide-react';
+import { History, Eye, GitCompare, Sparkles, Loader2, X, RotateCcw, AlertTriangle, Info } from 'lucide-react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { toast } from 'sonner';
 import type {
   PageVersionsResponse,
   PageVersionDetail,
 } from '@compendiq/contracts';
-import { apiFetch } from '../../shared/lib/api';
+import { apiFetch, ApiError } from '../../shared/lib/api';
 import { DiffView } from '../../shared/components/article/DiffView';
 import { cn } from '../../shared/lib/cn';
 import { useIsLightTheme } from '../../shared/hooks/use-is-light-theme';
@@ -85,7 +85,7 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
   const [compareVersions, setCompareVersions] = useState<[number, number] | null>(null);
   const [showSemanticDiff, setShowSemanticDiff] = useState(false);
 
-  const { data: versionsData, isLoading } = useVersionHistory(pageId, open);
+  const { data: versionsData, isLoading, isError, error, refetch } = useVersionHistory(pageId, open);
   const { data: selectedVersionData } = useVersionDetail(
     pageId,
     selectedVersion,
@@ -101,6 +101,16 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
 
   const versions = versionsData?.versions ?? [];
   const currentVersionNumber = versions.find((v) => v.isCurrent)?.versionNumber;
+  // #763: non-ok backfill means the historical Confluence import never ran or
+  // failed — the list still renders, but with a hint that it may be incomplete.
+  const backfillStatus = versionsData?.backfillStatus;
+  const backfillNotice =
+    backfillStatus === 'skipped_no_credentials' || backfillStatus === 'failed'
+      ? versionsData?.backfillDetail ??
+        (backfillStatus === 'skipped_no_credentials'
+          ? 'Historical versions could not be imported: no Confluence credentials are configured for your account. Add your PAT in Settings → Confluence.'
+          : 'Importing historical versions from Confluence failed — the list below may be incomplete.')
+      : null;
 
   const restoreMutation = useMutation({
     mutationFn: ({ version, expected }: { version: number; expected?: number }) =>
@@ -207,11 +217,42 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
                 <Loader2 size={14} className="animate-spin" />
                 <span className="text-sm">Loading versions...</span>
               </div>
+            ) : isError ? (
+              /* #763: a failed request is NOT an empty history — surface the
+                 backend reason (401/403/500) instead of the empty state. */
+              <div className="flex flex-col items-center gap-2 px-5 py-6 text-center">
+                <div className="flex items-center gap-2 text-destructive">
+                  <AlertTriangle size={14} />
+                  <span className="text-sm font-medium">Failed to load version history.</span>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {error instanceof ApiError
+                    ? `${error.message} (HTTP ${error.statusCode})`
+                    : error instanceof Error
+                      ? error.message
+                      : 'Unknown error'}
+                </p>
+                <button
+                  onClick={() => void refetch()}
+                  className="nm-card mt-1 px-3 py-1.5 text-xs hover:bg-foreground/5"
+                >
+                  Retry
+                </button>
+              </div>
             ) : versions.length === 0 ? (
-              <div className="py-6 text-center text-sm text-muted-foreground">
-                No version history available. Versions are saved during sync.
+              <div className="px-5 py-6 text-center text-sm text-muted-foreground">
+                No version history available yet. Historical versions are imported
+                from Confluence when this dialog opens — importing them requires a
+                Confluence PAT (Settings &rarr; Confluence).
               </div>
             ) : (
+              <>
+              {backfillNotice && (
+                <div className="flex items-start gap-2 border-b border-border/50 bg-warning/10 px-5 py-2.5 text-xs text-muted-foreground">
+                  <Info size={12} className="mt-0.5 shrink-0 text-warning" />
+                  <span>{backfillNotice}</span>
+                </div>
+              )}
               <div className="max-h-72 overflow-y-auto">
                 {versions.map((version, i) => (
                   <div
@@ -307,6 +348,7 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
                   </div>
                 ))}
               </div>
+              </>
             )}
 
             {/* Version preview */}

--- a/frontend/src/features/pages/VersionHistory.tsx
+++ b/frontend/src/features/pages/VersionHistory.tsx
@@ -217,9 +217,13 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
                 <Loader2 size={14} className="animate-spin" />
                 <span className="text-sm">Loading versions...</span>
               </div>
-            ) : isError ? (
+            ) : isError && !versionsData ? (
               /* #763: a failed request is NOT an empty history — surface the
-                 backend reason (401/403/500) instead of the empty state. */
+                 backend reason (401/403/500) instead of the empty state. Only
+                 when nothing is loaded yet: TanStack Query retains the previous
+                 data on a failed refetch, so transient background failures
+                 (e.g. the invalidation after a restore) fall through to the
+                 inline notice below instead of replacing the rendered list. */
               <div className="flex flex-col items-center gap-2 px-5 py-6 text-center">
                 <div className="flex items-center gap-2 text-destructive">
                   <AlertTriangle size={14} />
@@ -239,13 +243,28 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
                   Retry
                 </button>
               </div>
-            ) : versions.length === 0 ? (
+            ) : (
+              <>
+              {isError && (
+                /* Background refetch failed but data is loaded — keep the list. */
+                <div className="flex items-center gap-2 border-b border-border/50 bg-destructive/10 px-5 py-2.5 text-xs text-muted-foreground">
+                  <AlertTriangle size={12} className="shrink-0 text-destructive" />
+                  <span>Could not refresh version history &mdash; showing the last loaded versions.</span>
+                  <button
+                    onClick={() => void refetch()}
+                    className="ml-auto shrink-0 rounded px-2 py-0.5 font-medium text-foreground hover:bg-foreground/5"
+                  >
+                    Retry
+                  </button>
+                </div>
+              )}
+              {versions.length === 0 ? (
               <div className="px-5 py-6 text-center text-sm text-muted-foreground">
                 No version history available yet. Historical versions are imported
                 from Confluence when this dialog opens — importing them requires a
                 Confluence PAT (Settings &rarr; Confluence).
               </div>
-            ) : (
+              ) : (
               <>
               {backfillNotice && (
                 <div className="flex items-start gap-2 border-b border-border/50 bg-warning/10 px-5 py-2.5 text-xs text-muted-foreground">
@@ -348,6 +367,8 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
                   </div>
                 ))}
               </div>
+              </>
+              )}
               </>
             )}
 

--- a/frontend/src/features/settings/SettingsLayout.test.tsx
+++ b/frontend/src/features/settings/SettingsLayout.test.tsx
@@ -51,6 +51,10 @@ vi.mock('../../shared/hooks/use-settings', () => ({
     },
     isLoading: false,
   }),
+  useUpdateSettings: () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn().mockResolvedValue({}),
+  }),
 }));
 
 // Stub api-fetch so lazy-loaded panels don't explode on mount in JSDOM.

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -1,10 +1,7 @@
 import { useState } from 'react';
 import { m } from 'framer-motion';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-import { apiFetch } from '../../shared/lib/api';
 import { useAuthStore } from '../../stores/auth-store';
-import { useSettings } from '../../shared/hooks/use-settings';
+import { useSettings, useUpdateSettings } from '../../shared/hooks/use-settings';
 import { SpacesTab } from './SpacesTab';
 import { LabelManager } from './LabelManager';
 import { ErrorDashboard } from './ErrorDashboard';
@@ -43,23 +40,13 @@ import {
 type TabId = 'confluence' | 'sync' | 'sync-conflict-policy' | 'sync-conflicts' | 'ollama' | 'ai-prompts' | 'ai-safety' | 'rate-limits' | 'spaces' | 'theme' | 'labels' | 'errors' | 'embedding' | 'workers' | 'mcp-docs' | 'searxng' | 'email' | 'license' | 'sso' | 'ip-allowlist' | 'webhooks' | 'llm-policy' | 'retention' | 'compliance-reports' | 'llm-audit' | 'ai-reviews' | 'ai-review-policy' | 'pii-policy' | 'scim' | 'system';
 
 export function SettingsPage() {
-  const queryClient = useQueryClient();
   const user = useAuthStore((s) => s.user);
   const isAdmin = user?.role === 'admin';
   const { isEnterprise, hasFeature } = useEnterprise();
   const [activeTab, setActiveTab] = useState<TabId>('confluence');
 
   const { data: settings, isLoading } = useSettings();
-
-  const updateSettings = useMutation({
-    mutationFn: (body: Record<string, unknown>) =>
-      apiFetch('/settings', { method: 'PUT', body: JSON.stringify(body) }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['settings'] });
-      toast.success('Settings saved');
-    },
-    onError: (err) => toast.error(err.message),
-  });
+  const updateSettings = useUpdateSettings();
 
   const tabs: { id: TabId; label: string; adminOnly?: boolean; enterpriseOnly?: boolean; requiresFeature?: string }[] = [
     { id: 'confluence', label: 'Confluence' },

--- a/frontend/src/features/settings/SettingsPanelRoute.tsx
+++ b/frontend/src/features/settings/SettingsPanelRoute.tsx
@@ -2,11 +2,8 @@ import { lazy, type ComponentType, type ReactElement } from 'react';
 import { Navigate, useOutletContext, useParams } from 'react-router-dom';
 import { SETTINGS_NAV, canSeeItem, firstVisiblePath } from './settings-nav';
 import type { AccessContextWithLoading } from './SettingsLayout';
-import { useSettings } from '../../shared/hooks/use-settings';
+import { useSettings, useUpdateSettings } from '../../shared/hooks/use-settings';
 import { useAuthStore } from '../../stores/auth-store';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiFetch } from '../../shared/lib/api';
-import { toast } from 'sonner';
 import { SkeletonFormFields } from '../../shared/components/feedback/Skeleton';
 import type { SettingsResponse } from '@compendiq/contracts';
 
@@ -98,18 +95,8 @@ export function SettingsPanelRoute() {
   const key = `${category ?? ''}/${item ?? ''}`;
 
   const user = useAuthStore((s) => s.user);
-  const queryClient = useQueryClient();
   const { data: settings, isLoading } = useSettings();
-
-  const updateSettings = useMutation({
-    mutationFn: (body: Record<string, unknown>) =>
-      apiFetch('/settings', { method: 'PUT', body: JSON.stringify(body) }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['settings'] });
-      toast.success('Settings saved');
-    },
-    onError: (err: Error) => toast.error(err.message),
-  });
+  const updateSettings = useUpdateSettings();
 
   // Gating check against the live nav config.
   const groupId = category;

--- a/frontend/src/shared/hooks/use-settings.test.ts
+++ b/frontend/src/shared/hooks/use-settings.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import { useUpdateSettings } from './use-settings';
+
+// Mock at the network boundary only.
+const apiFetchMock = vi.fn();
+vi.mock('../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}));
+
+function createQueryClientAndWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  apiFetchMock.mockReset();
+});
+
+describe('useUpdateSettings', () => {
+  it('PUTs the body and invalidates the settings query', async () => {
+    apiFetchMock.mockResolvedValue({});
+    const { queryClient, wrapper } = createQueryClientAndWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUpdateSettings(), { wrapper });
+    result.current.mutate({ theme: 'honey-linen' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiFetchMock).toHaveBeenCalledWith('/settings', {
+      method: 'PUT',
+      body: JSON.stringify({ theme: 'honey-linen' }),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['settings'] });
+  });
+
+  it('invalidates cached page-versions queries when Confluence credentials are saved (#763 stale skipped_no_credentials hint)', async () => {
+    apiFetchMock.mockResolvedValue({});
+    const { queryClient, wrapper } = createQueryClientAndWrapper();
+    // Seed a cached versions list carrying the stale "no credentials" hint,
+    // a cached version detail, and an unrelated page query.
+    queryClient.setQueryData(['pages', 'page-1', 'versions'], {
+      versions: [],
+      pageId: 'page-1',
+      backfillStatus: 'skipped_no_credentials',
+    });
+    queryClient.setQueryData(['pages', 'page-1', 'versions', 2], { versionNumber: 2 });
+    queryClient.setQueryData(['pages', 'page-1'], { id: 1, title: 'Article' });
+
+    const { result } = renderHook(() => useUpdateSettings(), { wrapper });
+    result.current.mutate({ confluenceUrl: 'https://confluence.example.com', confluencePat: 'pat-123' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    // Version list + detail are stale now; the article query is untouched.
+    expect(queryClient.getQueryState(['pages', 'page-1', 'versions'])?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(['pages', 'page-1', 'versions', 2])?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(['pages', 'page-1'])?.isInvalidated).toBe(false);
+  });
+
+  it('does not touch page-versions queries on unrelated settings saves', async () => {
+    apiFetchMock.mockResolvedValue({});
+    const { queryClient, wrapper } = createQueryClientAndWrapper();
+    queryClient.setQueryData(['pages', 'page-1', 'versions'], {
+      versions: [],
+      pageId: 'page-1',
+      backfillStatus: 'ok',
+    });
+
+    const { result } = renderHook(() => useUpdateSettings(), { wrapper });
+    result.current.mutate({ theme: 'graphite-honey' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryState(['pages', 'page-1', 'versions'])?.isInvalidated).toBe(false);
+  });
+});

--- a/frontend/src/shared/hooks/use-settings.ts
+++ b/frontend/src/shared/hooks/use-settings.ts
@@ -1,4 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import type { SettingsResponse } from '@compendiq/contracts';
 import { apiFetch } from '../lib/api';
 
@@ -7,5 +8,34 @@ export function useSettings() {
     queryKey: ['settings'],
     queryFn: () => apiFetch('/settings'),
     staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}
+
+/**
+ * Shared `PUT /settings` mutation used by both settings UIs
+ * (`SettingsPage` tabs and the `SettingsPanelRoute` registry).
+ *
+ * Saving Confluence credentials also invalidates the cached page-versions
+ * queries: their `backfillStatus: 'skipped_no_credentials'` hint is cached
+ * for 5 minutes, so without this a user who just added a PAT would reopen
+ * the version-history dialog and still be told to add one (#763 follow-up).
+ */
+export function useUpdateSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: Record<string, unknown>) =>
+      apiFetch('/settings', { method: 'PUT', body: JSON.stringify(body) }),
+    onSuccess: (_data, body) => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      if ('confluenceUrl' in body || 'confluencePat' in body) {
+        // ['pages', <id>, 'versions'] (list) and ['pages', <id>, 'versions', n]
+        // (detail) — both depend on the viewer's Confluence credentials.
+        queryClient.invalidateQueries({
+          predicate: (q) => q.queryKey[0] === 'pages' && q.queryKey[2] === 'versions',
+        });
+      }
+      toast.success('Settings saved');
+    },
+    onError: (err: Error) => toast.error(err.message),
   });
 }

--- a/packages/contracts/src/schemas/page-versions.ts
+++ b/packages/contracts/src/schemas/page-versions.ts
@@ -11,9 +11,29 @@ export const PageVersionSummarySchema = z.object({
 });
 export type PageVersionSummary = z.infer<typeof PageVersionSummarySchema>;
 
+/**
+ * #763: outcome of the lazy on-open Confluence version-list backfill.
+ *
+ * - `ok` — the historical list was (re)imported; the response is complete.
+ * - `skipped_no_credentials` — the viewing user has no stored Confluence
+ *   URL/PAT, so the import never ran; historical versions may be missing.
+ * - `failed` — the import was attempted but errored (Confluence unreachable,
+ *   auth rejected, …); the list may be incomplete.
+ */
+export const VersionBackfillStatusSchema = z.enum(['ok', 'skipped_no_credentials', 'failed']);
+export type VersionBackfillStatus = z.infer<typeof VersionBackfillStatusSchema>;
+
 export const PageVersionsResponseSchema = z.object({
   versions: z.array(PageVersionSummarySchema),
   pageId: z.string(),
+  /**
+   * Optional for backward compatibility; absent for standalone pages (no
+   * Confluence backfill applies) and for older backends. Clients must treat
+   * a missing value as "no signal", not as a failure.
+   */
+  backfillStatus: VersionBackfillStatusSchema.optional(),
+  /** Human-readable detail accompanying a non-`ok` backfillStatus. */
+  backfillDetail: z.string().optional(),
 });
 export type PageVersionsResponse = z.infer<typeof PageVersionsResponseSchema>;
 


### PR DESCRIPTION
## Summary

Post-#728, the Version History dialog showed **"No version history available. Versions are saved during sync."** for three unrelated conditions: a stale copy string, swallowed backfill failures, and outright request errors rendered as the empty state. This PR makes each state distinct.

## Root cause

1. **Stale copy** — #728 moved the version-list import from sync-time to **lazy-on-open**, but `VersionHistory.tsx` still told users to sync (which cannot help).
2. **Invisible errors** — on a TanStack Query error `data` is `undefined` → `versions = []` → the *empty state* rendered; there was no `isError` branch. On the backend, `GET /api/pages/:id/versions` swallowed every backfill failure as `request.log.warn`, so the UI had no signal.
3. **Per-user PAT dependency** — backfill uses `getClientForUser(viewingUserId)`; a viewer without a stored PAT silently never imports history for pages synced under another account.

## Changes

- **Contracts** (`packages/contracts/src/schemas/page-versions.ts`): `PageVersionsResponseSchema` gains optional `backfillStatus` (`'ok' | 'skipped_no_credentials' | 'failed'`) + `backfillDetail` (human-readable). Backward-compatible; omitted for standalone pages and older backends.
- **Backend** (`backend/src/routes/knowledge/pages-versions.ts`): the lazy backfill on the list endpoint now records its outcome and returns it. Failures still never fail the request (the synthetic current row is always returned for a resolvable page), but the outcome is no longer log-only.
- **Frontend** (`frontend/src/features/pages/VersionHistory.tsx`):
  - explicit **error branch**: "Failed to load version history." + backend reason with HTTP status (401/403/500) + **Retry** button (`refetch()`);
  - **hint banner** above the list when `backfillStatus` is `skipped_no_credentials` (points the user to Settings → Confluence to add a PAT) or `failed` (list may be incomplete); prefers server-sent `backfillDetail`;
  - **empty-state copy rewritten** to describe lazy-on-open import and the PAT requirement — "saved during sync" is gone.
- **Docs**: `docs/architecture/08-flow-sync.md` backfill section updated to describe the `backfillStatus` signal.

## Credential-model scope decision

The issue suggested falling back to a service/admin Confluence client when the viewer has no PAT. **There is no established fallback-client precedent in CE** — `getClientForUser` (per-user `user_settings` PAT) is the *only* `ConfluenceClient` factory in the codebase; every caller (sync, attachments, tags, embeddings, conversations, pages-crud) uses it. Borrowing another user's PAT or introducing a service account would be a new credential model, which is out of scope here. Instead, the missing-PAT case is surfaced as `skipped_no_credentials` with a UI hint telling the user to configure their PAT in Settings → Confluence.

## Test plan

- **Backend (mocked suite, `pages-versions.test.ts`)**: `backfillStatus` is `ok` / `skipped_no_credentials` / `failed` per path; current row still returned when backfill is skipped or throws; field omitted for standalone pages. 39 → 43 tests, all pass.
- **Backend (new real-Postgres integration suite, `pages-versions.backfill-status.integration.test.ts`)**: real users/spaces/pages/user_settings rows (PAT via `encryptPat`), Confluence HTTP boundary mocked only via `vi.spyOn(ConfluenceClient.prototype, 'getPageVersions')`; asserts the `ok` path actually persists `page_versions` rows, the skip path never calls Confluence, and the failed path still returns the current row.
- **Frontend (`VersionHistory.test.tsx`)**: error branch renders reason + HTTP status (not the empty state) and Retry refetches successfully; skipped-credentials hint and failed-import hint render alongside the list; no hint when `ok`; copy regression — `/saved during sync/i` asserted absent. 14 → 20 tests, all pass.
- `npm run lint` + `npm run typecheck` clean for backend and frontend; contracts build clean.

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)