### PR TITLE
feat(onboarding): first-login banner prompting Confluence PAT setup

### DIFF
--- a/backend/src/core/db/migrations/078_user_settings_pat_prompt_dismissed.sql
+++ b/backend/src/core/db/migrations/078_user_settings_pat_prompt_dismissed.sql
@@ -1,0 +1,15 @@
+-- Migration 078: Confluence-PAT onboarding prompt dismissal (#771)
+--
+-- The Confluence PAT is per-user (user_settings.confluence_pat) and nothing
+-- prompts a freshly-onboarded user to configure one — the setup wizard's
+-- Confluence step runs once per deployment and is skippable. The frontend now
+-- shows a dismissible banner to users without a PAT; dismissal is persisted
+-- server-side so it follows the user across devices and survives refresh.
+--
+-- NULL  = never dismissed (banner may show while no PAT is configured).
+-- NOW() = written by PUT /api/settings { confluencePatPromptDismissed: true }.
+--
+-- Only the derived boolean (IS NOT NULL) is exposed via GET /api/settings as
+-- `confluencePatPromptDismissed` — the timestamp itself stays server-side.
+
+ALTER TABLE user_settings ADD COLUMN IF NOT EXISTS confluence_pat_prompt_dismissed_at TIMESTAMPTZ NULL;

--- a/backend/src/core/db/migrations/__tests__/078_user_settings_pat_prompt_dismissed.test.ts
+++ b/backend/src/core/db/migrations/__tests__/078_user_settings_pat_prompt_dismissed.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { setupTestDb, truncateAllTables, teardownTestDb, isDbAvailable } from '../../../../test-db-helper.js';
+import { query } from '../../postgres.js';
+
+const dbAvailable = await isDbAvailable();
+
+describe.skipIf(!dbAvailable)('Migration 078 — user_settings.confluence_pat_prompt_dismissed_at (#771)', () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
+  beforeEach(async () => { await truncateAllTables(); });
+
+  it('adds a nullable TIMESTAMPTZ column', async () => {
+    const cols = await query<{ column_name: string; data_type: string; is_nullable: string }>(
+      `SELECT column_name, data_type, is_nullable FROM information_schema.columns
+        WHERE table_name='user_settings' AND column_name='confluence_pat_prompt_dismissed_at'`,
+    );
+    expect(cols.rows).toHaveLength(1);
+    expect(cols.rows[0]!.data_type).toBe('timestamp with time zone');
+    expect(cols.rows[0]!.is_nullable).toBe('YES');
+  });
+
+  it('defaults to NULL for new rows (banner never dismissed)', async () => {
+    const user = await query<{ id: string }>(
+      `INSERT INTO users (username, password_hash, role) VALUES ('mig078_user', 'h', 'user') RETURNING id`,
+    );
+    await query('INSERT INTO user_settings (user_id) VALUES ($1)', [user.rows[0]!.id]);
+
+    const res = await query<{ confluence_pat_prompt_dismissed_at: Date | null }>(
+      'SELECT confluence_pat_prompt_dismissed_at FROM user_settings WHERE user_id = $1',
+      [user.rows[0]!.id],
+    );
+    expect(res.rows[0]!.confluence_pat_prompt_dismissed_at).toBeNull();
+  });
+});

--- a/backend/src/routes/foundation/settings-pat-prompt.test.ts
+++ b/backend/src/routes/foundation/settings-pat-prompt.test.ts
@@ -1,0 +1,190 @@
+/**
+ * #771 — Confluence-PAT onboarding prompt: real-Postgres round-trip.
+ *
+ * Covers the full loop the dismissible banner depends on:
+ *   GET  /api/settings → confluencePatPromptDismissed (derived boolean)
+ *   PUT  /api/settings { confluencePatPromptDismissed } → sets/clears the
+ *        server-side timestamp in user_settings.confluence_pat_prompt_dismissed_at
+ *
+ * Uses buildApp() + real Postgres + real JWTs (admin AND non-admin) per the
+ * repo rule: DB tests never mock the DB.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// Short-circuit DNS lookups performed by the SSRF guard (no real network in tests).
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async () => {
+    const err = new Error('getaddrinfo ENOTFOUND (mocked)') as NodeJS.ErrnoException;
+    err.code = 'ENOTFOUND';
+    throw err;
+  }),
+}));
+
+import { setupTestDb, truncateAllTables, teardownTestDb, isDbAvailable } from '../../test-db-helper.js';
+import { query } from '../../core/db/postgres.js';
+import { buildApp } from '../../app.js';
+import { generateAccessToken } from '../../core/plugins/auth.js';
+
+async function createUser(username: string, role: 'admin' | 'user'): Promise<{ token: string; userId: string }> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO users (username, password_hash, role)
+     VALUES ($1, 'fakehash', $2) RETURNING id`,
+    [username, role],
+  );
+  const userId = result.rows[0]!.id;
+  await query('INSERT INTO user_settings (user_id) VALUES ($1)', [userId]);
+  const token = await generateAccessToken({ sub: userId, username, role });
+  return { token, userId };
+}
+
+const dbAvailable = await isDbAvailable();
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  if (!dbAvailable) return;
+  await setupTestDb();
+  app = await buildApp();
+  await app.ready();
+}, 30_000);
+
+afterAll(async () => {
+  if (!dbAvailable) return;
+  await app?.close();
+  await teardownTestDb();
+});
+
+beforeEach(async () => {
+  if (!dbAvailable) return;
+  await truncateAllTables();
+});
+
+describe.skipIf(!dbAvailable)('Confluence PAT prompt dismissal (#771)', () => {
+  it('GET /api/settings returns confluencePatPromptDismissed=false for a fresh user', async () => {
+    const { token } = await createUser('pat_prompt_fresh', 'user');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/settings',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.hasConfluencePat).toBe(false);
+    expect(body.confluencePatPromptDismissed).toBe(false);
+  });
+
+  it('GET /api/settings returns confluencePatPromptDismissed=false when the row is auto-created', async () => {
+    // No user_settings row — GET creates the default row on first fetch.
+    const result = await query<{ id: string }>(
+      `INSERT INTO users (username, password_hash, role)
+       VALUES ('pat_prompt_norow', 'fakehash', 'user') RETURNING id`,
+    );
+    const token = await generateAccessToken({
+      sub: result.rows[0]!.id, username: 'pat_prompt_norow', role: 'user',
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/settings',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().confluencePatPromptDismissed).toBe(false);
+  });
+
+  it('PUT { confluencePatPromptDismissed: true } sets the timestamp and round-trips via GET', async () => {
+    const { token, userId } = await createUser('pat_prompt_dismiss', 'user');
+
+    const put = await app.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { confluencePatPromptDismissed: true },
+    });
+    expect(put.statusCode).toBe(200);
+
+    // Timestamp is set server-side…
+    const row = await query<{ confluence_pat_prompt_dismissed_at: Date | null }>(
+      'SELECT confluence_pat_prompt_dismissed_at FROM user_settings WHERE user_id = $1',
+      [userId],
+    );
+    expect(row.rows[0]!.confluence_pat_prompt_dismissed_at).toBeInstanceOf(Date);
+
+    // …and only the derived boolean is exposed.
+    const get = await app.inject({
+      method: 'GET',
+      url: '/api/settings',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const body = get.json();
+    expect(body.confluencePatPromptDismissed).toBe(true);
+    expect(JSON.stringify(body)).not.toContain('confluence_pat_prompt_dismissed_at');
+  });
+
+  it('PUT { confluencePatPromptDismissed: false } clears the dismissal', async () => {
+    const { token, userId } = await createUser('pat_prompt_clear', 'user');
+    await query(
+      'UPDATE user_settings SET confluence_pat_prompt_dismissed_at = NOW() WHERE user_id = $1',
+      [userId],
+    );
+
+    const put = await app.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { confluencePatPromptDismissed: false },
+    });
+    expect(put.statusCode).toBe(200);
+
+    const get = await app.inject({
+      method: 'GET',
+      url: '/api/settings',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(get.json().confluencePatPromptDismissed).toBe(false);
+  });
+
+  it('works for admin users too', async () => {
+    const { token } = await createUser('pat_prompt_admin', 'admin');
+
+    const put = await app.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { confluencePatPromptDismissed: true },
+    });
+    expect(put.statusCode).toBe(200);
+
+    const get = await app.inject({
+      method: 'GET',
+      url: '/api/settings',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(get.json().confluencePatPromptDismissed).toBe(true);
+  });
+
+  it('requires authentication', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      payload: { confluencePatPromptDismissed: true },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects non-boolean values', async () => {
+    const { token } = await createUser('pat_prompt_invalid', 'user');
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { confluencePatPromptDismissed: 'yes' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/backend/src/routes/foundation/settings.ts
+++ b/backend/src/routes/foundation/settings.ts
@@ -25,8 +25,9 @@ export async function settingsRoutes(fastify: FastifyInstance) {
       sync_interval_min: number;
       show_space_home_content: boolean;
       custom_prompts: Record<string, string>;
+      confluence_pat_prompt_dismissed_at: Date | null;
     }>(
-      'SELECT confluence_url, confluence_pat, theme, sync_interval_min, show_space_home_content, custom_prompts FROM user_settings WHERE user_id = $1',
+      'SELECT confluence_url, confluence_pat, theme, sync_interval_min, show_space_home_content, custom_prompts, confluence_pat_prompt_dismissed_at FROM user_settings WHERE user_id = $1',
       [request.userId],
     );
     // #721: Use explicit editor assignments rather than getUserAccessibleSpaces
@@ -47,6 +48,7 @@ export async function settingsRoutes(fastify: FastifyInstance) {
         confluenceConnected: false,
         showSpaceHomeContent: true,
         customPrompts: {},
+        confluencePatPromptDismissed: false,
       };
     }
 
@@ -60,6 +62,8 @@ export async function settingsRoutes(fastify: FastifyInstance) {
       confluenceConnected: !!(row.confluence_url && row.confluence_pat),
       showSpaceHomeContent: row.show_space_home_content,
       customPrompts: row.custom_prompts ?? {},
+      // #771: boolean only — the dismissal timestamp stays server-side.
+      confluencePatPromptDismissed: !!row.confluence_pat_prompt_dismissed_at,
     };
   });
 
@@ -144,6 +148,17 @@ export async function settingsRoutes(fastify: FastifyInstance) {
     if (body.customPrompts !== undefined) {
       updates.push(`custom_prompts = $${paramIdx++}`);
       values.push(JSON.stringify(body.customPrompts));
+    }
+
+    // #771: dismissal of the Confluence-PAT onboarding banner. The client
+    // sends a boolean; the server owns the timestamp (NOW() on dismiss,
+    // NULL to clear). Static SQL fragments only — no user input involved.
+    if (body.confluencePatPromptDismissed !== undefined) {
+      updates.push(
+        body.confluencePatPromptDismissed
+          ? 'confluence_pat_prompt_dismissed_at = NOW()'
+          : 'confluence_pat_prompt_dismissed_at = NULL',
+      );
     }
 
     // Handle selectedSpaces via RBAC space_role_assignments

--- a/docs/architecture/04-frontend-structure.md
+++ b/docs/architecture/04-frontend-structure.md
@@ -42,7 +42,7 @@ flowchart TB
     subgraph shared["shared/"]
         direction LR
         sEnt["enterprise/<br/>context · loader · types · hook"]
-        sComp["components/<br/>layout · article · diagrams ·<br/>badges · feedback · effects"]
+        sComp["components/<br/>layout · article · diagrams · badges ·<br/>banners (TrialBanner · ConfluencePatBanner #771) ·<br/>feedback · effects"]
         sHooks["hooks/<br/>useSessionInit · useTokenRefreshTimer ·<br/>useThemeEffect · useSetupStatus"]
         sLib["lib/ (api client, utils)"]
     end

--- a/docs/architecture/06-data-model.md
+++ b/docs/architecture/06-data-model.md
@@ -55,6 +55,7 @@ erDiagram
         text ollama_model
         text theme
         int sync_interval_min
+        timestamptz confluence_pat_prompt_dismissed_at "PAT onboarding banner dismissed (#771)"
     }
 
     pages {

--- a/frontend/src/features/settings/settings-nav.test.ts
+++ b/frontend/src/features/settings/settings-nav.test.ts
@@ -6,6 +6,7 @@ import {
   type AccessContext,
   type SettingsNavItem,
 } from './settings-nav';
+import { CONFLUENCE_SETTINGS_PATH } from '../../shared/lib/routes';
 
 function ctx(partial: Partial<AccessContext> = {}): AccessContext {
   return {
@@ -70,6 +71,13 @@ describe('canSeeItem', () => {
 describe('firstVisiblePath', () => {
   it('returns /settings/personal/confluence for a vanilla user (first item in first group)', () => {
     expect(firstVisiblePath(ctx())).toBe('/settings/personal/confluence');
+  });
+
+  it('stays in sync with the shared CONFLUENCE_SETTINGS_PATH constant', () => {
+    // shared/lib/routes.ts duplicates this path so shared/ components
+    // (ConfluencePatBanner) can link to it without importing features/.
+    // Guard the constant against drifting from the nav-derived path.
+    expect(firstVisiblePath(ctx())).toBe(CONFLUENCE_SETTINGS_PATH);
   });
 });
 

--- a/frontend/src/features/settings/settings-nav.ts
+++ b/frontend/src/features/settings/settings-nav.ts
@@ -16,6 +16,8 @@
  * items without touching the underlying panel components.
  */
 
+import { CONFLUENCE_SETTINGS_PATH } from '../../shared/lib/routes';
+
 type SettingsCategoryId =
   | 'personal'
   | 'knowledge'
@@ -147,5 +149,5 @@ export function firstVisiblePath(ctx: AccessContext): string {
     }
   }
   // Fallback — should be unreachable because `confluence` is always visible.
-  return '/settings/personal/confluence';
+  return CONFLUENCE_SETTINGS_PATH;
 }

--- a/frontend/src/shared/components/banners/ConfluencePatBanner.test.tsx
+++ b/frontend/src/shared/components/banners/ConfluencePatBanner.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { SettingsResponse } from '@compendiq/contracts';
+import { ConfluencePatBanner, CONFLUENCE_SETTINGS_PATH } from './ConfluencePatBanner';
+
+const baseSettings: SettingsResponse = {
+  confluenceUrl: null,
+  hasConfluencePat: false,
+  selectedSpaces: [],
+  ollamaModel: 'qwen3.5',
+  llmProvider: 'ollama',
+  openaiBaseUrl: null,
+  hasOpenaiApiKey: false,
+  openaiModel: null,
+  embeddingModel: 'bge-m3',
+  theme: 'glass-dark',
+  syncIntervalMin: 15,
+  confluenceConnected: false,
+  showSpaceHomeContent: true,
+  customPrompts: {},
+  confluencePatPromptDismissed: false,
+};
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * Network-boundary mock: serves GET /api/settings from in-memory state and
+ * records PUT /api/settings bodies, applying confluencePatPromptDismissed so
+ * the post-dismiss refetch behaves like the real backend.
+ */
+function mockSettingsApi(overrides: Partial<SettingsResponse> = {}) {
+  const state = { settings: { ...baseSettings, ...overrides } };
+  const puts: Array<Record<string, unknown>> = [];
+
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const method = init?.method ?? 'GET';
+    if (url.endsWith('/api/settings') && method === 'GET') {
+      return jsonResponse(state.settings);
+    }
+    if (url.endsWith('/api/settings') && method === 'PUT') {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      puts.push(body);
+      if (typeof body.confluencePatPromptDismissed === 'boolean') {
+        state.settings = {
+          ...state.settings,
+          confluencePatPromptDismissed: body.confluencePatPromptDismissed,
+        };
+      }
+      return jsonResponse({ message: 'Settings updated' });
+    }
+    return new Response('Not found', { status: 404 });
+  });
+
+  return { state, puts };
+}
+
+function renderBanner() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<ConfluencePatBanner />} />
+          <Route
+            path={CONFLUENCE_SETTINGS_PATH}
+            element={<div data-testid="confluence-settings-page">Confluence settings</div>}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ConfluencePatBanner', () => {
+  it('shows for a user without a PAT who has not dismissed the prompt', async () => {
+    mockSettingsApi({ hasConfluencePat: false, confluencePatPromptDismissed: false });
+    renderBanner();
+
+    const banner = await screen.findByTestId('confluence-pat-banner');
+    expect(banner).toHaveTextContent('personal access token');
+    expect(banner).toHaveAttribute('role', 'status');
+    expect(screen.getByRole('link', { name: /configure pat/i })).toHaveAttribute(
+      'href',
+      CONFLUENCE_SETTINGS_PATH,
+    );
+  });
+
+  it('renders nothing while settings are still loading', () => {
+    // Fetch never resolves → query stays pending.
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => new Promise(() => {}));
+    renderBanner();
+    expect(screen.queryByTestId('confluence-pat-banner')).toBeNull();
+  });
+
+  it('renders nothing when a PAT is already configured', async () => {
+    mockSettingsApi({ hasConfluencePat: true });
+    renderBanner();
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(screen.queryByTestId('confluence-pat-banner')).toBeNull();
+  });
+
+  it('renders nothing when the prompt was previously dismissed', async () => {
+    mockSettingsApi({ confluencePatPromptDismissed: true });
+    renderBanner();
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(screen.queryByTestId('confluence-pat-banner')).toBeNull();
+  });
+
+  it('hides optimistically on dismiss, before the PUT resolves', async () => {
+    // GET resolves normally; PUT hangs forever — the banner must still hide.
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      if (init?.method === 'PUT') return new Promise<Response>(() => {});
+      void input;
+      return Promise.resolve(jsonResponse(baseSettings));
+    });
+    renderBanner();
+
+    await screen.findByTestId('confluence-pat-banner');
+    fireEvent.click(screen.getByRole('button', { name: /dismiss confluence pat reminder/i }));
+
+    await waitFor(() => expect(screen.queryByTestId('confluence-pat-banner')).toBeNull());
+  });
+
+  it('persists the dismissal via PUT /api/settings and stays hidden after refetch', async () => {
+    const { puts } = mockSettingsApi();
+    renderBanner();
+
+    await screen.findByTestId('confluence-pat-banner');
+    fireEvent.click(screen.getByRole('button', { name: /dismiss confluence pat reminder/i }));
+
+    // Dismissal reaches the server…
+    await waitFor(() => expect(puts).toEqual([{ confluencePatPromptDismissed: true }]));
+
+    // …and after the settings query is invalidated + refetched (mock server
+    // now reports dismissed=true), the banner stays hidden.
+    await waitFor(() =>
+      expect(
+        (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+          ([, init]) => (init as RequestInit | undefined)?.method !== 'PUT',
+        ).length,
+      ).toBeGreaterThanOrEqual(2),
+    );
+    expect(screen.queryByTestId('confluence-pat-banner')).toBeNull();
+  });
+
+  it('CTA navigates to Settings → Confluence', async () => {
+    mockSettingsApi();
+    renderBanner();
+
+    fireEvent.click(await screen.findByRole('link', { name: /configure pat/i }));
+
+    expect(await screen.findByTestId('confluence-settings-page')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/components/banners/ConfluencePatBanner.test.tsx
+++ b/frontend/src/shared/components/banners/ConfluencePatBanner.test.tsx
@@ -3,7 +3,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { SettingsResponse } from '@compendiq/contracts';
-import { ConfluencePatBanner, CONFLUENCE_SETTINGS_PATH } from './ConfluencePatBanner';
+import { ConfluencePatBanner } from './ConfluencePatBanner';
+import { CONFLUENCE_SETTINGS_PATH } from '../../lib/routes';
 
 const baseSettings: SettingsResponse = {
   confluenceUrl: null,

--- a/frontend/src/shared/components/banners/ConfluencePatBanner.tsx
+++ b/frontend/src/shared/components/banners/ConfluencePatBanner.tsx
@@ -1,0 +1,87 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { KeyRound, X } from 'lucide-react';
+import type { SettingsResponse } from '@compendiq/contracts';
+import { apiFetch } from '../../lib/api';
+import { useSettings } from '../../hooks/use-settings';
+
+/** Settings → Confluence tab — always visible to every role (see settings-nav.ts). */
+export const CONFLUENCE_SETTINGS_PATH = '/settings/personal/confluence';
+
+/**
+ * Onboarding banner prompting users without a Confluence PAT to configure one
+ * (#771). The Confluence PAT is per-user; the setup wizard's Confluence step
+ * runs once per deployment and is skippable, so users who log in afterwards
+ * land on the dashboard with no hint that Settings → Confluence needs their
+ * token before sync/search can work.
+ *
+ * Visibility is fully derived from `GET /api/settings`:
+ *   show ⇔ settings loaded ∧ !hasConfluencePat ∧ !confluencePatPromptDismissed
+ *
+ * No "first login" flag needed — the condition is stateless on the client and
+ * survives refresh and device switches. Dismissal persists server-side
+ * (user_settings.confluence_pat_prompt_dismissed_at) via PUT /api/settings;
+ * the cache is updated optimistically so the banner hides instantly.
+ *
+ * Rendered in AppLayout (TrialBanner pattern), which only wraps authenticated
+ * app routes — the login page and setup wizard never show it.
+ */
+export function ConfluencePatBanner() {
+  const { data: settings } = useSettings();
+  const queryClient = useQueryClient();
+
+  const dismiss = useMutation({
+    mutationFn: () =>
+      apiFetch('/settings', {
+        method: 'PUT',
+        body: JSON.stringify({ confluencePatPromptDismissed: true }),
+      }),
+    onMutate: async () => {
+      // Optimistic hide: stop in-flight settings fetches from clobbering the
+      // flip, then mark the prompt dismissed in the cache.
+      await queryClient.cancelQueries({ queryKey: ['settings'] });
+      queryClient.setQueryData<SettingsResponse>(['settings'], (old) =>
+        old ? { ...old, confluencePatPromptDismissed: true } : old,
+      );
+    },
+    onSettled: () => {
+      // Re-sync with the server either way (confirms the dismissal, or rolls
+      // the optimistic update back if the PUT failed).
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+    },
+  });
+
+  // Never flash while settings are loading / unavailable.
+  if (!settings) return null;
+  if (settings.hasConfluencePat || settings.confluencePatPromptDismissed) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="confluence-pat-banner"
+      className="nm-card mt-2 flex flex-wrap items-center gap-3 px-3 py-2 text-sm text-foreground"
+    >
+      <KeyRound size={16} className="shrink-0 text-primary" aria-hidden="true" />
+      <span className="min-w-0 flex-1">
+        Connect Compendiq to Confluence — add your personal access token (PAT)
+        so your spaces can sync.
+      </span>
+      <Link
+        to={CONFLUENCE_SETTINGS_PATH}
+        className="nm-button-primary shrink-0 px-3 py-1.5 text-xs"
+      >
+        Configure PAT
+      </Link>
+      <button
+        type="button"
+        onClick={() => dismiss.mutate()}
+        disabled={dismiss.isPending}
+        aria-label="Dismiss Confluence PAT reminder"
+        className="nm-icon-button h-8 w-8 shrink-0"
+      >
+        <X size={14} aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/shared/components/banners/ConfluencePatBanner.tsx
+++ b/frontend/src/shared/components/banners/ConfluencePatBanner.tsx
@@ -4,9 +4,7 @@ import { KeyRound, X } from 'lucide-react';
 import type { SettingsResponse } from '@compendiq/contracts';
 import { apiFetch } from '../../lib/api';
 import { useSettings } from '../../hooks/use-settings';
-
-/** Settings → Confluence tab — always visible to every role (see settings-nav.ts). */
-export const CONFLUENCE_SETTINGS_PATH = '/settings/personal/confluence';
+import { CONFLUENCE_SETTINGS_PATH } from '../../lib/routes';
 
 /**
  * Onboarding banner prompting users without a Confluence PAT to configure one

--- a/frontend/src/shared/components/layout/AppLayout.test.tsx
+++ b/frontend/src/shared/components/layout/AppLayout.test.tsx
@@ -15,7 +15,7 @@ vi.mock('./SidebarTreeView', () => ({
   ),
 }));
 
-vi.mock('./ArticleRightPane', () => ({
+vi.mock('../article/ArticleRightPane', () => ({
   ArticleRightPane: () => <div data-testid="article-right-pane">Article Right Pane</div>,
 }));
 
@@ -23,8 +23,14 @@ vi.mock('./CommandPalette', () => ({
   CommandPalette: () => null,
 }));
 
-vi.mock('./ServiceStatus', () => ({
+vi.mock('../badges/ServiceStatus', () => ({
   ServiceStatus: () => null,
+}));
+
+// Self-fetching banner (GET /api/settings) — mock it so AppLayout tests stay
+// hermetic (no unmocked fetch through jsdom).
+vi.mock('../banners/ConfluencePatBanner', () => ({
+  ConfluencePatBanner: () => null,
 }));
 
 vi.mock('./ThemeToggle', () => ({

--- a/frontend/src/shared/components/layout/AppLayout.tsx
+++ b/frontend/src/shared/components/layout/AppLayout.tsx
@@ -10,6 +10,7 @@ import { CommandPalette } from './CommandPalette';
 import { KeyboardShortcutsModal } from './KeyboardShortcutsModal';
 import { ServiceStatus } from '../badges/ServiceStatus';
 import { TrialBanner } from '../banners/TrialBanner';
+import { ConfluencePatBanner } from '../banners/ConfluencePatBanner';
 import { UserMenu } from './UserMenu';
 import { SidebarTreeView } from './SidebarTreeView';
 import { SettingsSidebar } from './SettingsSidebar';
@@ -278,6 +279,7 @@ export function AppLayout({ children }: { children: ReactNode }) {
       <div className="shrink-0 px-4 sm:px-6">
         <ServiceStatus />
         <TrialBanner />
+        <ConfluencePatBanner />
       </div>
 
       {/* Below header: sidebar + content area, edge-to-edge with borders. */}

--- a/frontend/src/shared/lib/routes.ts
+++ b/frontend/src/shared/lib/routes.ts
@@ -1,0 +1,18 @@
+/**
+ * App route paths referenced from more than one module.
+ *
+ * Lives in `shared/` so both `shared/` components and `features/` code can
+ * import it (frontend layering: `features/` → `shared/` only, never the
+ * reverse). Most routes are defined once in App.tsx / settings-nav.ts and
+ * need no constant — add one here only when a literal would otherwise be
+ * duplicated across the `shared/` ↔ `features/` boundary.
+ */
+
+/**
+ * Settings → Confluence tab — always visible to every role.
+ *
+ * Must match the path settings-nav.ts derives for the `personal/confluence`
+ * nav item (`/settings/<category>/<item>`); settings-nav.test.ts guards the
+ * two against drifting apart.
+ */
+export const CONFLUENCE_SETTINGS_PATH = '/settings/personal/confluence';

--- a/packages/contracts/src/schemas/settings.ts
+++ b/packages/contracts/src/schemas/settings.ts
@@ -36,6 +36,10 @@ export const UpdateSettingsSchema = z.object({
   syncIntervalMin: z.number().int().min(1).max(1440).optional(),
   showSpaceHomeContent: z.boolean().optional(),
   customPrompts: CustomPromptsSchema.optional(),
+  // #771: true → record dismissal of the Confluence-PAT onboarding banner
+  // (server stores NOW() in user_settings.confluence_pat_prompt_dismissed_at);
+  // false → clear the dismissal so the banner can reappear.
+  confluencePatPromptDismissed: z.boolean().optional(),
 });
 
 export const SettingsResponseSchema = z.object({
@@ -53,6 +57,10 @@ export const SettingsResponseSchema = z.object({
   confluenceConnected: z.boolean(),
   showSpaceHomeContent: z.boolean(),
   customPrompts: CustomPromptsSchema,
+  // #771: whether the user dismissed the Confluence-PAT onboarding banner.
+  // Derived server-side from confluence_pat_prompt_dismissed_at IS NOT NULL —
+  // the timestamp itself is never exposed.
+  confluencePatPromptDismissed: z.boolean(),
 });
 
 export const SyncProgressSchema = z.object({


### PR DESCRIPTION
## Summary

Closes #771. Users without a Confluence PAT now see a dismissible onboarding banner (TrialBanner pattern, rendered in `AppLayout`) explaining that a personal access token is required to connect Confluence, with a CTA to **Settings → Confluence** (`/settings/personal/confluence`) and a server-persisted dismiss.

## Design decisions

- **Surface: dismissible banner** (issue's recommended option) — low friction, follows the established `TrialBanner` pattern in `shared/components/banners/`, ADR-010 `nm-*` neumorphic styling, works in both themes, `role="status"` + keyboard-operable dismiss.
- **Settings-derived state instead of a `firstLogin` login-response flag.** The banner condition is really "no PAT configured AND not dismissed", both of which `GET /api/settings` can carry (`hasConfluencePat`, new `confluencePatPromptDismissed`). That makes the logic stateless on the client, correct across refreshes/devices/sessions, and avoids touching the auth flow entirely. The issue's pointers were explicitly non-prescriptive; this is the simpler, more robust variant (a `firstLogin` flag would also wrongly suppress the prompt on every login after the first).
- **Server-side dismissal persistence** (issue's recommended option): new nullable `user_settings.confluence_pat_prompt_dismissed_at TIMESTAMPTZ` (migration 078). The client sends a boolean via the existing `PUT /api/settings`; the server owns the timestamp (`NOW()` on dismiss, `NULL` to clear). Only the derived boolean is ever exposed — no PAT material, no timestamp leaves the server.
- **Re-surfacing on later PAT removal is out of scope** per the issue's resolved open question (the `false → NULL` clear path exists if we want it later).

## Changes

- `packages/contracts`: `UpdateSettingsSchema` + `SettingsResponseSchema` gain `confluencePatPromptDismissed`.
- `backend`: migration `078_user_settings_pat_prompt_dismissed.sql`; `GET /api/settings` returns the derived boolean; `PUT /api/settings` sets/clears the timestamp (auth inherited from the settings routes' `fastify.authenticate` hook; static SQL fragments only).
- `frontend`: new `ConfluencePatBanner` in `shared/components/banners/`, rendered in `AppLayout` (so it never appears on login or the setup wizard); hidden while settings load, when a PAT exists, or when dismissed; dismiss = optimistic cache update + `['settings']` invalidation.
- `docs/architecture`: `06-data-model.md` (user_settings ERD column) and `04-frontend-structure.md` (shared banners).

## Test plan

- **Backend (real Postgres, no DB mocks):**
  - `078_user_settings_pat_prompt_dismissed.test.ts` — column exists, TIMESTAMPTZ, nullable, defaults NULL.
  - `settings-pat-prompt.test.ts` — full `buildApp()` round-trip with real JWTs: GET defaults false (existing + auto-created rows), PUT true sets the timestamp and round-trips, PUT false clears, works for admin and non-admin, 401 unauthenticated, 400 on non-boolean.
- **Frontend (jsdom, network-boundary fetch mocks):**
  - `ConfluencePatBanner.test.tsx` — shows for no-PAT + not-dismissed (with role + CTA href), hidden while loading / with PAT / when dismissed, hides optimistically before the PUT resolves, persists via PUT body + stays hidden after refetch, CTA navigates to the Confluence settings route.
- Existing settings route/UI suites re-run green; lint + typecheck clean across contracts/backend/frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)