### PR TITLE
feat(editor): merge selection bubble menu and AI Improve into a single popup (#782)

### DIFF
--- a/frontend/src/shared/components/article/EditorBubbleMenu.test.tsx
+++ b/frontend/src/shared/components/article/EditorBubbleMenu.test.tsx
@@ -12,7 +12,11 @@ vi.mock('../../lib/sse', () => ({
   streamSSE: (...args: unknown[]) => streamSSE(...args),
 }));
 
-import { BubbleMenuContent, selectionShouldShow } from './EditorBubbleMenu';
+import {
+  BubbleMenuContent,
+  selectionShouldShow,
+  editorBubbleMenuPluginKey,
+} from './EditorBubbleMenu';
 import { IMPROVE_DECORATION_CLASS } from './improve-decoration';
 
 function gen(chunks: Array<Record<string, unknown>>) {
@@ -40,12 +44,9 @@ beforeAll(() => {
 function Harness({
   content,
   onReady,
-  scrollable,
 }: {
   content: string;
   onReady: (editor: EditorType) => void;
-  /** Wrap the editor in an overflow container (mimics AppLayout's `data-scroll-container`). */
-  scrollable?: boolean;
 }) {
   const editor = useEditor({
     extensions: [StarterKit, Highlight.configure({ multicolor: true })],
@@ -58,25 +59,17 @@ function Harness({
   }, [editor, onReady]);
 
   if (!editor) return null;
-  const body = (
+  return (
     <>
       <EditorContent editor={editor} />
       <BubbleMenuContent editor={editor} />
     </>
   );
-  return scrollable
-    ? <div data-testid="scroll-container" style={{ overflow: 'auto' }}>{body}</div>
-    : body;
 }
 
-async function mountEditor(
-  content: string,
-  opts?: { scrollable?: boolean },
-): Promise<EditorType> {
+async function mountEditor(content: string): Promise<EditorType> {
   let editor: EditorType | null = null;
-  render(
-    <Harness content={content} onReady={(e) => { editor = e; }} scrollable={opts?.scrollable} />,
-  );
+  render(<Harness content={content} onReady={(e) => { editor = e; }} />);
   await waitFor(() => expect(editor).not.toBeNull());
   return editor!;
 }
@@ -109,7 +102,7 @@ describe('selectionShouldShow', () => {
     expect(selectionShouldShow(editor, false)).toBe(false);
   });
 
-  it('stays shown while the AI popover is open, regardless of selection', async () => {
+  it('stays shown while the AI section is open, regardless of selection', async () => {
     const editor = await mountEditor('<p>Hello world</p>');
     act(() => { editor.commands.setTextSelection(2); }); // collapsed
     expect(selectionShouldShow(editor, true)).toBe(true);
@@ -238,7 +231,7 @@ describe('BubbleMenuContent — selection decoration lifecycle (#764)', () => {
   const decorated = (editor: EditorType) =>
     editor.view.dom.querySelector(`.${IMPROVE_DECORATION_CLASS}`);
 
-  it('decorates the captured range while the Improve popover is open, without mutating the doc', async () => {
+  it('decorates the captured range while the Improve section is open, without mutating the doc', async () => {
     const editor = await mountEditor('<p>Hello world</p>');
     act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
 
@@ -252,7 +245,7 @@ describe('BubbleMenuContent — selection decoration lifecycle (#764)', () => {
     expect(editor.getHTML()).toBe('<p>Hello world</p>');
   });
 
-  it('clears the decoration when the popover closes via Escape', async () => {
+  it('clears the decoration when the AI section closes via Escape', async () => {
     const editor = await mountEditor('<p>Hello world</p>');
     act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
 
@@ -342,45 +335,161 @@ describe('BubbleMenuContent — selection decoration lifecycle (#764)', () => {
   });
 });
 
-describe('BubbleMenuContent — AI popover scroll tracking (#764)', () => {
+describe('BubbleMenuContent — single merged surface (#782)', () => {
   beforeEach(() => streamSSE.mockReset());
 
-  it('attaches a scroll listener to the article scroll container via the virtual anchor', async () => {
-    const editor = await mountEditor('<p>Hello world</p>', { scrollable: true });
-    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
-
-    const container = screen.getByTestId('scroll-container');
-    const addListener = vi.spyOn(container, 'addEventListener');
-
-    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
-    await screen.findByTestId('bubble-ai-popover');
-
-    // The popover is portalled to <body>, so the article's scroll container
-    // is reachable only through the virtual reference's `contextElement`.
-    // Floating UI's autoUpdate must derive a scroll listener from it —
-    // without `contextElement` no reference-side listeners attach and the
-    // popover would stay put while the decorated text scrolls away.
-    await waitFor(() => {
-      expect(addListener.mock.calls.some(([type]) => type === 'scroll')).toBe(true);
-    });
-  });
-});
-
-describe('BubbleMenuContent — AI popover placement (#764)', () => {
-  beforeEach(() => streamSSE.mockReset());
-
-  it('opens below the selection anchor (side bottom, align start)', async () => {
+  it('expands the AI section INSIDE the bubble-menu container — no detached popover', async () => {
     const editor = await mountEditor('<p>Hello world</p>');
     act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
 
     fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
 
-    const popover = await screen.findByTestId('bubble-ai-popover');
-    // Radix reflects the resolved placement as data attributes. `bottom` +
-    // the selection-rect virtual anchor stacks the popover under the bubble
-    // menu (which floats above the selection) instead of over the text.
-    await waitFor(() => expect(popover).toHaveAttribute('data-side', 'bottom'));
-    expect(popover).toHaveAttribute('data-align', 'start');
+    const panel = await screen.findByTestId('bubble-ai-panel');
+    // One container: the AI section is a child of the bubble menu, sharing its
+    // single Floating UI anchor on the selection.
+    expect(screen.getByTestId('editor-bubble-menu')).toContainElement(panel);
+    // The old #764 layout portalled a Radix popover to <body> on the opposite
+    // side of the selection — it must be gone.
+    expect(screen.queryByTestId('bubble-ai-popover')).not.toBeInTheDocument();
+    expect(document.querySelector('[data-radix-popper-content-wrapper]')).toBeNull();
+  });
+
+  it('marks the trigger expanded while open and collapses (clearing the decoration) on second click', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    const trigger = screen.getByTestId('bubble-ai-trigger');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(editor.view.dom.querySelector(`.${IMPROVE_DECORATION_CLASS}`)).not.toBeNull();
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('bubble-ai-panel')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(editor.view.dom.querySelector(`.${IMPROVE_DECORATION_CLASS}`)).toBeNull();
+    });
+  });
+
+  it('expands in place on Cmd/Ctrl+J', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.keyDown(document, { key: 'j', ctrlKey: true });
+
+    const panel = await screen.findByTestId('bubble-ai-panel');
+    expect(screen.getByTestId('editor-bubble-menu')).toContainElement(panel);
+    expect(editor.view.dom.querySelector(`.${IMPROVE_DECORATION_CLASS}`)).not.toBeNull();
+  });
+
+  it('focuses the prompt input on open while the menu stays mounted (focus-retention, #764)', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+
+    const input = await screen.findByLabelText('Ask AI to edit the selection');
+    expect(input).toHaveFocus();
+    // The editor lost focus to the input, but the shouldShow contract keeps
+    // the (single) panel mounted while the AI section is open.
+    expect(selectionShouldShow(editor, true)).toBe(true);
+    expect(screen.getByTestId('editor-bubble-menu')).toBeInTheDocument();
+  });
+
+  it('collapses and clears the decoration on outside pointerdown', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    await screen.findByTestId('bubble-ai-panel');
+
+    fireEvent.pointerDown(document.body);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('bubble-ai-panel')).not.toBeInTheDocument();
+    });
+    expect(editor.view.dom.querySelector(`.${IMPROVE_DECORATION_CLASS}`)).toBeNull();
+    expect(editor.getHTML()).toBe('<p>Hello world</p>'); // never mutated
+  });
+
+  it('does NOT collapse on pointerdown inside the panel (e.g. quick actions, toolbar row)', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    const panel = await screen.findByTestId('bubble-ai-panel');
+
+    fireEvent.pointerDown(panel);
+    fireEvent.pointerDown(screen.getByTitle('Bold (Ctrl+B)'));
+
+    expect(screen.getByTestId('bubble-ai-panel')).toBeInTheDocument();
+  });
+});
+
+describe('BubbleMenuContent — Floating UI repositioning on panel growth (#782)', () => {
+  beforeEach(() => streamSSE.mockReset());
+
+  /** Collect `updatePosition` requests dispatched to the BubbleMenu plugin. */
+  function trackPositionUpdates(editor: EditorType): { count: () => number } {
+    let n = 0;
+    editor.on('transaction', ({ transaction }) => {
+      if (transaction.getMeta(editorBubbleMenuPluginKey) === 'updatePosition') n += 1;
+    });
+    return { count: () => n };
+  }
+
+  it('requests a position update when the AI section expands', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    const updates = trackPositionUpdates(editor);
+    const before = updates.count();
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+
+    // The plugin only repositions on selection/doc/scroll/resize by itself —
+    // expanding the panel must explicitly ask Floating UI to recompute so the
+    // grown container is re-anchored (flip/shift re-evaluate) instead of
+    // growing over the decorated selection.
+    await waitFor(() => expect(updates.count()).toBeGreaterThan(before));
+  });
+
+  it('requests position updates as streamed content grows the preview', async () => {
+    streamSSE.mockReturnValue(gen([{ content: 'How' }, { content: 'dy' }]));
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    const updates = trackPositionUpdates(editor);
+    const before = updates.count();
+
+    fireEvent.click(await screen.findByText('Improve writing'));
+    await waitFor(() => expect(screen.getByTestId('bubble-ai-preview')).toHaveTextContent('Howdy'));
+
+    await waitFor(() => expect(updates.count()).toBeGreaterThan(before));
+  });
+});
+
+describe('BubbleMenuContent — error state', () => {
+  beforeEach(() => streamSSE.mockReset());
+
+  it('surfaces the stream error with retry, inside the merged panel', async () => {
+    streamSSE.mockReturnValue(gen([{ error: 'LLM unavailable' }]));
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    fireEvent.click(await screen.findByText('Improve writing'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('LLM unavailable');
+    expect(screen.getByTestId('editor-bubble-menu')).toContainElement(alert);
+
+    // Retry from the error state streams again into the same panel.
+    streamSSE.mockReturnValue(gen([{ content: 'Recovered' }]));
+    fireEvent.click(screen.getByText('Try again'));
+    await waitFor(() => expect(screen.getByTestId('bubble-ai-preview')).toHaveTextContent('Recovered'));
   });
 });
 

--- a/frontend/src/shared/components/article/EditorBubbleMenu.test.tsx
+++ b/frontend/src/shared/components/article/EditorBubbleMenu.test.tsx
@@ -426,6 +426,51 @@ describe('BubbleMenuContent — single merged surface (#782)', () => {
 
     expect(screen.getByTestId('bubble-ai-panel')).toBeInTheDocument();
   });
+
+  it('does NOT collapse on Escape targeted at a foreign overlay (e.g. a dialog stacked above)', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    await screen.findByTestId('bubble-ai-panel');
+
+    // A modal portalled to <body> above the editor — its Escape must close the
+    // modal, not also collapse the AI section underneath.
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    const dialogInput = document.createElement('input');
+    dialog.appendChild(dialogInput);
+    document.body.appendChild(dialog);
+    try {
+      fireEvent.keyDown(dialogInput, { key: 'Escape' });
+
+      expect(screen.getByTestId('bubble-ai-panel')).toBeInTheDocument();
+      expect(editor.view.dom.querySelector(`.${IMPROVE_DECORATION_CLASS}`)).not.toBeNull();
+    } finally {
+      dialog.remove();
+    }
+  });
+
+  it('does NOT collapse on an Escape a higher-priority handler already consumed (defaultPrevented)', async () => {
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    await screen.findByTestId('bubble-ai-panel');
+
+    // Simulate an overlay's capture-phase handler claiming the Escape before
+    // our document-level listener sees it.
+    const consume = (e: KeyboardEvent) => { if (e.key === 'Escape') e.preventDefault(); };
+    document.addEventListener('keydown', consume, { capture: true });
+    try {
+      fireEvent.keyDown(document.body, { key: 'Escape' });
+
+      expect(screen.getByTestId('bubble-ai-panel')).toBeInTheDocument();
+      expect(editor.view.dom.querySelector(`.${IMPROVE_DECORATION_CLASS}`)).not.toBeNull();
+    } finally {
+      document.removeEventListener('keydown', consume, { capture: true });
+    }
+  });
 });
 
 describe('BubbleMenuContent — Floating UI repositioning on panel growth (#782)', () => {
@@ -468,6 +513,61 @@ describe('BubbleMenuContent — Floating UI repositioning on panel growth (#782)
     await waitFor(() => expect(screen.getByTestId('bubble-ai-preview')).toHaveTextContent('Howdy'));
 
     await waitFor(() => expect(updates.count()).toBeGreaterThan(before));
+  });
+
+  it('coalesces per-chunk reposition requests into one animation frame (no dispatch per SSE chunk)', async () => {
+    streamSSE.mockReturnValue(gen([
+      { content: 'How' }, { content: 'dy ' }, { content: 'part' }, { content: 'ner' },
+    ]));
+    const editor = await mountEditor('<p>Hello world</p>');
+    act(() => { editor.commands.setTextSelection({ from: 1, to: 6 }); });
+
+    fireEvent.click(screen.getByTestId('bubble-ai-trigger'));
+    await screen.findByTestId('bubble-ai-panel');
+    // Let any reposition frame scheduled by opening the panel fire before
+    // stubbing rAF (frame callbacks run in registration order, so awaiting a
+    // fresh frame guarantees earlier ones have run).
+    await act(async () => {
+      await new Promise<void>((resolve) => { requestAnimationFrame(() => resolve()); });
+    });
+
+    // Deterministic rAF: frames only run when flushed manually.
+    const pendingFrames = new Map<number, FrameRequestCallback>();
+    let nextFrameId = 1;
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      const id = nextFrameId++;
+      pendingFrames.set(id, cb);
+      return id;
+    });
+    const caf = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => {
+      pendingFrames.delete(id);
+    });
+
+    try {
+      const updates = trackPositionUpdates(editor);
+      fireEvent.click(screen.getByText('Improve writing'));
+      await waitFor(() => expect(screen.getByTestId('bubble-ai-preview')).toHaveTextContent('Howdy partner'));
+
+      // Only the immediate (layout-effect) path dispatched so far: one for
+      // idle→streaming and one for streaming→done. The four chunks did NOT
+      // dispatch per-chunk transactions.
+      await waitFor(() => expect(updates.count()).toBe(2));
+
+      // The four output changes coalesced into a single pending frame
+      // (earlier frames were cancelled on re-schedule).
+      expect(pendingFrames.size).toBe(1);
+
+      act(() => {
+        const frames = [...pendingFrames.values()];
+        pendingFrames.clear();
+        for (const cb of frames) cb(performance.now());
+      });
+      // The coalesced frame dispatched exactly one position update.
+      expect(updates.count()).toBe(3);
+    } finally {
+      raf.mockRestore();
+      caf.mockRestore();
+    }
   });
 });
 

--- a/frontend/src/shared/components/article/EditorBubbleMenu.tsx
+++ b/frontend/src/shared/components/article/EditorBubbleMenu.tsx
@@ -231,10 +231,20 @@ export function BubbleMenuContent({
   useEffect(() => {
     if (!aiOpen) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        closeAi();
-      }
+      if (e.key !== 'Escape') return;
+      // A layer stacked above us (modal, dropdown) already consumed this
+      // Escape — don't double-dismiss.
+      if (e.defaultPrevented) return;
+      // The Escape belongs to a foreign floating layer (dialog / Radix popper
+      // portalled to <body>) that is open above the editor — let it close
+      // itself instead of swallowing the key here.
+      const root = rootRef.current;
+      const foreignLayer = (e.target as Element | null)?.closest?.(
+        '[role="dialog"], [role="alertdialog"], [data-radix-popper-content-wrapper]',
+      );
+      if (foreignLayer && !(root && root.contains(foreignLayer))) return;
+      e.preventDefault();
+      closeAi();
     };
     const onPointerDown = (e: PointerEvent) => {
       const root = rootRef.current;
@@ -258,7 +268,22 @@ export function BubbleMenuContent({
   useLayoutEffect(() => {
     if (editor.isDestroyed) return;
     editor.view.dispatch(editor.state.tr.setMeta(editorBubbleMenuPluginKey, 'updatePosition'));
-  }, [editor, aiOpen, stream.status, stream.output]);
+  }, [editor, aiOpen, stream.status]);
+
+  // The streamed preview grows on EVERY SSE chunk; dispatching a reposition
+  // transaction per chunk would run a full state apply + Floating UI
+  // computePosition each time. Coalesce via requestAnimationFrame — at most
+  // one dispatch per frame (re-scheduling within a frame keeps the same
+  // next-paint slot), cancelled on unmount. Open/close and status transitions
+  // above stay layout-effect-synchronous so expansion never flashes over the
+  // selection; only this high-frequency path is throttled.
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      if (editor.isDestroyed) return;
+      editor.view.dispatch(editor.state.tr.setMeta(editorBubbleMenuPluginKey, 'updatePosition'));
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [editor, stream.output]);
 
   // #764 — the decoration set is remapped through every transaction (see
   // improve-decoration.ts), while `rangeRef` keeps the offsets captured when

--- a/frontend/src/shared/components/article/EditorBubbleMenu.tsx
+++ b/frontend/src/shared/components/article/EditorBubbleMenu.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import { BubbleMenu } from '@tiptap/react/menus';
 import { useEditorState } from '@tiptap/react';
-import { posToDOMRect } from '@tiptap/core';
-import * as Popover from '@radix-ui/react-popover';
+import { PluginKey } from '@tiptap/pm/state';
 import type { Editor as EditorType } from '@tiptap/react';
 import {
   Bold, Italic, Underline, Strikethrough, Code, Highlighter,
@@ -21,11 +20,29 @@ import {
 } from './improve-decoration';
 
 /**
- * #708 — Notion-style selection bubble menu for the article editor (edit mode
- * only). Shows core inline-formatting actions plus an "Improve" entry that
- * streams an AI rewrite of ONLY the selected fragment into a popover preview.
- * The document is never mutated until the user accepts (Replace / Insert).
+ * #708 / #782 — Notion-style selection bubble menu for the article editor
+ * (edit mode only). A SINGLE floating panel: core inline-formatting actions in
+ * a toolbar row, plus an "Improve" entry that expands the SAME container in
+ * place into the AI section (prompt input, quick actions, streamed preview,
+ * accept controls). The AI rewrite targets ONLY the selected fragment and the
+ * document is never mutated until the user accepts (Replace / Insert).
+ *
+ * Before #782 the AI section was a separate Radix Popover portalled to <body>
+ * and anchored below the selection — two disconnected popups stacked around
+ * the selected text. Now everything rides the one TipTap BubbleMenu container
+ * (Floating UI: placement top, flip/shift on collision); the selection stays
+ * visible below the panel via the #764 decoration.
  */
+
+/**
+ * Plugin key for the bubble-menu Floating UI plugin. Exported so the content
+ * can ask the plugin to recompute its position when the panel changes size
+ * (the plugin repositions on selection/doc/scroll/resize, but does not observe
+ * the floating element itself). Documented mechanism:
+ * `editor.view.dispatch(editor.state.tr.setMeta(pluginKey, 'updatePosition'))`.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export const editorBubbleMenuPluginKey = new PluginKey('editorBubbleMenu');
 
 interface QuickAction {
   key: string;
@@ -121,7 +138,7 @@ function MenuButton({
  * The visible menu body. Split out from `EditorBubbleMenu` so it can be tested
  * directly with an editor instance, independent of the TipTap BubbleMenu
  * wrapper (which relies on Floating UI + a ProseMirror plugin that does not
- * render in jsdom). `onAiOpenChange` lets the wrapper mirror AI-popover state
+ * render in jsdom). `onAiOpenChange` lets the wrapper mirror AI-section state
  * into `shouldShow`.
  */
 export function BubbleMenuContent({
@@ -140,6 +157,8 @@ export function BubbleMenuContent({
   // replays the user's actual choice rather than a hardcoded default.
   const lastRunRef = useRef<{ action: QuickAction; freeForm: string } | null>(null);
   const stream = useImproveStream();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const aiPanelId = useId();
 
   // #764 — register the non-destructive selection-decoration plugin for the
   // life of the menu. It stays inert (empty DecorationSet) until `openAi`
@@ -150,43 +169,6 @@ export function BubbleMenuContent({
     editor.registerPlugin(createImproveDecorationPlugin());
     return () => { editor.unregisterPlugin(improveDecorationKey); };
   }, [editor]);
-
-  // Latest-ref so the stable virtual-anchor object below always measures the
-  // current editor. Assigned in an effect rather than during render for
-  // concurrent-rendering safety.
-  const editorRef = useRef(editor);
-  useEffect(() => { editorRef.current = editor; }, [editor]);
-
-  // #764 — Radix virtual anchor that measures the captured selection rect, so
-  // the AI popover positions relative to the SELECTION rather than the Improve
-  // trigger. The bubble menu floats above the selection, so `side="bottom"`
-  // from the trigger would land the popover exactly on top of the selected
-  // text; anchored to the selection rect instead, the stack reads predictably
-  // top-to-bottom as bubble menu → decorated selection → popover.
-  const selectionAnchorRef = useRef({
-    getBoundingClientRect: (): DOMRect => {
-      const range = rangeRef.current;
-      const e = editorRef.current;
-      if (range && !e.isDestroyed) {
-        try {
-          return posToDOMRect(e.view, range.from, range.to);
-        } catch {
-          // jsdom / detached view — fall through to the zero rect below.
-        }
-      }
-      const zero = { top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0, x: 0, y: 0 };
-      return { ...zero, toJSON: () => zero } as DOMRect;
-    },
-    // Floating UI's `autoUpdate` unwraps virtual references via
-    // `contextElement` to derive scroll/move listeners. The popover is
-    // portalled to <body> while the article scrolls in an inner container, so
-    // without this the popover would stay put as the decorated text scrolls
-    // away. Extra properties pass through Radix's `Measurable` untouched.
-    get contextElement(): HTMLElement | undefined {
-      const e = editorRef.current;
-      return e.isDestroyed ? undefined : e.view.dom;
-    },
-  });
 
   // Subscribe to active marks so the formatting buttons re-render their
   // active/pressed state on selection and toggle changes (mirrors EditorToolbar).
@@ -229,7 +211,7 @@ export function BubbleMenuContent({
     lastRunRef.current = null;
   }, [editor, stream, setAi]);
 
-  // Cmd/Ctrl+J opens the AI popover on the current selection (#708 optional
+  // Cmd/Ctrl+J expands the AI section on the current selection (#708 optional
   // keyboard trigger).
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -243,10 +225,45 @@ export function BubbleMenuContent({
     return () => document.removeEventListener('keydown', handler);
   }, [editor, openAi]);
 
+  // #782 — dismissal was previously Radix Popover's job. Escape and
+  // outside-pointerdown collapse the AI section (abort + clear decoration);
+  // clicks inside the merged panel (toolbar row included) never dismiss.
+  useEffect(() => {
+    if (!aiOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeAi();
+      }
+    };
+    const onPointerDown = (e: PointerEvent) => {
+      const root = rootRef.current;
+      if (root && e.target instanceof Node && !root.contains(e.target)) closeAi();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('pointerdown', onPointerDown);
+    };
+  }, [aiOpen, closeAi]);
+
+  // #782 — the BubbleMenu plugin repositions on selection/doc changes, scroll
+  // and window resize, but it does NOT observe the floating element's own
+  // size. Expanding/collapsing the AI section and the preview growing while
+  // streaming change the panel height, so ask the plugin to re-run Floating UI
+  // (flip/shift re-pick the side with room) via its documented
+  // `updatePosition` transaction meta. Layout effect so the reposition happens
+  // in the same frame as the DOM growth (no flash over the selection).
+  useLayoutEffect(() => {
+    if (editor.isDestroyed) return;
+    editor.view.dispatch(editor.state.tr.setMeta(editorBubbleMenuPluginKey, 'updatePosition'));
+  }, [editor, aiOpen, stream.status, stream.output]);
+
   // #764 — the decoration set is remapped through every transaction (see
   // improve-decoration.ts), while `rangeRef` keeps the offsets captured when
-  // the popover opened. Read the live range from the decoration so actions
-  // track the passage even if the document changed while the popover was
+  // the AI section opened. Read the live range from the decoration so actions
+  // track the passage even if the document changed while the section was
   // open; fall back to the captured range when no decoration exists.
   const currentRange = useCallback((): { from: number; to: number } | null => {
     if (!editor.isDestroyed) {
@@ -308,253 +325,247 @@ export function BubbleMenuContent({
 
   return (
     <div
+      ref={rootRef}
       data-testid="editor-bubble-menu"
       className={cn(
-        'flex items-center gap-0.5 rounded-lg border border-border bg-card p-1 shadow-lg',
+        'flex flex-col rounded-lg border border-border bg-card shadow-lg',
         'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-95',
       )}
-      role="toolbar"
-      aria-label="Selection formatting"
     >
-      <MenuButton
-        onClick={() => editor.chain().focus().toggleBold().run()}
-        active={active.bold}
-        title="Bold (Ctrl+B)"
+      <div
+        role="toolbar"
+        aria-label="Selection formatting"
+        className="flex items-center gap-0.5 p-1"
       >
-        <Bold size={15} />
-      </MenuButton>
-      <MenuButton
-        onClick={() => editor.chain().focus().toggleItalic().run()}
-        active={active.italic}
-        title="Italic (Ctrl+I)"
-      >
-        <Italic size={15} />
-      </MenuButton>
-      <MenuButton
-        onClick={() => editor.chain().focus().toggleUnderline().run()}
-        active={active.underline}
-        title="Underline (Ctrl+U)"
-      >
-        <Underline size={15} />
-      </MenuButton>
-      <MenuButton
-        onClick={() => editor.chain().focus().toggleStrike().run()}
-        active={active.strike}
-        title="Strikethrough (Ctrl+Shift+X)"
-      >
-        <Strikethrough size={15} />
-      </MenuButton>
-      <MenuButton
-        onClick={() => editor.chain().focus().toggleCode().run()}
-        active={active.code}
-        title="Inline code (Ctrl+E)"
-      >
-        <Code size={15} />
-      </MenuButton>
-      <MenuButton
-        onClick={() => editor.chain().focus().toggleHighlight().run()}
-        active={active.highlight}
-        title="Highlight (Ctrl+Shift+H)"
-      >
-        <Highlighter size={15} />
-      </MenuButton>
+        <MenuButton
+          onClick={() => editor.chain().focus().toggleBold().run()}
+          active={active.bold}
+          title="Bold (Ctrl+B)"
+        >
+          <Bold size={15} />
+        </MenuButton>
+        <MenuButton
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+          active={active.italic}
+          title="Italic (Ctrl+I)"
+        >
+          <Italic size={15} />
+        </MenuButton>
+        <MenuButton
+          onClick={() => editor.chain().focus().toggleUnderline().run()}
+          active={active.underline}
+          title="Underline (Ctrl+U)"
+        >
+          <Underline size={15} />
+        </MenuButton>
+        <MenuButton
+          onClick={() => editor.chain().focus().toggleStrike().run()}
+          active={active.strike}
+          title="Strikethrough (Ctrl+Shift+X)"
+        >
+          <Strikethrough size={15} />
+        </MenuButton>
+        <MenuButton
+          onClick={() => editor.chain().focus().toggleCode().run()}
+          active={active.code}
+          title="Inline code (Ctrl+E)"
+        >
+          <Code size={15} />
+        </MenuButton>
+        <MenuButton
+          onClick={() => editor.chain().focus().toggleHighlight().run()}
+          active={active.highlight}
+          title="Highlight (Ctrl+Shift+H)"
+        >
+          <Highlighter size={15} />
+        </MenuButton>
 
-      <div role="separator" aria-orientation="vertical" className="mx-0.5 h-5 w-px bg-border" />
+        <div role="separator" aria-orientation="vertical" className="mx-0.5 h-5 w-px bg-border" />
 
-      <Popover.Root open={aiOpen} onOpenChange={(o) => (o ? openAi() : closeAi())}>
-        <Popover.Trigger asChild>
-          <button
-            type="button"
-            onMouseDown={(e) => e.preventDefault()}
-            title="Improve with AI"
-            aria-label="Improve with AI"
-            data-testid="bubble-ai-trigger"
-            className={cn(
-              'flex h-8 items-center gap-1 rounded px-2 text-sm font-medium transition-colors',
-              'text-primary hover:bg-primary/10',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
-            )}
-          >
-            <Sparkles size={15} />
-            <span>Improve</span>
-          </button>
-        </Popover.Trigger>
-        {/* #764 — virtual anchor on the captured selection rect (see
-            selectionAnchorRef above); renders no DOM node of its own.
-            MUST come after Popover.Trigger: on the first render Radix's
-            `hasCustomAnchor` is still false, so the Trigger wraps itself in
-            its own popper Anchor whose mount effect would otherwise run last
-            and permanently override the virtual anchor with the trigger
-            button (nothing re-asserts the virtual anchor afterwards). */}
-        <Popover.Anchor virtualRef={selectionAnchorRef} />
-        <Popover.Portal>
-          <Popover.Content
-            // #764 — anchored to the selection rect (virtual anchor above):
-            // `side="bottom"` opens BELOW the selection, i.e. under the bubble
-            // menu (which floats above it) without covering the decorated text.
-            align="start"
-            side="bottom"
-            sideOffset={8}
-            collisionPadding={12}
-            data-testid="bubble-ai-popover"
-            // Keep focus inside; closing is explicit (Discard / Escape).
-            onOpenAutoFocus={(e) => { if (hasResult || isStreaming) e.preventDefault(); }}
-            className={cn(
-              'z-50 w-80 rounded-lg border border-border bg-card p-3 shadow-xl outline-none',
-              'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-95',
-            )}
-          >
-            {!hasResult && !isStreaming && !emptyResult && stream.status !== 'error' && (
-              <div className="flex flex-col gap-2">
-                <input
-                  type="text"
-                  value={freeForm}
-                  autoFocus
-                  onChange={(e) => setFreeForm(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && freeForm.trim()) {
-                      e.preventDefault();
-                      runAction(QUICK_ACTIONS[0]!, freeForm);
-                    }
-                  }}
-                  placeholder="Ask AI to edit the selection…"
-                  aria-label="Ask AI to edit the selection"
-                  className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                />
-                <div className="flex flex-col gap-0.5">
-                  {QUICK_ACTIONS.map((action) => (
-                    <button
-                      key={action.key}
-                      type="button"
-                      onClick={() => runAction(action, freeForm)}
-                      className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                    >
-                      <Sparkles size={14} className="text-primary" />
-                      {action.label}
-                    </button>
-                  ))}
-                </div>
+        <button
+          type="button"
+          onMouseDown={(e) => e.preventDefault()} // keep editor selection on click
+          onClick={() => (aiOpen ? closeAi() : openAi())}
+          title="Improve with AI"
+          aria-label="Improve with AI"
+          aria-expanded={aiOpen}
+          aria-controls={aiOpen ? aiPanelId : undefined}
+          data-testid="bubble-ai-trigger"
+          className={cn(
+            'flex h-8 items-center gap-1 rounded px-2 text-sm font-medium transition-colors',
+            'text-primary hover:bg-primary/10',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+            aiOpen && 'bg-primary/10',
+          )}
+        >
+          <Sparkles size={15} />
+          <span>Improve</span>
+        </button>
+      </div>
+
+      {/* #782 — the AI section expands the SAME container in place (below the
+          toolbar row) instead of opening a second portalled popover on the
+          other side of the selection. The container floats above the selection
+          (placement 'top' on the wrapper), so growing downward is re-anchored
+          by the updatePosition effect and never covers the decorated text. */}
+      {aiOpen && (
+        <div
+          id={aiPanelId}
+          role="group"
+          aria-label="Improve selection with AI"
+          data-testid="bubble-ai-panel"
+          className="w-80 border-t border-border p-3"
+        >
+          {!hasResult && !isStreaming && !emptyResult && stream.status !== 'error' && (
+            <div className="flex flex-col gap-2">
+              <input
+                type="text"
+                value={freeForm}
+                autoFocus
+                onChange={(e) => setFreeForm(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && freeForm.trim()) {
+                    e.preventDefault();
+                    runAction(QUICK_ACTIONS[0]!, freeForm);
+                  }
+                }}
+                placeholder="Ask AI to edit the selection…"
+                aria-label="Ask AI to edit the selection"
+                className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              />
+              <div className="flex flex-col gap-0.5">
+                {QUICK_ACTIONS.map((action) => (
+                  <button
+                    key={action.key}
+                    type="button"
+                    onClick={() => runAction(action, freeForm)}
+                    className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    <Sparkles size={14} className="text-primary" />
+                    {action.label}
+                  </button>
+                ))}
               </div>
-            )}
+            </div>
+          )}
 
-            {(isStreaming || hasResult) && (
-              <div className="flex flex-col gap-2">
-                <div
-                  data-testid="bubble-ai-preview"
-                  aria-live="polite"
-                  className={cn(
-                    'prose prose-sm max-h-56 max-w-none overflow-y-auto rounded-md border border-border/60 bg-background p-2 text-sm',
-                    isStreaming && !hasResult && 'motion-safe:animate-pulse',
-                  )}
+          {(isStreaming || hasResult) && (
+            <div className="flex flex-col gap-2">
+              <div
+                data-testid="bubble-ai-preview"
+                aria-live="polite"
+                className={cn(
+                  'prose prose-sm max-h-56 max-w-none overflow-y-auto rounded-md border border-border/60 bg-background p-2 text-sm',
+                  isStreaming && !hasResult && 'motion-safe:animate-pulse',
+                )}
+              >
+                {hasResult
+                  ? <SanitizedHtml html={previewHtml} />
+                  : <span className="text-muted-foreground">Improving selection…</span>}
+              </div>
+
+              <div className="flex flex-wrap items-center gap-1">
+                <button
+                  type="button"
+                  onClick={replaceSelection}
+                  disabled={!hasResult || isStreaming}
+                  title="Replace selection"
+                  className="flex items-center gap-1 rounded-md bg-primary/15 px-2 py-1 text-xs font-medium text-primary hover:bg-primary/25 disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 >
-                  {hasResult
-                    ? <SanitizedHtml html={previewHtml} />
-                    : <span className="text-muted-foreground">Improving selection…</span>}
-                </div>
-
-                <div className="flex flex-wrap items-center gap-1">
-                  <button
-                    type="button"
-                    onClick={replaceSelection}
-                    disabled={!hasResult || isStreaming}
-                    title="Replace selection"
-                    className="flex items-center gap-1 rounded-md bg-primary/15 px-2 py-1 text-xs font-medium text-primary hover:bg-primary/25 disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                  >
-                    <Check size={13} /> Replace
-                  </button>
-                  <button
-                    type="button"
-                    onClick={insertBelow}
-                    disabled={!hasResult || isStreaming}
-                    title="Insert below selection"
-                    className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                  >
-                    <ArrowDownToLine size={13} /> Insert below
-                  </button>
-                  <button
-                    type="button"
-                    onClick={retry}
-                    disabled={isStreaming}
-                    title="Try again"
-                    className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                  >
-                    <RotateCcw size={13} /> Try again
-                  </button>
-                  <button
-                    type="button"
-                    onClick={closeAi}
-                    title="Discard"
-                    className="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                  >
-                    <X size={13} /> Discard
-                  </button>
-                </div>
+                  <Check size={13} /> Replace
+                </button>
+                <button
+                  type="button"
+                  onClick={insertBelow}
+                  disabled={!hasResult || isStreaming}
+                  title="Insert below selection"
+                  className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                >
+                  <ArrowDownToLine size={13} /> Insert below
+                </button>
+                <button
+                  type="button"
+                  onClick={retry}
+                  disabled={isStreaming}
+                  title="Try again"
+                  className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                >
+                  <RotateCcw size={13} /> Try again
+                </button>
+                <button
+                  type="button"
+                  onClick={closeAi}
+                  title="Discard"
+                  className="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                >
+                  <X size={13} /> Discard
+                </button>
               </div>
-            )}
+            </div>
+          )}
 
-            {isStreaming && (
-              <div className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
-                <Loader2 size={13} className="motion-safe:animate-spin" />
-                Streaming…
-              </div>
-            )}
+          {isStreaming && (
+            <div className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Loader2 size={13} className="motion-safe:animate-spin" />
+              Streaming…
+            </div>
+          )}
 
-            {emptyResult && (
-              <div className="flex flex-col gap-2" data-testid="bubble-ai-empty">
-                <p className="text-sm text-muted-foreground" role="status">
-                  No changes returned. Try again or adjust your request.
-                </p>
-                <div className="flex gap-1">
-                  <button
-                    type="button"
-                    onClick={retry}
-                    title="Try again"
-                    className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                  >
-                    <RotateCcw size={13} /> Try again
-                  </button>
-                  <button
-                    type="button"
-                    onClick={closeAi}
-                    title="Discard"
-                    className="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                  >
-                    <X size={13} /> Discard
-                  </button>
-                </div>
+          {emptyResult && (
+            <div className="flex flex-col gap-2" data-testid="bubble-ai-empty">
+              <p className="text-sm text-muted-foreground" role="status">
+                No changes returned. Try again or adjust your request.
+              </p>
+              <div className="flex gap-1">
+                <button
+                  type="button"
+                  onClick={retry}
+                  title="Try again"
+                  className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                >
+                  <RotateCcw size={13} /> Try again
+                </button>
+                <button
+                  type="button"
+                  onClick={closeAi}
+                  title="Discard"
+                  className="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                >
+                  <X size={13} /> Discard
+                </button>
               </div>
-            )}
+            </div>
+          )}
 
-            {stream.status === 'error' && (
-              <div className="flex flex-col gap-2">
-                <p className="text-sm text-destructive" role="alert">{stream.error}</p>
-                <div className="flex gap-1">
-                  <button
-                    type="button"
-                    onClick={retry}
-                    className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                  >
-                    <RotateCcw size={13} /> Try again
-                  </button>
-                  <button
-                    type="button"
-                    onClick={closeAi}
-                    className="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                  >
-                    <X size={13} /> Close
-                  </button>
-                </div>
+          {stream.status === 'error' && (
+            <div className="flex flex-col gap-2">
+              <p className="text-sm text-destructive" role="alert">{stream.error}</p>
+              <div className="flex gap-1">
+                <button
+                  type="button"
+                  onClick={retry}
+                  className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                >
+                  <RotateCcw size={13} /> Try again
+                </button>
+                <button
+                  type="button"
+                  onClick={closeAi}
+                  className="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                >
+                  <X size={13} /> Close
+                </button>
               </div>
-            )}
-          </Popover.Content>
-        </Popover.Portal>
-      </Popover.Root>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
 
 export function EditorBubbleMenu({ editor }: { editor: EditorType }) {
-  // Mirror the AI-popover open state in a ref so the stable `shouldShow`
+  // Mirror the AI-section open state in a ref so the stable `shouldShow`
   // closure passed to the BubbleMenu plugin keeps the menu mounted while the
   // AI input has focus.
   const aiOpenRef = useRef(false);
@@ -567,8 +578,19 @@ export function EditorBubbleMenu({ editor }: { editor: EditorType }) {
   return (
     <BubbleMenu
       editor={editor}
+      pluginKey={editorBubbleMenuPluginKey}
       shouldShow={shouldShow}
-      options={{ placement: 'top' }}
+      // #782 — single merged panel, single Floating UI anchor (the selection).
+      // Primary side is 'top' so the decorated passage stays readable below
+      // the panel; `flip` drops it below the selection when the expanded panel
+      // runs out of room above, and `shift` keeps it on-screen horizontally.
+      // 8px viewport padding mirrors the old Radix collisionPadding intent.
+      options={{
+        placement: 'top',
+        offset: 8,
+        flip: { padding: 8 },
+        shift: { padding: 8 },
+      }}
       updateDelay={100}
     >
       <BubbleMenuContent editor={editor} onAiOpenChange={(open) => { aiOpenRef.current = open; }} />


### PR DESCRIPTION
Fixes #782

## Summary

The article editor previously showed **two disconnected floating surfaces** around a selection when using AI Improve: the formatting toolbar above (TipTap `BubbleMenu`) and a separate AI popover below (Radix `Popover` portalled to `<body>`, anchored to the selection rect through a virtual ref — #764). This PR merges them into a **single floating panel**: activating **Improve** expands the same bubble-menu container in place — toolbar row on top, AI section (prompt input, quick actions, streamed preview, Replace / Insert below / Try again / Discard) underneath.

## Design decisions

- **Chosen side: `top` (above the selection).** This keeps the existing toolbar placement, and the #764 selection decoration keeps the passage visible directly below the panel. Since Floating UI anchors a `top`-placed element by its bottom edge, the expanded panel grows upward away from the text and never covers it.
- **Flip/shift on collision.** The TipTap v3 BubbleMenu `options` pass Floating UI middleware directly; the wrapper now sets `placement: 'top'`, `offset: 8`, `flip: { padding: 8 }`, `shift: { padding: 8 }` explicitly. Near the viewport top the panel flips below the selection; near horizontal edges it shifts to stay on-screen (8px padding mirrors the old Radix `collisionPadding` intent).
- **What replaced the Radix Popover:** nothing portalled — the AI section is a conditionally rendered child of the bubble-menu container, so it shares the plugin's single Floating UI anchor on the selection and scrolls with the article content natively (the plugin host lives inside the editor's parent, not `<body>`, so the #764 virtual-anchor `contextElement` scroll plumbing is no longer needed and was removed).
- **Repositioning on growth:** the BubbleMenu plugin repositions on selection/doc/scroll/window-resize but does **not** observe the floating element's own size. A `useLayoutEffect` dispatches the plugin's documented `setMeta(pluginKey, 'updatePosition')` transaction whenever the AI section opens/closes or streamed output grows, so flip/shift re-evaluate against the grown panel (the plugin key is now an exported `editorBubbleMenuPluginKey`).
- **Dismissal** (previously Radix's job): document-level Escape and outside-`pointerdown` handlers collapse the AI section, abort the stream, and clear the decoration; clicks inside the merged panel (toolbar row included) never dismiss.
- **Focus retention preserved:** `selectionShouldShow(editor, aiOpen)` is unchanged — the menu stays mounted while the AI input holds focus; the prompt input still autofocuses on open.
- All existing behavior preserved: captured-range tracking via the remapped decoration, Replace / Insert below / Try again (replays last action) / Discard, streaming preview with sanitized HTML (`SanitizedHtml` + `buildImproveHtml`), empty and error states, Cmd/Ctrl+J shortcut.

No architecture diagram applies (component-internal UI change; no new modules, routes, or boundaries).

## Verification

- `cd frontend && npx vitest run src/shared/components/article/EditorBubbleMenu.test.tsx` — **29 tests pass** (formatting commands, replace-range, try-again replay, decoration lifecycle incl. Escape/Discard/remap, merged-surface assertions: panel inside container + no portalled popover, expand via trigger and Cmd/Ctrl+J, focus retention, outside-click dismissal, `updatePosition` dispatch on expand and on streamed growth, empty + error states).
- `npx vitest run src/shared/components/article/Editor.test.tsx src/shared/components/article/use-improve-stream.test.ts src/shared/components/article/improve-markdown.test.ts` — **53 tests pass** (Editor mounts the real wrapper).
- `npm run lint -w frontend` — clean (`--max-warnings=0`).
- `npm run typecheck -w frontend` — clean.
- **Not verified:** visual positioning (flip near viewport edges, reposition-on-growth timing) was not manually checked in a browser — jsdom has no layout engine, so Floating UI placement is asserted only via the plugin's documented `updatePosition` contract. Please sanity-check visually in dev mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)