### PR TITLE
fix: show full version history, not just the current version (#780)

### DIFF
--- a/backend/src/domains/confluence/services/confluence-client.ts
+++ b/backend/src/domains/confluence/services/confluence-client.ts
@@ -880,8 +880,64 @@ export class ConfluenceClient {
     return ids;
   }
 
-  /** #722: list a page's full version history (metadata only — cheap). Paginates automatically. */
+  /**
+   * #722/#780: list a page's full version history (metadata only — cheap).
+   * Paginates automatically.
+   *
+   * Confluence DATA CENTER serves the version *list* only at the experimental
+   * path `/rest/experimental/content/{id}/version`. On DC, the stable path
+   * `/rest/api/content/{id}/version` has NO GET collection (only DELETE of a
+   * single version), so it answers 404 — which made every backfill fail and
+   * collapsed the Version History dialog to just the current version (#780).
+   * The experimental path is therefore tried first (it is the one that exists
+   * on the supported platform, DC 9.x); a 404/405 there falls back to the
+   * Cloud-style stable path for forward-compatibility (e.g. a future DC
+   * promoting the endpoint, or a gateway exposing Cloud semantics). Whichever
+   * path answers is reused for the remaining pagination pages.
+   */
   async getPageVersions(pageId: string): Promise<ConfluenceVersionMeta[]> {
+    type VersionListPage = {
+      results: Array<{ number: number; when: string; by?: { displayName?: string }; message?: string; minorEdit?: boolean }>;
+      size: number;
+      _links?: { next?: string };
+    };
+
+    const encodedId = encodeURIComponent(pageId);
+    const candidatePaths = [
+      `/rest/experimental/content/${encodedId}/version`,
+      `/rest/api/content/${encodedId}/version`,
+    ] as const;
+    let resolvedPath: string | null = null;
+
+    const fetchPage = async (start: number, limit: number): Promise<VersionListPage> => {
+      const queryString = `?expand=by,message&start=${start}&limit=${limit}`;
+      if (resolvedPath) {
+        return this.fetch<VersionListPage>(`${resolvedPath}${queryString}`, { method: 'GET' });
+      }
+      let lastErr: unknown;
+      for (const path of candidatePaths) {
+        try {
+          const page = await this.fetch<VersionListPage>(`${path}${queryString}`, { method: 'GET' });
+          resolvedPath = path;
+          return page;
+        } catch (err) {
+          // 404/405 = this deployment doesn't serve the path → try the next
+          // one. Any other error (401/403/5xx) is a real failure on a path the
+          // server understands — propagate it instead of masking it with the
+          // other path's inevitable 404.
+          if (err instanceof ConfluenceError && (err.statusCode === 404 || err.statusCode === 405)) {
+            lastErr = err;
+            continue;
+          }
+          throw err;
+        }
+      }
+      throw new ConfluenceError(
+        `Failed to list versions for pageId=${pageId}: neither ${candidatePaths[0]} nor ${candidatePaths[1]} is available (HTTP 404/405 on both)`,
+        lastErr instanceof ConfluenceError ? lastErr.statusCode : 404,
+      );
+    };
+
     const out: ConfluenceVersionMeta[] = [];
     let start = 0;
     const limit = 100;
@@ -890,11 +946,7 @@ export class ConfluenceClient {
     // beyond any real page's history.
     const maxIterations = 1000;
     for (let i = 0; i < maxIterations; i++) {
-      const res = await this.fetch<{
-        results: Array<{ number: number; when: string; by?: { displayName?: string }; message?: string; minorEdit?: boolean }>;
-        size: number;
-        _links?: { next?: string };
-      }>(`/rest/api/content/${encodeURIComponent(pageId)}/version?expand=by,message&start=${start}&limit=${limit}`, { method: 'GET' });
+      const res = await fetchPage(start, limit);
       for (const v of res.results) {
         out.push({ number: v.number, when: v.when, author: v.by?.displayName ?? null, message: v.message ?? null, minorEdit: v.minorEdit ?? false });
       }

--- a/backend/src/domains/confluence/services/confluence-client.versions.test.ts
+++ b/backend/src/domains/confluence/services/confluence-client.versions.test.ts
@@ -26,16 +26,21 @@ vi.mock('./confluence-rate-limiter.js', () => ({
 }));
 
 import { request } from 'undici';
-import { ConfluenceClient } from './confluence-client.js';
+import { ConfluenceClient, ConfluenceError } from './confluence-client.js';
 
 const mockRequest = vi.mocked(request);
 
-function jsonResponse(data: unknown): { statusCode: number; headers: Record<string, string>; body: { text: () => Promise<string> } } {
+function jsonResponse(data: unknown, statusCode = 200): { statusCode: number; headers: Record<string, string>; body: { text: () => Promise<string> } } {
   return {
-    statusCode: 200,
+    statusCode,
     headers: {},
     body: { text: async () => JSON.stringify(data) },
   };
+}
+
+/** URL (first positional arg) of the n-th `request()` call. */
+function calledUrl(n: number): string {
+  return String(mockRequest.mock.calls[n]?.[0]);
 }
 
 describe('ConfluenceClient version methods (#722)', () => {
@@ -65,6 +70,81 @@ describe('ConfluenceClient version methods (#722)', () => {
     expect(versions.map((v) => v.number)).toEqual([3, 2]);
     expect(versions[0]).toMatchObject({ author: 'A', message: 'm3' });
     expect(versions[1]).toMatchObject({ author: 'B', message: null });
+  });
+
+  it('getPageVersions queries the Data Center (experimental) version endpoint, for every pagination page (#780)', async () => {
+    // Confluence DC has NO `GET /rest/api/content/{id}/version` (only DELETE of
+    // a single version) — the list lives at /rest/experimental/... only. Hitting
+    // the stable path 404s on DC, which made every backfill fail (#780).
+    mockRequest
+      .mockResolvedValueOnce(jsonResponse({
+        results: [{ number: 2, when: '2026-01-02T00:00:00Z' }],
+        size: 1,
+        _links: { next: '/next' },
+      }) as never)
+      .mockResolvedValueOnce(jsonResponse({
+        results: [{ number: 1, when: '2026-01-01T00:00:00Z' }],
+        size: 1,
+        _links: {},
+      }) as never);
+
+    const client = new ConfluenceClient(baseUrl, pat);
+    const versions = await client.getPageVersions('123');
+
+    expect(versions.map((v) => v.number)).toEqual([2, 1]);
+    expect(calledUrl(0)).toContain('/rest/experimental/content/123/version?');
+    expect(calledUrl(0)).toContain('start=0');
+    // Pagination must keep using the path that worked — no re-probing.
+    expect(calledUrl(1)).toContain('/rest/experimental/content/123/version?');
+    expect(calledUrl(1)).toContain('start=100');
+  });
+
+  it('getPageVersions falls back to the stable (Cloud-style) path when the experimental one 404s (#780)', async () => {
+    mockRequest
+      // experimental → 404 (deployment without the experimental resource)
+      .mockResolvedValueOnce(jsonResponse({ message: 'no such resource' }, 404) as never)
+      // stable path → works, paginated
+      .mockResolvedValueOnce(jsonResponse({
+        results: [{ number: 2, when: '2026-01-02T00:00:00Z', by: { displayName: 'A' } }],
+        size: 1,
+        _links: { next: '/next' },
+      }) as never)
+      .mockResolvedValueOnce(jsonResponse({
+        results: [{ number: 1, when: '2026-01-01T00:00:00Z' }],
+        size: 1,
+        _links: {},
+      }) as never);
+
+    const client = new ConfluenceClient(baseUrl, pat);
+    const versions = await client.getPageVersions('123');
+
+    expect(versions.map((v) => v.number)).toEqual([2, 1]);
+    expect(calledUrl(0)).toContain('/rest/experimental/content/123/version?');
+    expect(calledUrl(1)).toContain('/rest/api/content/123/version?');
+    // Page 2 reuses the stable path directly — the experimental one is not re-probed.
+    expect(calledUrl(2)).toContain('/rest/api/content/123/version?');
+    expect(calledUrl(2)).toContain('start=100');
+    expect(mockRequest).toHaveBeenCalledTimes(3);
+  });
+
+  it('getPageVersions throws a combined ConfluenceError when both paths 404 (#780)', async () => {
+    mockRequest.mockResolvedValue(jsonResponse({ message: 'nope' }, 404) as never);
+
+    const client = new ConfluenceClient(baseUrl, pat);
+    await expect(client.getPageVersions('123')).rejects.toThrow(
+      /rest\/experimental\/content\/123\/version.*rest\/api\/content\/123\/version/s,
+    );
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('getPageVersions does NOT fall back on non-404 errors (e.g. 403) — the real error propagates', async () => {
+    mockRequest.mockResolvedValue(jsonResponse({ message: 'forbidden' }, 403) as never);
+
+    const client = new ConfluenceClient(baseUrl, pat);
+    await expect(client.getPageVersions('123')).rejects.toThrow(ConfluenceError);
+    await expect(client.getPageVersions('123')).rejects.toThrow(/permission/i);
+    // 403 is not retried and not fallback-eligible: exactly one HTTP call per attempt.
+    expect(mockRequest).toHaveBeenCalledTimes(2);
   });
 
   it('getPageVersions stops on an empty page even when a next link persists (pagination guard)', async () => {

--- a/backend/src/routes/knowledge/pages-versions.full-history.integration.test.ts
+++ b/backend/src/routes/knowledge/pages-versions.full-history.integration.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import sensible from '@fastify/sensible';
+
+// #780: mock undici at the HTTP boundary ONLY — `request` is what the
+// ConfluenceClient uses for every REST call. Everything else (Agent for
+// tls-config, etc.) stays real, as does the entire DB path.
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return { ...actual, request: vi.fn() };
+});
+
+import { request } from 'undici';
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../test-db-helper.js';
+import { query } from '../../core/db/postgres.js';
+import { encryptPat } from '../../core/utils/crypto.js';
+import { pagesVersionRoutes } from './pages-versions.js';
+
+const mockRequest = vi.mocked(request);
+
+/**
+ * #780 reproduction: GET /api/pages/:id/versions on a Confluence DC page with a
+ * long edit history must return EVERY version (current + all historical),
+ * newest-first — not just the synthetic current row.
+ *
+ * Only the Confluence HTTP boundary (undici `request`) is mocked, simulating a
+ * real Confluence DATA CENTER instance:
+ *   - `GET /rest/experimental/content/{id}/version` → the full paginated list
+ *     (this is the only place DC serves the version list);
+ *   - `GET /rest/api/content/{id}/version`          → 404 (on DC that path has
+ *     no GET collection — only DELETE of a single version exists).
+ *
+ * Credentials, PAT decryption, RBAC, page resolution, the backfill upserts and
+ * the history read all run against the real test Postgres.
+ */
+
+const dbAvailable = await isDbAvailable();
+
+function jsonResponse(data: unknown, statusCode = 200) {
+  return {
+    statusCode,
+    headers: {},
+    body: { text: async () => JSON.stringify(data) },
+  } as never;
+}
+
+/** Build `count` Confluence version entries, newest-first starting at `from`. */
+function versionEntries(from: number, count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    number: from - i,
+    when: `2026-01-01T00:00:${String((from - i) % 60).padStart(2, '0')}Z`,
+    by: { displayName: `author-${from - i}` },
+    message: `edit ${from - i}`,
+    minorEdit: false,
+  }));
+}
+
+describe.skipIf(!dbAvailable)('GET /api/pages/:id/versions — full history from Confluence DC (#780, real DB)', () => {
+  let app: FastifyInstance;
+  let userId = '';
+
+  beforeAll(async () => {
+    await setupTestDb();
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+    app.decorate('authenticate', async (request: { userId: string }) => {
+      request.userId = userId;
+    });
+    app.decorate('redis', {} as never);
+    app.decorateRequest('userId', '');
+    await app.register(pagesVersionRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables();
+    const u = await query<{ id: string }>(
+      `INSERT INTO users (username, password_hash, role)
+       VALUES ('versions_780_admin', 'fakehash', 'admin') RETURNING id`,
+    );
+    userId = u.rows[0]!.id;
+    await query(`INSERT INTO spaces (space_key, space_name) VALUES ('DEV', 'Dev space')`);
+    await query(
+      `INSERT INTO user_settings (user_id, confluence_url, confluence_pat)
+       VALUES ($1, 'https://confluence.example.com', $2)`,
+      [userId, encryptPat('test-pat-780')],
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function seedConfluencePage(confluenceId: string, version: number): Promise<number> {
+    const res = await query<{ id: number }>(
+      `INSERT INTO pages (confluence_id, space_key, title, body_html, body_text, version, source, last_modified_at, embedding_dirty, embedding_status)
+       VALUES ($1, 'DEV', 'Page 780', '<p>live</p>', 'live', $2, 'confluence', NOW(), FALSE, 'not_embedded')
+       RETURNING id`,
+      [confluenceId, version],
+    );
+    return res.rows[0]!.id;
+  }
+
+  /**
+   * Simulate a Confluence DATA CENTER instance for one page id:
+   * version list only at the experimental path (paginated), 404 on the
+   * Cloud-style stable path.
+   */
+  function mockDataCenter(confluenceId: string, totalVersions: number, pageSize = 100) {
+    mockRequest.mockImplementation(async (rawUrl) => {
+      const url = new URL(String(rawUrl));
+      if (url.pathname === `/rest/experimental/content/${confluenceId}/version`) {
+        const start = Number(url.searchParams.get('start') ?? '0');
+        const limit = Number(url.searchParams.get('limit') ?? String(pageSize));
+        const remaining = Math.max(0, totalVersions - start);
+        const count = Math.min(limit, remaining, pageSize);
+        const results = versionEntries(totalVersions - start, count);
+        const hasMore = start + count < totalVersions;
+        return jsonResponse({
+          results,
+          start,
+          limit,
+          size: results.length,
+          _links: hasMore ? { next: `/rest/experimental/content/${confluenceId}/version?start=${start + count}` } : {},
+        });
+      }
+      if (url.pathname === `/rest/api/content/${confluenceId}/version`) {
+        // DC: no GET on the stable path — only DELETE of a single version.
+        return jsonResponse({ message: 'No resource and method matched' }, 404);
+      }
+      throw new Error(`Unexpected Confluence request in test: ${String(rawUrl)}`);
+    });
+  }
+
+  it('returns ALL versions of a multi-version DC page, newest-first, with backfillStatus ok', async () => {
+    // 120 versions → exercises pagination (100 + 20) at the HTTP boundary.
+    const total = 120;
+    const pageId = await seedConfluencePage('780123', total);
+    mockDataCenter('780123', total);
+
+    const r = await app.inject({ method: 'GET', url: `/api/pages/${pageId}/versions` });
+
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBe('ok');
+    expect(body.backfillDetail).toBeUndefined();
+
+    // Complete history: the synthetic current row + every historical version.
+    expect(body.versions).toHaveLength(total);
+    const numbers = body.versions.map((v: { versionNumber: number }) => v.versionNumber);
+    expect(numbers).toEqual(Array.from({ length: total }, (_, i) => total - i)); // 120..1, newest-first
+
+    // The live version appears exactly once (the backfilled duplicate of the
+    // current version number is dropped in favour of the synthetic row).
+    expect(numbers.filter((n: number) => n === total)).toHaveLength(1);
+    expect(body.versions[0]).toMatchObject({ versionNumber: total, isCurrent: true });
+    expect(body.versions[1]).toMatchObject({
+      versionNumber: total - 1,
+      isCurrent: false,
+      author: `author-${total - 1}`,
+      message: `edit ${total - 1}`,
+    });
+
+    // The import persisted to the real DB (all 120 metadata rows).
+    const db = await query<{ count: string }>(
+      'SELECT COUNT(*)::text AS count FROM page_versions WHERE page_id = $1',
+      [pageId],
+    );
+    expect(Number(db.rows[0]!.count)).toBe(total);
+  });
+
+  it('surfaces a "failed" status with the underlying reason when no version endpoint exists at all', async () => {
+    const pageId = await seedConfluencePage('780404', 3);
+    // Neither path is served (e.g. a proxy stripping /rest) — both 404.
+    mockRequest.mockImplementation(async () => jsonResponse({ message: 'nope' }, 404));
+
+    const r = await app.inject({ method: 'GET', url: `/api/pages/${pageId}/versions` });
+
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBe('failed');
+    // #780: the dialog must show WHY the import failed (the underlying
+    // Confluence error), not only a bare generic hint.
+    expect(body.backfillDetail).toMatch(/incomplete/i);
+    expect(body.backfillDetail).toMatch(/404/);
+    expect(body.versions).toHaveLength(1);
+    expect(body.versions[0]).toMatchObject({ versionNumber: 3, isCurrent: true });
+  });
+});

--- a/backend/src/routes/knowledge/pages-versions.full-history.integration.test.ts
+++ b/backend/src/routes/knowledge/pages-versions.full-history.integration.test.ts
@@ -193,6 +193,8 @@ describe.skipIf(!dbAvailable)('GET /api/pages/:id/versions — full history from
     // Confluence error), not only a bare generic hint.
     expect(body.backfillDetail).toMatch(/incomplete/i);
     expect(body.backfillDetail).toMatch(/404/);
+    // PR #784 review: the reason is sanitized for the dialog — single-line.
+    expect(body.backfillDetail).not.toMatch(/\n/);
     expect(body.versions).toHaveLength(1);
     expect(body.versions[0]).toMatchObject({ versionNumber: 3, isCurrent: true });
   });

--- a/backend/src/routes/knowledge/pages-versions.test.ts
+++ b/backend/src/routes/knowledge/pages-versions.test.ts
@@ -359,6 +359,40 @@ describe('GET /api/pages/:id/versions', () => {
     expect(body.versions[0]).toMatchObject({ versionNumber: 5, isCurrent: true });
   });
 
+  it('collapses a multi-line backfill error to a single line in backfillDetail (#780 review)', async () => {
+    mockResolvedPage({ id: 7, confluence_id: 'page-1', space_key: 'DEV', version: 5 });
+    mockGetClientForUser.mockResolvedValue({});
+    mockBackfillVersionHistory.mockRejectedValue(
+      new Error('Confluence call failed:\n  upstream said\n\nHTTP 502'),
+    );
+    mockGetVersionHistory.mockResolvedValue([]);
+
+    const r = await app.inject({ method: 'GET', url: '/api/pages/page-1/versions' });
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBe('failed');
+    // Dialog-safe: whitespace runs (incl. newlines) collapse to single spaces.
+    expect(body.backfillDetail).not.toMatch(/\n/);
+    expect(body.backfillDetail).toContain('(Confluence call failed: upstream said HTTP 502)');
+  });
+
+  it('truncates an over-long backfill error with a trailing ellipsis (#780 review)', async () => {
+    mockResolvedPage({ id: 7, confluence_id: 'page-1', space_key: 'DEV', version: 5 });
+    mockGetClientForUser.mockResolvedValue({});
+    mockBackfillVersionHistory.mockRejectedValue(new Error('x'.repeat(500)));
+    mockGetVersionHistory.mockResolvedValue([]);
+
+    const r = await app.inject({ method: 'GET', url: '/api/pages/page-1/versions' });
+    expect(r.statusCode).toBe(200);
+    const body = r.json();
+    expect(body.backfillStatus).toBe('failed');
+    // Capped for the dialog: 200 chars of reason + '…', never the raw 500.
+    expect(body.backfillDetail).toContain(`(${'x'.repeat(200)}…)`);
+    expect(body.backfillDetail).not.toContain('x'.repeat(201));
+    // The generic hint still leads the sentence.
+    expect(body.backfillDetail).toMatch(/Importing historical versions from Confluence failed/);
+  });
+
   it('reports "failed" with a credentials-specific detail when client construction throws — Confluence never contacted (#763 follow-up)', async () => {
     mockResolvedPage({ id: 7, confluence_id: 'page-1', space_key: 'DEV', version: 5 });
     // e.g. PAT decryption failure after a PAT_ENCRYPTION_KEY change.

--- a/backend/src/routes/knowledge/pages-versions.ts
+++ b/backend/src/routes/knowledge/pages-versions.ts
@@ -131,8 +131,12 @@ export async function pagesVersionRoutes(fastify: FastifyInstance) {
           backfillStatus = 'ok';
         } catch (err) {
           backfillStatus = 'failed';
+          // #780: include the underlying Confluence error so the dialog shows
+          // WHY the import failed (e.g. endpoint missing, permissions) instead
+          // of a bare generic hint that leaves the user guessing.
+          const reason = err instanceof Error && err.message ? ` (${err.message})` : '';
           backfillDetail =
-            'Importing historical versions from Confluence failed — the list below may be incomplete.';
+            `Importing historical versions from Confluence failed — the list below may be incomplete.${reason}`;
           request.log.warn({ err, pageId: id }, '#722: version backfill failed (Confluence unavailable)');
         }
       } else if (backfillStatus === undefined) {

--- a/backend/src/routes/knowledge/pages-versions.ts
+++ b/backend/src/routes/knowledge/pages-versions.ts
@@ -33,6 +33,24 @@ const SemanticDiffSchema = z.object({
   model: z.string().optional(),
 });
 
+/**
+ * #780: the underlying backfill error is rendered inside the Version History
+ * dialog, so make it dialog-safe before embedding: collapse all whitespace
+ * runs (incl. newlines) to single spaces, trim, and cap the length with an
+ * ellipsis. Returns '' (no parenthesised suffix) when there is nothing usable.
+ */
+const BACKFILL_REASON_MAX_CHARS = 200;
+function formatBackfillFailureReason(err: unknown): string {
+  if (!(err instanceof Error) || !err.message) return '';
+  const collapsed = err.message.replace(/\s+/g, ' ').trim();
+  if (!collapsed) return '';
+  const capped =
+    collapsed.length > BACKFILL_REASON_MAX_CHARS
+      ? `${collapsed.slice(0, BACKFILL_REASON_MAX_CHARS).trimEnd()}…`
+      : collapsed;
+  return ` (${capped})`;
+}
+
 /** Resolved page identity + the fields needed for RBAC and Confluence push. */
 interface PageContext {
   id: number;
@@ -133,8 +151,9 @@ export async function pagesVersionRoutes(fastify: FastifyInstance) {
           backfillStatus = 'failed';
           // #780: include the underlying Confluence error so the dialog shows
           // WHY the import failed (e.g. endpoint missing, permissions) instead
-          // of a bare generic hint that leaves the user guessing.
-          const reason = err instanceof Error && err.message ? ` (${err.message})` : '';
+          // of a bare generic hint that leaves the user guessing. Sanitized
+          // (single-line, length-capped) for the dialog surface.
+          const reason = formatBackfillFailureReason(err);
           backfillDetail =
             `Importing historical versions from Confluence failed — the list below may be incomplete.${reason}`;
           request.log.warn({ err, pageId: id }, '#722: version backfill failed (Confluence unavailable)');

--- a/docs/architecture/08-flow-sync.md
+++ b/docs/architecture/08-flow-sync.md
@@ -239,7 +239,8 @@ backfill uses the *viewing user's* credentials via `getClientForUser`) or failed
 For `failed`, the `backfillDetail` wording further distinguishes a client-construction
 failure (stored credentials unusable, e.g. PAT decryption error — Confluence was
 never contacted) from a failed Confluence import call; for the latter the underlying
-Confluence error message is appended so the dialog shows *why* the import failed (#780).
+Confluence error message is appended (whitespace-collapsed and truncated to ~200 chars
+for the dialog) so it still shows *why* the import failed (#780).
 The field is omitted for standalone pages, where no Confluence backfill applies.
 
 The `edited_at` column holds the real Confluence edit timestamp; the existing

--- a/docs/architecture/08-flow-sync.md
+++ b/docs/architecture/08-flow-sync.md
@@ -220,9 +220,14 @@ Confluence version metadata (edit time, author, commit message) is not fetched
 during the regular sync — only the latest body and version number are written.
 Full version list import is **lazy-on-open**: when a user opens the Version History
 dialog, `GET /api/pages/:id/versions` calls `backfillVersionHistory` which hits
-`GET /rest/api/content/{id}/version?expand=by,message` and upserts each row into
-`page_versions` via `upsertVersionMetadata` (idempotent ON CONFLICT DO UPDATE with
-COALESCE). The historical body (`body_html`) for each old version is fetched even
+`GET /rest/experimental/content/{id}/version?expand=by,message` and upserts each row
+into `page_versions` via `upsertVersionMetadata` (idempotent ON CONFLICT DO UPDATE
+with COALESCE). The experimental path is the only one Confluence **Data Center**
+serves for the version list — on DC, `/rest/api/content/{id}/version` has no GET
+collection (only DELETE of a single version), which used to 404 every backfill and
+collapse the dialog to just the current version (#780). A 404/405 on the
+experimental path falls back to the Cloud-style stable path for forward
+compatibility; whichever path answers is reused for the remaining pagination pages. The historical body (`body_html`) for each old version is fetched even
 more lazily — only when a user previews or compares that specific version
 (`GET /api/pages/:id/versions/:version` triggers `getHistoricalBody` when
 `body_html IS NULL`). Both calls are best-effort: failures never fail the request,
@@ -233,7 +238,8 @@ history from one whose Confluence import never ran (viewer has no stored PAT —
 backfill uses the *viewing user's* credentials via `getClientForUser`) or failed.
 For `failed`, the `backfillDetail` wording further distinguishes a client-construction
 failure (stored credentials unusable, e.g. PAT decryption error — Confluence was
-never contacted) from a failed Confluence import call.
+never contacted) from a failed Confluence import call; for the latter the underlying
+Confluence error message is appended so the dialog shows *why* the import failed (#780).
 The field is omitted for standalone pages, where no Confluence backfill applies.
 
 The `edited_at` column holds the real Confluence edit timestamp; the existing


### PR DESCRIPTION
Fixes #780

## Root cause

`ConfluenceClient.getPageVersions()` listed versions via `GET /rest/api/content/{id}/version`. That path is **Cloud-only** — on Confluence **Data Center** (the supported platform, DC 9.2) the only operation on `/rest/api/content/{id}/version/...` is `DELETE` of a single version; there is no GET collection ([DC REST docs — Content Version](https://developer.atlassian.com/server/confluence/rest/v10213/api-group-content-version/), [Atlassian KB: retrieving all previous versions on DC](https://support.atlassian.com/confluence/kb/how-to-retrieve-all-previous-versions-of-content-using-the-rest-api/)). Every backfill therefore got a 404, `backfillVersionHistory()` threw, the route degraded to `backfillStatus='failed'`, and the dialog collapsed to just the synthetic current row (cause #2 from the issue, with the generic failure notice as the only hint).

## Fix

- `getPageVersions()` now queries `/rest/experimental/content/{id}/version` first (the path DC actually serves) and falls back to the Cloud-style stable path on 404/405 for forward compatibility. The path that answers is reused for all remaining pagination pages; non-404 errors (401/403/5xx) propagate instead of being masked by the other path's inevitable 404; both paths missing throws a combined `ConfluenceError` naming both URLs.
- `GET /api/pages/:id/versions` appends the underlying Confluence error message to `backfillDetail` on a failed import, so the dialog notice states *why* history could not be imported.
- Updated `docs/architecture/08-flow-sync.md` (version-backfill section) to document the DC endpoint + fallback.

## Other suspected causes from the issue — verified, no change needed

- **Notice rendering (cause #1):** the frontend already renders `backfillNotice` whenever the list is non-empty (always true for a resolvable page — the synthetic current row is always present); covered by the existing #763 tests in `VersionHistory.test.tsx`.
- **Duplicate-version filter (cause #4):** drops exactly the one backfilled row whose number equals the live version — the `(page_id, version_number)` unique upsert guarantees at most one such row. The new integration test asserts the live version appears exactly once in a 120-version payload.
- **Standalone pages (cause #3):** they do accrue local history — `pages-crud.ts` snapshots the prior live version into `page_versions` on every publish (line ~1617). A never-edited standalone page legitimately shows only its current version. No gap to build.

## Verification

All run in this branch's worktree (backend tests against real Postgres):

- `npx vitest run src/domains/confluence/services/confluence-client.versions.test.ts src/routes/knowledge/pages-versions.full-history.integration.test.ts` — TDD: 5 failed before the fix, **11 passed** after. The new integration test mocks only `undici.request` (the Confluence HTTP boundary), simulating a DC instance: experimental path serves 120 versions across two pagination pages (100+20), stable path 404s; asserts the route payload contains **all 120 versions newest-first** (`backfillStatus: 'ok'`, current row first, live version exactly once, 120 rows persisted in `page_versions`), plus the failed-import case surfacing the underlying 404 reason in `backfillDetail`.
- Regression: `npx vitest run src/routes/knowledge/pages-versions.test.ts src/routes/knowledge/pages-versions.backfill-status.integration.test.ts src/domains/confluence/services/version-backfill.test.ts src/domains/confluence/services/confluence-client.test.ts` — **150 passed**.
- `npm run lint -w backend` — clean. `npm run typecheck -w backend` — clean.
- Frontend (unchanged): `npx vitest run src/features/pages/VersionHistory.test.tsx` — **21 passed** (confirms the backfill-notice rendering paths).

Not verified: manual run against a live Confluence DC instance (no instance available in this environment); the endpoint behaviour is sourced from the Atlassian DC REST docs/KB linked above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)