### PR TITLE
fix(llm): recover mangled layout tokens instead of flattening (#781)

### DIFF
--- a/backend/src/core/services/__fixtures__/confluence-xhtml.ts
+++ b/backend/src/core/services/__fixtures__/confluence-xhtml.ts
@@ -265,6 +265,20 @@ export const LAYOUT_RIGHT_SIDEBAR_PAGE = `<h2>Right Sidebar Layout</h2>
 export const LAYOUT_THREE_EQUAL_PAGE = `<h2>Three Column Layout</h2>
 <ac:layout><ac:layout-section ac:type="three_equal"><ac:layout-cell><p>Column one</p></ac:layout-cell><ac:layout-cell><p>Column two</p></ac:layout-cell><ac:layout-cell><p>Column three</p></ac:layout-cell></ac:layout-section></ac:layout>`;
 
+/**
+ * Page with layout macros — three_with_sidebars, stacked between two `single`
+ * sections. Mirrors the canonical example from the official Confluence DC
+ * storage-format docs ("Page layouts" section).
+ */
+export const LAYOUT_THREE_WITH_SIDEBARS_PAGE = `<ac:layout><ac:layout-section ac:type="single"><ac:layout-cell><h2>Header section</h2><p>Intro paragraph.</p></ac:layout-cell></ac:layout-section><ac:layout-section ac:type="three_with_sidebars"><ac:layout-cell><p>Left sidebar nav</p></ac:layout-cell><ac:layout-cell><p>Wide middle content</p></ac:layout-cell><ac:layout-cell><p>Right sidebar widgets</p></ac:layout-cell></ac:layout-section><ac:layout-section ac:type="single"><ac:layout-cell><p>Footer text.</p></ac:layout-cell></ac:layout-section></ac:layout>`;
+
+/**
+ * Real-DC attribute variants: extra/unknown attributes on ac:layout and
+ * ac:layout-section (e.g. breakout-mode emitted by newer editors) must be
+ * tolerated — the converter keys off the element name + ac:type only.
+ */
+export const LAYOUT_DC_EXTRA_ATTRS_PAGE = `<ac:layout ac:schema-version="1"><ac:layout-section ac:type="two_left_sidebar" ac:breakout-mode="default"><ac:layout-cell ac:custom="x"><p>Sidebar cell</p></ac:layout-cell><ac:layout-cell><p>Main cell</p></ac:layout-cell></ac:layout-section></ac:layout>`;
+
 /** Page with multiple stacked layout sections */
 export const LAYOUT_STACKED_SECTIONS_PAGE = `<h2>Stacked Layouts</h2>
 <ac:layout><ac:layout-section ac:type="single"><ac:layout-cell><h3>Introduction</h3><p>Welcome to the guide.</p></ac:layout-cell></ac:layout-section><ac:layout-section ac:type="two_equal"><ac:layout-cell><p>Left details</p></ac:layout-cell><ac:layout-cell><p>Right details</p></ac:layout-cell></ac:layout-section><ac:layout-section ac:type="three_equal"><ac:layout-cell><p>Feature A</p></ac:layout-cell><ac:layout-cell><p>Feature B</p></ac:layout-cell><ac:layout-cell><p>Feature C</p></ac:layout-cell></ac:layout-section></ac:layout>`;

--- a/backend/src/core/services/content-converter.test.ts
+++ b/backend/src/core/services/content-converter.test.ts
@@ -1827,6 +1827,78 @@ describe('content-converter: #781 layout-token resilience', () => {
   });
 
   // ------------------------------------------------------------------
+  // Strictness ladder: loose matching only when the echo needs it
+  // (#785 review — finding 1)
+  // ------------------------------------------------------------------
+  describe('strictness ladder — prose lookalikes vs mangled echoes (#785 review)', () => {
+    it('keeps token lookalikes in prose as literal text when every real token is intact', async () => {
+      const { skeleton, md } = prepare(LAYOUT_TWO_EQUAL_PAGE);
+      const withLookalikes = md.replace(
+        'Left column content',
+        'Left column content — see [[[layout]]] and [[[section intro]]] in the style guide',
+      );
+      const html = await markdownToHtml(withLookalikes, { layoutSkeleton: skeleton });
+      // Every real token aligned strictly, so the loose scan never ran: the
+      // non-canonical lookalikes are prose and must reach the output verbatim.
+      expect(html).toContain('[[[layout]]]');
+      expect(html).toContain('[[[section intro]]]');
+      expect(html).toContain('data-layout-type="two_equal"');
+      expect((html.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(2);
+    });
+
+    it('still escalates to loose matching when the echo is mangled (lookalike exposure accepted)', async () => {
+      const { skeleton, md } = prepare(LAYOUT_TWO_EQUAL_PAGE);
+      const mangled = md
+        .replace('[[[/LAYOUT-CELL]]]', '[[[/layout-cell]]]') // first close lower-cased by the model
+        .replace('Left column content', 'Left column content mentions [[[layout]]]');
+      const html = await markdownToHtml(mangled, { layoutSkeleton: skeleton });
+      // Loose escalation rescued the layout; the lookalike was consumed as
+      // token debris — the accepted price of recovering a mangled echo.
+      expect(html).toContain('data-layout-type="two_equal"');
+      expect((html.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(2);
+      expect(html).toContain('Left column content mentions');
+      expect(html).not.toContain('[[[');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Unambiguous single-slot recovery (#785 review — finding 2)
+  // ------------------------------------------------------------------
+  describe('single prose-bearing slot — wrap recovery without any tokens (#785 review)', () => {
+    it('recovers a single-cell layout when the model dropped every token (prose can only belong in the one cell)', async () => {
+      const { skeleton, md } = prepare(LAYOUT_SINGLE_PAGE);
+      const tokenFree = md.replace(/\[\[\[[^\]]+\]\]\]\n*/g, '');
+      expect(tokenFree).not.toContain('[[[');
+      const html = await markdownToHtml(tokenFree, { layoutSkeleton: skeleton });
+      expect(html).toContain('data-layout-type="single"');
+      expect((html.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(1);
+      expect(html).not.toContain('[[[');
+      // The prose must land INSIDE the one cell, not at top level next to an
+      // empty rebuilt layout.
+      const xhtml = htmlToConfluence(html);
+      expect(xhtml).toMatch(/<ac:layout-cell>[\s\S]*Full width content[\s\S]*<\/ac:layout-cell>/);
+    });
+
+    it('strips stray mangled-token debris and still wraps the prose into the single slot', async () => {
+      const { skeleton, md } = prepare(LAYOUT_SINGLE_PAGE);
+      const mangled = md
+        .replace(/\[\[\[[^\]]+\]\]\]\n*/g, '')
+        .replace('Full width content', 'Full width content\n\n[[[/layout cell]]]');
+      const html = await markdownToHtml(mangled, { layoutSkeleton: skeleton });
+      expect(html).not.toContain('[[[');
+      expect((html.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(1);
+      const xhtml = htmlToConfluence(html);
+      expect(xhtml).toMatch(/<ac:layout-cell>[\s\S]*Full width content[\s\S]*<\/ac:layout-cell>/);
+    });
+
+    it('still throws for multi-slot skeletons with all tokens dropped (prose-to-cell assignment would be a guess)', async () => {
+      const { skeleton, md } = prepare(LAYOUT_TWO_EQUAL_PAGE);
+      const tokenFree = md.replace(/\[\[\[[^\]]+\]\]\]\n*/g, '');
+      await expect(markdownToHtml(tokenFree, { layoutSkeleton: skeleton })).rejects.toThrow(LayoutRecoveryError);
+    });
+  });
+
+  // ------------------------------------------------------------------
   // Hard fallback: unrecoverable mangling must throw, never flatten
   // ------------------------------------------------------------------
   describe('predictable failure when recovery is impossible', () => {

--- a/backend/src/core/services/content-converter.test.ts
+++ b/backend/src/core/services/content-converter.test.ts
@@ -7,6 +7,8 @@ import {
   htmlToText,
   protectMedia,
   restoreMedia,
+  extractLayoutSkeleton,
+  LayoutRecoveryError,
 } from './content-converter.js';
 import {
   SIMPLE_PAGE,
@@ -32,6 +34,8 @@ import {
   LAYOUT_LEFT_SIDEBAR_PAGE,
   LAYOUT_RIGHT_SIDEBAR_PAGE,
   LAYOUT_THREE_EQUAL_PAGE,
+  LAYOUT_THREE_WITH_SIDEBARS_PAGE,
+  LAYOUT_DC_EXTRA_ATTRS_PAGE,
   LAYOUT_STACKED_SECTIONS_PAGE,
   LAYOUT_NESTED_CONTENT_PAGE,
   SECTION_COLUMN_PAGE,
@@ -1515,6 +1519,355 @@ describe('content-converter: #765 layout preservation through AI Improve round-t
       const { xhtml } = await improveRoundTrip(storage);
       expect(xhtml).toContain('ac:name="code"');
       expect(xhtml).toContain('[[[LAYOUT]]] opens a layout');
+    });
+  });
+});
+
+// ==========================================================================
+// #781 — skeleton-guided recovery of LLM-mangled layout tokens.
+//
+// #774's all-or-nothing drop-guard silently flattened the layout whenever a
+// real model mangled a single token. The system KNOWS the expected token
+// skeleton (derived from the page's own body HTML), so markdownToHtml can
+// align whatever came back against it and rebuild the layout from the
+// ORIGINAL skeleton — and when alignment is impossible it throws
+// LayoutRecoveryError instead of silently flattening.
+// ==========================================================================
+
+describe('content-converter: #781 layout-token resilience', () => {
+  /** body HTML → expected skeleton + the markdown the Improve route would send. */
+  function prepare(storageXhtml: string): {
+    skeleton: ReturnType<typeof extractLayoutSkeleton>;
+    md: string;
+    media: ReturnType<typeof protectMedia>['media'];
+  } {
+    const bodyHtml = confluenceToHtml(storageXhtml);
+    const { html: protectedHtml, media } = protectMedia(bodyHtml);
+    return {
+      skeleton: extractLayoutSkeleton(protectedHtml),
+      md: htmlToMarkdown(protectedHtml, { layoutTokens: true }),
+      media,
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Layout-type coverage: sidebar/fixed layouts through the Improve path
+  // ------------------------------------------------------------------
+  describe('sidebar layout coverage through the Improve round-trip', () => {
+    async function improveRoundTrip(storageXhtml: string): Promise<string> {
+      const { skeleton, md, media } = prepare(storageXhtml);
+      const html = restoreMedia(await markdownToHtml(md, { layoutSkeleton: skeleton }), media);
+      return htmlToConfluence(html);
+    }
+
+    it('preserves a two_left_sidebar layout end to end', async () => {
+      const xhtml = await improveRoundTrip(LAYOUT_LEFT_SIDEBAR_PAGE);
+      expect(xhtml).toContain('ac:type="two_left_sidebar"');
+      expect((xhtml.match(/<ac:layout-cell>/g) ?? []).length).toBe(2);
+      expect(xhtml).toContain('Sidebar navigation');
+      expect(xhtml).toContain('Main content area');
+    });
+
+    it('preserves a two_right_sidebar layout end to end', async () => {
+      const xhtml = await improveRoundTrip(LAYOUT_RIGHT_SIDEBAR_PAGE);
+      expect(xhtml).toContain('ac:type="two_right_sidebar"');
+      expect((xhtml.match(/<ac:layout-cell>/g) ?? []).length).toBe(2);
+      expect(xhtml).toContain('Sidebar widgets');
+    });
+
+    it('preserves a three_with_sidebars layout stacked between single sections (official docs shape)', async () => {
+      const xhtml = await improveRoundTrip(LAYOUT_THREE_WITH_SIDEBARS_PAGE);
+      expect(xhtml).toContain('ac:type="three_with_sidebars"');
+      expect((xhtml.match(/ac:type="single"/g) ?? []).length).toBe(2);
+      expect((xhtml.match(/<ac:layout-cell>/g) ?? []).length).toBe(5);
+      expect(xhtml).toContain('Left sidebar nav');
+      expect(xhtml).toContain('Wide middle content');
+      expect(xhtml).toContain('Right sidebar widgets');
+      expect(xhtml).toContain('Footer text.');
+    });
+
+    it('tolerates extra/unknown attributes a real DC may emit on ac:layout*', async () => {
+      const html = confluenceToHtml(LAYOUT_DC_EXTRA_ATTRS_PAGE);
+      expect(html).toContain('data-layout-type="two_left_sidebar"');
+      expect((html.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(2);
+      const xhtml = await improveRoundTrip(LAYOUT_DC_EXTRA_ATTRS_PAGE);
+      expect(xhtml).toContain('ac:type="two_left_sidebar"');
+      expect(xhtml).toContain('Sidebar cell');
+      expect(xhtml).toContain('Main cell');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // extractLayoutSkeleton
+  // ------------------------------------------------------------------
+  describe('extractLayoutSkeleton', () => {
+    it('extracts the ordered open/close token skeleton with section types', () => {
+      const bodyHtml = confluenceToHtml(LAYOUT_TWO_EQUAL_PAGE);
+      const skeleton = extractLayoutSkeleton(bodyHtml);
+      expect(skeleton.map((t) => `${t.isClose ? '/' : ''}${t.kind}${t.attrs ? ' ' + t.attrs : ''}`)).toEqual([
+        'LAYOUT',
+        'LAYOUT-SECTION two_equal',
+        'LAYOUT-CELL', '/LAYOUT-CELL',
+        'LAYOUT-CELL', '/LAYOUT-CELL',
+        '/LAYOUT-SECTION',
+        '/LAYOUT',
+      ]);
+    });
+
+    it('extracts legacy section/column with border and width attrs', () => {
+      const bodyHtml = confluenceToHtml(SECTION_COLUMN_PAGE);
+      const skeleton = extractLayoutSkeleton(bodyHtml);
+      const opens = skeleton.filter((t) => !t.isClose).map((t) => `${t.kind}${t.attrs ? ' ' + t.attrs : ''}`);
+      expect(opens).toEqual(['SECTION', 'COLUMN width=30%', 'COLUMN width=70%']);
+    });
+
+    it('returns an empty skeleton for layout-free HTML', () => {
+      expect(extractLayoutSkeleton('<h1>Title</h1><p>Prose</p>')).toEqual([]);
+    });
+
+    it('skips frozen legacy wrappers (nested in constrained containers) but keeps top-level ones', () => {
+      const SECTION_MACRO =
+        '<ac:structured-macro ac:name="section"><ac:rich-text-body>' +
+        '<ac:structured-macro ac:name="column"><ac:rich-text-body><p>Nested</p></ac:rich-text-body></ac:structured-macro>' +
+        '</ac:rich-text-body></ac:structured-macro>';
+      const bodyHtml = confluenceToHtml(
+        `<table><tbody><tr><td>${SECTION_MACRO}</td></tr></tbody></table>${SECTION_MACRO}`,
+      );
+      const skeleton = extractLayoutSkeleton(bodyHtml);
+      // Only the top-level section/column pair is tokenized (the in-table one
+      // travels opaquely via protectMedia, matching htmlToMarkdown).
+      expect(skeleton.filter((t) => t.kind === 'SECTION' && !t.isClose)).toHaveLength(1);
+      expect(skeleton.filter((t) => t.kind === 'COLUMN' && !t.isClose)).toHaveLength(1);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Recovery of realistically mangled LLM output
+  // ------------------------------------------------------------------
+  describe('skeleton-guided recovery of mangled tokens', () => {
+    async function recover(storageXhtml: string, mangle: (md: string) => string): Promise<string> {
+      const { skeleton, md } = prepare(storageXhtml);
+      return markdownToHtml(mangle(md), { layoutSkeleton: skeleton });
+    }
+
+    function expectTwoEqualRebuilt(html: string): void {
+      expect(html).toContain('class="confluence-layout"');
+      expect(html).toContain('data-layout-type="two_equal"');
+      expect((html.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(2);
+      expect(html).toContain('Left column content');
+      expect(html).toContain('Right column content');
+      expect(html).not.toContain('[[[');
+    }
+
+    it('recovers lower-cased tokens (the #781 report case — was silently flattened)', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md.replace(/\[\[\[([^\]]+)\]\]\]/g, (m) => m.toLowerCase()),
+      );
+      expectTwoEqualRebuilt(html);
+    });
+
+    it('recovers a single case-mangled close token', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md.replace('[[[/LAYOUT-CELL]]]', '[[[/layout-cell]]]'),
+      );
+      expectTwoEqualRebuilt(html);
+    });
+
+    it('recovers tokens merged onto one line inside prose', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md
+          .replace(/\n+\[\[\[LAYOUT\]\]\]\n+/g, ' [[[LAYOUT]]] ')
+          .replace(/\n+\[\[\[LAYOUT-SECTION two_equal\]\]\]\n+/g, ' [[[LAYOUT-SECTION two_equal]]] '),
+      );
+      expectTwoEqualRebuilt(html);
+    });
+
+    it('recovers a dropped close token (re-derived from the skeleton)', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) => md.replace('[[[/LAYOUT-CELL]]]', ''));
+      expectTwoEqualRebuilt(html);
+    });
+
+    it('recovers dropped trailing closes (everything after the last cell open stays in that cell)', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md
+          .replace('[[[/LAYOUT-SECTION]]]', '')
+          .replace('[[[/LAYOUT]]]', '')
+          .replace(/\[\[\[\/LAYOUT-CELL\]\]\](?![\s\S]*\[\[\[\/LAYOUT-CELL\]\]\])/, ''),
+      );
+      expectTwoEqualRebuilt(html);
+    });
+
+    it('recovers a dropped section-type argument (type comes from the skeleton, never the echo)', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md.replace('[[[LAYOUT-SECTION two_equal]]]', '[[[LAYOUT-SECTION]]]'),
+      );
+      expectTwoEqualRebuilt(html);
+    });
+
+    it('ignores a section type the LLM rewrote — the skeleton wins', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md.replace('[[[LAYOUT-SECTION two_equal]]]', '[[[LAYOUT-SECTION three_equal]]]'),
+      );
+      expectTwoEqualRebuilt(html); // asserts data-layout-type="two_equal"
+    });
+
+    it('recovers bracket-count variants ([[…]] and [[[[…]]]])', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md
+          .replace('[[[LAYOUT]]]', '[[LAYOUT]]')
+          .replace('[[[/LAYOUT]]]', '[[[[/LAYOUT]]]]'),
+      );
+      expectTwoEqualRebuilt(html);
+    });
+
+    it('recovers markdown-escaped tokens (\\[\\[\\[LAYOUT\\]\\]\\])', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md.replace('[[[LAYOUT]]]', '\\[\\[\\[LAYOUT\\]\\]\\]'),
+      );
+      expectTwoEqualRebuilt(html);
+    });
+
+    it('recovers emphasis-wrapped tokens (**[[[LAYOUT-CELL]]]**)', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md.replace('[[[LAYOUT-CELL]]]', '**[[[LAYOUT-CELL]]]**'),
+      );
+      expectTwoEqualRebuilt(html);
+    });
+
+    it('recovers underscore/space kind variants (LAYOUT_CELL, LAYOUT SECTION)', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md
+          .replace('[[[LAYOUT-SECTION two_equal]]]', '[[[LAYOUT SECTION two_equal]]]')
+          .replace('[[[LAYOUT-CELL]]]', '[[[LAYOUT_CELL]]]'),
+      );
+      expectTwoEqualRebuilt(html);
+    });
+
+    it('recovers tokens the LLM wrapped in their own code fence', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md.replace('[[[LAYOUT]]]\n\n[[[LAYOUT-SECTION two_equal]]]', '```\n[[[LAYOUT]]]\n[[[LAYOUT-SECTION two_equal]]]\n```'),
+      );
+      expectTwoEqualRebuilt(html);
+    });
+
+    it('recovers when the LLM fenced its ENTIRE output', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) => '```markdown\n' + md + '\n```');
+      expectTwoEqualRebuilt(html);
+    });
+
+    it('strips duplicated/hallucinated extra tokens and still rebuilds per the skeleton', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md.replace('[[[/LAYOUT]]]', '[[[/LAYOUT]]]\n\n[[[LAYOUT]]]\n\n[[[/LAYOUT]]]'),
+      );
+      // Exactly ONE layout — the duplicate echo is debris.
+      expect((html.match(/class="confluence-layout"/g) ?? []).length).toBe(1);
+      expectTwoEqualRebuilt(html);
+    });
+
+    it('keeps prose the LLM placed between cell boundaries out of the bare section (folds into the next cell)', async () => {
+      const html = await recover(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md.replace('[[[LAYOUT-CELL]]]\n\nRight column content', 'Stray inter-cell prose\n\n[[[LAYOUT-CELL]]]\n\nRight column content'),
+      );
+      expect(html).toContain('Stray inter-cell prose');
+      // The stray prose must live inside a cell, not directly in the section div.
+      const sectionInner = html.slice(html.indexOf('confluence-layout-section'));
+      const firstCellIdx = sectionInner.indexOf('confluence-layout-cell');
+      const strayIdx = sectionInner.indexOf('Stray inter-cell prose');
+      expect(strayIdx).toBeGreaterThan(firstCellIdx);
+      expect((html.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(2);
+    });
+
+    it('recovers mangled legacy SECTION/COLUMN tokens with widths from the skeleton', async () => {
+      const { skeleton, md } = prepare(SECTION_COLUMN_PAGE);
+      const mangled = md
+        .replace('[[[SECTION]]]', '[[[section]]]')
+        .replace('[[[COLUMN width=30%]]]', '[[[COLUMN]]]'); // width dropped by the LLM
+      const html = await markdownToHtml(mangled, { layoutSkeleton: skeleton });
+      const xhtml = htmlToConfluence(html);
+      expect(xhtml).toContain('ac:name="section"');
+      expect((xhtml.match(/ac:name="column"/g) ?? []).length).toBe(2);
+      // Width restored from the skeleton even though the echo dropped it.
+      expect(xhtml).toContain('<ac:parameter ac:name="width">30%</ac:parameter>');
+      expect(xhtml).toContain('<ac:parameter ac:name="width">70%</ac:parameter>');
+      expect(xhtml).not.toContain('[[[');
+    });
+
+    it('recovers a mangled sidebar layout end to end (acceptance: sidebar layout survives a misbehaving model)', async () => {
+      const { skeleton, md } = prepare(LAYOUT_THREE_WITH_SIDEBARS_PAGE);
+      const mangled = md
+        .replace(/\[\[\[([^\]]+)\]\]\]/g, (m) => m.toLowerCase())
+        .replace('[[[layout-section three_with_sidebars]]]', '[[[layout-section]]]');
+      const html = await markdownToHtml(mangled, { layoutSkeleton: skeleton });
+      const xhtml = htmlToConfluence(html);
+      expect(xhtml).toContain('ac:type="three_with_sidebars"');
+      expect((xhtml.match(/ac:type="single"/g) ?? []).length).toBe(2);
+      expect((xhtml.match(/<ac:layout-cell>/g) ?? []).length).toBe(5);
+      expect(xhtml).toContain('Wide middle content');
+    });
+
+    it('still treats literal token text inside code blocks as data when real tokens are intact', async () => {
+      const { skeleton, md } = prepare(LAYOUT_TWO_EQUAL_PAGE);
+      const withDocs = md.replace(
+        'Left column content',
+        'Left column content\n\n```\n[[[LAYOUT]]] is the open marker\n```',
+      );
+      const html = await markdownToHtml(withDocs, { layoutSkeleton: skeleton });
+      expect(html).toContain('[[[LAYOUT]]] is the open marker');
+      expect((html.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(2);
+    });
+
+    it('strips hallucinated tokens on a layout-free page instead of inventing a layout', async () => {
+      const hallucinated =
+        '[[[LAYOUT]]]\n\n[[[LAYOUT-SECTION two_equal]]]\n\n[[[LAYOUT-CELL]]]\n\nProse\n\n[[[/LAYOUT-CELL]]]\n\n[[[/LAYOUT-SECTION]]]\n\n[[[/LAYOUT]]]';
+      const html = await markdownToHtml(hallucinated, { layoutSkeleton: [] });
+      expect(html).not.toContain('[[[');
+      expect(html).not.toContain('confluence-layout');
+      expect(html).toContain('Prose');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Hard fallback: unrecoverable mangling must throw, never flatten
+  // ------------------------------------------------------------------
+  describe('predictable failure when recovery is impossible', () => {
+    async function expectRecoveryError(storageXhtml: string, mangle: (md: string) => string): Promise<LayoutRecoveryError> {
+      const { skeleton, md } = prepare(storageXhtml);
+      try {
+        await markdownToHtml(mangle(md), { layoutSkeleton: skeleton });
+      } catch (err) {
+        expect(err).toBeInstanceOf(LayoutRecoveryError);
+        return err as LayoutRecoveryError;
+      }
+      throw new Error('expected markdownToHtml to throw LayoutRecoveryError');
+    }
+
+    it('throws when the LLM translated/reworded the tokens (unrecoverable)', async () => {
+      const err = await expectRecoveryError(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md
+          .replace(/\[\[\[LAYOUT-CELL\]\]\]/g, '[[[SPALTE]]]')
+          .replace(/\[\[\[\/LAYOUT-CELL\]\]\]/g, '[[[/SPALTE]]]'),
+      );
+      expect(err.details.expectedTokens).toBeGreaterThan(0);
+    });
+
+    it('throws when the LLM merged two cells into one (a cell boundary is gone)', async () => {
+      await expectRecoveryError(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md.replace('[[[/LAYOUT-CELL]]]\n\n[[[LAYOUT-CELL]]]', ''),
+      );
+    });
+
+    it('throws when the LLM dropped every token', async () => {
+      await expectRecoveryError(LAYOUT_TWO_EQUAL_PAGE, (md) =>
+        md.replace(/\[\[\[[^\]]+\]\]\]\n*/g, ''),
+      );
+    });
+
+    it('without a skeleton the legacy drop-guard behavior is unchanged (flatten, strip tokens)', async () => {
+      const { md } = prepare(LAYOUT_TWO_EQUAL_PAGE);
+      const html = await markdownToHtml(md.replace('[[[/LAYOUT-CELL]]]', ''));
+      expect(html).not.toContain('[[[');
+      expect(html).not.toContain('confluence-layout');
+      expect(html).toContain('Left column content');
     });
   });
 });

--- a/backend/src/core/services/content-converter.ts
+++ b/backend/src/core/services/content-converter.ts
@@ -1378,10 +1378,14 @@ function transformOutsideHtmlCode(html: string, transform: (segment: string) => 
 //   1. extractLayoutSkeleton() derives the expected open/close token sequence
 //      (with section types / column widths) from the page's own body HTML —
 //      deterministic, like #723's media tokens, so nothing is persisted.
-//   2. scanLooseLayoutTokens() recognizes realistic mangled spellings of the
-//      tokens (outside code constructs).
-//   3. alignTokens() greedily maps them, in order, onto the skeleton. Close
-//      tokens and pure container opens (LAYOUT, LAYOUT-SECTION) are
+//   2. Strictness ladder (#785 review): candidates are first scanned with
+//      scanStrictLayoutTokenSpans() (canonical spellings only) — when the
+//      echo's real tokens are intact, token lookalikes in user prose (e.g.
+//      a literal "[[[layout]]]") survive as prose. Only when the strict scan
+//      cannot align the FULL skeleton does scanLooseLayoutTokens() run,
+//      recognizing realistic mangled spellings (outside code constructs).
+//   3. alignLayoutTokens() greedily maps them, in order, onto the skeleton.
+//      Close tokens and pure container opens (LAYOUT, LAYOUT-SECTION) are
 //      re-derivable, so they may be dropped; every PROSE-BEARING open
 //      (LAYOUT-CELL / COLUMN / SECTION) must be found — otherwise cell
 //      boundaries are genuinely lost (e.g. the model merged two cells).
@@ -1392,7 +1396,9 @@ function transformOutsideHtmlCode(html: string, transform: (segment: string) => 
 //   5. The result is verified token-for-token against the skeleton before
 //      use. Any residual mismatch — and any unrecoverable mangling — throws
 //      LayoutRecoveryError so the caller can reject the apply instead of
-//      silently flattening the page.
+//      silently flattening the page. Exception (#785 review): a skeleton
+//      with exactly ONE prose-bearing slot is unambiguous even when every
+//      token was dropped — wrapProseInSingleSlot() places all prose in it.
 // ---------------------------------------------------------------------------
 
 export interface LayoutSkeletonToken { kind: string; isClose: boolean; attrs: string; }
@@ -1471,11 +1477,11 @@ const LAYOUT_TOKEN_LOOSE_SRC =
   String.raw`(?:\\?\]){2,4}` +
   String.raw`(?:\*{1,2}|_{1,2})?`;
 
-interface LooseLayoutToken { start: number; end: number; kind: string; isClose: boolean; }
+interface ScannedLayoutToken { start: number; end: number; kind: string; isClose: boolean; }
 
 /** Scan markdown (outside code constructs) for mangled-token candidates. */
-function scanLooseLayoutTokens(markdown: string): LooseLayoutToken[] {
-  const tokens: LooseLayoutToken[] = [];
+function scanLooseLayoutTokens(markdown: string): ScannedLayoutToken[] {
+  const tokens: ScannedLayoutToken[] = [];
   let offset = 0;
   for (const [i, part] of markdown.split(MARKDOWN_CODE_SEGMENT).entries()) {
     if (i % 2 === 0) {
@@ -1489,6 +1495,38 @@ function scanLooseLayoutTokens(markdown: string): LooseLayoutToken[] {
           end: offset + m.index + m[0].length,
           kind: rawKind.toUpperCase().replace(/[_ ]/g, '-'),
           isClose: m[2] !== undefined,
+        });
+      }
+    }
+    offset += part.length;
+  }
+  return tokens;
+}
+
+// #785 review (strictness ladder): canonical-spelling-only spans — exactly
+// `[[[`, optional `/`, UPPERCASE kind, optional attrs, `]]]`. The lookarounds
+// reject tokens touching emphasis/bracket/escape decoration (e.g.
+// **[[[LAYOUT-CELL]]]** or [[[[/LAYOUT]]]]): a decorated token counts as
+// MANGLED — handled by the loose pass, which consumes the decoration too —
+// instead of leaving the stray `**` / `[` behind as prose.
+const LAYOUT_TOKEN_STRICT_SPAN_SRC = String.raw`(?<![*_\[\\])${LAYOUT_TOKEN_CAPTURE}(?![*_\]])`;
+
+/**
+ * Position-aware STRICT scan (outside code constructs): canonical token
+ * spellings only. Same shape as scanLooseLayoutTokens so both can feed
+ * alignLayoutTokens — see the strictness ladder in recoverLayoutMarkdown.
+ */
+function scanStrictLayoutTokenSpans(markdown: string): ScannedLayoutToken[] {
+  const tokens: ScannedLayoutToken[] = [];
+  let offset = 0;
+  for (const [i, part] of markdown.split(MARKDOWN_CODE_SEGMENT).entries()) {
+    if (i % 2 === 0) {
+      for (const m of part.matchAll(new RegExp(LAYOUT_TOKEN_STRICT_SPAN_SRC, 'g'))) {
+        tokens.push({
+          start: offset + m.index,
+          end: offset + m.index + m[0].length,
+          kind: m[2]!,
+          isClose: m[1] === '/',
         });
       }
     }
@@ -1535,9 +1573,9 @@ function unwrapFullDocumentFence(markdown: string): string | null {
 // their first child), so their positions are re-derivable from neighbors.
 const PROSE_BEARING_KINDS = new Set(['LAYOUT-CELL', 'COLUMN', 'SECTION']);
 
-/** Greedy in-order alignment of loose tokens onto the skeleton. */
+/** Greedy in-order alignment of scanned tokens onto the skeleton. */
 function alignLayoutTokens(
-  found: LooseLayoutToken[],
+  found: ScannedLayoutToken[],
   skeleton: LayoutSkeletonToken[],
 ): { matched: number[]; ok: boolean; matchedCount: number } {
   const matched: number[] = new Array<number>(skeleton.length).fill(-1);
@@ -1574,7 +1612,7 @@ function proseAllowedIn(stack: string[]): boolean {
  */
 function reconstructLayoutMarkdown(
   markdown: string,
-  found: LooseLayoutToken[],
+  found: ScannedLayoutToken[],
   matched: number[],
   skeleton: LayoutSkeletonToken[],
 ): string {
@@ -1644,11 +1682,60 @@ function scanStrictLayoutTokens(markdown: string): LayoutToken[] {
   return tokens;
 }
 
+/** Fail-closed verification: strict token sequence equals the skeleton. */
+function matchesSkeleton(markdown: string, skeleton: LayoutSkeletonToken[]): boolean {
+  const strict = scanStrictLayoutTokens(markdown);
+  return (
+    strict.length === skeleton.length &&
+    strict.every(
+      (t, i) => t.kind === skeleton[i]!.kind && t.isClose === skeleton[i]!.isClose && t.attrs === skeleton[i]!.attrs,
+    )
+  );
+}
+
+/**
+ * Last-resort recovery for skeletons with exactly ONE prose-bearing slot
+ * (#785 review): even when alignment found nothing — the model dropped
+ * every token — there is no ambiguity about where the prose belongs. Emit
+ * the skeleton's canonical tokens in order and place ALL (debris-stripped)
+ * prose inside that single slot. Multi-slot skeletons stay unrecoverable:
+ * assigning prose to one of several cells would be a guess.
+ *
+ * Built explicitly rather than via reconstructLayoutMarkdown: its
+ * trailing-dropped-token path appends unmatched tokens AFTER the prose,
+ * which would leave the prose at top level and the rebuilt layout empty.
+ */
+function wrapProseInSingleSlot(markdown: string, skeleton: LayoutSkeletonToken[]): string {
+  // Alignment already failed, so every token-shaped fragment is debris.
+  const debris = scanLooseLayoutTokens(markdown);
+  let prose = '';
+  let pos = 0;
+  for (const d of debris) {
+    prose += markdown.slice(pos, d.start);
+    pos = d.end;
+  }
+  prose += markdown.slice(pos);
+  prose = prose.replace(/^\n+|\n+$/g, '');
+
+  const out: string[] = [];
+  for (const t of skeleton) {
+    out.push(`\n\n${canonicalLayoutToken(t)}\n\n`);
+    if (!t.isClose && PROSE_BEARING_KINDS.has(t.kind)) out.push(`\n\n${prose}\n\n`);
+  }
+  return out.join('');
+}
+
 /**
  * Recover the LLM's (possibly mangled) layout tokens against the known
  * skeleton and return canonical markdown, or throw LayoutRecoveryError.
- * Fail-closed: the reconstruction is verified token-for-token against the
- * skeleton before it is accepted, so no edge case can silently flatten.
+ * Strictness ladder (#785 review): candidates are evaluated with the strict
+ * canonical scan first — only when that cannot align the FULL skeleton does
+ * the tolerant loose scan run, so token lookalikes in user prose survive
+ * intact echoes. Fail-closed: the reconstruction is verified token-for-token
+ * against the skeleton before it is accepted, so no edge case can silently
+ * flatten. Note: alignment is greedy and in-order — it guards layout
+ * STRUCTURE, not prose-to-cell assignment; a model that swaps two cells'
+ * content yields the swapped prose inside the preserved structure.
  */
 function recoverLayoutMarkdown(markdown: string, skeleton: LayoutSkeletonToken[]): string {
   const rawFound = scanLooseLayoutTokens(markdown);
@@ -1665,31 +1752,53 @@ function recoverLayoutMarkdown(markdown: string, skeleton: LayoutSkeletonToken[]
     if (unfencedUnwrapped !== unfenced) candidates.push(unfencedUnwrapped);
   }
 
-  // Evaluate every candidate; prefer the one aligning the most skeleton
-  // tokens, tie-broken toward the LEAST-transformed markdown so code-as-data
-  // is only consumed when it actually rescues the layout.
-  const attempts = candidates
-    .map((candidate, order) => {
-      const found = scanLooseLayoutTokens(candidate);
-      return { candidate, found, order, ...alignLayoutTokens(found, skeleton) };
-    })
-    .sort((a, b) => b.matchedCount - a.matchedCount || a.order - b.order);
+  // Evaluate every candidate with the given scanner; prefer the one aligning
+  // the most skeleton tokens, tie-broken toward the LEAST-transformed
+  // markdown so code-as-data is only consumed when it rescues the layout.
+  // Attempts aligning fewer than `minMatched` skeleton tokens are rejected.
+  const tryRecover = (
+    scan: (md: string) => ScannedLayoutToken[],
+    minMatched: number,
+  ): { rebuilt: string | null; bestMatched: number } => {
+    const attempts = candidates
+      .map((candidate, order) => {
+        const found = scan(candidate);
+        return { candidate, found, order, ...alignLayoutTokens(found, skeleton) };
+      })
+      .sort((a, b) => b.matchedCount - a.matchedCount || a.order - b.order);
+    for (const attempt of attempts) {
+      if (!attempt.ok || attempt.matchedCount < minMatched) continue;
+      const rebuilt = reconstructLayoutMarkdown(attempt.candidate, attempt.found, attempt.matched, skeleton);
+      if (matchesSkeleton(rebuilt, skeleton)) return { rebuilt, bestMatched: attempt.matchedCount };
+    }
+    return { rebuilt: null, bestMatched: attempts[0]?.matchedCount ?? 0 };
+  };
 
-  for (const attempt of attempts) {
-    if (!attempt.ok) continue;
-    const rebuilt = reconstructLayoutMarkdown(attempt.candidate, attempt.found, attempt.matched, skeleton);
-    const strict = scanStrictLayoutTokens(rebuilt);
-    const exact =
-      strict.length === skeleton.length &&
-      strict.every(
-        (t, i) => t.kind === skeleton[i]!.kind && t.isClose === skeleton[i]!.isClose && t.attrs === skeleton[i]!.attrs,
-      );
-    if (exact) return rebuilt;
+  // Strict pass: when some candidate's CANONICAL tokens already cover the
+  // whole skeleton, the echo is intact — tolerant matching would only
+  // consume prose lookalikes (e.g. a literal "[[[layout]]]" in cell text)
+  // as token debris. Requiring the FULL skeleton (not just prose-bearing
+  // opens) matters: a partially-strict echo means something WAS mangled,
+  // and accepting it here would leave the mangled token behind as prose.
+  const strictPass = tryRecover(scanStrictLayoutTokenSpans, skeleton.length);
+  if (strictPass.rebuilt !== null) return strictPass.rebuilt;
+
+  // Loose pass: the echo is mangled — tolerant matching rescues it,
+  // accepting that lookalikes may now be consumed as debris.
+  const loosePass = tryRecover(scanLooseLayoutTokens, 0);
+  if (loosePass.rebuilt !== null) return loosePass.rebuilt;
+
+  // Single-slot wrap (#785 review): with exactly one prose-bearing open the
+  // assignment is unambiguous even when nothing aligned at all.
+  const proseSlots = skeleton.filter((t) => !t.isClose && PROSE_BEARING_KINDS.has(t.kind));
+  if (proseSlots.length === 1) {
+    const wrapped = wrapProseInSingleSlot(markdown, skeleton);
+    if (matchesSkeleton(wrapped, skeleton)) return wrapped;
   }
 
   throw new LayoutRecoveryError({
     expectedTokens: skeleton.length,
-    recoveredTokens: attempts[0]?.matchedCount ?? 0,
+    recoveredTokens: loosePass.bestMatched,
   });
 }
 
@@ -1742,9 +1851,16 @@ export async function markdownToHtml(markdown: string, options?: MarkdownToHtmlO
 
     // #765 drop-guard backstop: strip any token-shaped remnant that failed
     // structural matching (e.g. the LLM lower-cased a marker) — raw [[[…]]]
-    // text must never reach the saved page.
+    // text must never reach the saved page. With a skeleton (#781) recovery
+    // has already rewritten every real token canonically and consumed all
+    // mangled debris, so the strip stays case-SENSITIVE there: a surviving
+    // lower-case token shape is a prose lookalike the strictness ladder
+    // deliberately preserved, not a failed marker (#785 review).
     out = out.replace(
-      new RegExp(`<p>\\s*${LAYOUT_TOKEN_BARE}\\s*</p>|${LAYOUT_TOKEN_BARE}`, 'gi'),
+      new RegExp(
+        `<p>\\s*${LAYOUT_TOKEN_BARE}\\s*</p>|${LAYOUT_TOKEN_BARE}`,
+        options?.layoutSkeleton ? 'g' : 'gi',
+      ),
       '',
     );
     return out;

--- a/backend/src/core/services/content-converter.ts
+++ b/backend/src/core/services/content-converter.ts
@@ -1363,16 +1363,364 @@ function transformOutsideHtmlCode(html: string, transform: (segment: string) => 
   return transform(masked).replace(/\u0000CQ_CODE_REGION_(\d+)\u0000/g, (m, i) => regions[Number(i)] ?? m);
 }
 
+// ---------------------------------------------------------------------------
+// #781: skeleton-guided recovery of LLM-mangled layout tokens.
+//
+// #774's all-or-nothing drop-guard silently flattened the layout whenever a
+// real model mangled a single [[[…]]] token — which local models do routinely
+// (case changes, merged lines, dropped closes, dropped section args, code
+// fences around tokens, translations). The fix exploits the one thing the
+// LLM cannot corrupt: the system KNOWS the expected token skeleton, because
+// it generated it from the original document. Recovery therefore never
+// trusts the LLM's echo — it ALIGNS whatever came back against the known
+// skeleton:
+//
+//   1. extractLayoutSkeleton() derives the expected open/close token sequence
+//      (with section types / column widths) from the page's own body HTML —
+//      deterministic, like #723's media tokens, so nothing is persisted.
+//   2. scanLooseLayoutTokens() recognizes realistic mangled spellings of the
+//      tokens (outside code constructs).
+//   3. alignTokens() greedily maps them, in order, onto the skeleton. Close
+//      tokens and pure container opens (LAYOUT, LAYOUT-SECTION) are
+//      re-derivable, so they may be dropped; every PROSE-BEARING open
+//      (LAYOUT-CELL / COLUMN / SECTION) must be found — otherwise cell
+//      boundaries are genuinely lost (e.g. the model merged two cells).
+//   4. reconstructLayoutMarkdown() rewrites the markdown with CANONICAL
+//      tokens from the skeleton (types/widths always from the skeleton,
+//      never from the echo), strips unmatched token debris, and keeps prose
+//      out of slots where the storage format allows none.
+//   5. The result is verified token-for-token against the skeleton before
+//      use. Any residual mismatch — and any unrecoverable mangling — throws
+//      LayoutRecoveryError so the caller can reject the apply instead of
+//      silently flattening the page.
+// ---------------------------------------------------------------------------
+
+export interface LayoutSkeletonToken { kind: string; isClose: boolean; attrs: string; }
+
+export class LayoutRecoveryError extends Error {
+  constructor(
+    public readonly details: { expectedTokens: number; recoveredTokens: number },
+  ) {
+    super('AI output lost the page layout: boundary tokens could not be recovered');
+    this.name = 'LayoutRecoveryError';
+  }
+}
+
+const LAYOUT_SECTION_TYPE_RE = /^[a-z_]+$/;
+const COLUMN_WIDTH_RE = /^[\d.]+(%|px|em|rem)?$/;
+
+/** Token kind + canonical attrs for a layout wrapper element (else null). */
+function layoutWrapperKind(el: Element): { kind: string; attrs: string } | null {
+  const cls = el.classList;
+  if (cls.contains('confluence-layout')) return { kind: 'LAYOUT', attrs: '' };
+  if (cls.contains('confluence-layout-section')) {
+    const raw = el.getAttribute('data-layout-type') ?? 'single';
+    return { kind: 'LAYOUT-SECTION', attrs: LAYOUT_SECTION_TYPE_RE.test(raw) ? raw : 'single' };
+  }
+  if (cls.contains('confluence-layout-cell')) return { kind: 'LAYOUT-CELL', attrs: '' };
+  if (cls.contains('confluence-section')) {
+    const border = el.getAttribute('data-border');
+    return { kind: 'SECTION', attrs: border === 'true' || border === 'false' ? `border=${border}` : '' };
+  }
+  if (cls.contains('confluence-column')) {
+    let width = el.getAttribute('data-cell-width');
+    if (!width) {
+      const m = (el.getAttribute('style') ?? '').match(/flex:\s*0\s+0\s+(\S+)/);
+      if (m) width = m[1] ?? null;
+    }
+    return { kind: 'COLUMN', attrs: width && COLUMN_WIDTH_RE.test(width) ? `width=${width}` : '' };
+  }
+  return null;
+}
+
+/**
+ * Derive the expected layout-token skeleton from body HTML. Mirrors the
+ * token emission rules of htmlToMarkdown({ layoutTokens: true }) exactly:
+ * same kinds, same attrs validation, and frozen legacy wrappers (nested in
+ * markdown-constrained containers — see protectMedia) are skipped because
+ * they travel opaquely, never as boundary tokens.
+ */
+export function extractLayoutSkeleton(html: string): LayoutSkeletonToken[] {
+  const dom = new JSDOM(`<body>${html}</body>`);
+  const tokens: LayoutSkeletonToken[] = [];
+  const visit = (el: Element): void => {
+    if (isFrozenLegacyWrapper(el)) return; // opaque-protected whole — no tokens
+    const wrapper = layoutWrapperKind(el);
+    if (wrapper) tokens.push({ kind: wrapper.kind, isClose: false, attrs: wrapper.attrs });
+    for (const child of Array.from(el.children)) visit(child);
+    // Close tokens carry no attrs (matching their canonical [[[/KIND]]] form).
+    if (wrapper) tokens.push({ kind: wrapper.kind, isClose: true, attrs: '' });
+  };
+  for (const child of Array.from(dom.window.document.body.children)) visit(child);
+  return tokens;
+}
+
+// Tolerant recognition of mangled token spellings: 2–4 bracket runs (incl.
+// markdown-escaped \[), optional emphasis wrappers, `/` or `\` closes,
+// hyphen→underscore/space kind variants, arbitrary junk attrs, lower/mixed
+// case. Prose collisions (e.g. "[[Section 2]]" wiki-style links) are kept
+// out by requiring EXACTLY three brackets for case-insensitive matches —
+// other bracket counts only count when the kind is spelled all-uppercase.
+const LAYOUT_KIND_LOOSE = 'LAYOUT[-_ ]SECTION|LAYOUT[-_ ]CELL|LAYOUT|SECTION|COLUMN';
+const LAYOUT_TOKEN_LOOSE_SRC =
+  String.raw`(?:\*{1,2}|_{1,2})?` +
+  String.raw`((?:\\?\[){2,4})` +
+  String.raw`[ \t]*([/\\])?[ \t]*` +
+  String.raw`(${LAYOUT_KIND_LOOSE})` +
+  String.raw`((?:[^\]\n\\]|\\[^\]\n])*)` +
+  String.raw`(?:\\?\]){2,4}` +
+  String.raw`(?:\*{1,2}|_{1,2})?`;
+
+interface LooseLayoutToken { start: number; end: number; kind: string; isClose: boolean; }
+
+/** Scan markdown (outside code constructs) for mangled-token candidates. */
+function scanLooseLayoutTokens(markdown: string): LooseLayoutToken[] {
+  const tokens: LooseLayoutToken[] = [];
+  let offset = 0;
+  for (const [i, part] of markdown.split(MARKDOWN_CODE_SEGMENT).entries()) {
+    if (i % 2 === 0) {
+      for (const m of part.matchAll(new RegExp(LAYOUT_TOKEN_LOOSE_SRC, 'gi'))) {
+        const brackets = (m[1]!.match(/\[/g) ?? []).length;
+        const rawKind = m[3]!;
+        // Non-3-bracket spellings must be all-uppercase to count as tokens.
+        if (brackets !== 3 && rawKind !== rawKind.toUpperCase()) continue;
+        tokens.push({
+          start: offset + m.index,
+          end: offset + m.index + m[0].length,
+          kind: rawKind.toUpperCase().replace(/[_ ]/g, '-'),
+          isClose: m[2] !== undefined,
+        });
+      }
+    }
+    offset += part.length;
+  }
+  return tokens;
+}
+
+/** Does this line consist of exactly one loose token? */
+function isLooseTokenLine(line: string): boolean {
+  return new RegExp(`^(?:${LAYOUT_TOKEN_LOOSE_SRC})$`, 'i').test(line);
+}
+
+/**
+ * Unwrap code constructs whose ENTIRE content is layout-token lines — the
+ * "model fenced the tokens" failure mode. Genuine token documentation in
+ * code blocks always carries surrounding prose lines and is left alone; and
+ * candidate selection (below) prefers the un-unwrapped markdown whenever it
+ * aligns equally well, so code-as-data is only consumed when the alternative
+ * is losing the layout.
+ */
+function unwrapTokenOnlyCode(markdown: string): string {
+  return markdown.replace(MARKDOWN_CODE_SEGMENT, (seg) => {
+    let inner: string | undefined;
+    let m = seg.match(/^(?:```|~~~)[^\n]*\n([\s\S]*?)(?:```|~~~)?\s*$/);
+    if (m) inner = m[1];
+    else if ((m = seg.match(/^``([\s\S]+)``$/) ?? seg.match(/^`([^`\n]+)`$/))) inner = m[1];
+    if (inner === undefined) return seg;
+    const lines = inner.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+    if (lines.length === 0 || !lines.every(isLooseTokenLine)) return seg;
+    return `\n\n${lines.join('\n\n')}\n\n`;
+  });
+}
+
+/** Unwrap a single code fence spanning the whole document, if present. */
+function unwrapFullDocumentFence(markdown: string): string | null {
+  const m = markdown.trim().match(/^```[^\n]*\n([\s\S]*?)\n?```$/);
+  return m ? m[1]! : null;
+}
+
+// Opens that carry prose: if one of these cannot be aligned, a cell boundary
+// is genuinely lost and recovery must fail. LAYOUT / LAYOUT-SECTION opens
+// are pure containers (the storage format puts nothing between them and
+// their first child), so their positions are re-derivable from neighbors.
+const PROSE_BEARING_KINDS = new Set(['LAYOUT-CELL', 'COLUMN', 'SECTION']);
+
+/** Greedy in-order alignment of loose tokens onto the skeleton. */
+function alignLayoutTokens(
+  found: LooseLayoutToken[],
+  skeleton: LayoutSkeletonToken[],
+): { matched: number[]; ok: boolean; matchedCount: number } {
+  const matched: number[] = new Array<number>(skeleton.length).fill(-1);
+  let s = 0;
+  for (let f = 0; f < found.length; f++) {
+    let k = s;
+    while (k < skeleton.length && !(skeleton[k]!.kind === found[f]!.kind && skeleton[k]!.isClose === found[f]!.isClose)) k++;
+    if (k < skeleton.length) {
+      matched[k] = f;
+      s = k + 1;
+    }
+    // else: unmatched echo — debris, stripped during reconstruction.
+  }
+  const ok = skeleton.every((t, i) => matched[i] !== -1 || t.isClose || !PROSE_BEARING_KINDS.has(t.kind));
+  return { matched, ok, matchedCount: matched.filter((f) => f !== -1).length };
+}
+
+function canonicalLayoutToken(t: LayoutSkeletonToken): string {
+  return t.isClose ? `[[[/${t.kind}]]]` : `[[[${t.kind}${t.attrs ? ` ${t.attrs}` : ''}]]]`;
+}
+
+/** Prose may live at top level and inside cells/columns/legacy sections. */
+function proseAllowedIn(stack: string[]): boolean {
+  const top = stack[stack.length - 1];
+  return top === undefined || top === 'LAYOUT-CELL' || top === 'COLUMN' || top === 'SECTION';
+}
+
+/**
+ * Rewrite the markdown with canonical skeleton tokens at the aligned
+ * positions. Dropped tokens are re-inserted just before the next aligned
+ * anchor (or at the end); unmatched token debris is stripped; prose that
+ * would land in a slot the storage format forbids (e.g. between two cells,
+ * directly inside a section) is deferred into the next valid slot.
+ */
+function reconstructLayoutMarkdown(
+  markdown: string,
+  found: LooseLayoutToken[],
+  matched: number[],
+  skeleton: LayoutSkeletonToken[],
+): string {
+  const matchedFound = new Set(matched.filter((f) => f !== -1));
+  const debris = found.filter((_, i) => !matchedFound.has(i));
+  const sliceWithoutDebris = (from: number, to: number): string => {
+    let out = '';
+    let pos = from;
+    for (const d of debris) {
+      if (d.end <= from || d.start >= to) continue;
+      out += markdown.slice(pos, Math.max(d.start, from));
+      pos = Math.min(d.end, to);
+    }
+    return out + markdown.slice(pos, to);
+  };
+
+  const out: string[] = [];
+  const stack: string[] = [];
+  let pendingText = '';
+  let pendingDropped: LayoutSkeletonToken[] = [];
+  let cursor = 0;
+
+  const placeText = (raw: string): void => {
+    const seg = raw.replace(/^\n+|\n+$/g, ''); // outer newlines only — keep code indentation
+    if (seg.trim().length === 0) return;
+    if (proseAllowedIn(stack)) out.push(`\n\n${seg}\n\n`);
+    else pendingText += (pendingText ? '\n\n' : '') + seg;
+  };
+  const placeToken = (t: LayoutSkeletonToken): void => {
+    out.push(`\n\n${canonicalLayoutToken(t)}\n\n`);
+    if (t.isClose) stack.pop();
+    else stack.push(t.kind);
+    if (pendingText && proseAllowedIn(stack)) {
+      out.push(`\n\n${pendingText}\n\n`);
+      pendingText = '';
+    }
+  };
+
+  for (let i = 0; i < skeleton.length; i++) {
+    const f = matched[i]!;
+    if (f === -1) {
+      pendingDropped.push(skeleton[i]!);
+      continue;
+    }
+    const tok = found[f]!;
+    placeText(sliceWithoutDebris(cursor, tok.start));
+    cursor = tok.end;
+    for (const d of pendingDropped) placeToken(d);
+    pendingDropped = [];
+    placeToken(skeleton[i]!);
+  }
+  placeText(sliceWithoutDebris(cursor, markdown.length));
+  for (const d of pendingDropped) placeToken(d);
+  if (pendingText) out.push(`\n\n${pendingText}\n\n`);
+  return out.join('');
+}
+
+/** Strict token sequence (outside code constructs) of a markdown string. */
+function scanStrictLayoutTokens(markdown: string): LayoutToken[] {
+  const tokens: LayoutToken[] = [];
+  for (const [i, part] of markdown.split(MARKDOWN_CODE_SEGMENT).entries()) {
+    if (i % 2 !== 0) continue;
+    for (const m of part.matchAll(new RegExp(LAYOUT_TOKEN_CAPTURE, 'g'))) {
+      tokens.push({ isClose: m[1] === '/', kind: m[2]!, attrs: (m[3] ?? '').trim() });
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Recover the LLM's (possibly mangled) layout tokens against the known
+ * skeleton and return canonical markdown, or throw LayoutRecoveryError.
+ * Fail-closed: the reconstruction is verified token-for-token against the
+ * skeleton before it is accepted, so no edge case can silently flatten.
+ */
+function recoverLayoutMarkdown(markdown: string, skeleton: LayoutSkeletonToken[]): string {
+  const rawFound = scanLooseLayoutTokens(markdown);
+  // Fast path: layout-free page and a clean echo — nothing to do.
+  if (skeleton.length === 0 && rawFound.length === 0) return markdown;
+
+  const candidates: string[] = [markdown];
+  const unwrappedCode = unwrapTokenOnlyCode(markdown);
+  if (unwrappedCode !== markdown) candidates.push(unwrappedCode);
+  const unfenced = unwrapFullDocumentFence(markdown);
+  if (unfenced !== null) {
+    candidates.push(unfenced);
+    const unfencedUnwrapped = unwrapTokenOnlyCode(unfenced);
+    if (unfencedUnwrapped !== unfenced) candidates.push(unfencedUnwrapped);
+  }
+
+  // Evaluate every candidate; prefer the one aligning the most skeleton
+  // tokens, tie-broken toward the LEAST-transformed markdown so code-as-data
+  // is only consumed when it actually rescues the layout.
+  const attempts = candidates
+    .map((candidate, order) => {
+      const found = scanLooseLayoutTokens(candidate);
+      return { candidate, found, order, ...alignLayoutTokens(found, skeleton) };
+    })
+    .sort((a, b) => b.matchedCount - a.matchedCount || a.order - b.order);
+
+  for (const attempt of attempts) {
+    if (!attempt.ok) continue;
+    const rebuilt = reconstructLayoutMarkdown(attempt.candidate, attempt.found, attempt.matched, skeleton);
+    const strict = scanStrictLayoutTokens(rebuilt);
+    const exact =
+      strict.length === skeleton.length &&
+      strict.every(
+        (t, i) => t.kind === skeleton[i]!.kind && t.isClose === skeleton[i]!.isClose && t.attrs === skeleton[i]!.attrs,
+      );
+    if (exact) return rebuilt;
+  }
+
+  throw new LayoutRecoveryError({
+    expectedTokens: skeleton.length,
+    recoveredTokens: attempts[0]?.matchedCount ?? 0,
+  });
+}
+
+export interface MarkdownToHtmlOptions {
+  /**
+   * #781: the expected layout-token skeleton of the document being edited
+   * (from extractLayoutSkeleton on the page's CURRENT body HTML). When set,
+   * mangled tokens in the markdown are recovered against it — and when
+   * recovery is impossible, LayoutRecoveryError is thrown instead of
+   * silently flattening. When omitted, the legacy #774 all-or-nothing
+   * drop-guard applies (markdown imports, no expected structure).
+   */
+  layoutSkeleton?: LayoutSkeletonToken[];
+}
+
 /**
  * Converts Markdown to HTML (for LLM output -> editor).
  */
-export async function markdownToHtml(markdown: string): Promise<string> {
+export async function markdownToHtml(markdown: string, options?: MarkdownToHtmlOptions): Promise<string> {
+  // #781: with a known skeleton, align the LLM's echo against it first —
+  // throws LayoutRecoveryError when the layout is unrecoverable.
+  const input = options?.layoutSkeleton
+    ? recoverLayoutMarkdown(markdown, options.layoutSkeleton)
+    : markdown;
+
   // #765: force every layout boundary token onto its own paragraph so marked
   // wraps it in a lone <p>, even when the LLM merged adjacent token lines or
   // pulled a token into surrounding prose. Code constructs are skipped —
   // literal token text in a fenced block must survive verbatim.
   const tokenLine = new RegExp(`[ \\t]*(${LAYOUT_TOKEN_BARE})[ \\t]*`, 'g');
-  const normalized = transformOutsideMarkdownCode(markdown, (segment) =>
+  const normalized = transformOutsideMarkdownCode(input, (segment) =>
     segment.replace(tokenLine, '\n\n$1\n\n'),
   );
 

--- a/backend/src/domains/llm/services/prompts.ts
+++ b/backend/src/domains/llm/services/prompts.ts
@@ -15,8 +15,34 @@ export const LANGUAGE_PRESERVATION_INSTRUCTION = `IMPORTANT: Keep the text in it
 
 // #765: appended to improve prompts when the markdown contains layout
 // boundary tokens or media placeholders, so the LLM keeps the page structure
-// intact. markdownToHtml() has a drop-guard for when it still mangles them.
-export const STRUCTURE_PRESERVATION_INSTRUCTION = `The text contains structural placeholder tokens: standalone lines like [[[LAYOUT]]], [[[LAYOUT-SECTION two_equal]]], [[[LAYOUT-CELL]]], [[[SECTION]]], [[[COLUMN width=50%]]] and their matching closing forms ([[[/LAYOUT]]], [[[/LAYOUT-SECTION]]], …), plus opaque CQ_MEDIA_PLACEHOLDER_N tokens. These mark page structure that must survive your edit. Keep every token EXACTLY as written, each on its own line, in the same order and nesting. Improve only the prose between them. Never delete, rename, reorder, or merge tokens.`;
+// intact. #781 hardened it with a few-shot example (models echo tokens far
+// more reliably when shown one) — and markdownToHtml() now recovers mangled
+// tokens against the known skeleton when the model still misbehaves.
+export const STRUCTURE_PRESERVATION_INSTRUCTION = `The text contains structural placeholder tokens: standalone lines like [[[LAYOUT]]], [[[LAYOUT-SECTION two_equal]]], [[[LAYOUT-CELL]]], [[[SECTION]]], [[[COLUMN width=50%]]] and their matching closing forms ([[[/LAYOUT]]], [[[/LAYOUT-SECTION]]], …), plus opaque CQ_MEDIA_PLACEHOLDER_N tokens. These mark page structure that must survive your edit. Keep every token EXACTLY as written — same UPPERCASE spelling, same triple brackets, each on its own line, in the same order and nesting. Improve only the prose between them. Never delete, rename, translate, reorder, or merge tokens, and never wrap them in code fences or quotes.
+
+Example. Given this input:
+[[[LAYOUT]]]
+[[[LAYOUT-SECTION two_equal]]]
+[[[LAYOUT-CELL]]]
+left text to improve
+[[[/LAYOUT-CELL]]]
+[[[LAYOUT-CELL]]]
+right text to improve
+[[[/LAYOUT-CELL]]]
+[[[/LAYOUT-SECTION]]]
+[[[/LAYOUT]]]
+
+A correct response keeps every token verbatim and edits only the prose:
+[[[LAYOUT]]]
+[[[LAYOUT-SECTION two_equal]]]
+[[[LAYOUT-CELL]]]
+The left text, improved.
+[[[/LAYOUT-CELL]]]
+[[[LAYOUT-CELL]]]
+The right text, improved.
+[[[/LAYOUT-CELL]]]
+[[[/LAYOUT-SECTION]]]
+[[[/LAYOUT]]]`;
 
 const SYSTEM_PROMPTS = {
   improve_grammar: `You are a technical writing assistant. Improve the grammar, spelling, and punctuation of the following article while preserving its meaning and structure. Return the improved text in Markdown format. Only output the improved text, no explanations. ${LANGUAGE_PRESERVATION_INSTRUCTION}`,

--- a/backend/src/routes/llm/apply-improvement-media.test.ts
+++ b/backend/src/routes/llm/apply-improvement-media.test.ts
@@ -292,10 +292,11 @@ describe('POST /api/llm/improvements/apply — layout boundary tokens with REAL 
     expect(savedHtml).not.toContain('[[[');
   });
 
-  it('drop-guard: mangled tokens flatten gracefully — no raw [[[…]]] and no unbalanced divs', async () => {
+  it('#781: mangled tokens are recovered against the page skeleton — layout survives (was silently flattened)', async () => {
     mockPageWith(layoutBodyHtml);
 
-    // The LLM dropped one closing token and lower-cased another.
+    // The LLM dropped one closing token and lower-cased another — the exact
+    // failure mode #781 reported from real local models.
     const improvedMarkdown = [
       '[[[LAYOUT]]]', '',
       '[[[LAYOUT-SECTION two_equal]]]', '',
@@ -317,10 +318,65 @@ describe('POST /api/llm/improvements/apply — layout boundary tokens with REAL 
     expect(response.statusCode).toBe(200);
     const savedHtml = captureUpdatedBodyHtml();
     expect(savedHtml).not.toContain('[[[');
-    expect(savedHtml).not.toContain('confluence-layout');
+    // The layout is rebuilt from the page's own skeleton, not flattened.
+    expect(savedHtml).toContain('class="confluence-layout"');
+    expect(savedHtml).toContain('data-layout-type="two_equal"');
+    expect((savedHtml.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(2);
     expect(savedHtml).toContain('Left prose survives.');
     expect(savedHtml).toContain('Right prose survives.');
-    // No dangling open/close divs.
     expect((savedHtml.match(/<div/g) ?? []).length).toBe((savedHtml.match(/<\/div>/g) ?? []).length);
+  });
+
+  it('#781: unrecoverable token loss rejects the apply with 422 — the page is NOT modified or pushed', async () => {
+    mockPageWith(layoutBodyHtml);
+
+    // The model rewrote the markers in German prose — nothing to align.
+    const improvedMarkdown = [
+      'Beginn des Seitenlayouts.', '',
+      'Linke Spalte: Left prose.', '',
+      'Rechte Spalte: Right prose.', '',
+      'Ende des Seitenlayouts.',
+    ].join('\n');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/improvements/apply',
+      payload: { pageId: '42', improvedMarkdown, version: 5, title: 'My Article' },
+    });
+
+    expect(response.statusCode).toBe(422);
+    expect(response.json().message).toContain('column layout');
+    // Predictable failure: NO page write happened — flattened content can
+    // never be saved locally nor pushed back to Confluence.
+    const updateCall = (mockQuery.mock.calls as unknown[][]).find(
+      (args) => typeof args[0] === 'string' && (args[0] as string).includes('UPDATE pages'),
+    );
+    expect(updateCall).toBeUndefined();
+  });
+
+  it('#781: hallucinated layout tokens on a layout-free page are stripped, never built', async () => {
+    mockPageWith('<h1>Plain page</h1><p>No layout here.</p>');
+
+    const improvedMarkdown = [
+      '[[[LAYOUT]]]', '',
+      '[[[LAYOUT-SECTION two_equal]]]', '',
+      '[[[LAYOUT-CELL]]]', '',
+      'Hallucinated structure around real prose.', '',
+      '[[[/LAYOUT-CELL]]]', '',
+      '[[[/LAYOUT-SECTION]]]', '',
+      '[[[/LAYOUT]]]',
+    ].join('\n');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/improvements/apply',
+      payload: { pageId: '42', improvedMarkdown, version: 5, title: 'My Article' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const savedHtml = captureUpdatedBodyHtml();
+    expect(savedHtml).not.toContain('[[[');
+    expect(savedHtml).not.toContain('confluence-layout');
+    expect(savedHtml).toContain('Hallucinated structure around real prose.');
   });
 });

--- a/backend/src/routes/llm/apply-improvement-media.test.ts
+++ b/backend/src/routes/llm/apply-improvement-media.test.ts
@@ -354,6 +354,35 @@ describe('POST /api/llm/improvements/apply — layout boundary tokens with REAL 
     expect(updateCall).toBeUndefined();
   });
 
+  it('#785: single-cell layout page applies even when the LLM dropped every token (unambiguous wrap recovery)', async () => {
+    mockPageWith(
+      '<div class="confluence-layout"><div class="confluence-layout-section" data-layout-type="single">' +
+      '<div class="confluence-layout-cell"><p>Full width content</p></div>' +
+      '</div></div>',
+    );
+
+    // Token-free echo: with exactly ONE prose-bearing cell there is no
+    // ambiguity — the apply must succeed with the prose wrapped in the cell.
+    const improvedMarkdown = '## Improved heading\n\nFresh single-column prose, no tokens at all.';
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/improvements/apply',
+      payload: { pageId: '42', improvedMarkdown, version: 5, title: 'My Article' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const savedHtml = captureUpdatedBodyHtml();
+    expect(savedHtml).not.toContain('[[[');
+    expect(savedHtml).toContain('data-layout-type="single"');
+    expect((savedHtml.match(/class="confluence-layout-cell"/g) ?? []).length).toBe(1);
+    // The prose landed INSIDE the cell (before the layout's closing divs),
+    // not at top level after an empty rebuilt layout.
+    const proseIdx = savedHtml.indexOf('Fresh single-column prose');
+    expect(proseIdx).toBeGreaterThan(savedHtml.indexOf('confluence-layout-cell'));
+    expect(savedHtml.lastIndexOf('</div>')).toBeGreaterThan(proseIdx);
+  });
+
   it('#781: hallucinated layout tokens on a layout-free page are stripped, never built', async () => {
     mockPageWith('<h1>Plain page</h1><p>No layout here.</p>');
 

--- a/backend/src/routes/llm/apply-improvement.test.ts
+++ b/backend/src/routes/llm/apply-improvement.test.ts
@@ -45,6 +45,10 @@ vi.mock('../../core/services/content-converter.js', () => ({
   markdownToHtml: (...args: unknown[]) => mockMarkdownToHtml(...args),
   protectMedia: (...args: unknown[]) => mockProtectMedia(...args),
   restoreMedia: (...args: unknown[]) => mockRestoreMedia(...args),
+  // #781: the apply route derives the layout skeleton and matches the
+  // recovery error by instance — keep the class real-ish in the mock.
+  extractLayoutSkeleton: vi.fn(() => []),
+  LayoutRecoveryError: class LayoutRecoveryError extends Error {},
 }));
 
 vi.mock('../../domains/llm/services/embedding-service.js', () => ({
@@ -236,7 +240,10 @@ describe('POST /api/llm/improvements/apply', () => {
     expect(response.statusCode).toBe(200);
 
     // Markdown → HTML conversion
-    expect(mockMarkdownToHtml).toHaveBeenCalledWith('## Improved\n\nBetter content.');
+    expect(mockMarkdownToHtml).toHaveBeenCalledWith(
+      '## Improved\n\nBetter content.',
+      { layoutSkeleton: [] }, // #781: skeleton from the page's current body
+    );
 
     // HTML → Confluence XHTML conversion
     expect(mockHtmlToConfluence).toHaveBeenCalledWith('<p>Improved HTML content</p>');

--- a/backend/src/routes/llm/llm-conversations.ts
+++ b/backend/src/routes/llm/llm-conversations.ts
@@ -3,7 +3,7 @@ import { query } from '../../core/db/postgres.js';
 import { ChatMessage } from '../../domains/llm/services/prompts.js';
 import { RedisCache } from '../../core/services/redis-cache.js';
 import { ApplyImprovementRequestSchema } from '@compendiq/contracts';
-import { confluenceToHtml, htmlToConfluence, htmlToText, markdownToHtml, protectMedia, restoreMedia } from '../../core/services/content-converter.js';
+import { confluenceToHtml, htmlToConfluence, htmlToText, markdownToHtml, protectMedia, restoreMedia, extractLayoutSkeleton, LayoutRecoveryError } from '../../core/services/content-converter.js';
 import { getClientForUser } from '../../domains/confluence/services/sync-service.js';
 import { logAuditEvent } from '../../core/services/audit-service.js';
 import { IdParamSchema, ImprovementsQuerySchema } from './_helpers.js';
@@ -157,8 +157,31 @@ export async function llmConversationRoutes(fastify: FastifyInstance) {
     // is the backstop: any media original not present after restoreMedia
     // (including the worst case where restoreMedia was a complete no-op because
     // no tokens survived) is re-appended, so media is never silently lost.
-    const { media } = protectMedia(existingPage.body_html ?? '');
-    let bodyHtml = await markdownToHtml(improvedMarkdown);
+    const { html: protectedCurrentHtml, media } = protectMedia(existingPage.body_html ?? '');
+
+    // #781: derive the expected layout-token skeleton from the page's CURRENT
+    // body_html (deterministic, same re-derivation idea as the media tokens
+    // above) and let markdownToHtml align the LLM's — possibly mangled —
+    // boundary tokens against it. When the layout is unrecoverable (e.g. the
+    // model merged two cells' prose or dropped every token), the apply is
+    // REJECTED with a 422 instead of silently flattening the page and
+    // pushing the flattened body back to Confluence.
+    const layoutSkeleton = extractLayoutSkeleton(protectedCurrentHtml);
+    let bodyHtml: string;
+    try {
+      bodyHtml = await markdownToHtml(improvedMarkdown, { layoutSkeleton });
+    } catch (err) {
+      if (err instanceof LayoutRecoveryError) {
+        fastify.log.warn(
+          { pageId, ...err.details },
+          '#781: AI Improve output lost the page layout — apply rejected, page not modified',
+        );
+        throw fastify.httpErrors.unprocessableEntity(
+          "The AI response lost this page's column layout and it could not be recovered, so the change was not applied. The page is unchanged — run AI Improve again, or edit the page manually.",
+        );
+      }
+      throw err;
+    }
     bodyHtml = restoreMedia(bodyHtml, media);
     const dropped = media.filter((m) => !bodyHtml.includes(m.html));
     if (dropped.length > 0) {

--- a/docs/architecture/11-content-pipeline.md
+++ b/docs/architecture/11-content-pipeline.md
@@ -271,7 +271,14 @@ the LLM's echo; it aligns whatever came back against the known skeleton:
    case, 2–4 bracket runs, markdown-escaped `\[`, `\` instead of `/` closes,
    `LAYOUT_CELL` / `LAYOUT SECTION` kind variants, emphasis-wrapped tokens,
    junk attrs — plus two unwrapping fallbacks for token-only code fences and
-   a fence wrapped around the entire output.
+   a fence wrapped around the entire output. The tolerant matcher is an
+   **escalation**, not the default: candidates are first evaluated with the
+   strict canonical matcher, and only when no candidate's intact canonical
+   tokens cover the full skeleton does the loose scan run. So when the
+   echo's real tokens are intact, token lookalikes in user prose (e.g. a
+   literal `[[[layout]]]` in a sentence about the syntax) survive as prose
+   instead of being consumed as debris — only exact-canonical lookalikes
+   remain exposed, the pre-#781 status quo.
 3. Found tokens are **greedily aligned, in order, onto the skeleton**. Close
    tokens and pure container opens (`LAYOUT`, `LAYOUT-SECTION`) are
    re-derivable and may be dropped by the model; every **prose-bearing open**
@@ -289,7 +296,19 @@ the LLM's echo; it aligns whatever came back against the known skeleton:
    toast by the frontend). The page is **not** modified locally and nothing
    is pushed to Confluence — a flattened body can never be saved silently.
    An empty skeleton (layout-free page) also strips any *hallucinated*
-   tokens instead of building layout that never existed.
+   tokens instead of building layout that never existed. One exception:
+   a skeleton with exactly **one** prose-bearing slot (a `single`-layout
+   page) is recovered even when the model dropped every token — all prose
+   can only belong in that one cell, so it is wrapped there (debris
+   stripped, same token-for-token verification). With two or more slots the
+   assignment would be a guess, and the 422 stands.
+
+Note that greedy in-order alignment guards the layout **structure**, not the
+prose-to-cell **assignment**: a model that swaps two cells' content yields
+the swapped prose inside the correctly preserved structure — every boundary
+still aligns, so the 422 cannot (and does not try to) detect it. The
+guarantee is "never flatten, never corrupt the grid", not "every paragraph
+is in the cell the model meant".
 
 Callers without an expected structure (markdown page imports, the summary
 worker) keep the legacy no-skeleton drop-guard semantics of step 4 above.

--- a/docs/architecture/11-content-pipeline.md
+++ b/docs/architecture/11-content-pipeline.md
@@ -158,7 +158,11 @@ On `POST /llm/improvements/apply` the route:
 
 1. Re-derives the same token map from the **current** `body_html` stored in
    the DB (same deterministic order — no token map needs to be persisted).
-2. Calls `markdownToHtml(improvedMarkdown)` on the LLM output.
+2. Calls `markdownToHtml(improvedMarkdown, { layoutSkeleton })` on the LLM
+   output, where the skeleton is re-derived from the same `body_html`
+   (#781, see "Skeleton-guided token recovery" below). An unrecoverable
+   layout throws and the apply is rejected with **422** — nothing is saved
+   or pushed.
 3. Calls `restoreMedia(html, media)` to replace tokens (and their
    turndown-escaped variants `CQ\_MEDIA\_PLACEHOLDER\_N`) with the original
    HTML verbatim.
@@ -229,10 +233,10 @@ Tokens carry the structural attributes (`data-layout-type`, `data-border`,
    `div.confluence-layout*` / `div.confluence-section` /
    `div.confluence-column` wrappers (which `htmlToConfluence()` already maps
    losslessly to `ac:layout*` / `section` / `column`);
-4. **drop-guard:** if the LLM mangled the tokens (unbalanced, reordered,
-   case-changed), ALL tokens are stripped instead — the content degrades to
-   the old flattened form, but the page is never corrupted and raw
-   `[[[…]]]` text never reaches the saved page.
+4. **drop-guard (no skeleton — markdown imports etc.):** if the LLM mangled
+   the tokens (unbalanced, reordered, case-changed), ALL tokens are stripped
+   instead — the content degrades to the old flattened form, but the page is
+   never corrupted and raw `[[[…]]]` text never reaches the saved page.
 
 Steps 2–4 operate only **outside `<pre>`/`<code>` elements**: literal token
 text inside code blocks (e.g. documentation about the token syntax) is
@@ -241,7 +245,54 @@ poison the balance validation of the real tokens.
 
 `/llm/improve` appends `STRUCTURE_PRESERVATION_INSTRUCTION` (from
 `prompts.ts`) to the system prompt whenever the markdown contains boundary
-or media tokens, instructing the model to keep them verbatim.
+or media tokens, instructing the model — with a few-shot example (#781) —
+to keep them verbatim.
+
+### Skeleton-guided token recovery + 422 fallback (#781)
+
+The #765 drop-guard was all-or-nothing: one token mangled by the model
+(real local models routinely lower-case, merge, translate, or drop the
+unusual `[[[…]]]` lines) silently flattened the whole layout — and the
+flattened body was pushed back to Confluence. #781 replaces silence with a
+layered defense built on one invariant: **never silently flatten**.
+
+The key insight: the system *knows* the exact expected token sequence — it
+generated it from the original document. Recovery therefore never trusts
+the LLM's echo; it aligns whatever came back against the known skeleton:
+
+1. `extractLayoutSkeleton(bodyHtml)` derives the expected open/close token
+   sequence (with section types / column widths) from the page's **current**
+   `body_html` — deterministic, exactly like the #723 media-token
+   re-derivation, so nothing is persisted. Frozen legacy wrappers are
+   skipped (they travel opaquely, see above).
+2. The apply route passes it to
+   `markdownToHtml(improvedMarkdown, { layoutSkeleton })`, which scans the
+   markdown (outside code) with a *tolerant* token matcher — lower/mixed
+   case, 2–4 bracket runs, markdown-escaped `\[`, `\` instead of `/` closes,
+   `LAYOUT_CELL` / `LAYOUT SECTION` kind variants, emphasis-wrapped tokens,
+   junk attrs — plus two unwrapping fallbacks for token-only code fences and
+   a fence wrapped around the entire output.
+3. Found tokens are **greedily aligned, in order, onto the skeleton**. Close
+   tokens and pure container opens (`LAYOUT`, `LAYOUT-SECTION`) are
+   re-derivable and may be dropped by the model; every **prose-bearing open**
+   (`LAYOUT-CELL`, `COLUMN`, `SECTION`) must be found — otherwise a cell
+   boundary is genuinely lost (e.g. two cells' prose merged).
+4. The markdown is rewritten with **canonical tokens from the skeleton**
+   (section types and widths always come from the skeleton, never from the
+   echo), unmatched token debris is stripped, and prose that would land in a
+   storage-format-invalid slot (e.g. between two cells) is deferred into the
+   next cell. The result is verified token-for-token against the skeleton
+   before use — any residual mismatch fails closed.
+5. **Hard fallback:** when alignment is impossible, `markdownToHtml` throws
+   `LayoutRecoveryError` and `POST /llm/improvements/apply` responds
+   **422 Unprocessable Entity** with a human-readable message (surfaced as a
+   toast by the frontend). The page is **not** modified locally and nothing
+   is pushed to Confluence — a flattened body can never be saved silently.
+   An empty skeleton (layout-free page) also strips any *hallucinated*
+   tokens instead of building layout that never existed.
+
+Callers without an expected structure (markdown page imports, the summary
+worker) keep the legacy no-skeleton drop-guard semantics of step 4 above.
 
 The in-body **labels macro** is the opposite case: it is atomic (no editable
 prose), so since #765 it is kept as a


### PR DESCRIPTION
Fixes #781

## Problem

PR #774 preserved Confluence row/column layouts through AI Improve via `[[[…]]]` boundary tokens, but its drop-guard was **all-or-nothing**: a single token mangled by the model (case change, merged line, dropped close, dropped section arg, code fence, translation — all routine for local Ollama-class models) stripped EVERY token and silently flattened the layout, and the flattened body was pushed back to Confluence. Net effect: the old #765 data loss, just less often.

## Design — layered defense, invariant: **never silently flatten**

The key insight: the system *knows* the exact expected token skeleton, because it generated it from the original document. Recovery therefore never trusts the LLM's echo — it aligns whatever came back against the known skeleton.

**Layer 1 — skeleton-guided tolerant recovery** (`content-converter.ts`):
- `extractLayoutSkeleton(bodyHtml)` derives the expected open/close token sequence (section types, column widths, border params) from the page's **current** `body_html` — deterministic, exactly like the #723 media-token re-derivation; nothing persisted. Frozen legacy wrappers (nested in constrained containers) are skipped, mirroring `htmlToMarkdown`'s emission rules.
- `markdownToHtml(md, { layoutSkeleton })` scans the echo (outside code constructs) with a *tolerant* matcher: lower/mixed case, 2–4 bracket runs, markdown-escaped `\[`, `\` instead of `/` closes, `LAYOUT_CELL` / `LAYOUT SECTION` kind variants, emphasis-wrapped tokens, junk attrs. Prose collisions (`[[Section 2]]`-style links) are excluded by requiring exactly 3 brackets for case-insensitive matches. Two unwrapping fallbacks handle token-only code fences and a fence wrapped around the entire output (candidate selection prefers the least-transformed markdown, so token docs in code blocks stay data whenever the real tokens survive).
- Found tokens are greedily aligned **in order** onto the skeleton. Close tokens and pure container opens (`LAYOUT`, `LAYOUT-SECTION`) are re-derivable; every **prose-bearing open** (`LAYOUT-CELL`, `COLUMN`, `SECTION`) must be found.
- The markdown is rewritten with **canonical tokens from the skeleton** (types/widths always from the skeleton, never from the echo), debris is stripped, stray inter-cell prose is folded into the next cell, and the result is **verified token-for-token against the skeleton** before use — fail-closed against any residual edge case.
- An **empty skeleton** (layout-free page) strips *hallucinated* tokens instead of building layout that never existed (previously they would have been rebuilt).

**Layer 2 — hard fallback**: when alignment is impossible (e.g. the model merged two cells' prose, translated the markers, or dropped everything), `markdownToHtml` throws `LayoutRecoveryError` and `POST /llm/improvements/apply` responds **422** with a human-readable message (surfaced as a toast by the existing frontend error path). The page is **not** modified locally and **nothing is pushed to Confluence** — predictable, documented, never silent.

**Layer 3 — prompt hardening**: `STRUCTURE_PRESERVATION_INSTRUCTION` now includes a few-shot verbatim-echo example (reduces failure *frequency*; layers 1–2 remove the *damage*).

**Layer 4 — coverage**: Improve-path round-trips for `two_left_sidebar`, `two_right_sidebar`, `three_with_sidebars` (fixture mirrors the canonical example in the official Confluence DC storage-format reference, incl. the recognized `ac:type` list) and a real-DC extra-attribute variant (`ac:breakout-mode` etc. tolerated). No-skeleton callers (markdown page imports) keep the legacy #774 drop-guard semantics unchanged.

## Behavior matrix

| LLM echo | Before | After |
|---|---|---|
| Tokens intact | layout kept | layout kept (unchanged) |
| Case-mangled / merged / dropped close / dropped arg / escaped / fenced | **silently flattened + pushed** | layout rebuilt from skeleton |
| Translated/reworded tokens, merged cells, all tokens dropped | **silently flattened + pushed** | **422, page untouched, nothing pushed** |
| Hallucinated tokens on a layout-free page | hallucinated layout built | tokens stripped |

## Files

- `backend/src/core/services/content-converter.ts` — `extractLayoutSkeleton`, `LayoutRecoveryError`, recovery pipeline, `markdownToHtml` options
- `backend/src/routes/llm/llm-conversations.ts` — apply route: skeleton derivation + 422 rejection
- `backend/src/domains/llm/services/prompts.ts` — few-shot prompt hardening
- `backend/src/core/services/__fixtures__/confluence-xhtml.ts` — `three_with_sidebars` + DC extra-attrs fixtures
- Tests: `content-converter.test.ts` (31 new), `apply-improvement-media.test.ts` (recovered/422/hallucination route tests), `apply-improvement.test.ts` (mock updated)
- `docs/architecture/11-content-pipeline.md` — recovery + fallback semantics (CLAUDE.md rule 6)

## Verification

Ran locally (dedicated test Postgres on :5442, shared Redis):

- `npx vitest run src/core/services/content-converter.test.ts src/core/services/content-converter.media.test.ts src/routes/llm/ src/domains/confluence/services/subpage-context.test.ts src/routes/knowledge/pages-import.test.ts` → **30 files, 444 tests, all passing** (includes all pre-existing #765/#723 suites — no behavior regressions for intact tokens, code-as-data, frozen wrappers, media protection)
- `npm run lint -w backend` → clean (`--max-warnings=0`)
- `npm run typecheck -w backend` → clean
- TDD: the 31 new converter tests + 3 route tests were written first and observed failing (23 failing on the mechanism, the rest on missing exports) before implementation

## **Not verified here**

A live **Confluence DC + real LLM** end-to-end run was **not possible in this environment**: no Ollama/LLM provider is reachable on this machine, and no Confluence DC instance/volume exists (booting one requires an interactive setup wizard + license). The regression tests simulate the documented real-model failure modes synthetically against the real converter and the real apply route.

The live end-to-end verification (acceptance criterion of #781) is tracked separately in #786 — *Verify #781 layout-token recovery end-to-end against local Confluence DC + real LLM* — using the repro steps below.

**Manual E2E repro steps for the maintainer:**
1. Start Confluence DC 9.2 + an Ollama provider; configure both in Compendiq (Settings → Confluence / LLM, `chat` use case on a small local model — small models mangle tokens most reliably).
2. In Confluence, create a page using a **two-column**, a **three-column**, and a **sidebar** layout (`two_left_sidebar` or `three_with_sidebars`), with distinct prose per cell; sync the space.
3. In Compendiq, open the page → AI Improve (any type) → Accept.
4. Expected: the page in Compendiq AND the body pushed to Confluence keep the multi-column layout (view storage format: `<ac:layout-section ac:type="…">` count/types unchanged); prose edits applied inside the cells.
5. To exercise the hard fallback: add `Translate all bracketed marker lines to German` as the custom instruction (or use a model that reliably destroys the markers). Expected: Accept shows the error toast "The AI response lost this page's column layout …", returns 422, and the page is unchanged in both Compendiq and Confluence — never a flattened single-column page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
