### PR TITLE
UX review fixes: state consistency, trash repair, degraded-state UX, system-account shielding

### DIFF
--- a/backend/src/core/services/admin-user-service.test.ts
+++ b/backend/src/core/services/admin-user-service.test.ts
@@ -437,6 +437,68 @@ describe.skipIf(!dbAvailable)('admin-user-service (#304)', () => {
     expect(parseInt(after.rows[0]!.c, 10)).toBe(1);
   });
 
+  // UX-fix Task 4 — the system sentinel user (migration 032) must be
+  // invisible to the admin Users page and immune to every mutation. It owns
+  // reassigned templates and cannot log in; deactivating or deleting it
+  // would break the install.
+  describe('system account protection', () => {
+    const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
+
+    /** Re-seed the sentinel row (truncateAllTables wipes the migration seed). */
+    async function seedSystemUser(): Promise<void> {
+      await query(
+        `INSERT INTO users (id, username, password_hash, role)
+           VALUES ($1, '__system__', 'nologin', 'admin')
+           ON CONFLICT (id) DO NOTHING`,
+        [SYSTEM_USER_ID],
+      );
+    }
+
+    it('listUsers excludes the system sentinel user', async () => {
+      await seedSystemUser();
+      await createUser({ username: 'visible', role: 'user', password: 'x12345678' });
+      const users = await listUsers();
+      expect(users.map((u) => u.id)).not.toContain(SYSTEM_USER_ID);
+      expect(users.map((u) => u.username)).toEqual(['visible']);
+    });
+
+    it('deactivateUser refuses the system user with SYSTEM_USER_PROTECTED', async () => {
+      await seedSystemUser();
+      const adminId = await seedAdmin('sys-deact');
+      await expect(
+        deactivateUser(SYSTEM_USER_ID, { actorUserId: adminId }),
+      ).rejects.toMatchObject({ code: 'SYSTEM_USER_PROTECTED' });
+    });
+
+    it('deleteUser refuses the system user with SYSTEM_USER_PROTECTED', async () => {
+      await seedSystemUser();
+      const adminId = await seedAdmin('sys-del');
+      await expect(
+        deleteUser(SYSTEM_USER_ID, { actorUserId: adminId }),
+      ).rejects.toMatchObject({ code: 'SYSTEM_USER_PROTECTED' });
+      // Row must survive untouched.
+      const res = await query(`SELECT 1 FROM users WHERE id = $1`, [SYSTEM_USER_ID]);
+      expect(res.rows.length).toBe(1);
+    });
+
+    it('updateUser refuses the system user with SYSTEM_USER_PROTECTED', async () => {
+      await seedSystemUser();
+      await expect(
+        updateUser(SYSTEM_USER_ID, { role: 'user' }),
+      ).rejects.toMatchObject({ code: 'SYSTEM_USER_PROTECTED' });
+      await expect(
+        updateUser(SYSTEM_USER_ID, { displayName: 'Sneaky' }),
+      ).rejects.toMatchObject({ code: 'SYSTEM_USER_PROTECTED' });
+    });
+
+    it('reactivateUser refuses the system user with SYSTEM_USER_PROTECTED', async () => {
+      await seedSystemUser();
+      await expect(
+        reactivateUser(SYSTEM_USER_ID),
+      ).rejects.toMatchObject({ code: 'SYSTEM_USER_PROTECTED' });
+    });
+  });
+
   it('concurrent role-demote of two admins leaves at least one active (no TOCTOU)', async () => {
     const aId = await seedAdmin('race-dem-a');
     const bId = await seedAdmin('race-dem-b');

--- a/backend/src/core/services/admin-user-service.ts
+++ b/backend/src/core/services/admin-user-service.ts
@@ -33,6 +33,7 @@ export class AdminUserServiceError extends Error {
       | 'EMAIL_TAKEN'
       | 'NOT_FOUND'
       | 'SELF_FORBIDDEN'
+      | 'SYSTEM_USER_PROTECTED'
       | 'LAST_ADMIN',
     message: string,
   ) {
@@ -83,10 +84,28 @@ const USER_SELECT = `
 `;
 
 export async function listUsers(): Promise<AdminUser[]> {
+  // The system sentinel user (migration 032) is an implementation detail —
+  // it owns reassigned templates and cannot log in. Hide it from the admin
+  // Users page so nobody tries to manage it.
   const res = await query<UserRow>(
-    `${USER_SELECT} ORDER BY username`,
+    `${USER_SELECT} WHERE id <> $1 ORDER BY username`,
+    [SYSTEM_USER_ID],
   );
   return res.rows.map(rowToAdminUser);
+}
+
+/**
+ * Raise `SYSTEM_USER_PROTECTED` when a mutation targets the system sentinel
+ * user. Deactivating, deleting, or editing it would break the install — it
+ * owns reassigned templates and the deletion flow depends on its existence.
+ */
+function assertNotSystemUser(targetUserId: string): void {
+  if (targetUserId === SYSTEM_USER_ID) {
+    throw new AdminUserServiceError(
+      'SYSTEM_USER_PROTECTED',
+      'The system account cannot be modified',
+    );
+  }
 }
 
 export async function getUser(id: string): Promise<AdminUser | null> {
@@ -160,6 +179,8 @@ interface UpdateUserOptions {
 }
 
 export async function updateUser(id: string, patch: UpdateUserOptions): Promise<AdminUser> {
+  assertNotSystemUser(id);
+
   // The existence check + optional last-admin guard + mutation all run in
   // the same transaction so concurrent role-demotes can't both pass a
   // stale precheck (PR #311 Finding #2).
@@ -254,6 +275,7 @@ export async function deactivateUser(
   targetUserId: string,
   opts: DeactivateOptions,
 ): Promise<AdminUser> {
+  assertNotSystemUser(targetUserId);
   if (targetUserId === opts.actorUserId) {
     throw new AdminUserServiceError('SELF_FORBIDDEN', 'Cannot deactivate yourself');
   }
@@ -311,6 +333,7 @@ export async function deactivateUser(
 }
 
 export async function reactivateUser(targetUserId: string): Promise<AdminUser> {
+  assertNotSystemUser(targetUserId);
   const res = await query<UserRow>(
     `UPDATE users
        SET deactivated_at = NULL,
@@ -340,6 +363,7 @@ export async function deleteUser(
   targetUserId: string,
   opts: DeleteUserOptions,
 ): Promise<void> {
+  assertNotSystemUser(targetUserId);
   if (targetUserId === opts.actorUserId) {
     throw new AdminUserServiceError('SELF_FORBIDDEN', 'Cannot delete yourself');
   }

--- a/backend/src/core/services/admin-user-service.ts
+++ b/backend/src/core/services/admin-user-service.ts
@@ -20,8 +20,11 @@ const BCRYPT_ROUNDS = 10;
  * System sentinel user that owns built-in templates (migration 032). When a
  * real user is hard-deleted we reassign their `templates.created_by` rows
  * to this UUID rather than blocking the delete on the NOT NULL FK.
+ *
+ * Exported so other user-listing endpoints (e.g. the rbac principal picker)
+ * can exclude it the same way `listUsers()` does.
  */
-const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
+export const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
 
 /**
  * Errors thrown by the service. Routes map them to HTTP status codes.

--- a/backend/src/core/services/bulk-page-selection.ts
+++ b/backend/src/core/services/bulk-page-selection.ts
@@ -246,6 +246,9 @@ export async function resolveBulkSelection(
       source: string;
       labels: string[] | null;
     }>(
+      // Deliberately NOT visiblePagesPredicate(): ids-mode grants owners access
+      // to their private pages regardless of visibility, and the space branch
+      // is not gated on source = 'confluence'.
       `SELECT cp.id, cp.confluence_id, cp.space_key, cp.source, cp.labels FROM pages cp
        WHERE (cp.id = ANY($1::int[]) OR cp.confluence_id = ANY($2::text[]))
          AND cp.deleted_at IS NULL

--- a/backend/src/core/services/bulk-page-selection.ts
+++ b/backend/src/core/services/bulk-page-selection.ts
@@ -20,6 +20,7 @@
  */
 import { z } from 'zod';
 import { query } from '../db/postgres.js';
+import { visiblePagesPredicate } from './page-visibility.js';
 
 /**
  * Subset of the GET /pages filter shape that's safe + useful for bulk
@@ -293,11 +294,7 @@ export async function resolveBulkSelection(
     baseValues.length + 1,
   );
   const whereParts = ['cp.deleted_at IS NULL', ...parts];
-  const where = `WHERE (
-      (cp.source = 'confluence' AND cp.space_key = ANY($1::text[]))
-      OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-      OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $2)
-    ) AND ${whereParts.join(' AND ')}`;
+  const where = `WHERE ${visiblePagesPredicate(1, 2)} AND ${whereParts.join(' AND ')}`;
 
   const allValues = [...baseValues, ...filterValues];
 

--- a/backend/src/core/services/data-retention-service.test.ts
+++ b/backend/src/core/services/data-retention-service.test.ts
@@ -24,8 +24,22 @@ vi.mock('./audit-service.js', () => ({
   logAuditEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { runRetentionCleanup, startRetentionWorker, stopRetentionWorker, RETENTION_DEFAULTS } from './data-retention-service.js';
+import {
+  runRetentionCleanup,
+  startRetentionWorker,
+  stopRetentionWorker,
+  RETENTION_DEFAULTS,
+  STANDALONE_TRASH_RETENTION_DAYS,
+} from './data-retention-service.js';
 import { logAuditEvent as mockLogAuditEvent } from './audit-service.js';
+
+// pool.query call order inside runRetentionCleanup (pending_sync_versions is
+// absent: its retention-days getter is not mocked above, so that sweep skips
+// before touching the pool):
+//   [0] audit_log  [1] search_analytics  [2] error_log
+//   [3..] ADMIN_ACCESS_DENIED batches (#264)
+//   [next] standalone trash purge (UX review)
+//   [last] page_versions
 
 describe('data-retention-service', () => {
   beforeEach(() => {
@@ -48,6 +62,10 @@ describe('data-retention-service', () => {
       expect(RETENTION_DEFAULTS.error_log).toBe(30);
       expect(RETENTION_DEFAULTS.page_versions).toBe(50);
     });
+
+    it('keeps the standalone trash window at the 30 days the Trash UI promises', () => {
+      expect(STANDALONE_TRASH_RETENTION_DAYS).toBe(30);
+    });
   });
 
   describe('runRetentionCleanup', () => {
@@ -61,6 +79,8 @@ describe('data-retention-service', () => {
         .mockResolvedValueOnce({ rowCount: 3 })
         // ADMIN_ACCESS_DENIED targeted purge (#264) — short batch signals drained
         .mockResolvedValueOnce({ rowCount: 0 })
+        // standalone trash purge
+        .mockResolvedValueOnce({ rowCount: 4 })
         // page_versions
         .mockResolvedValueOnce({ rowCount: 2 });
 
@@ -71,6 +91,7 @@ describe('data-retention-service', () => {
       expect(results.error_log).toBe(3);
       expect(results.page_versions).toBe(2);
       expect(results.audit_log_admin_access_denied).toBe(0);
+      expect(results.pages_standalone_trash).toBe(4);
     });
 
     it('uses parameterized queries for time-based tables', async () => {
@@ -78,8 +99,9 @@ describe('data-retention-service', () => {
 
       await runRetentionCleanup();
 
-      // 3 umbrella time-based + 1 ADMIN_ACCESS_DENIED targeted + 1 count-based = 5
-      expect(mockPool.query).toHaveBeenCalledTimes(5);
+      // 3 umbrella time-based + 1 ADMIN_ACCESS_DENIED targeted
+      // + 1 standalone trash purge + 1 count-based = 6
+      expect(mockPool.query).toHaveBeenCalledTimes(6);
 
       // Verify audit_log uses default 365 days
       const auditCall = mockPool.query.mock.calls[0];
@@ -102,6 +124,13 @@ describe('data-retention-service', () => {
       expect(deniedCall[0]).toContain(`action = 'ADMIN_ACCESS_DENIED'`);
       expect(deniedCall[0]).toContain('LIMIT $2');
       expect(deniedCall[1]).toEqual([90, 10_000]);
+
+      // Standalone trash purge is source-scoped and parameterized on the
+      // 30-day window — never touches Confluence-synced rows.
+      const trashCall = mockPool.query.mock.calls[4];
+      expect(trashCall[0]).toContain('DELETE FROM pages');
+      expect(trashCall[0]).toContain(`source = 'standalone'`);
+      expect(trashCall[1]).toEqual([STANDALONE_TRASH_RETENTION_DAYS]);
     });
 
     it('uses ROW_NUMBER for count-based page_versions cleanup', async () => {
@@ -109,9 +138,9 @@ describe('data-retention-service', () => {
 
       await runRetentionCleanup();
 
-      // Now at index 4 (umbrella audit_log, search_analytics, error_log,
-      // ADMIN_ACCESS_DENIED targeted, page_versions).
-      const versionsCall = mockPool.query.mock.calls[4];
+      // Now at index 5 (umbrella audit_log, search_analytics, error_log,
+      // ADMIN_ACCESS_DENIED targeted, standalone trash purge, page_versions).
+      const versionsCall = mockPool.query.mock.calls[5];
       expect(versionsCall[0]).toContain('ROW_NUMBER()');
       expect(versionsCall[0]).toContain('PARTITION BY page_id');
       expect(versionsCall[1]).toEqual([50]);
@@ -128,8 +157,8 @@ describe('data-retention-service', () => {
       const auditCall = mockPool.query.mock.calls[0];
       expect(auditCall[1]).toEqual([7]);
 
-      // page_versions should use overridden max (now at index 4)
-      const versionsCall = mockPool.query.mock.calls[4];
+      // page_versions should use overridden max (now at index 5)
+      const versionsCall = mockPool.query.mock.calls[5];
       expect(versionsCall[1]).toEqual([10]);
     });
 
@@ -139,6 +168,7 @@ describe('data-retention-service', () => {
         .mockResolvedValueOnce({ rowCount: 5 })                    // search_analytics
         .mockResolvedValueOnce({ rowCount: 3 })                    // error_log
         .mockResolvedValueOnce({ rowCount: 0 })                    // ADMIN_ACCESS_DENIED (#264)
+        .mockResolvedValueOnce({ rowCount: 0 })                    // standalone trash purge
         .mockResolvedValueOnce({ rowCount: 0 });                   // page_versions
 
       const results = await runRetentionCleanup();
@@ -148,6 +178,7 @@ describe('data-retention-service', () => {
       expect(results.error_log).toBe(3);
       expect(results.page_versions).toBe(0);
       expect(results.audit_log_admin_access_denied).toBe(0);
+      expect(results.pages_standalone_trash).toBe(0);
     });
 
     it('handles null rowCount gracefully', async () => {
@@ -160,6 +191,7 @@ describe('data-retention-service', () => {
       expect(results.error_log).toBe(0);
       expect(results.page_versions).toBe(0);
       expect(results.audit_log_admin_access_denied).toBe(0);
+      expect(results.pages_standalone_trash).toBe(0);
     });
 
     // ─── #264 — ADMIN_ACCESS_DENIED targeted purge ────────────────────────
@@ -169,6 +201,7 @@ describe('data-retention-service', () => {
         .mockResolvedValueOnce({ rowCount: 0 }) // search_analytics
         .mockResolvedValueOnce({ rowCount: 0 }) // error_log
         .mockResolvedValueOnce({ rowCount: 42 }) // ADMIN_ACCESS_DENIED batch 1 (short — drained)
+        .mockResolvedValueOnce({ rowCount: 0 }) // standalone trash purge
         .mockResolvedValueOnce({ rowCount: 0 }); // page_versions
 
       const results = await runRetentionCleanup();
@@ -183,6 +216,7 @@ describe('data-retention-service', () => {
         .mockResolvedValueOnce({ rowCount: 10_000 }) // batch 1 full — loop again
         .mockResolvedValueOnce({ rowCount: 10_000 }) // batch 2 full — loop again
         .mockResolvedValueOnce({ rowCount: 1234 })  // batch 3 short — drained
+        .mockResolvedValueOnce({ rowCount: 0 })     // standalone trash purge
         .mockResolvedValueOnce({ rowCount: 0 });    // page_versions
 
       const results = await runRetentionCleanup();
@@ -195,12 +229,30 @@ describe('data-retention-service', () => {
         .mockResolvedValueOnce({ rowCount: 0 }) // search_analytics
         .mockResolvedValueOnce({ rowCount: 0 }) // error_log
         .mockRejectedValueOnce(new Error('lock timeout')) // ADMIN_ACCESS_DENIED
+        .mockResolvedValueOnce({ rowCount: 7 }) // standalone trash purge
         .mockResolvedValueOnce({ rowCount: 0 }); // page_versions
 
       const results = await runRetentionCleanup();
       expect(results.audit_log_admin_access_denied).toBe(0);
       // Adjacent sweeps still complete.
+      expect(results.pages_standalone_trash).toBe(7);
       expect(results.page_versions).toBe(0);
+    });
+
+    // ─── Standalone trash purge (UX review) ──────────────────────────────
+    it('swallows errors inside the standalone trash purge and reports 0', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rowCount: 0 }) // audit_log
+        .mockResolvedValueOnce({ rowCount: 0 }) // search_analytics
+        .mockResolvedValueOnce({ rowCount: 0 }) // error_log
+        .mockResolvedValueOnce({ rowCount: 0 }) // ADMIN_ACCESS_DENIED drained
+        .mockRejectedValueOnce(new Error('lock timeout')) // standalone trash purge
+        .mockResolvedValueOnce({ rowCount: 2 }); // page_versions
+
+      const results = await runRetentionCleanup();
+      expect(results.pages_standalone_trash).toBe(0);
+      // Adjacent sweeps still complete.
+      expect(results.page_versions).toBe(2);
     });
 
     // ─── #307 Finding #4 — zero-row heartbeat attestation ────────────────
@@ -223,6 +275,16 @@ describe('data-retention-service', () => {
         (call) => call[1] === 'RETENTION_PRUNED' && (call[4] as Record<string, unknown>).rows_pruned === 0,
       );
       expect(zeroCalls.length).toBeGreaterThanOrEqual(3);
+
+      // The standalone trash purge emits its own heartbeat too.
+      const trashCall = (mockLogAuditEvent as ReturnType<typeof vi.fn>).mock.calls.find(
+        (call) => call[1] === 'RETENTION_PRUNED' && (call[3] as string) === 'pages_standalone_trash',
+      );
+      expect(trashCall).toBeDefined();
+      expect((trashCall![4] as Record<string, unknown>).rows_pruned).toBe(0);
+      expect((trashCall![4] as Record<string, unknown>).retention_days).toBe(
+        STANDALONE_TRASH_RETENTION_DAYS,
+      );
     });
 
     it('emits RETENTION_PRUNED with the actual non-zero rows_pruned value when rows are removed', async () => {
@@ -231,6 +293,7 @@ describe('data-retention-service', () => {
         .mockResolvedValueOnce({ rowCount: 5 })  // search_analytics
         .mockResolvedValueOnce({ rowCount: 3 })  // error_log
         .mockResolvedValueOnce({ rowCount: 0 })  // ADMIN_ACCESS_DENIED drained
+        .mockResolvedValueOnce({ rowCount: 0 })  // standalone trash purge
         .mockResolvedValueOnce({ rowCount: 2 }); // page_versions
 
       await runRetentionCleanup();

--- a/backend/src/core/services/data-retention-service.ts
+++ b/backend/src/core/services/data-retention-service.ts
@@ -245,6 +245,7 @@ export async function purgeExpiredStandalonePages(): Promise<number> {
     const { rowCount } = await pool.query(
       `DELETE FROM pages
         WHERE source = 'standalone'
+          AND deleted_at IS NOT NULL
           AND deleted_at < NOW() - INTERVAL '1 day' * $1`,
       [STANDALONE_TRASH_RETENTION_DAYS],
     );

--- a/backend/src/core/services/data-retention-service.ts
+++ b/backend/src/core/services/data-retention-service.ts
@@ -10,6 +10,9 @@
  *       time-based purge with an admin-configurable window (default 90d).
  *       Narrower than the umbrella audit_log sweep; rows that survive the
  *       narrow sweep still fall under the umbrella 365d policy.
+ *   - standalone pages in the trash (soft-deleted) for more than 30 days —
+ *       the Trash UI promises "purged after 30 days"; Confluence-synced pages
+ *       have their own purge in sync-service (upstream re-confirmation).
  *
  * Retention periods are configurable via environment variables:
  *   RETENTION_AUDIT_LOG_DAYS, RETENTION_SEARCH_ANALYTICS_DAYS,
@@ -84,6 +87,10 @@ export async function runRetentionCleanup(): Promise<Record<string, number>> {
   // Scoped by action so the umbrella retention policy for every other audit
   // action remains independently tunable.
   results['audit_log_admin_access_denied'] = await runAdminAccessDeniedRetention();
+
+  // Standalone trash purge (UX review): hard-delete standalone pages whose
+  // soft-delete is older than the 30-day window the Trash UI promises.
+  results['pages_standalone_trash'] = await purgeExpiredStandalonePages();
 
   // pending_sync_versions retention (Compendiq/compendiq-ee#118).
   // Drains the conflict-pending queue of rows that nobody resolved and are
@@ -204,6 +211,72 @@ async function runAdminAccessDeniedRetention(): Promise<number> {
     logger.error({ err, retentionDays: days }, 'ADMIN_ACCESS_DENIED retention cleanup failed');
   }
   return totalDeleted;
+}
+
+/**
+ * Days a soft-deleted standalone page survives in the trash before the
+ * maintenance job hard-deletes it. The Trash UI's `autoPurgeAt` field
+ * (GET /api/pages/trash) is computed from the same constant so the promise
+ * shown to the user and the actual purge can never drift apart.
+ */
+export const STANDALONE_TRASH_RETENTION_DAYS = 30;
+
+/**
+ * Hard-delete standalone pages whose soft-delete (`pages.deleted_at`) is older
+ * than the 30-day trash window (UX review: the Trash UI promised "purged after
+ * 30 days" but nothing ever purged standalone pages — the only purge was
+ * Confluence-sync-scoped in sync-service's `purgeDeletedPages`, which this
+ * deliberately does NOT touch: it stays `source = 'standalone'`-scoped, so
+ * Confluence rows keep their upstream re-confirmation flow).
+ *
+ * Dependent rows (pinned_pages, page_embeddings, page_versions, comments,
+ * local_attachments, page_relationships, …) are removed via their
+ * `ON DELETE CASCADE` FKs on pages(id) — same contract the Confluence purge
+ * relies on (migrations 030/033/034/036/064/069).
+ *
+ * Returns the number of pages deleted this run. Never throws (errors are
+ * logged and the promise resolves with the count so far).
+ */
+export async function purgeExpiredStandalonePages(): Promise<number> {
+  const pool = getPool();
+  let deleted = 0;
+
+  try {
+    const { rowCount } = await pool.query(
+      `DELETE FROM pages
+        WHERE source = 'standalone'
+          AND deleted_at < NOW() - INTERVAL '1 day' * $1`,
+      [STANDALONE_TRASH_RETENTION_DAYS],
+    );
+    deleted = rowCount ?? 0;
+    if (deleted > 0) {
+      logger.info(
+        { deleted, retentionDays: STANDALONE_TRASH_RETENTION_DAYS },
+        'Standalone trash purge completed',
+      );
+    }
+    // Heartbeat audit row, including zero-row sweeps — see the umbrella loop
+    // in runRetentionCleanup() for the compliance rationale (#307 Finding #4).
+    await logAuditEvent(
+      null,
+      'RETENTION_PRUNED',
+      'table',
+      'pages_standalone_trash',
+      {
+        table: 'pages',
+        source_scope: 'standalone',
+        rows_pruned: deleted,
+        retention_days: STANDALONE_TRASH_RETENTION_DAYS,
+      },
+    );
+  } catch (err) {
+    logger.error(
+      { err, retentionDays: STANDALONE_TRASH_RETENTION_DAYS },
+      'Standalone trash purge failed',
+    );
+  }
+
+  return deleted;
 }
 
 /**

--- a/backend/src/core/services/page-visibility.test.ts
+++ b/backend/src/core/services/page-visibility.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { visiblePagesPredicate } from './page-visibility.js';
+
+describe('visiblePagesPredicate', () => {
+  it('binds the spaces and user parameter indexes where expected', () => {
+    const sql = visiblePagesPredicate(1, 2);
+
+    expect(sql).toContain(`cp.space_key = ANY($1::text[])`);
+    expect(sql).toContain(`cp.created_by_user_id = $2`);
+    // Exactly the three OR'd visibility branches, wrapped in parens
+    expect(sql.trim().startsWith('(')).toBe(true);
+    expect(sql.trim().endsWith(')')).toBe(true);
+    expect(sql).toContain(`(cp.source = 'confluence' AND cp.space_key = ANY($1::text[]))`);
+    expect(sql).toContain(`OR (cp.source = 'standalone' AND cp.visibility = 'shared')`);
+    expect(sql).toContain(`OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $2)`);
+  });
+
+  it('supports arbitrary parameter indexes', () => {
+    const sql = visiblePagesPredicate(7, 9);
+
+    expect(sql).toContain(`ANY($7::text[])`);
+    expect(sql).toContain(`created_by_user_id = $9`);
+    // No stray references to other parameter slots
+    expect(sql.match(/\$\d+/g)).toEqual(['$7', '$9']);
+  });
+
+  it('applies a custom table alias to every column reference', () => {
+    const sql = visiblePagesPredicate(1, 2, 'p');
+
+    expect(sql).toContain(`p.source = 'confluence'`);
+    expect(sql).toContain(`p.space_key = ANY($1::text[])`);
+    expect(sql).toContain(`p.visibility = 'shared'`);
+    expect(sql).toContain(`p.created_by_user_id = $2`);
+    expect(sql).not.toContain('cp.');
+  });
+
+  it('does not interpolate user data — only numeric indexes and the alias appear', () => {
+    // Parameter indexes are typed as numbers, so the only dynamic text is the
+    // alias (a compile-time constant at call sites) and "$<n>" placeholders.
+    const sql = visiblePagesPredicate(3, 4);
+    expect(sql).not.toContain('undefined');
+    expect(sql).toMatch(/\$3::text\[\]/);
+    expect(sql).toMatch(/\$4\)/);
+  });
+});

--- a/backend/src/core/services/page-visibility.ts
+++ b/backend/src/core/services/page-visibility.ts
@@ -1,0 +1,14 @@
+/**
+ * SQL fragment selecting pages visible to a user: Confluence pages in their
+ * accessible spaces, shared standalone pages, and their own private standalone
+ * pages. Call sites bind accessible-space keys and the user id at the given
+ * parameter indexes. `deleted_at` filtering stays at the call site (trash
+ * views differ).
+ */
+export function visiblePagesPredicate(spacesParamIdx: number, userParamIdx: number, alias = 'cp'): string {
+  return `(
+        (${alias}.source = 'confluence' AND ${alias}.space_key = ANY($${spacesParamIdx}::text[]))
+        OR (${alias}.source = 'standalone' AND ${alias}.visibility = 'shared')
+        OR (${alias}.source = 'standalone' AND ${alias}.visibility = 'private' AND ${alias}.created_by_user_id = $${userParamIdx})
+      )`;
+}

--- a/backend/src/domains/knowledge/services/duplicate-detector.integration.test.ts
+++ b/backend/src/domains/knowledge/services/duplicate-detector.integration.test.ts
@@ -127,6 +127,34 @@ describe.skipIf(!dbAvailable)('duplicate-detector integration — RBAC kNN filte
     expect(results.map((r) => r.confluenceId)).toContain('dup-secret');
   });
 
+  it('excludes soft-deleted (trashed) pages from duplicate candidates', async () => {
+    const vec = fakeVec(19);
+    await seedPage({ confluenceId: 'src-1', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy guide', vec });
+    await seedPage({ confluenceId: 'dup-live', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy guide copy', vec });
+    const trashedId = await seedPage({ confluenceId: 'dup-trashed', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy guide trashed copy', vec });
+    await query(`UPDATE pages SET deleted_at = NOW() WHERE id = $1`, [trashedId]);
+
+    const results = await findDuplicates(USER_A, 'src-1');
+    const ids = results.map((r) => r.confluenceId);
+
+    // Live near-duplicates still surface…
+    expect(ids).toContain('dup-live');
+    // …but trashed pages must never be offered as duplicate candidates.
+    expect(ids).not.toContain('dup-trashed');
+  });
+
+  it('returns [] when the source page itself is trashed', async () => {
+    const vec = fakeVec(23);
+    const srcId = await seedPage({ confluenceId: 'src-trashed', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy guide', vec });
+    await seedPage({ confluenceId: 'dup-a', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy guide copy', vec });
+    await query(`UPDATE pages SET deleted_at = NOW() WHERE id = $1`, [srcId]);
+
+    const results = await findDuplicates(USER_A, 'src-trashed');
+
+    // A trashed source behaves like a nonexistent one.
+    expect(results).toEqual([]);
+  });
+
   it('includes the caller-owned private standalone pages as candidates', async () => {
     const vec = fakeVec(17);
     await seedPage({ confluenceId: 'src-1', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy guide', vec });

--- a/backend/src/domains/knowledge/services/duplicate-detector.ts
+++ b/backend/src/domains/knowledge/services/duplicate-detector.ts
@@ -1,5 +1,6 @@
 import { query, getPool } from '../../../core/db/postgres.js';
 import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
+import { visiblePagesPredicate } from '../../../core/services/page-visibility.js';
 import { logger } from '../../../core/utils/logger.js';
 
 const RAG_EF_SEARCH = parseInt(process.env.RAG_EF_SEARCH ?? '100', 10);
@@ -104,11 +105,7 @@ export async function findDuplicates(
        source_avg
        WHERE pe2.page_id != $1
          AND source_avg.avg_embedding IS NOT NULL
-         AND (
-           (cp2.source = 'confluence' AND cp2.space_key = ANY($3::text[]))
-           OR (cp2.source = 'standalone' AND cp2.visibility = 'shared')
-           OR (cp2.source = 'standalone' AND cp2.visibility = 'private' AND cp2.created_by_user_id = $4)
-         )
+         AND ${visiblePagesPredicate(3, 4, 'cp2')}
        ORDER BY cp2.confluence_id, pe2.embedding <=> source_avg.avg_embedding
        LIMIT $2`,
       // #733: over-fetch to filter later; candidates restricted to the same

--- a/backend/src/domains/knowledge/services/duplicate-detector.ts
+++ b/backend/src/domains/knowledge/services/duplicate-detector.ts
@@ -105,6 +105,7 @@ export async function findDuplicates(
        source_avg
        WHERE pe2.page_id != $1
          AND source_avg.avg_embedding IS NOT NULL
+         AND cp2.deleted_at IS NULL
          AND ${visiblePagesPredicate(3, 4, 'cp2')}
        ORDER BY cp2.confluence_id, pe2.embedding <=> source_avg.avg_embedding
        LIMIT $2`,

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -6,6 +6,7 @@ import { htmlToText } from '../../../core/services/content-converter.js';
 import { logger } from '../../../core/utils/logger.js';
 import { invalidateGraphCache, acquireEmbeddingLock, releaseEmbeddingLock, isEmbeddingLocked, getRedisClient, listActiveEmbeddingLocks } from '../../../core/services/redis-cache.js';
 import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
+import { visiblePagesPredicate } from '../../../core/services/page-visibility.js';
 import { CircuitBreakerOpenError, getProviderBreaker } from '../../../core/services/circuit-breaker.js';
 import { getReembedHistoryRetention } from '../../../core/services/admin-settings-service.js';
 import { enqueueJob } from '../../../core/services/queue-service.js';
@@ -992,7 +993,8 @@ export async function computePageRelationships(changedPageIds?: number[]): Promi
 
 /**
  * Get embedding status scoped to the pages the user can see — the same
- * visibility predicate as the pages tree/list routes:
+ * predicate as the pages list route (tree additionally merges legacy
+ * local-space keys):
  *   - Confluence pages from RBAC-accessible spaces
  *   - shared standalone articles (visible to all)
  *   - the caller's own private standalone articles
@@ -1004,11 +1006,7 @@ export async function getEmbeddingStatus(userId: string): Promise<EmbeddingStatu
   const statusSpaces = await getUserAccessibleSpaces(userId);
   // Static SQL fragment shared by the four COUNT queries below; all user
   // input flows through the $1/$2 parameters.
-  const visibleWhere = `(
-         (cp.source = 'confluence' AND cp.space_key = ANY($1::text[]))
-         OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-         OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $2)
-       ) AND cp.deleted_at IS NULL`;
+  const visibleWhere = `${visiblePagesPredicate(1, 2)} AND cp.deleted_at IS NULL`;
   const visibleParams = [statusSpaces, userId];
   const [totalResult, dirtyResult, embeddingResult, embeddedPagesResult, isProcessing, resolvedEmbedding, lastRunAt] = await Promise.all([
     query<{ count: string }>(

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -991,36 +991,48 @@ export async function computePageRelationships(changedPageIds?: number[]): Promi
 }
 
 /**
- * Get embedding status scoped to a user's selected spaces.
+ * Get embedding status scoped to the pages the user can see — the same
+ * visibility predicate as the pages tree/list routes:
+ *   - Confluence pages from RBAC-accessible spaces
+ *   - shared standalone articles (visible to all)
+ *   - the caller's own private standalone articles
+ * Keeps the dashboard KPI counts consistent with what the sidebar tree shows
+ * (previously standalone articles never counted because only `space_key =
+ * ANY(rbac spaces)` was applied, so regular users saw "0 total").
  */
 export async function getEmbeddingStatus(userId: string): Promise<EmbeddingStatus> {
   const statusSpaces = await getUserAccessibleSpaces(userId);
+  // Static SQL fragment shared by the four COUNT queries below; all user
+  // input flows through the $1/$2 parameters.
+  const visibleWhere = `(
+         (cp.source = 'confluence' AND cp.space_key = ANY($1::text[]))
+         OR (cp.source = 'standalone' AND cp.visibility = 'shared')
+         OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $2)
+       ) AND cp.deleted_at IS NULL`;
+  const visibleParams = [statusSpaces, userId];
   const [totalResult, dirtyResult, embeddingResult, embeddedPagesResult, isProcessing, resolvedEmbedding, lastRunAt] = await Promise.all([
     query<{ count: string }>(
       `SELECT COUNT(*) as count FROM pages cp
-       WHERE cp.space_key = ANY($1::text[])
-         AND cp.deleted_at IS NULL`,
-      [statusSpaces],
+       WHERE ${visibleWhere}`,
+      visibleParams,
     ),
     query<{ count: string }>(
       `SELECT COUNT(*) as count FROM pages cp
-       WHERE cp.space_key = ANY($1::text[])
-         AND cp.deleted_at IS NULL AND cp.embedding_dirty = TRUE`,
-      [statusSpaces],
+       WHERE ${visibleWhere}
+         AND cp.embedding_dirty = TRUE`,
+      visibleParams,
     ),
     query<{ count: string }>(
       `SELECT COUNT(*) as count FROM page_embeddings pe
        JOIN pages cp ON pe.page_id = cp.id
-       WHERE cp.space_key = ANY($1::text[])
-         AND cp.deleted_at IS NULL`,
-      [statusSpaces],
+       WHERE ${visibleWhere}`,
+      visibleParams,
     ),
     query<{ count: string }>(
       `SELECT COUNT(DISTINCT pe.page_id) as count FROM page_embeddings pe
        JOIN pages cp ON pe.page_id = cp.id
-       WHERE cp.space_key = ANY($1::text[])
-         AND cp.deleted_at IS NULL`,
-      [statusSpaces],
+       WHERE ${visibleWhere}`,
+      visibleParams,
     ),
     isEmbeddingLocked(userId),
     resolveUsecase('embedding').catch(() => null),

--- a/backend/src/domains/llm/services/rag-service.ts
+++ b/backend/src/domains/llm/services/rag-service.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../core/services/rbac-service.js';
 import { CircuitBreakerOpenError } from '../../../core/services/circuit-breaker.js';
 import { getFtsLanguage } from '../../../core/services/fts-language.js';
+import { visiblePagesPredicate } from '../../../core/services/page-visibility.js';
 import { isFeatureEnabled } from '../../../core/enterprise/loader.js';
 import { ENTERPRISE_FEATURES } from '../../../core/enterprise/features.js';
 import pgvector from 'pgvector';
@@ -58,11 +59,7 @@ export async function vectorSearch(userId: string, questionEmbedding: number[], 
               pe.embedding <=> $2 AS distance
        FROM page_embeddings pe
        JOIN pages cp ON pe.page_id = cp.id
-       WHERE (
-         (cp.source = 'confluence' AND cp.space_key = ANY($1::text[]))
-         OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-         OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $4)
-       )
+       WHERE ${visiblePagesPredicate(1, 4)}
        AND cp.deleted_at IS NULL
        ORDER BY pe.embedding <=> $2
        LIMIT $3`,
@@ -115,11 +112,7 @@ export async function keywordSearch(userId: string, questionText: string, limit 
             ts_rank(cp.tsv, plainto_tsquery('${ftsLang}', $2)) AS rank
      FROM pages cp
      WHERE cp.tsv @@ plainto_tsquery('${ftsLang}', $2)
-       AND (
-         (cp.source = 'confluence' AND cp.space_key = ANY($1::text[]))
-         OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-         OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $4)
-       )
+       AND ${visiblePagesPredicate(1, 4)}
        AND cp.deleted_at IS NULL
      ORDER BY rank DESC
      LIMIT $3`,

--- a/backend/src/routes/confluence/attachments.ts
+++ b/backend/src/routes/confluence/attachments.ts
@@ -111,7 +111,9 @@ export async function attachmentRoutes(fastify: FastifyInstance) {
          AND cp.confluence_id = $2`,
       [attachSpaces, pageId],
     );
-    // Fallback: standalone pages use integer PK as their attachment pageId
+    // Fallback: standalone pages use integer PK as their attachment pageId.
+    // Deliberately NOT visiblePagesPredicate(): this branch is standalone-only
+    // by construction (Confluence pages were handled by the query above).
     if (pageResult.rows.length === 0 && /^\d+$/.test(pageId)) {
       pageResult = await query<{ body_storage: string | null; space_key: string; source: string }>(
         `SELECT cp.body_storage, cp.space_key, cp.source

--- a/backend/src/routes/foundation/admin-users.test.ts
+++ b/backend/src/routes/foundation/admin-users.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Route-level tests for the admin user-lifecycle endpoints (#304).
+ *
+ * Focus: the system sentinel user (UX-fix Task 4) — it must never appear in
+ * GET /api/admin/users and every mutating route must refuse it with HTTP 400
+ * (service code SYSTEM_USER_PROTECTED, mapped like SELF_FORBIDDEN).
+ *
+ * The real `admin-user-service` runs underneath; only the boundaries
+ * (Postgres, Redis-backed security cache, SMTP, audit log) are mocked —
+ * mirroring `admin.test.ts` / `rbac.test.ts` conventions.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+import { ZodError } from 'zod';
+import { adminUsersRoutes } from './admin-users.js';
+
+// Mock the database
+vi.mock('../../core/db/postgres.js', () => ({
+  query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+  getPool: vi.fn().mockReturnValue({}),
+  runMigrations: vi.fn(),
+  closePool: vi.fn(),
+}));
+
+vi.mock('../../core/utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../core/services/audit-service.js', () => ({
+  logAuditEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../core/services/email-service.js', () => ({
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../core/services/rate-limit-service.js', () => ({
+  getRateLimits: vi.fn().mockResolvedValue({ admin: { max: 100, timeWindow: '1 minute' } }),
+}));
+
+// admin-user-service publishes invalidations through the Redis cache-bus —
+// stub it so route tests stay Redis-free (#737).
+vi.mock('../../core/services/user-security-cache.js', () => ({
+  invalidateUserSecurityState: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { query as mockQueryImport } from '../../core/db/postgres.js';
+
+const mockQuery = mockQueryImport as ReturnType<typeof vi.fn>;
+
+const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
+
+describe('admin-users routes — system account protection', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    // Match production error handler for Zod validation errors
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof ZodError) {
+        reply.status(400).send({
+          error: 'ValidationError',
+          message: error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join('; '),
+          statusCode: 400,
+        });
+        return;
+      }
+      reply
+        .status(error.statusCode ?? 500)
+        .send({ error: error.message, statusCode: error.statusCode ?? 500 });
+    });
+
+    // Decorate with mock auth (admin)
+    app.decorate('authenticate', async (request: { userId: string; username: string; userRole: string }) => {
+      request.userId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+      request.username = 'admin';
+      request.userRole = 'admin';
+    });
+    app.decorate('requireAdmin', async (request: { userId: string; username: string; userRole: string }) => {
+      request.userId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+      request.username = 'admin';
+      request.userRole = 'admin';
+    });
+
+    await app.register(adminUsersRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+  });
+
+  describe('GET /api/admin/users', () => {
+    it('queries with the system user excluded and returns the rows', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22',
+            username: 'alice',
+            email: 'alice@example.com',
+            display_name: 'Alice',
+            role: 'user',
+            auth_provider: 'local',
+            deactivated_at: null,
+            deactivated_by: null,
+            deactivated_reason: null,
+            created_at: new Date('2026-01-01T00:00:00Z'),
+          },
+        ],
+      });
+
+      const response = await app.inject({ method: 'GET', url: '/api/admin/users' });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.users).toHaveLength(1);
+      expect(body.users[0].username).toBe('alice');
+
+      // The SELECT must exclude the system sentinel id at the SQL level so
+      // the UI never sees it (behavioral proof against the real DB lives in
+      // admin-user-service.test.ts).
+      const listCall = mockQuery.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('FROM users'),
+      );
+      expect(listCall).toBeDefined();
+      expect(listCall![0]).toMatch(/id\s*<>/);
+      expect(listCall![1]).toContain(SYSTEM_USER_ID);
+    });
+  });
+
+  describe('PUT /api/admin/users/:id', () => {
+    it('refuses to update the system user with 400', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/admin/users/${SYSTEM_USER_ID}`,
+        payload: { role: 'user' },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body).error).toBe('The system account cannot be modified');
+    });
+  });
+
+  describe('POST /api/admin/users/:id/deactivate', () => {
+    it('refuses to deactivate the system user with 400', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/admin/users/${SYSTEM_USER_ID}/deactivate`,
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body).error).toBe('The system account cannot be modified');
+    });
+  });
+
+  describe('POST /api/admin/users/:id/reactivate', () => {
+    it('refuses to reactivate the system user with 400', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/admin/users/${SYSTEM_USER_ID}/reactivate`,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body).error).toBe('The system account cannot be modified');
+    });
+  });
+
+  describe('DELETE /api/admin/users/:id', () => {
+    it('refuses to delete the system user with 400', async () => {
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/api/admin/users/${SYSTEM_USER_ID}`,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body).error).toBe('The system account cannot be modified');
+    });
+  });
+});

--- a/backend/src/routes/foundation/admin-users.ts
+++ b/backend/src/routes/foundation/admin-users.ts
@@ -56,6 +56,7 @@ function mapServiceError(
       case 'EMAIL_TAKEN':
         throw fastify.httpErrors.conflict(err.message);
       case 'SELF_FORBIDDEN':
+      case 'SYSTEM_USER_PROTECTED':
         throw fastify.httpErrors.badRequest(err.message);
       case 'LAST_ADMIN':
         throw fastify.httpErrors.conflict(err.message);

--- a/backend/src/routes/foundation/health-api.integration.test.ts
+++ b/backend/src/routes/foundation/health-api.integration.test.ts
@@ -21,6 +21,7 @@ import {
 import { query } from '../../core/db/postgres.js';
 import { buildApp } from '../../app.js';
 import { generateAccessToken } from '../../core/plugins/auth.js';
+import { SYSTEM_USER_ID } from '../../core/services/admin-user-service.js';
 import { healthApiRoutes } from './health-api.js';
 
 /**
@@ -121,6 +122,30 @@ describe.skipIf(!dbAvailable)('health-api integration — Compendiq/compendiq-ee
     expect(body.tier).toBe('community');
     expect(body.edition).toBeDefined();
     expect(body.version).toBeDefined();
+  });
+
+  it('excludes the __system__ sentinel user from total/active counts', async () => {
+    // Migration 032 seeds a nil-UUID sentinel that owns built-in templates.
+    // truncateAllTables wipes it, so re-seed it exactly as the migration does.
+    await query(
+      `INSERT INTO users (id, username, password_hash, role)
+       VALUES ('${SYSTEM_USER_ID}', '__system__', 'nologin', 'admin')`,
+    );
+    await query(
+      `INSERT INTO users (username, password_hash, role) VALUES ('real1', 'x', 'user')`,
+    );
+
+    const token = await readToken();
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/internal/health?token=${token}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Record<string, unknown>;
+    // The sentinel is not a seat — only the real user counts.
+    expect(body.userCount).toBe(1);
+    expect(body.activeUserCount).toBe(1);
   });
 
   it('returns 401 when the token is wrong against a real seeded row', async () => {

--- a/backend/src/routes/foundation/health-api.integration.test.ts
+++ b/backend/src/routes/foundation/health-api.integration.test.ts
@@ -129,7 +129,8 @@ describe.skipIf(!dbAvailable)('health-api integration — Compendiq/compendiq-ee
     // truncateAllTables wipes it, so re-seed it exactly as the migration does.
     await query(
       `INSERT INTO users (id, username, password_hash, role)
-       VALUES ('${SYSTEM_USER_ID}', '__system__', 'nologin', 'admin')`,
+       VALUES ($1, '__system__', 'nologin', 'admin')`,
+      [SYSTEM_USER_ID],
     );
     await query(
       `INSERT INTO users (username, password_hash, role) VALUES ('real1', 'x', 'user')`,

--- a/backend/src/routes/foundation/health-api.ts
+++ b/backend/src/routes/foundation/health-api.ts
@@ -40,6 +40,7 @@ import { logger } from '../../core/utils/logger.js';
 import { APP_VERSION, APP_BUILD_INFO } from '../../core/utils/version.js';
 import { logAuditEvent } from '../../core/services/audit-service.js';
 import { getRateLimits } from '../../core/services/rate-limit-service.js';
+import { SYSTEM_USER_ID } from '../../core/services/admin-user-service.js';
 
 /**
  * Admin-route rate limit config. Mirrors the convention used by other
@@ -131,9 +132,14 @@ interface HealthReport {
 async function buildHealthReport(fastify: FastifyInstance): Promise<HealthReport> {
   const [users, dirty, lastSync, errors] = await Promise.all([
     query<{ total: string; active: string }>(
+      // Exclude the nil-UUID `__system__` sentinel (migration 032) — it owns
+      // built-in templates and is not a seat, so counting it would overstate
+      // both metrics by one on every instance.
       `SELECT COUNT(*)::text AS total,
               COUNT(*) FILTER (WHERE deactivated_at IS NULL)::text AS active
-         FROM users`,
+         FROM users
+        WHERE id <> $1`,
+      [SYSTEM_USER_ID],
     ),
     query<{ c: string }>(
       // `pages.embedding_status = 'not_embedded'` is the modern "needs

--- a/backend/src/routes/foundation/rbac.test.ts
+++ b/backend/src/routes/foundation/rbac.test.ts
@@ -648,5 +648,24 @@ describe('RBAC routes', () => {
       expect(usersCall).toBeDefined();
       expect(usersCall![0]).toContain('last_login_at');
     });
+
+    // UX-fix Task 4 follow-up: the system sentinel user (migration 032) must
+    // not appear in the role-assignment principal picker either — exclude it
+    // at the SQL level, same as admin-user-service.listUsers().
+    it('should exclude the system sentinel user from the SELECT', async () => {
+      const queryMock = mockQuery as ReturnType<typeof vi.fn>;
+      queryMock.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({ method: 'GET', url: '/api/users' });
+      expect(response.statusCode).toBe(200);
+
+      const usersCall = queryMock.mock.calls.find((call) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('FROM users'),
+      );
+      expect(usersCall).toBeDefined();
+      expect(usersCall![0]).toMatch(/id\s*<>/);
+      expect(usersCall![1]).toContain('00000000-0000-0000-0000-000000000000');
+    });
   });
 });

--- a/backend/src/routes/foundation/rbac.ts
+++ b/backend/src/routes/foundation/rbac.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { query } from '../../core/db/postgres.js';
 import { invalidateRbacCache, userHasPermission, getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
 import { logAuditEvent } from '../../core/services/audit-service.js';
+import { SYSTEM_USER_ID } from '../../core/services/admin-user-service.js';
 
 // ---- Zod schemas ----
 
@@ -705,6 +706,8 @@ export async function rbacRoutes(fastify: FastifyInstance) {
     // GET /api/users -- list all users (for admin assignment UIs)
     // #307 Finding #1: expose `last_login_at` so the user-admin UI (#304)
     // needs no backend follow-up. Column added by migration 062.
+    // The system sentinel user (migration 032) is excluded — it cannot log
+    // in and must not be assignable as a principal (UX-fix Task 4).
     admin.get('/users', RBAC_RATE_LIMIT, async () => {
       const result = await query<{
         id: string;
@@ -713,7 +716,8 @@ export async function rbacRoutes(fastify: FastifyInstance) {
         created_at: string;
         last_login_at: string | null;
       }>(
-        'SELECT id, username, role, created_at, last_login_at FROM users ORDER BY username',
+        'SELECT id, username, role, created_at, last_login_at FROM users WHERE id <> $1 ORDER BY username',
+        [SYSTEM_USER_ID],
       );
 
       return result.rows.map((r) => ({

--- a/backend/src/routes/knowledge/embedding-status-visibility.test.ts
+++ b/backend/src/routes/knowledge/embedding-status-visibility.test.ts
@@ -11,16 +11,21 @@
  *   - the caller's own private standalone articles
  */
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
-import Fastify from 'fastify';
-import sensible from '@fastify/sensible';
-import { ZodError } from 'zod';
+import type { FastifyInstance } from 'fastify';
 import {
   setupTestDb,
   truncateAllTables,
   teardownTestDb,
   isDbAvailable,
 } from '../../test-db-helper.js';
-import { query } from '../../core/db/postgres.js';
+import {
+  insertUser,
+  insertLocalSpace,
+  insertStandalonePage,
+  insertConfluencePage,
+  insertEmbeddings,
+  buildKnowledgeTestApp,
+} from './pages.test-helpers.js';
 
 // --- Boundary mocks (everything else is real) ---
 
@@ -32,70 +37,13 @@ vi.mock('../../core/services/rbac-service.js', () => ({
 
 const dbAvailable = await isDbAvailable();
 
-// --- Fixtures ---
-
-let userA: string;
-let userB: string;
-let currentUserId: string;
-
-async function insertUser(username: string): Promise<string> {
-  const res = await query<{ id: string }>(
-    "INSERT INTO users (username, email, password_hash, role) VALUES ($1, $2, 'x', 'user') RETURNING id",
-    [username, `${username}@test`],
-  );
-  return res.rows[0]!.id;
-}
-
-async function insertLocalSpace(spaceKey: string, createdBy: string): Promise<void> {
-  await query(
-    `INSERT INTO spaces (space_key, space_name, source, created_by, last_synced)
-     VALUES ($1, $1, 'local', $2, NOW())`,
-    [spaceKey, createdBy],
-  );
-}
-
-async function insertStandalonePage(
-  title: string,
-  visibility: 'private' | 'shared',
-  createdBy: string,
-  spaceKey: string,
-  opts: { dirty?: boolean } = {},
-): Promise<number> {
-  const res = await query<{ id: number }>(
-    `INSERT INTO pages (space_key, title, body_html, body_text, version, source,
-                        visibility, created_by_user_id, embedding_dirty, embedding_status)
-     VALUES ($1, $2, '<p>x</p>', 'x', 1, 'standalone', $3, $4, $5, 'not_embedded')
-     RETURNING id`,
-    [spaceKey, title, visibility, createdBy, opts.dirty ?? false],
-  );
-  return res.rows[0]!.id;
-}
-
-async function insertConfluencePage(confluenceId: string, title: string, spaceKey: string): Promise<void> {
-  await query(
-    `INSERT INTO pages (confluence_id, source, space_key, title, body_text,
-                        body_storage, body_html, inherit_perms, embedding_dirty)
-     VALUES ($1, 'confluence', $2, $3, 'text', '', '', TRUE, FALSE)`,
-    [confluenceId, spaceKey, title],
-  );
-}
-
-/** Insert `chunks` embedding rows for a page (zero vector, dims match schema). */
-async function insertEmbeddings(pageId: number, chunks: number): Promise<void> {
-  const zeroVector = `[${new Array(1024).fill(0).join(',')}]`;
-  for (let i = 0; i < chunks; i++) {
-    await query(
-      `INSERT INTO page_embeddings (page_id, chunk_index, chunk_text, embedding, metadata)
-       VALUES ($1, $2, 'chunk', $3::vector, '{}')`,
-      [pageId, i, zeroVector],
-    );
-  }
-}
-
 // --- Tests ---
 
 describe.skipIf(!dbAvailable)('GET /api/llm/embedding-status — visibility scope (DB)', () => {
-  let app: ReturnType<typeof Fastify>;
+  let app: FastifyInstance;
+  let userA: string;
+  let userB: string;
+  let currentUserId: string;
 
   async function statusAs(asUser: string): Promise<{
     totalPages: number;
@@ -111,25 +59,13 @@ describe.skipIf(!dbAvailable)('GET /api/llm/embedding-status — visibility scop
 
   beforeAll(async () => {
     await setupTestDb();
-
-    app = Fastify({ logger: false });
-    await app.register(sensible);
-    app.setErrorHandler((error: Error & { statusCode?: number }, _request, reply) => {
-      if (error instanceof ZodError) {
-        return reply.status(400).send({ error: 'Validation failed' });
-      }
-      return reply.status(error.statusCode ?? 500).send({ error: error.message });
-    });
-    app.decorate('authenticate', async (request: { userId: string }) => {
-      request.userId = currentUserId;
-    });
-    app.decorate('requireAdmin', async (request: { userId: string }) => {
-      request.userId = currentUserId;
-    });
-    app.decorate('redis', {});
-    const { knowledgeAdminRoutes } = await import('./knowledge-admin.js');
-    await app.register(knowledgeAdminRoutes, { prefix: '/api' });
-    await app.ready();
+    app = await buildKnowledgeTestApp(
+      () => currentUserId,
+      async (a) => {
+        const { knowledgeAdminRoutes } = await import('./knowledge-admin.js');
+        await a.register(knowledgeAdminRoutes, { prefix: '/api' });
+      },
+    );
   });
 
   afterAll(async () => {

--- a/backend/src/routes/knowledge/embedding-status-visibility.test.ts
+++ b/backend/src/routes/knowledge/embedding-status-visibility.test.ts
@@ -1,0 +1,192 @@
+/**
+ * GET /api/llm/embedding-status — visibility scope against a REAL PostgreSQL.
+ *
+ * Regression: the dashboard KPI counts (Total Articles/Pages, Embedded Pages,
+ * coverage %) only counted pages whose space_key was in the caller's RBAC
+ * spaces, so standalone articles never counted — a regular user saw
+ * "0 total" while their sidebar tree showed pages. The status counts must
+ * apply the same visibility predicate as the pages tree/list routes:
+ *   - Confluence pages from RBAC-accessible spaces
+ *   - shared standalone articles (visible to all)
+ *   - the caller's own private standalone articles
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+import { ZodError } from 'zod';
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../test-db-helper.js';
+import { query } from '../../core/db/postgres.js';
+
+// --- Boundary mocks (everything else is real) ---
+
+const mockGetUserAccessibleSpaces = vi.fn();
+vi.mock('../../core/services/rbac-service.js', () => ({
+  getUserAccessibleSpaces: (...args: unknown[]) => mockGetUserAccessibleSpaces(...args),
+  invalidateRbacCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+const dbAvailable = await isDbAvailable();
+
+// --- Fixtures ---
+
+let userA: string;
+let userB: string;
+let currentUserId: string;
+
+async function insertUser(username: string): Promise<string> {
+  const res = await query<{ id: string }>(
+    "INSERT INTO users (username, email, password_hash, role) VALUES ($1, $2, 'x', 'user') RETURNING id",
+    [username, `${username}@test`],
+  );
+  return res.rows[0]!.id;
+}
+
+async function insertLocalSpace(spaceKey: string, createdBy: string): Promise<void> {
+  await query(
+    `INSERT INTO spaces (space_key, space_name, source, created_by, last_synced)
+     VALUES ($1, $1, 'local', $2, NOW())`,
+    [spaceKey, createdBy],
+  );
+}
+
+async function insertStandalonePage(
+  title: string,
+  visibility: 'private' | 'shared',
+  createdBy: string,
+  spaceKey: string,
+  opts: { dirty?: boolean } = {},
+): Promise<number> {
+  const res = await query<{ id: number }>(
+    `INSERT INTO pages (space_key, title, body_html, body_text, version, source,
+                        visibility, created_by_user_id, embedding_dirty, embedding_status)
+     VALUES ($1, $2, '<p>x</p>', 'x', 1, 'standalone', $3, $4, $5, 'not_embedded')
+     RETURNING id`,
+    [spaceKey, title, visibility, createdBy, opts.dirty ?? false],
+  );
+  return res.rows[0]!.id;
+}
+
+async function insertConfluencePage(confluenceId: string, title: string, spaceKey: string): Promise<void> {
+  await query(
+    `INSERT INTO pages (confluence_id, source, space_key, title, body_text,
+                        body_storage, body_html, inherit_perms, embedding_dirty)
+     VALUES ($1, 'confluence', $2, $3, 'text', '', '', TRUE, FALSE)`,
+    [confluenceId, spaceKey, title],
+  );
+}
+
+/** Insert `chunks` embedding rows for a page (zero vector, dims match schema). */
+async function insertEmbeddings(pageId: number, chunks: number): Promise<void> {
+  const zeroVector = `[${new Array(1024).fill(0).join(',')}]`;
+  for (let i = 0; i < chunks; i++) {
+    await query(
+      `INSERT INTO page_embeddings (page_id, chunk_index, chunk_text, embedding, metadata)
+       VALUES ($1, $2, 'chunk', $3::vector, '{}')`,
+      [pageId, i, zeroVector],
+    );
+  }
+}
+
+// --- Tests ---
+
+describe.skipIf(!dbAvailable)('GET /api/llm/embedding-status — visibility scope (DB)', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  async function statusAs(asUser: string): Promise<{
+    totalPages: number;
+    embeddedPages: number;
+    dirtyPages: number;
+    totalEmbeddings: number;
+  }> {
+    currentUserId = asUser;
+    const response = await app.inject({ method: 'GET', url: '/api/llm/embedding-status' });
+    expect(response.statusCode).toBe(200);
+    return response.json();
+  }
+
+  beforeAll(async () => {
+    await setupTestDb();
+
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+    app.setErrorHandler((error: Error & { statusCode?: number }, _request, reply) => {
+      if (error instanceof ZodError) {
+        return reply.status(400).send({ error: 'Validation failed' });
+      }
+      return reply.status(error.statusCode ?? 500).send({ error: error.message });
+    });
+    app.decorate('authenticate', async (request: { userId: string }) => {
+      request.userId = currentUserId;
+    });
+    app.decorate('requireAdmin', async (request: { userId: string }) => {
+      request.userId = currentUserId;
+    });
+    app.decorate('redis', {});
+    const { knowledgeAdminRoutes } = await import('./knowledge-admin.js');
+    await app.register(knowledgeAdminRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await truncateAllTables();
+    userA = await insertUser('embed_status_a');
+    userB = await insertUser('embed_status_b');
+    await insertLocalSpace('NOTES', userA);
+    mockGetUserAccessibleSpaces.mockResolvedValue([]);
+  });
+
+  it("counts only B-visible pages for user B (shared note, not A's private one)", async () => {
+    await insertStandalonePage('Private note', 'private', userA, 'NOTES');
+    await insertStandalonePage('Shared note', 'shared', userA, 'NOTES');
+
+    const status = await statusAs(userB);
+    expect(status.totalPages).toBe(1);
+  });
+
+  it('counts both standalone pages for their owner', async () => {
+    await insertStandalonePage('Private note', 'private', userA, 'NOTES');
+    await insertStandalonePage('Shared note', 'shared', userA, 'NOTES');
+
+    const status = await statusAs(userA);
+    expect(status.totalPages).toBe(2);
+  });
+
+  it('limits Confluence pages to RBAC-accessible spaces', async () => {
+    await insertConfluencePage('conf-dev', 'Dev page', 'DEV');
+    await insertConfluencePage('conf-secret', 'Secret page', 'SECRET');
+    mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
+
+    const status = await statusAs(userB);
+    expect(status.totalPages).toBe(1);
+  });
+
+  it('scopes dirty, embedded-page and chunk counts to visible pages', async () => {
+    const privateId = await insertStandalonePage('Private note', 'private', userA, 'NOTES', { dirty: true });
+    const sharedId = await insertStandalonePage('Shared note', 'shared', userA, 'NOTES');
+    await insertEmbeddings(privateId, 1);
+    await insertEmbeddings(sharedId, 2);
+
+    const asB = await statusAs(userB);
+    expect(asB.totalPages).toBe(1);
+    expect(asB.dirtyPages).toBe(0);
+    expect(asB.embeddedPages).toBe(1);
+    expect(asB.totalEmbeddings).toBe(2);
+
+    const asA = await statusAs(userA);
+    expect(asA.totalPages).toBe(2);
+    expect(asA.dirtyPages).toBe(1);
+    expect(asA.embeddedPages).toBe(2);
+    expect(asA.totalEmbeddings).toBe(3);
+  });
+});

--- a/backend/src/routes/knowledge/page-update.test.ts
+++ b/backend/src/routes/knowledge/page-update.test.ts
@@ -24,11 +24,15 @@ vi.mock('../../core/services/content-converter.js', () => ({
   htmlToText: (...args: unknown[]) => mockHtmlToText(...args),
 }));
 
+const mockCacheInvalidate = vi.fn();
+const mockCacheInvalidateAcrossUsers = vi.fn();
+
 vi.mock('../../core/services/redis-cache.js', () => ({
   RedisCache: class MockRedisCache {
     get = vi.fn().mockResolvedValue(null);
     set = vi.fn().mockResolvedValue(undefined);
-    invalidate = vi.fn().mockResolvedValue(undefined);
+    invalidate = (...args: unknown[]) => mockCacheInvalidate(...args);
+    invalidateAcrossUsers = (...args: unknown[]) => mockCacheInvalidateAcrossUsers(...args);
   },
 }));
 
@@ -134,5 +138,65 @@ describe('PUT /api/pages/:id', () => {
       'page-1',
       'OPS',
     );
+  });
+
+  describe('standalone visibility change — cache invalidation', () => {
+    function mockStandalonePage(visibility: 'private' | 'shared') {
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('SELECT id, version, space_key')) {
+          return Promise.resolve({
+            rows: [{
+              id: 7, version: 3, space_key: 'NOTES', source: 'standalone',
+              created_by_user_id: 'user-1', visibility,
+              confluence_id: null, deleted_at: null, page_type: 'page',
+            }],
+          });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+    }
+
+    it('invalidates the pages cache across all users when the update changes visibility', async () => {
+      mockStandalonePage('private');
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/7',
+        payload: { title: 'Note', bodyHtml: '<p>note</p>', version: 3, visibility: 'shared' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      // Other users' cached trees/lists would otherwise serve stale data
+      // for up to the cache TTL after a private → shared flip (and vice versa).
+      expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('pages');
+    });
+
+    it('keeps per-user invalidation when the payload sends the same visibility', async () => {
+      mockStandalonePage('shared');
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/7',
+        payload: { title: 'Note', bodyHtml: '<p>note</p>', version: 3, visibility: 'shared' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockCacheInvalidateAcrossUsers).not.toHaveBeenCalled();
+      expect(mockCacheInvalidate).toHaveBeenCalledWith('user-1', 'pages');
+    });
+
+    it('keeps per-user invalidation when the payload omits visibility', async () => {
+      mockStandalonePage('private');
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/7',
+        payload: { title: 'Note', bodyHtml: '<p>note</p>', version: 3 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockCacheInvalidateAcrossUsers).not.toHaveBeenCalled();
+      expect(mockCacheInvalidate).toHaveBeenCalledWith('user-1', 'pages');
+    });
   });
 });

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -21,6 +21,7 @@ import { emitWebhookEvent } from '../../core/services/webhook-emit-hook.js';
 import { processDirtyPages, isProcessingUser } from '../../domains/llm/services/embedding-service.js';
 import { triggerQualityBatch } from '../../domains/knowledge/services/quality-worker.js';
 import { getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
+import { visiblePagesPredicate } from '../../core/services/page-visibility.js';
 import { PageListQuerySchema, PageTreeQuerySchema, CreatePageSchema, UpdatePageSchema, SaveDraftSchema } from '@compendiq/contracts';
 import { z } from 'zod';
 import { logger } from '../../core/utils/logger.js';
@@ -316,11 +317,7 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     //   - Shared standalone articles (visible to all)
     //   - Their own private standalone articles
     const accessibleSpaces = await getUserAccessibleSpaces(userId);
-    const whereBase = `WHERE (
-        (cp.source = 'confluence' AND cp.space_key = ANY($1::text[]))
-        OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-        OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $2)
-      )`;
+    const whereBase = `WHERE ${visiblePagesPredicate(1, 2)}`;
     const values: unknown[] = [accessibleSpaces, userId];
     let paramIdx = 3;
 
@@ -594,11 +591,7 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     const localSpaceKeys = localSpacesResult.rows.map((r) => r.space_key);
     const treeSpaces = Array.from(new Set([...rbacSpaces, ...localSpaceKeys]));
     const values: unknown[] = [treeSpaces, userId];
-    let treeWhereClause = `WHERE (
-        (cp.source = 'confluence' AND cp.space_key = ANY($1::text[]))
-        OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-        OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $2)
-      ) AND cp.deleted_at IS NULL`;
+    let treeWhereClause = `WHERE ${visiblePagesPredicate(1, 2)} AND cp.deleted_at IS NULL`;
 
     if (params.spaceKey) {
       treeWhereClause += ' AND cp.space_key = $3';

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -23,7 +23,7 @@ import { processDirtyPages, isProcessingUser } from '../../domains/llm/services/
 import { triggerQualityBatch } from '../../domains/knowledge/services/quality-worker.js';
 import { getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
 import { visiblePagesPredicate } from '../../core/services/page-visibility.js';
-import { PageListQuerySchema, PageTreeQuerySchema, CreatePageSchema, UpdatePageSchema, SaveDraftSchema } from '@compendiq/contracts';
+import { PageListQuerySchema, PageTreeQuerySchema, CreatePageSchema, UpdatePageSchema, SaveDraftSchema, TrashListResponseSchema } from '@compendiq/contracts';
 import { z } from 'zod';
 import { logger } from '../../core/utils/logger.js';
 import pLimit from 'p-limit';
@@ -707,14 +707,14 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       [userId],
     );
 
-    return {
+    return TrashListResponseSchema.parse({
       items: result.rows.map((row) => ({
         id: String(row.id),
         title: row.title,
         source: row.source,
         visibility: row.visibility,
-        deletedAt: row.deleted_at,
-        createdAt: row.last_synced,
+        deletedAt: row.deleted_at.toISOString(),
+        createdAt: row.last_synced.toISOString(),
         deletedBy: row.deleted_by,
         // Mirrors the maintenance purge (purgeExpiredStandalonePages) so the
         // date shown in the Trash UI matches when the row actually disappears.
@@ -723,7 +723,7 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
         ).toISOString(),
       })),
       total: result.rows.length,
-    };
+    });
   });
 
   // GET /api/pages/:id - get page with content

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -580,18 +580,28 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     const cached = await cache.get(userId, 'pages', cacheKey);
     if (cached) return cached;
 
-    // Access control via RBAC + local spaces (local spaces bypass RBAC)
+    // Access control: same visibility predicate as the list route —
+    //   - Confluence pages from user's accessible spaces (via RBAC)
+    //   - Shared standalone articles (visible to all)
+    //   - Their own private standalone articles
+    // Local-space pages are always standalone, so they surface through the
+    // visibility branches (#527/#528); local space keys are still merged into
+    // the Confluence branch as belt-and-braces against legacy data drift.
     const rbacSpaces = await getUserAccessibleSpaces(userId);
     const localSpacesResult = await query<{ space_key: string }>(
       `SELECT space_key FROM spaces WHERE source = 'local'`,
     );
     const localSpaceKeys = localSpacesResult.rows.map((r) => r.space_key);
     const treeSpaces = Array.from(new Set([...rbacSpaces, ...localSpaceKeys]));
-    const values: unknown[] = [treeSpaces];
-    let treeWhereClause = 'WHERE cp.space_key = ANY($1::text[]) AND cp.deleted_at IS NULL';
+    const values: unknown[] = [treeSpaces, userId];
+    let treeWhereClause = `WHERE (
+        (cp.source = 'confluence' AND cp.space_key = ANY($1::text[]))
+        OR (cp.source = 'standalone' AND cp.visibility = 'shared')
+        OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $2)
+      ) AND cp.deleted_at IS NULL`;
 
     if (params.spaceKey) {
-      treeWhereClause += ' AND cp.space_key = $2';
+      treeWhereClause += ' AND cp.space_key = $3';
       values.push(params.spaceKey);
     }
 

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -18,6 +18,7 @@ import {
   type BulkSelection,
 } from '../../core/services/bulk-page-selection.js';
 import { emitWebhookEvent } from '../../core/services/webhook-emit-hook.js';
+import { STANDALONE_TRASH_RETENTION_DAYS } from '../../core/services/data-retention-service.js';
 import { processDirtyPages, isProcessingUser } from '../../domains/llm/services/embedding-service.js';
 import { triggerQualityBatch } from '../../domains/knowledge/services/quality-worker.js';
 import { getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
@@ -691,14 +692,18 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
   fastify.get('/pages/trash', async (request) => {
     const userId = request.userId;
 
+    // JOIN users for the deleter's username: only the owner can soft-delete a
+    // standalone article (see DELETE /pages/:id), so owner == deleter.
     const result = await query<{
       id: number; title: string; source: string; visibility: string;
-      deleted_at: Date; last_synced: Date;
+      deleted_at: Date; last_synced: Date; deleted_by: string;
     }>(
-      `SELECT id, title, source, visibility, deleted_at, last_synced
-       FROM pages
-       WHERE source = 'standalone' AND deleted_at IS NOT NULL AND created_by_user_id = $1
-       ORDER BY deleted_at DESC`,
+      `SELECT p.id, p.title, p.source, p.visibility, p.deleted_at, p.last_synced,
+              u.username AS deleted_by
+       FROM pages p
+       JOIN users u ON u.id = p.created_by_user_id
+       WHERE p.source = 'standalone' AND p.deleted_at IS NOT NULL AND p.created_by_user_id = $1
+       ORDER BY p.deleted_at DESC`,
       [userId],
     );
 
@@ -710,6 +715,12 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
         visibility: row.visibility,
         deletedAt: row.deleted_at,
         createdAt: row.last_synced,
+        deletedBy: row.deleted_by,
+        // Mirrors the maintenance purge (purgeExpiredStandalonePages) so the
+        // date shown in the Trash UI matches when the row actually disappears.
+        autoPurgeAt: new Date(
+          row.deleted_at.getTime() + STANDALONE_TRASH_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+        ).toISOString(),
       })),
       total: result.rows.length,
     };

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -1249,7 +1249,14 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
           : [id, body.title, body.bodyHtml, bodyText, newVersion, userId],
       );
 
-      await cache.invalidate(userId, 'pages');
+      // A visibility change alters what OTHER users can see — their cached
+      // trees/lists would serve stale data for up to the cache TTL (15 min)
+      // if we only invalidated the editor's own cache.
+      if (body.visibility && body.visibility !== existingPage.visibility) {
+        await cache.invalidateAcrossUsers('pages');
+      } else {
+        await cache.invalidate(userId, 'pages');
+      }
       await logAuditEvent(userId, 'PAGE_UPDATED', 'page', String(id), { source: 'standalone', title: body.title }, request);
 
       emitWebhookEvent({

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -849,6 +849,10 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       summaryError: row.summary_error,
       source: row.source,
       visibility: row.visibility,
+      // Creator's user id (standalone pages only; null for Confluence-synced).
+      // Benign for viewers — lets the UI detect "own page" (e.g. to hide the
+      // helpfulness widget on pages the current user authored).
+      createdByUserId: row.created_by_user_id,
       hasDraft: row.has_draft,
       draftUpdatedAt: row.draft_updated_at?.toISOString() ?? null,
     };

--- a/backend/src/routes/knowledge/pages-trash.test.ts
+++ b/backend/src/routes/knowledge/pages-trash.test.ts
@@ -1,0 +1,157 @@
+/**
+ * GET /api/pages/trash contract + standalone auto-purge — REAL PostgreSQL.
+ *
+ * Regression (UX review, trash contract repair): the Trash UI renders
+ * `deletedBy` and `autoPurgeAt` per item and promises "purged after 30 days",
+ * but the backend returned neither field and nothing ever purged soft-deleted
+ * standalone pages (the only purge was Confluence-sync-scoped). Contract:
+ *   - each trash item carries `deletedBy` (owner's username — owner == deleter
+ *     for standalone articles) and `autoPurgeAt` (= deleted_at + 30 days, ISO);
+ *   - `purgeExpiredStandalonePages()` hard-deletes standalone pages
+ *     soft-deleted more than 30 days ago, leaves newer trash and Confluence
+ *     pages alone, and returns the purged count.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../test-db-helper.js';
+import { query } from '../../core/db/postgres.js';
+import {
+  insertUser,
+  insertLocalSpace,
+  insertStandalonePage,
+  insertConfluencePage,
+  buildKnowledgeTestApp,
+} from './pages.test-helpers.js';
+
+// --- Boundary mocks (everything else is real) ---
+
+// No Redis in tests — no-op cache so every request hits the real DB.
+vi.mock('../../core/services/redis-cache.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../core/services/redis-cache.js')>()),
+  RedisCache: class MockRedisCache {
+    get = vi.fn().mockResolvedValue(null);
+    set = vi.fn().mockResolvedValue(undefined);
+    invalidate = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+const mockGetUserAccessibleSpaces = vi.fn();
+vi.mock('../../core/services/rbac-service.js', () => ({
+  getUserAccessibleSpaces: (...args: unknown[]) => mockGetUserAccessibleSpaces(...args),
+  invalidateRbacCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+const dbAvailable = await isDbAvailable();
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const daysAgo = (days: number): Date => new Date(Date.now() - days * DAY_MS);
+
+// --- Tests ---
+
+describe.skipIf(!dbAvailable)('GET /api/pages/trash + standalone auto-purge (DB)', () => {
+  let app: FastifyInstance;
+  let userA: string;
+  let currentUserId: string;
+
+  beforeAll(async () => {
+    await setupTestDb();
+    app = await buildKnowledgeTestApp(
+      () => currentUserId,
+      async (a) => {
+        const { pagesCrudRoutes } = await import('./pages-crud.js');
+        await a.register(pagesCrudRoutes, { prefix: '/api' });
+      },
+    );
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await truncateAllTables();
+    userA = await insertUser('trash_owner_a');
+    await insertLocalSpace('NOTES', userA);
+    mockGetUserAccessibleSpaces.mockResolvedValue([]);
+  });
+
+  it('returns deletedBy (owner username) and autoPurgeAt (= deletedAt + 30 days, ISO) per item', async () => {
+    const oldDeletedAt = daysAgo(31);
+    const newDeletedAt = new Date();
+    await insertStandalonePage('Old trashed note', 'private', userA, 'NOTES', { deletedAt: oldDeletedAt });
+    await insertStandalonePage('Fresh trashed note', 'private', userA, 'NOTES', { deletedAt: newDeletedAt });
+
+    currentUserId = userA;
+    const response = await app.inject({ method: 'GET', url: '/api/pages/trash' });
+    expect(response.statusCode).toBe(200);
+
+    const body = response.json() as {
+      items: Array<{
+        title: string;
+        deletedAt: string;
+        deletedBy: string;
+        autoPurgeAt: string;
+        source: string;
+        visibility: string;
+      }>;
+      total: number;
+    };
+    expect(body.total).toBe(2);
+
+    // Ordered by deleted_at DESC → freshest first
+    expect(body.items.map((i) => i.title)).toEqual(['Fresh trashed note', 'Old trashed note']);
+
+    for (const [item, deletedAt] of [
+      [body.items[0]!, newDeletedAt],
+      [body.items[1]!, oldDeletedAt],
+    ] as const) {
+      expect(item.deletedBy).toBe('trash_owner_a');
+      expect(item.deletedAt).toBe(deletedAt.toISOString());
+      expect(item.autoPurgeAt).toBe(new Date(deletedAt.getTime() + 30 * DAY_MS).toISOString());
+      // Existing fields stay on the wire
+      expect(item.source).toBe('standalone');
+      expect(item.visibility).toBe('private');
+    }
+  });
+
+  it('purges standalone pages trashed >30 days ago, keeps fresh trash, returns the count', async () => {
+    const expiredId = await insertStandalonePage('Expired trash', 'private', userA, 'NOTES', {
+      deletedAt: daysAgo(31),
+    });
+    const freshId = await insertStandalonePage('Fresh trash', 'private', userA, 'NOTES', {
+      deletedAt: new Date(),
+    });
+    const liveId = await insertStandalonePage('Live note', 'private', userA, 'NOTES');
+    // Soft-deleted Confluence page older than the window — must NOT be touched
+    // (its purge is Confluence-sync-scoped with upstream re-confirmation).
+    const confluenceId = await insertConfluencePage('conf-trashed', 'Conf trashed', 'DEV', {
+      deletedAt: daysAgo(45),
+    });
+    // FK-cascade check: a pin on the expired page must not block the purge.
+    await query('INSERT INTO pinned_pages (user_id, page_id) VALUES ($1, $2)', [userA, expiredId]);
+
+    const { purgeExpiredStandalonePages } = await import(
+      '../../core/services/data-retention-service.js'
+    );
+    const purged = await purgeExpiredStandalonePages();
+    expect(purged).toBe(1);
+
+    const remaining = await query<{ id: number }>('SELECT id FROM pages ORDER BY id');
+    expect(remaining.rows.map((r) => r.id)).toEqual(
+      [freshId, liveId, confluenceId].sort((a, b) => a - b),
+    );
+
+    const pins = await query('SELECT page_id FROM pinned_pages');
+    expect(pins.rows).toEqual([]);
+
+    // Second run finds nothing — count is per-run, not cumulative.
+    expect(await purgeExpiredStandalonePages()).toBe(0);
+  });
+});

--- a/backend/src/routes/knowledge/pages-trash.test.ts
+++ b/backend/src/routes/knowledge/pages-trash.test.ts
@@ -20,6 +20,7 @@ import {
   isDbAvailable,
 } from '../../test-db-helper.js';
 import { query } from '../../core/db/postgres.js';
+import { TrashListResponseSchema } from '@compendiq/contracts';
 import {
   insertUser,
   insertLocalSpace,
@@ -92,17 +93,9 @@ describe.skipIf(!dbAvailable)('GET /api/pages/trash + standalone auto-purge (DB)
     const response = await app.inject({ method: 'GET', url: '/api/pages/trash' });
     expect(response.statusCode).toBe(200);
 
-    const body = response.json() as {
-      items: Array<{
-        title: string;
-        deletedAt: string;
-        deletedBy: string;
-        autoPurgeAt: string;
-        source: string;
-        visibility: string;
-      }>;
-      total: number;
-    };
+    // Wire contract: the body must satisfy the shared schema exactly
+    // (string id, ISO-string dates, enum source/visibility).
+    const body = TrashListResponseSchema.parse(response.json());
     expect(body.total).toBe(2);
 
     // Ordered by deleted_at DESC → freshest first

--- a/backend/src/routes/knowledge/pages-trash.test.ts
+++ b/backend/src/routes/knowledge/pages-trash.test.ts
@@ -154,4 +154,33 @@ describe.skipIf(!dbAvailable)('GET /api/pages/trash + standalone auto-purge (DB)
     // Second run finds nothing — count is per-run, not cumulative.
     expect(await purgeExpiredStandalonePages()).toBe(0);
   });
+
+  // Nested here to reuse the real-DB app bootstrap + seeders (this file is
+  // the pagesCrudRoutes-against-real-Postgres harness).
+  describe('GET /api/pages/:id — createdByUserId exposure', () => {
+    it('exposes createdByUserId for a standalone page so the UI can detect own pages', async () => {
+      const pageId = await insertStandalonePage('My own note', 'private', userA, 'NOTES');
+
+      currentUserId = userA;
+      const response = await app.inject({ method: 'GET', url: `/api/pages/${pageId}` });
+      expect(response.statusCode).toBe(200);
+
+      const body = response.json() as { source: string; createdByUserId: string | null };
+      expect(body.source).toBe('standalone');
+      expect(body.createdByUserId).toBe(userA);
+    });
+
+    it('returns null createdByUserId for a synced Confluence page', async () => {
+      const pageId = await insertConfluencePage('conf-own-1', 'Conf page', 'DEV');
+      mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
+
+      currentUserId = userA;
+      const response = await app.inject({ method: 'GET', url: `/api/pages/${pageId}` });
+      expect(response.statusCode).toBe(200);
+
+      const body = response.json() as { source: string; createdByUserId: string | null };
+      expect(body.source).toBe('confluence');
+      expect(body.createdByUserId).toBeNull();
+    });
+  });
 });

--- a/backend/src/routes/knowledge/pages-tree-visibility.test.ts
+++ b/backend/src/routes/knowledge/pages-tree-visibility.test.ts
@@ -1,0 +1,170 @@
+/**
+ * GET /api/pages/tree — visibility predicate against a REAL PostgreSQL.
+ *
+ * Regression: the tree route filtered only by space + `deleted_at IS NULL`,
+ * so another user's PRIVATE standalone article appeared in the sidebar tree
+ * while the detail route refused to serve it ("Article not found"). The tree
+ * must apply the same predicate as the list route:
+ *   - Confluence pages from RBAC-accessible spaces
+ *   - shared standalone articles (visible to all)
+ *   - the caller's own private standalone articles
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+import { ZodError } from 'zod';
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../test-db-helper.js';
+import { query } from '../../core/db/postgres.js';
+
+// --- Boundary mocks (everything else is real) ---
+
+// No Redis in tests — no-op cache so every request hits the real DB.
+vi.mock('../../core/services/redis-cache.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../core/services/redis-cache.js')>()),
+  RedisCache: class MockRedisCache {
+    get = vi.fn().mockResolvedValue(null);
+    set = vi.fn().mockResolvedValue(undefined);
+    invalidate = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+const mockGetUserAccessibleSpaces = vi.fn();
+vi.mock('../../core/services/rbac-service.js', () => ({
+  getUserAccessibleSpaces: (...args: unknown[]) => mockGetUserAccessibleSpaces(...args),
+  invalidateRbacCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+const dbAvailable = await isDbAvailable();
+
+// --- Fixtures ---
+
+let userA: string;
+let userB: string;
+let currentUserId: string;
+
+async function insertUser(username: string): Promise<string> {
+  const res = await query<{ id: string }>(
+    "INSERT INTO users (username, email, password_hash, role) VALUES ($1, $2, 'x', 'user') RETURNING id",
+    [username, `${username}@test`],
+  );
+  return res.rows[0]!.id;
+}
+
+async function insertLocalSpace(spaceKey: string, createdBy: string): Promise<void> {
+  await query(
+    `INSERT INTO spaces (space_key, space_name, source, created_by, last_synced)
+     VALUES ($1, $1, 'local', $2, NOW())`,
+    [spaceKey, createdBy],
+  );
+}
+
+async function insertStandalonePage(
+  title: string,
+  visibility: 'private' | 'shared',
+  createdBy: string,
+  spaceKey: string,
+): Promise<void> {
+  await query(
+    `INSERT INTO pages (space_key, title, body_html, body_text, version, source,
+                        visibility, created_by_user_id, embedding_dirty, embedding_status)
+     VALUES ($1, $2, '<p>x</p>', 'x', 1, 'standalone', $3, $4, FALSE, 'not_embedded')`,
+    [spaceKey, title, visibility, createdBy],
+  );
+}
+
+async function insertConfluencePage(confluenceId: string, title: string, spaceKey: string): Promise<void> {
+  await query(
+    `INSERT INTO pages (confluence_id, source, space_key, title, body_text,
+                        body_storage, body_html, inherit_perms)
+     VALUES ($1, 'confluence', $2, $3, 'text', '', '', TRUE)`,
+    [confluenceId, spaceKey, title],
+  );
+}
+
+// --- Tests ---
+
+describe.skipIf(!dbAvailable)('GET /api/pages/tree — visibility predicate (DB)', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  async function treeTitles(asUser: string, url = '/api/pages/tree'): Promise<string[]> {
+    currentUserId = asUser;
+    const response = await app.inject({ method: 'GET', url });
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { items: Array<{ title: string }> };
+    return body.items.map((i) => i.title).sort();
+  }
+
+  beforeAll(async () => {
+    await setupTestDb();
+
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+    app.setErrorHandler((error: Error & { statusCode?: number }, _request, reply) => {
+      if (error instanceof ZodError) {
+        return reply.status(400).send({ error: 'Validation failed' });
+      }
+      return reply.status(error.statusCode ?? 500).send({ error: error.message });
+    });
+    app.decorate('authenticate', async (request: { userId: string }) => {
+      request.userId = currentUserId;
+    });
+    app.decorate('requireAdmin', async (request: { userId: string }) => {
+      request.userId = currentUserId;
+    });
+    app.decorate('redis', {});
+    const { pagesCrudRoutes } = await import('./pages-crud.js');
+    await app.register(pagesCrudRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await truncateAllTables();
+    userA = await insertUser('tree_vis_a');
+    userB = await insertUser('tree_vis_b');
+    await insertLocalSpace('NOTES', userA);
+    mockGetUserAccessibleSpaces.mockResolvedValue([]);
+  });
+
+  it("hides another user's private standalone article (user B sees only the shared one)", async () => {
+    await insertStandalonePage('Private note', 'private', userA, 'NOTES');
+    await insertStandalonePage('Shared note', 'shared', userA, 'NOTES');
+
+    expect(await treeTitles(userB)).toEqual(['Shared note']);
+  });
+
+  it('shows the owner both their private and shared standalone articles', async () => {
+    await insertStandalonePage('Private note', 'private', userA, 'NOTES');
+    await insertStandalonePage('Shared note', 'shared', userA, 'NOTES');
+
+    expect(await treeTitles(userA)).toEqual(['Private note', 'Shared note']);
+  });
+
+  it('limits Confluence pages to RBAC-accessible spaces', async () => {
+    await insertConfluencePage('conf-dev', 'Dev page', 'DEV');
+    await insertConfluencePage('conf-secret', 'Secret page', 'SECRET');
+    mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
+
+    expect(await treeTitles(userB)).toEqual(['Dev page']);
+  });
+
+  it('keeps the spaceKey filter working on top of the visibility predicate', async () => {
+    await insertConfluencePage('conf-dev', 'Dev page', 'DEV');
+    await insertStandalonePage('Private note', 'private', userA, 'NOTES');
+    await insertStandalonePage('Shared note', 'shared', userA, 'NOTES');
+    mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
+
+    expect(await treeTitles(userB, '/api/pages/tree?spaceKey=DEV')).toEqual(['Dev page']);
+    expect(await treeTitles(userB, '/api/pages/tree?spaceKey=NOTES')).toEqual(['Shared note']);
+  });
+});

--- a/backend/src/routes/knowledge/pages-tree-visibility.test.ts
+++ b/backend/src/routes/knowledge/pages-tree-visibility.test.ts
@@ -10,16 +10,20 @@
  *   - the caller's own private standalone articles
  */
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
-import Fastify from 'fastify';
-import sensible from '@fastify/sensible';
-import { ZodError } from 'zod';
+import type { FastifyInstance } from 'fastify';
 import {
   setupTestDb,
   truncateAllTables,
   teardownTestDb,
   isDbAvailable,
 } from '../../test-db-helper.js';
-import { query } from '../../core/db/postgres.js';
+import {
+  insertUser,
+  insertLocalSpace,
+  insertStandalonePage,
+  insertConfluencePage,
+  buildKnowledgeTestApp,
+} from './pages.test-helpers.js';
 
 // --- Boundary mocks (everything else is real) ---
 
@@ -41,55 +45,13 @@ vi.mock('../../core/services/rbac-service.js', () => ({
 
 const dbAvailable = await isDbAvailable();
 
-// --- Fixtures ---
-
-let userA: string;
-let userB: string;
-let currentUserId: string;
-
-async function insertUser(username: string): Promise<string> {
-  const res = await query<{ id: string }>(
-    "INSERT INTO users (username, email, password_hash, role) VALUES ($1, $2, 'x', 'user') RETURNING id",
-    [username, `${username}@test`],
-  );
-  return res.rows[0]!.id;
-}
-
-async function insertLocalSpace(spaceKey: string, createdBy: string): Promise<void> {
-  await query(
-    `INSERT INTO spaces (space_key, space_name, source, created_by, last_synced)
-     VALUES ($1, $1, 'local', $2, NOW())`,
-    [spaceKey, createdBy],
-  );
-}
-
-async function insertStandalonePage(
-  title: string,
-  visibility: 'private' | 'shared',
-  createdBy: string,
-  spaceKey: string,
-): Promise<void> {
-  await query(
-    `INSERT INTO pages (space_key, title, body_html, body_text, version, source,
-                        visibility, created_by_user_id, embedding_dirty, embedding_status)
-     VALUES ($1, $2, '<p>x</p>', 'x', 1, 'standalone', $3, $4, FALSE, 'not_embedded')`,
-    [spaceKey, title, visibility, createdBy],
-  );
-}
-
-async function insertConfluencePage(confluenceId: string, title: string, spaceKey: string): Promise<void> {
-  await query(
-    `INSERT INTO pages (confluence_id, source, space_key, title, body_text,
-                        body_storage, body_html, inherit_perms)
-     VALUES ($1, 'confluence', $2, $3, 'text', '', '', TRUE)`,
-    [confluenceId, spaceKey, title],
-  );
-}
-
 // --- Tests ---
 
 describe.skipIf(!dbAvailable)('GET /api/pages/tree — visibility predicate (DB)', () => {
-  let app: ReturnType<typeof Fastify>;
+  let app: FastifyInstance;
+  let userA: string;
+  let userB: string;
+  let currentUserId: string;
 
   async function treeTitles(asUser: string, url = '/api/pages/tree'): Promise<string[]> {
     currentUserId = asUser;
@@ -101,25 +63,13 @@ describe.skipIf(!dbAvailable)('GET /api/pages/tree — visibility predicate (DB)
 
   beforeAll(async () => {
     await setupTestDb();
-
-    app = Fastify({ logger: false });
-    await app.register(sensible);
-    app.setErrorHandler((error: Error & { statusCode?: number }, _request, reply) => {
-      if (error instanceof ZodError) {
-        return reply.status(400).send({ error: 'Validation failed' });
-      }
-      return reply.status(error.statusCode ?? 500).send({ error: error.message });
-    });
-    app.decorate('authenticate', async (request: { userId: string }) => {
-      request.userId = currentUserId;
-    });
-    app.decorate('requireAdmin', async (request: { userId: string }) => {
-      request.userId = currentUserId;
-    });
-    app.decorate('redis', {});
-    const { pagesCrudRoutes } = await import('./pages-crud.js');
-    await app.register(pagesCrudRoutes, { prefix: '/api' });
-    await app.ready();
+    app = await buildKnowledgeTestApp(
+      () => currentUserId,
+      async (a) => {
+        const { pagesCrudRoutes } = await import('./pages-crud.js');
+        await a.register(pagesCrudRoutes, { prefix: '/api' });
+      },
+    );
   });
 
   afterAll(async () => {

--- a/backend/src/routes/knowledge/pages.test-helpers.ts
+++ b/backend/src/routes/knowledge/pages.test-helpers.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared seeders + Fastify bootstrap for knowledge-route tests that hit the
+ * REAL test PostgreSQL (port 5433 via `test-db-helper.ts`).
+ *
+ * Extracted from `pages-tree-visibility.test.ts` /
+ * `embedding-status-visibility.test.ts`, which duplicated this block verbatim
+ * (review note on the UX-fixes plan). Module-level `vi.mock(...)` calls cannot
+ * live here (vitest hoists them per test file), so each test file keeps its
+ * own boundary mocks and passes a route-registration callback that performs
+ * the dynamic import AFTER the mocks are in place.
+ */
+import Fastify, { type FastifyInstance } from 'fastify';
+import sensible from '@fastify/sensible';
+import { ZodError } from 'zod';
+import type { RedisClientType } from 'redis';
+import { query } from '../../core/db/postgres.js';
+
+// --- Seeders ---
+
+export async function insertUser(username: string): Promise<string> {
+  const res = await query<{ id: string }>(
+    "INSERT INTO users (username, email, password_hash, role) VALUES ($1, $2, 'x', 'user') RETURNING id",
+    [username, `${username}@test`],
+  );
+  return res.rows[0]!.id;
+}
+
+export async function insertLocalSpace(spaceKey: string, createdBy: string): Promise<void> {
+  await query(
+    `INSERT INTO spaces (space_key, space_name, source, created_by, last_synced)
+     VALUES ($1, $1, 'local', $2, NOW())`,
+    [spaceKey, createdBy],
+  );
+}
+
+export async function insertStandalonePage(
+  title: string,
+  visibility: 'private' | 'shared',
+  createdBy: string,
+  spaceKey: string,
+  opts: { dirty?: boolean; deletedAt?: Date } = {},
+): Promise<number> {
+  const res = await query<{ id: number }>(
+    `INSERT INTO pages (space_key, title, body_html, body_text, version, source,
+                        visibility, created_by_user_id, embedding_dirty, embedding_status, deleted_at)
+     VALUES ($1, $2, '<p>x</p>', 'x', 1, 'standalone', $3, $4, $5, 'not_embedded', $6)
+     RETURNING id`,
+    [spaceKey, title, visibility, createdBy, opts.dirty ?? false, opts.deletedAt ?? null],
+  );
+  return res.rows[0]!.id;
+}
+
+export async function insertConfluencePage(
+  confluenceId: string,
+  title: string,
+  spaceKey: string,
+  opts: { deletedAt?: Date } = {},
+): Promise<number> {
+  const res = await query<{ id: number }>(
+    `INSERT INTO pages (confluence_id, source, space_key, title, body_text,
+                        body_storage, body_html, inherit_perms, embedding_dirty, deleted_at)
+     VALUES ($1, 'confluence', $2, $3, 'text', '', '', TRUE, FALSE, $4)
+     RETURNING id`,
+    [confluenceId, spaceKey, title, opts.deletedAt ?? null],
+  );
+  return res.rows[0]!.id;
+}
+
+/** Insert `chunks` embedding rows for a page (zero vector, dims match schema). */
+export async function insertEmbeddings(pageId: number, chunks: number): Promise<void> {
+  const zeroVector = `[${new Array(1024).fill(0).join(',')}]`;
+  for (let i = 0; i < chunks; i++) {
+    await query(
+      `INSERT INTO page_embeddings (page_id, chunk_index, chunk_text, embedding, metadata)
+       VALUES ($1, $2, 'chunk', $3::vector, '{}')`,
+      [pageId, i, zeroVector],
+    );
+  }
+}
+
+// --- App bootstrap ---
+
+/**
+ * Build a minimal Fastify app mirroring the production wiring the knowledge
+ * routes rely on: @fastify/sensible, Zod-aware error handler, and auth
+ * decorators that impersonate whichever user `getCurrentUserId()` returns.
+ */
+export async function buildKnowledgeTestApp(
+  getCurrentUserId: () => string,
+  registerRoutes: (app: FastifyInstance) => Promise<void>,
+): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(sensible);
+  app.setErrorHandler((error: Error & { statusCode?: number }, _request, reply) => {
+    if (error instanceof ZodError) {
+      return reply.status(400).send({ error: 'Validation failed' });
+    }
+    return reply.status(error.statusCode ?? 500).send({ error: error.message });
+  });
+  app.decorate('authenticate', async (request: { userId: string }) => {
+    request.userId = getCurrentUserId();
+  });
+  app.decorate('requireAdmin', async (request: { userId: string }) => {
+    request.userId = getCurrentUserId();
+  });
+  // Routes under test never touch fastify.redis (the RedisCache boundary is
+  // mocked per test file); the decoration only needs to exist.
+  app.decorate('redis', {} as RedisClientType);
+  await registerRoutes(app);
+  await app.ready();
+  return app;
+}

--- a/backend/src/routes/knowledge/search.ts
+++ b/backend/src/routes/knowledge/search.ts
@@ -7,6 +7,7 @@ import { query } from '../../core/db/postgres.js';
 // ADR-022.
 import { getUserAccessibleSpacesMemoized as getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
 import { getFtsLanguage } from '../../core/services/fts-language.js';
+import { visiblePagesPredicate } from '../../core/services/page-visibility.js';
 import {
   vectorSearch,
   hybridSearch,
@@ -95,11 +96,7 @@ export async function searchRoutes(fastify: FastifyInstance) {
            SELECT 1
            FROM page_embeddings pe
            JOIN pages cp ON pe.page_id = cp.id
-           WHERE (
-             (cp.source = 'confluence' AND cp.space_key = ANY($1::text[]))
-             OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-             OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $2)
-           )
+           WHERE ${visiblePagesPredicate(1, 2)}
            AND cp.deleted_at IS NULL
            LIMIT 1
          ) AS exists`,
@@ -213,13 +210,7 @@ export async function searchRoutes(fastify: FastifyInstance) {
 
     // Access control: RBAC-based space access for confluence pages; standalone pages
     // require shared visibility or ownership by the current user
-    conditions.push(
-      `(
-        (cp.source = 'confluence' AND cp.space_key = ANY($2::text[]))
-        OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-        OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $3)
-      )`,
-    );
+    conditions.push(visiblePagesPredicate(2, 3));
 
     // Exclude soft-deleted pages
     conditions.push('cp.deleted_at IS NULL');
@@ -323,11 +314,7 @@ export async function searchRoutes(fastify: FastifyInstance) {
        FROM pages cp
        WHERE similarity(cp.title, $1) > $4
          AND cp.title IS NOT NULL
-         AND (
-           (cp.source = 'confluence' AND cp.space_key = ANY($2::text[]))
-           OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-           OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $3)
-         )
+         AND ${visiblePagesPredicate(2, 3)}
          AND cp.deleted_at IS NULL
        ORDER BY rank DESC
        LIMIT $5`,
@@ -341,11 +328,7 @@ export async function searchRoutes(fastify: FastifyInstance) {
           `SELECT 'space' AS facet, cp.space_key AS value, COUNT(*)::TEXT AS count
            FROM pages cp
            WHERE cp.tsv @@ plainto_tsquery('${ftsLang}', $1)
-             AND (
-               (cp.source = 'confluence' AND cp.space_key = ANY($2::text[]))
-               OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-               OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $3)
-             )
+             AND ${visiblePagesPredicate(2, 3)}
              AND cp.deleted_at IS NULL
              AND cp.space_key IS NOT NULL
            GROUP BY cp.space_key
@@ -353,11 +336,7 @@ export async function searchRoutes(fastify: FastifyInstance) {
            SELECT 'author' AS facet, cp.author AS value, COUNT(*)::TEXT AS count
            FROM pages cp
            WHERE cp.tsv @@ plainto_tsquery('${ftsLang}', $1)
-             AND (
-               (cp.source = 'confluence' AND cp.space_key = ANY($2::text[]))
-               OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-               OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $3)
-             )
+             AND ${visiblePagesPredicate(2, 3)}
              AND cp.deleted_at IS NULL
              AND cp.author IS NOT NULL
            GROUP BY cp.author
@@ -366,11 +345,7 @@ export async function searchRoutes(fastify: FastifyInstance) {
            FROM pages cp
            CROSS JOIN unnest(cp.labels) AS tag
            WHERE cp.tsv @@ plainto_tsquery('${ftsLang}', $1)
-             AND (
-               (cp.source = 'confluence' AND cp.space_key = ANY($2::text[]))
-               OR (cp.source = 'standalone' AND cp.visibility = 'shared')
-               OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $3)
-             )
+             AND ${visiblePagesPredicate(2, 3)}
              AND cp.deleted_at IS NULL
            GROUP BY tag`,
           [q, searchSpaces, userId],

--- a/backend/src/routes/knowledge/verification.ts
+++ b/backend/src/routes/knowledge/verification.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { query } from '../../core/db/postgres.js';
 import { getUserAccessibleSpaces } from '../../core/services/rbac-service.js';
+import { visiblePagesPredicate } from '../../core/services/page-visibility.js';
 import { logger } from '../../core/utils/logger.js';
 
 const IdParamSchema = z.object({ id: z.string().min(1) });
@@ -26,11 +27,7 @@ export async function verificationRoutes(fastify: FastifyInstance) {
       `SELECT p.id FROM pages p
        WHERE ${isNumeric ? 'p.id = $2' : 'p.confluence_id = $2'}
          AND p.deleted_at IS NULL
-         AND (
-           (p.source = 'confluence' AND p.space_key = ANY($1::text[]))
-           OR (p.source = 'standalone' AND p.visibility = 'shared')
-           OR (p.source = 'standalone' AND p.visibility = 'private' AND p.created_by_user_id = $3)
-         )`,
+         AND ${visiblePagesPredicate(1, 3, 'p')}`,
       [verifySpaces, isNumeric ? parseInt(pageId, 10) : pageId, userId],
     );
     if (check.rows.length === 0) {

--- a/docs/ENTERPRISE-ARCHITECTURE.md
+++ b/docs/ENTERPRISE-ARCHITECTURE.md
@@ -755,11 +755,15 @@ export function isFeatureAvailable(
 ### 7.1 Frontend Plugin Loader
 
 The EE overlay bundle is served at `/api/enterprise/frontend.js` by the EE backend.
-CE deployments return 404 — the loader first probes the URL with a `fetch` HEAD request
-(a fetched 404 logs nothing to the browser console, unlike a failed `<script src>`, which
-logs a 404 plus a MIME-type refusal on every navigation); on 404 or a non-JavaScript
-content type it fails silently and `ui` stays null. Only when the probe succeeds is the
-`<script>` tag injected.
+On CE backends the bundle URL is **never requested at all**: `EnterpriseProvider` fetches
+`/api/admin/license` first and only calls `loadEnterpriseUI()` when the response marks the
+backend as EE (`canUpdate: true`; the CE noop omits it) — zero extra requests, zero console
+noise in community deployments. As defense-in-depth for EE backends that lack the bundle
+route, the loader HEAD-probes the URL before injecting the `<script>` tag; on 404 or a
+non-JavaScript content type it resolves `ui = null`. Note browsers still log a single
+network-level 404 line for a fetched 404 (there is no fully silent way to request a missing
+URL) — the probe only avoids the additional MIME-type refusal and script error that a failed
+`<script src>` would produce.
 Both CE and EE deployments use the same CE frontend image; no separate EE frontend image is needed.
 
 **Why IIFE, not an ES module**: ES modules with bare-specifier externals (e.g. `import React from 'react'`)
@@ -792,8 +796,8 @@ export async function loadEnterpriseUI(): Promise<EnterpriseUI | null> {
       ...(jsxRuntime as any), ...(ReactQuery as any), ...(FramerMotion as any),
     };
 
-    // HEAD-probe first (silent in CE), then inject <script> tag;
-    // IIFE runs and registers window.__COMPENDIQ_UI__
+    // HEAD-probe (defense-in-depth; only ever runs against EE backends),
+    // then inject <script> tag; IIFE runs and registers window.__COMPENDIQ_UI__
     await probeAndInjectScript(ENTERPRISE_BUNDLE_URL);
 
     const ui = (window as any)[EE_UI_GLOBAL];
@@ -814,6 +818,7 @@ export async function loadEnterpriseUI(): Promise<EnterpriseUI | null> {
 Key design decisions:
 - **`isEnterprise` from backend, not from whether the overlay loaded**: `license.edition !== 'community' && license.valid === true`. This means even without the overlay bundle, the CE can correctly report its tier.
 - **Always fetch `/admin/license`**: CE returns `{ edition:'community', valid:true, features:[] }`. The fetch is silently swallowed for unauthenticated users.
+- **License response gates the bundle load**: the provider fetches the license first and only calls `loadEnterpriseUI()` when the response carries `canUpdate: true` (EE backend marker). CE backends therefore generate no bundle traffic. The UI stays non-blocking — every consumer handles `ui === null`.
 - **`LicenseStatusCard` is self-fetching** (zero props): it calls the license API internally. The `license` state in context is for routing/gating decisions only.
 
 ```typescript
@@ -833,21 +838,26 @@ export function EnterpriseProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
 
     async function init() {
-      // Load enterprise UI module (fast, just a dynamic import attempt)
-      const enterpriseUi = await loadEnterpriseUI();
-      if (cancelled) return;
-      setUi(enterpriseUi);
-
-      // Always fetch license info — CE returns edition:'community', EE returns actual tier.
+      // License first — CE returns edition:'community', EE returns actual tier.
       // Silently swallowed for unauthenticated/non-admin users.
+      let info: LicenseInfo | null = null;
       try {
-        const info = await apiFetch<LicenseInfo>('/admin/license');
-        if (!cancelled) setLicense(info);
+        info = await apiFetch<LicenseInfo>('/admin/license');
       } catch {
         // Not admin or endpoint not available — license stays null
       }
+      if (cancelled) return;
+      if (info) setLicense(info);
 
-      if (!cancelled) setIsLoading(false);
+      // Only an EE backend (marked by canUpdate: true) can serve the overlay
+      // bundle — CE never requests the bundle URL at all.
+      if (info?.canUpdate === true) {
+        const enterpriseUi = await loadEnterpriseUI();
+        if (cancelled) return;
+        setUi(enterpriseUi);
+      }
+
+      setIsLoading(false);
     }
 
     init();

--- a/docs/ENTERPRISE-ARCHITECTURE.md
+++ b/docs/ENTERPRISE-ARCHITECTURE.md
@@ -755,7 +755,11 @@ export function isFeatureAvailable(
 ### 7.1 Frontend Plugin Loader
 
 The EE overlay bundle is served at `/api/enterprise/frontend.js` by the EE backend.
-CE deployments return 404 — the script tag errors silently and `ui` stays null.
+CE deployments return 404 — the loader first probes the URL with a `fetch` HEAD request
+(a fetched 404 logs nothing to the browser console, unlike a failed `<script src>`, which
+logs a 404 plus a MIME-type refusal on every navigation); on 404 or a non-JavaScript
+content type it fails silently and `ui` stays null. Only when the probe succeeds is the
+`<script>` tag injected.
 Both CE and EE deployments use the same CE frontend image; no separate EE frontend image is needed.
 
 **Why IIFE, not an ES module**: ES modules with bare-specifier externals (e.g. `import React from 'react'`)
@@ -788,8 +792,9 @@ export async function loadEnterpriseUI(): Promise<EnterpriseUI | null> {
       ...(jsxRuntime as any), ...(ReactQuery as any), ...(FramerMotion as any),
     };
 
-    // Inject <script> tag; IIFE runs and registers window.__COMPENDIQ_UI__
-    await injectScript(ENTERPRISE_BUNDLE_URL);
+    // HEAD-probe first (silent in CE), then inject <script> tag;
+    // IIFE runs and registers window.__COMPENDIQ_UI__
+    await probeAndInjectScript(ENTERPRISE_BUNDLE_URL);
 
     const ui = (window as any)[EE_UI_GLOBAL];
     if (ui && typeof ui.LicenseStatusCard === 'function') {

--- a/docs/architecture/06-data-model.md
+++ b/docs/architecture/06-data-model.md
@@ -309,6 +309,11 @@ erDiagram
   (`00000000-0000-0000-0000-000000000000`) inside the same transaction
   before issuing the `DELETE FROM users`.
 - **Soft delete** on `pages.deleted_at` — the Trash feature filters on this.
+  Standalone pages in the trash are hard-deleted after 30 days
+  (`purgeExpiredStandalonePages` in `data-retention-service.ts`, run by the
+  daily maintenance job; dependent rows go via `ON DELETE CASCADE`).
+  Confluence-synced pages have their own purge in `sync-service.ts`
+  (`purgeDeletedPages`, with upstream re-confirmation — see 08-flow-sync).
 - **Version history & restore** (`page_versions`, keyed by `page_id`). Snapshots
   are written on sync, on draft-publish, and before a restore — so both
   Confluence-synced and standalone/local pages accumulate history. The

--- a/docs/confluence-test-container.md
+++ b/docs/confluence-test-container.md
@@ -1,0 +1,96 @@
+# Confluence test container
+
+A real Confluence Data Center 9.2 instance for integration-testing the sync
+pipeline locally. Compose file: `docker/docker-compose.confluence.yml`
+(project `compendiq-confluence`: Confluence + its own Postgres 16).
+
+## Start / stop
+
+```bash
+# The compose file expects the shared backend network to exist
+docker network inspect compendiq_backend-net >/dev/null 2>&1 \
+  || docker network create compendiq_backend-net
+
+docker compose -f docker/docker-compose.confluence.yml up -d
+# First boot takes several minutes (2 GB JVM). Ready when:
+curl -fsS http://localhost:8090/status   # {"state":"FIRST_RUN"} → setup, {"state":"RUNNING"} → ready
+
+docker compose -f docker/docker-compose.confluence.yml down      # keep data
+docker compose -f docker/docker-compose.confluence.yml down -v   # wipe data
+```
+
+## One-time setup (fresh volume)
+
+The container preconfigures the database via `ATL_*` env vars, so the wizard
+only asks for a license, deployment type, and an admin account:
+
+1. Open <http://localhost:8090> → license entry. Use an Atlassian **timebomb
+   license for Data Center** (developer.atlassian.com → "Timebomb licenses
+   for testing Data Center apps" → "10 user Confluence Data Center license,
+   expires in 3 hours"). Copy the key exactly — strip line breaks only.
+   After the 3 h expiry the instance keeps running but locks editing; paste a
+   fresh timebomb under ⚙ → General Configuration → License Details, or wipe
+   the volume and redo setup.
+2. Deployment type: **Non-clustered (single node)** → Empty Site →
+   "Manage users and groups within Confluence".
+3. Admin account (dev-only, never reuse elsewhere): `admin` /
+   `confluence-admin-dev-2026` (email `admin@compendiq.local`).
+
+## Seed test content + PAT (REST)
+
+```bash
+AUTH="admin:confluence-admin-dev-2026"
+# Space
+curl -fsS -u "$AUTH" -X POST http://localhost:8090/rest/api/space \
+  -H 'Content-Type: application/json' \
+  -d '{"key":"TEST","name":"Compendiq Sync Test"}'
+# Page with code block + task list (exercises the content pipeline)
+curl -fsS -u "$AUTH" -X POST http://localhost:8090/rest/api/content \
+  -H 'Content-Type: application/json' -d '{
+    "type":"page","title":"Code and Tasks Sample","space":{"key":"TEST"},
+    "body":{"storage":{"representation":"storage","value":"<ac:structured-macro ac:name=\"code\"><ac:plain-text-body><![CDATA[print(1)]]></ac:plain-text-body></ac:structured-macro><ac:task-list><ac:task><ac:task-status>incomplete</ac:task-status><ac:task-body>Check sync</ac:task-body></ac:task></ac:task-list>"}}}'
+# Personal Access Token (Bearer auth for Compendiq)
+curl -fsS -u "$AUTH" -X POST http://localhost:8090/rest/pat/latest/tokens \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"compendiq-e2e","expirationDuration":90}'
+# → response field "rawToken" is shown ONCE; store it outside the repo.
+```
+
+## Reaching Confluence from the app
+
+- **Host / Vite dev / Playwright browser:** `http://localhost:8090`
+- **Compendiq backend container:** the Confluence compose joins the external
+  `compendiq_backend-net`. If your backend stack uses its own network (the EE
+  compose does), bridge it once:
+  ```bash
+  docker network connect --alias confluence <your-backend-network> \
+    compendiq-confluence-confluence-1
+  ```
+  then configure Compendiq with `http://confluence:8090`. The URL entered in
+  Settings → Confluence is used by the **backend**, so it must be resolvable
+  from inside the backend container, not (only) from the host.
+
+## Running the sync e2e
+
+`e2e/confluence-sync.spec.ts` skips unless both env vars are set:
+
+```bash
+E2E_BASE_URL=http://localhost:8082 \          # your running frontend
+E2E_CONFLUENCE_URL=http://confluence:8090 \   # backend-resolvable URL
+E2E_CONFLUENCE_PAT=<rawToken> \
+npx playwright test e2e/confluence-sync.spec.ts
+```
+
+The spec registers a throwaway user, connects the PAT, fetches spaces,
+selects + syncs one, and asserts synced Confluence pages are served by
+`/api/pages`. The CI-safe variant that needs no Confluence at all is
+`e2e/confluence-sync-mock.spec.ts` (route-intercepted fixtures).
+
+## Notes
+
+- Ports bind to `127.0.0.1` only (8090 HTTP, 8091 Synchrony).
+- The timebomb license, the dev admin password above, and seeded PATs are
+  throwaway dev credentials for this isolated container — treat anything you
+  paste into a real instance differently.
+- Confluence DC 9.2 serves XHTML storage format only (see ADR-003); the
+  seeded code-block/task-list page exercises the `confluenceToHtml` path.

--- a/docs/superpowers/plans/2026-06-10-ux-review-fixes.md
+++ b/docs/superpowers/plans/2026-06-10-ux-review-fixes.md
@@ -1,0 +1,368 @@
+# UX Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all findings from the 2026-06-10 usability review of Compendiq EE 0.5.2 (license-expiry invisibility, silent AI failures, broken trash UI, system-account exposure, degraded-state messaging, terminology/locale inconsistencies, console noise) and stand up the Confluence integration test container.
+
+**Architecture:** All code changes are CE-side (`compendiq-ce`, branch `feature/ux-review-fixes` off `dev`). Backend fixes align four inconsistently-scoped knowledge routes to one visibility predicate and shield the `__system__` account; frontend fixes surface degraded states (LLM down, expired license, 403s) that today fail silently. The EE repo needs no code change — final verification rebuilds the EE image with the `ce` submodule pointed at this branch.
+
+**Tech Stack:** Fastify 5 + Postgres (vitest + real DB on :5433), React 19 + TanStack Query (vitest + jsdom + testing-library), sonner toasts, nm-* design utilities, Playwright for live verification.
+
+**Conventions for every task:** Read each target file region before editing (line numbers may have drifted). Frontend tests are colocated `Foo.test.tsx`; backend route tests are `backend/src/routes/**/*.test.ts` using `setupTestDb/truncateAllTables/teardownTestDb` from `test-db-helper.ts` (skipIf no DB). Run a task's tests with `cd backend && npx vitest run <file>` or `cd frontend && npx vitest run <file>`. Commit after each task with the message given in the task.
+
+---
+
+### Task 0: Branch setup
+
+- [ ] **Step 0.1:** In `/home/simon/Documents/Compendiq/compendiq-ce`: `git checkout dev && git checkout -b feature/ux-review-fixes`. Run `npm install` if node_modules is stale. Start the test DB if not running (`docker ps | grep compendiq-test-postgres` — it runs on :5433).
+- [ ] **Step 0.2:** Commit the plan file itself: `git add docs/superpowers/plans/2026-06-10-ux-review-fixes.md && git commit -m "docs: UX review fixes implementation plan"`.
+
+---
+
+### Task 1: Backend — pages tree route applies the visibility predicate
+
+The tree route (`GET /api/pages/tree`) lists pages the detail/list/search routes refuse: it filters only by space + `deleted_at`, while the list route (pages-crud.ts ~line 318) also enforces `(confluence AND space ∈ RBAC) OR (standalone shared) OR (standalone private AND owner)`. Result: sidebar shows "Test Dokumentation." → click → "Article not found".
+
+**Files:**
+- Modify: `backend/src/routes/knowledge/pages-crud.ts` (~line 590, the `treeWhereClause`)
+- Test: `backend/src/routes/knowledge/pages-tree-visibility.test.ts` (new)
+
+- [ ] **Step 1.1: Write the failing DB test** — create `pages-tree-visibility.test.ts` following the `analytics.test.ts` pattern (build app via the same helper used there; check how existing pages-crud tests construct the Fastify instance and auth—mimic exactly). Seed: user A and user B; one standalone page `visibility='private', created_by_user_id=A`; one standalone `visibility='shared'` by A; assert `GET /api/pages/tree` as B returns only the shared page, as A returns both.
+- [ ] **Step 1.2:** Run it: `cd backend && npx vitest run src/routes/knowledge/pages-tree-visibility.test.ts` — expect FAIL (B sees the private page).
+- [ ] **Step 1.3: Implement** — in the tree route, change the where clause construction to:
+
+```ts
+const values: unknown[] = [treeSpaces, userId];
+let treeWhereClause = `WHERE cp.deleted_at IS NULL AND (
+  (cp.source = 'confluence' AND cp.space_key = ANY($1::text[]))
+  OR (cp.source = 'standalone' AND cp.visibility = 'shared')
+  OR (cp.source = 'standalone' AND cp.visibility = 'private' AND cp.created_by_user_id = $2)
+)`;
+if (params.spaceKey) {
+  treeWhereClause += ' AND cp.space_key = $3';
+  values.push(params.spaceKey);
+}
+```
+
+Keep the cache key user-scoped (it already is: `cache.get(userId, …)`).
+- [ ] **Step 1.4:** Re-run the test — expect PASS. Also run the existing pages-crud suite: `npx vitest run src/routes/knowledge/pages-crud.test.ts` (adjust any tree assertions that relied on the old behavior).
+- [ ] **Step 1.5:** Commit: `git commit -m "fix(pages): apply visibility predicate to pages tree route"`.
+
+---
+
+### Task 2: Backend — embedding-status stats use the same visibility scope
+
+`GET /api/llm/embedding-status` (`backend/src/routes/knowledge/knowledge-admin.ts:119`) feeds the dashboard KPI cards. A fresh regular user saw "Total Articles 0" while the tree showed 1 page. Scope `getEmbeddingStatus` to the same predicate as Task 1.
+
+**Files:**
+- Modify: `backend/src/domains/llm/services/embedding-service.ts` (`getEmbeddingStatus`), `backend/src/routes/knowledge/knowledge-admin.ts:119-123`
+- Test: extend `backend/src/routes/knowledge/pages-tree-visibility.test.ts`
+
+- [ ] **Step 2.1:** Read `getEmbeddingStatus` in `embedding-service.ts`. Add an optional scoping parameter `{ userId, accessibleSpaces }`; when provided, add the Task-1 predicate to its COUNT queries (same SQL fragment, parameterized).
+- [ ] **Step 2.2: Failing test** — as user B from Task 1's seed, `GET /api/llm/embedding-status` should report `totalPages` equal to what B's tree shows (1, the shared page), not the global count (2).
+- [ ] **Step 2.3:** Implement: in `knowledge-admin.ts` pass `{ userId: request.userId, accessibleSpaces: await getUserAccessibleSpaces(request.userId) }`. Run test → PASS. Run the embedding-service suite.
+- [ ] **Step 2.4:** Commit: `git commit -m "fix(stats): scope embedding-status counts to caller-visible pages"`.
+
+---
+
+### Task 3: Backend — trash contract repair + standalone auto-purge
+
+Frontend calls `GET /api/trash` and `POST /api/trash/:id/restore`; backend registers `GET /api/pages/trash` and `POST /api/pages/:id/restore` → the trash UI 404s and renders empty forever. The UI also renders `deletedBy` and `autoPurgeAt`, which the backend response omits. Nothing ever purges standalone pages, contradicting "purged after 30 days".
+
+**Files:**
+- Modify: `backend/src/routes/knowledge/pages-crud.ts` (trash route ~685-712): add fields
+- Modify: the maintenance job (locate via `grep -rn "maintenance" backend/src/domains --include="*.ts" -l`; the queue named `maintenance` from /api/health): add standalone purge
+- Test: `backend/src/routes/knowledge/pages-trash.test.ts` (new)
+
+- [ ] **Step 3.1: Failing test** — seed standalone page by user A, soft-delete it (`UPDATE pages SET deleted_at = NOW() - INTERVAL '31 days'`). Assert: (a) `GET /api/pages/trash` as A returns the item **with `deletedBy` (username) and `autoPurgeAt` (deleted_at + 30 days ISO)**; (b) after running the exported purge function, the row is gone; (c) a 29-day-old soft-deleted page survives the purge.
+- [ ] **Step 3.2:** Run → FAIL.
+- [ ] **Step 3.3: Implement** — trash route SELECT joins users for the deleter (deleter == owner for standalone: `JOIN users u ON u.id = cp.created_by_user_id`) and maps:
+
+```ts
+deletedBy: row.deleted_by_username,
+autoPurgeAt: new Date(row.deleted_at.getTime() + 30 * 24 * 3600 * 1000).toISOString(),
+```
+
+Add `purgeExpiredStandalonePages()` next to the existing purge logic (sync-service has the Confluence variant at ~line 1259) but for standalone pages, and call it from the maintenance job:
+
+```ts
+export async function purgeExpiredStandalonePages(): Promise<number> {
+  const res = await query(
+    `DELETE FROM pages WHERE source = 'standalone' AND deleted_at < NOW() - INTERVAL '30 days'`,
+  );
+  return res.rowCount ?? 0;
+}
+```
+
+(Place it in a knowledge-domain service the maintenance job may import without violating ESLint boundaries — check where the maintenance job lives first; if it's in `core`, put the function in the job's own domain-legal location.)
+- [ ] **Step 3.4:** Run → PASS. Commit: `git commit -m "fix(trash): expose deletedBy/autoPurgeAt and purge expired standalone pages"`.
+
+---
+
+### Task 4: Backend — shield the `__system__` account
+
+`GET /api/admin/users` lists the system account (id `00000000-0000-0000-0000-000000000000`) with live Deactivate/Delete actions.
+
+**Files:**
+- Modify: `backend/src/core/services/admin-user-service.ts` (`listUsers` ~line 84; `SYSTEM_USER_ID` const exists at ~line 23; `deactivateUser` ~238; `deleteUser` ~314; role update fn)
+- Test: extend the existing admin-users test file (locate: `backend/src/routes/foundation/admin-users.test.ts`)
+
+- [ ] **Step 4.1: Failing tests** — (a) list response contains no user with id SYSTEM_USER_ID; (b) `POST /api/admin/users/<SYSTEM_USER_ID>/deactivate` → 400 with `SYSTEM_USER_PROTECTED` error code; (c) `DELETE /api/admin/users/<SYSTEM_USER_ID>` → 400 same; (d) `PUT` role change on it → 400 same.
+- [ ] **Step 4.2:** Run → FAIL.
+- [ ] **Step 4.3: Implement** — `listUsers`: `WHERE id <> $1` (SYSTEM_USER_ID). Add at the top of deactivate/delete/update service functions:
+
+```ts
+if (targetUserId === SYSTEM_USER_ID) {
+  throw new AdminUserServiceError('SYSTEM_USER_PROTECTED', 'The system account cannot be modified');
+}
+```
+
+Map that error code to 400 in the route handlers the same way `SELF_FORBIDDEN` is mapped.
+- [ ] **Step 4.4:** Run → PASS. Commit: `git commit -m "fix(admin): hide and protect the __system__ account"`.
+
+---
+
+### Task 5: Frontend — trash hooks point at the real API
+
+**Files:**
+- Modify: `frontend/src/shared/hooks/use-standalone.ts` (lines ~69-83: `useTrash`, `useRestorePage`)
+- Test: extend `frontend/src/features/pages/TrashPage.test.tsx`
+
+- [ ] **Step 5.1: Failing test** — TrashPage test mocking fetch at the network boundary: respond to `/api/pages/trash` with one item `{id:'3', title:'X', deletedBy:'simon', deletedAt:…, autoPurgeAt:…}`; assert the row renders with "days until auto-purge"; assert clicking Restore POSTs `/api/pages/3/restore`. (Current code requests `/api/trash` → test fails.)
+- [ ] **Step 5.2:** Implement:
+
+```ts
+queryFn: () => apiFetch<{ items: TrashItem[]; total: number }>('/pages/trash'),
+…
+apiFetch(`/pages/${pageId}/restore`, { method: 'POST' }),
+```
+
+Align the `TrashItem` type with the Task-3 response (`deletedBy`, `autoPurgeAt`, `deletedAt`).
+- [ ] **Step 5.3:** Run `cd frontend && npx vitest run src/features/pages/TrashPage.test.tsx` → PASS. Commit: `git commit -m "fix(trash): call /pages/trash and /pages/:id/restore endpoints"`.
+
+---
+
+### Task 6: Frontend — license card shows expired/invalid state
+
+API already returns `valid:false`, `expiresAt`, `seats`, `displayKey`. The card renders "Community Edition — Free" with no hint the stored key expired.
+
+**Files:**
+- Modify: `frontend/src/features/admin/LicenseStatusCard.tsx`
+- Test: `frontend/src/features/admin/LicenseStatusCard.test.tsx`
+
+- [ ] **Step 6.1: Failing tests** — mock the license query (follow the file's existing test setup) with `{edition:'community', tier:'community', valid:false, displayKey:'ATM-enterprise-10-20260515-CPQ6ddb3390.****', expiresAt:'2026-05-15T23:59:59.999Z', seats:10, canUpdate:true, features:[]}`. Assert: text matching `/expired on/i` and `May 15, 2026` (or locale-stable check) renders; badge shows "Expired" not "Free". Second case `valid:false` without `expiresAt` in the past ⇒ "Invalid". Third case: valid enterprise ⇒ existing behavior unchanged.
+- [ ] **Step 6.2:** Implement — after the existing derived flags add:
+
+```ts
+const storedKeyInvalid = hasStoredKey && !isValid;
+const expiredDate = data?.expiresAt ? new Date(data.expiresAt) : null;
+const isExpired = storedKeyInvalid && expiredDate !== null && expiredDate.getTime() < Date.now();
+```
+
+Badge logic becomes `isValid ? 'Active' : storedKeyInvalid ? (isExpired ? 'Expired' : 'Invalid') : isCommunity ? 'Free' : 'Inactive'` (red `text-destructive` styling for the invalid pair). Below the header row, when `storedKeyInvalid`, render:
+
+```tsx
+<div className="border-t border-destructive/30 bg-destructive/10 px-5 py-3 text-sm" data-testid="license-expired-banner">
+  {isExpired ? (
+    <>Your stored license key expired on <strong>{expiredDate!.toLocaleDateString()}</strong>. Enterprise features are locked until a new key is saved.</>
+  ) : (
+    <>The stored license key is invalid. Enterprise features are locked until a valid key is saved.</>
+  )}
+</div>
+```
+
+Also render the seats/expiry stats grid when `hasStoredKey` even if tier is community (change `{!isCommunity && (` to `{(!isCommunity || hasStoredKey) && (`), and retitle its "Expires" label to "Expired" when `isExpired`.
+- [ ] **Step 6.3:** Run tests → PASS. Commit: `git commit -m "fix(license): surface expired/invalid stored-key state on the license card"`.
+
+---
+
+### Task 7: Frontend — edition label disambiguation
+
+**Files:**
+- Modify: `frontend/src/features/settings/panels/SystemTab.tsx` (~line 66 row label "Edition"), `frontend/src/features/admin/LicenseStatusCard.tsx` (PanelHeader subtitle)
+- Test: existing SystemTab/LicenseStatusCard tests
+
+- [ ] **Step 7.1:** SystemTab: change the row label "Edition" → "Build edition". LicenseStatusCard subtitle → `"License tier and the enterprise features each tier unlocks."`. Update test expectations (failing-first where the strings are asserted).
+- [ ] **Step 7.2:** Commit: `git commit -m "fix(settings): disambiguate build edition vs license tier labels"`.
+
+---
+
+### Task 8: Frontend — provider-aware LLM banner
+
+**Files:**
+- Modify: `frontend/src/shared/components/badges/ServiceStatus.tsx` (~lines 55-65)
+- Test: `frontend/src/shared/components/badges/ServiceStatus.test.tsx`
+
+- [ ] **Step 8.1: Failing test** — mock `/api/health` with `services.llm:false, llmProvider:'LMStudio'`; assert banner text `LLM provider "LMStudio" is unreachable` and a link to `/settings/ai/models`.
+- [ ] **Step 8.2:** Implement:
+
+```ts
+const label = data.llmProvider
+  ? `LLM provider "${data.llmProvider}" is unreachable`
+  : 'LLM provider is unreachable';
+```
+
+Add to the alert rendering (next to the label) a react-router `<Link to="/settings/ai/models" className="underline">Check LLM settings</Link>`. Keep alert id `'ollama'` (dismissal persistence) but update the aria-label to "Dismiss LLM provider alert". Reduce banner vertical padding to `py-1.5` for the compactness finding.
+- [ ] **Step 8.3:** Run tests → PASS. Commit: `git commit -m "fix(health): name the actual LLM provider in the outage banner"`.
+
+---
+
+### Task 9: Frontend — AI degraded states (models error, 403 ask feedback, summary offline note)
+
+**Files:**
+- Modify: `frontend/src/features/ai/AiContext.tsx` (modelsQuery ~318; runStream catch ~520), `frontend/src/features/ai/AiAssistantPage.tsx` (~293 "Loading models..."), `frontend/src/shared/components/article/ArticleSummary.tsx` (~88-93)
+- Test: AiAssistantPage/AiContext/ArticleSummary colocated tests
+
+- [ ] **Step 9.1: Failing tests** — (a) models fetch rejects ⇒ AiAssistantPage shows "Models unavailable" with a Retry button (not eternal spinner); (b) `runStream` rejects with `ApiError(403,…)` ⇒ messages end with an assistant-style error entry containing "permission" (not silently sliced); (c) ArticleSummary with summaryStatus pending + health `services.llm:false` ⇒ renders "AI summary unavailable — LLM provider offline".
+- [ ] **Step 9.2:** Implement (a): expose `modelsError: modelsQuery.isError` and `refetchModels: modelsQuery.refetch` in context; in AiAssistantPage:
+
+```tsx
+{modelsError ? (
+  <button onClick={() => refetchModels()} className="flex h-7 items-center gap-1.5 rounded-md border border-destructive/40 px-2.5 text-xs text-destructive">
+    <AlertTriangle size={12} /> Models unavailable — retry
+  </button>
+) : models.length === 0 ? ( /* existing spinner */ ) : ( /* existing picker */ )}
+```
+
+(b) in the catch block, instead of `setMessages((prev) => prev.slice(0, -1))`, replace the placeholder with an error message so the chat shows what happened:
+
+```ts
+const friendly = err instanceof ApiError && err.status === 403
+  ? 'You don\'t have permission to use AI features (permission "llm:query"). Ask an administrator to assign you a role that includes it.'
+  : err instanceof Error ? err.message : 'Request failed';
+setMessages((prev) => {
+  const updated = [...prev];
+  updated[updated.length - 1] = { ...updated[updated.length - 1]!, content: friendly, isError: true };
+  return updated;
+});
+```
+
+Add optional `isError?: boolean` to the message type and render error bubbles with destructive styling in the message list component (locate where messages render — same feature dir). Keep the toast for non-403s only.
+(c) ArticleSummary: add a lightweight health query (`useQuery(['health'], () => fetch('/api/health').then(r=>r.json()), {staleTime:30_000, retry:false})`) and when `summaryStatus !== 'summarizing'` and `health?.services?.llm === false` render "AI summary unavailable — LLM provider offline" (gray, no clock pulse) instead of "AI summary will be generated shortly".
+- [ ] **Step 9.3:** Run the three test files → PASS. Commit: `git commit -m "fix(ai): visible degraded states for models, ask 403s, and summary when LLM offline"`.
+
+---
+
+### Task 10: Frontend — embedding dimensions from the settings payload
+
+**Files:**
+- Modify: `frontend/src/features/settings/LlmTab.tsx` (~lines 34-40)
+- Test: LlmTab colocated test
+
+- [ ] **Step 10.1:** Replace the `['embedding-dimensions']` query (`/admin/embedding/dimensions` — endpoint doesn't exist, 404s on every visit) with a query for `/admin/settings` selecting `embeddingDimensions` (check whether LlmTab/parent already fetches `/admin/settings`; if so reuse that query's data instead of adding one). Keep the 1024 fallback.
+- [ ] **Step 10.2:** Failing-first test: mock `/admin/settings` → `{embeddingDimensions: 768, …}`; assert "768" renders where dims display; assert **no** request to `/admin/embedding/dimensions`.
+- [ ] **Step 10.3:** Commit: `git commit -m "fix(settings): read embedding dimensions from /admin/settings (kill 404)"`.
+
+---
+
+### Task 11: Frontend — ConfirmDialog component; replace native confirm(); select styling; disabled-create hint
+
+**Files:**
+- Create: `frontend/src/shared/components/ConfirmDialog.tsx` + `ConfirmDialog.test.tsx`
+- Modify: `frontend/src/features/pages/PageViewPage.tsx` (~line 357), `frontend/src/features/admin/UsersAdminPage.tsx` (delete confirm ~line 303, role select ~251), `frontend/src/features/pages/NewPagePage.tsx` (Create button ~165)
+
+- [ ] **Step 11.1:** Build `ConfirmDialog` on the Radix dialog primitive already in the bundle (check `package.json` / existing usage e.g. version-history popover; if only `@radix-ui/react-dialog` exists, use it):
+
+```tsx
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+```
+
+nm-card styling, destructive confirm button uses `bg-destructive`. Test: renders title/description, confirm fires `onConfirm`, Escape fires `onCancel`.
+- [ ] **Step 11.2:** PageViewPage: replace `window.confirm('Delete this article? This cannot be undone.')` with the dialog — copy: title "Move page to trash?", description "It can be restored from Trash for 30 days, then it is permanently deleted.", confirm "Move to trash". Success toast → "Page moved to trash.". Update PageViewPage test.
+- [ ] **Step 11.3:** UsersAdminPage: replace `window.confirm` with the dialog — title `Permanently delete "${u.username}"?`, description "This cannot be undone.", confirm "Delete user", destructive. Style the role `<select>` with the same `nm-select-md`-style classes used by NewPagePage's space selector (keep native element — project pattern). Update test.
+- [ ] **Step 11.4:** NewPagePage: on the Create Page button add `title={isCreateDisabled ? 'Enter a title and select a space first' : undefined}` and wrap in a span so the tooltip shows while disabled. Test asserts the title attr when disabled.
+- [ ] **Step 11.5:** Run all four test files → PASS. Commit: `git commit -m "feat(ui): ConfirmDialog replaces native confirm; consistent selects; create-page hint"`.
+
+---
+
+### Task 12: Frontend — copy sweep (terminology, locale, pluralization, labels, misc visibility)
+
+**Files / exact changes** (update each component's colocated test where the string is asserted; failing-first for the behavioral ones):
+
+- [ ] **Step 12.1:** Terminology "article"→"page" in user-facing strings:
+  - `PageViewPage.tsx`: "Article not found"→"Page not found"; "The selected page is unavailable…" keep; toasts "Article deleted."→handled in Task 11; line 786 "Was this article helpful?"→"Was this page helpful?".
+  - `TrashPage.tsx`: header sub "Deleted pages are automatically purged 30 days after deletion"; empty state "No pages in trash" / "Deleted local pages will appear here".
+  - `KPICards.tsx`: "Total Articles"→"Total Pages".
+  - `GraphPage.tsx` (~643): "start from one article"→"start from one page"; "that article and its closest neighbours"→"that page and its closest neighbors".
+  - Editor toolbar aria label "Article editor toolbar"→"Page editor toolbar" (locate via grep).
+  - ArticleRightPane "No headings in this article."→"No headings on this page." (locate via grep `No headings`).
+- [ ] **Step 12.2:** Locale en-US: `frontend/src/features/ai/ask-example-prompts.ts:9` "Summarise"→"Summarize". Grep the whole frontend for `ise\b` British forms (`summarise|organise|colour|neighbour|favourite`) and fix any user-facing hits.
+- [ ] **Step 12.3:** `SidebarTreeView.tsx` (~743): `{treeData.total} {treeData.total === 1 ? 'page' : 'pages'}{…}`.
+- [ ] **Step 12.4:** `KPICards.tsx`: add `title={fullLabel}` to each card label and let labels wrap to two lines (`line-clamp-2` instead of truncate) so "Embedding Coverage" isn't cut to "Embedding Co...".
+- [ ] **Step 12.5:** `UsersAdminPage.tsx`: compute `const showEmail = data.users.some((u) => u.email);` — render the Email column header/cells only when true.
+- [ ] **Step 12.6:** Helpful-widget author visibility (`PageViewPage.tsx` ~786): hide the feedback block when the page is standalone and `page.createdByUserId === currentUser.id` (check the page payload field name via the contracts schema; if absent, skip silently and note in PR).
+- [ ] **Step 12.7:** Settings unknown route: read `frontend/src/features/settings/SettingsPanelRoute.tsx`; replace the silent redirect-to-first-item fallback for an unrecognized `/settings/<a>/<b>` with a small panel: "This settings page doesn't exist." + link "Go to Settings" (`firstVisiblePath()`). Keep `/settings` index redirect behavior. Failing-first test with an unknown route via MemoryRouter.
+- [ ] **Step 12.8:** Registration form (`frontend/src/features/settings/LoginPage.tsx`): in register mode add a "Confirm password" input (same styling), hint text "At least 8 characters" under the password field, and client-side mismatch error "Passwords don't match" blocking submit. Failing-first test: register mode, mismatched passwords ⇒ error shown, no POST; matched ⇒ POST fired.
+- [ ] **Step 12.9:** Run the full frontend suite: `cd frontend && npx vitest run`. Fix any string assertions broken by the sweep. Commit: `git commit -m "fix(ui): terminology/locale/pluralization sweep + registration confirm + settings 404 panel"`.
+
+---
+
+### Task 13: Frontend — silent EE-bundle probe + CSP hash guard
+
+**Files:**
+- Modify: `frontend/src/shared/enterprise/loader.ts` (defaultScriptLoader, lines 20-32)
+- Modify: `frontend/index.html` + `frontend/nginx-security-headers.conf` (line 12) if hash differs
+- Create: `frontend/scripts/check-csp-hash.mjs`; wire into `frontend/package.json` `"prebuild"`
+- Test: `frontend/src/shared/enterprise/loader.test.ts`
+
+- [ ] **Step 13.1:** loader: probe before injecting so CE/404 deployments emit zero console errors:
+
+```ts
+const defaultScriptLoader: ScriptLoader = async (url) => {
+  if ((window as any)[EE_UI_GLOBAL]) return;
+  const res = await fetch(url, { method: 'HEAD' });
+  const type = res.headers.get('content-type') ?? '';
+  if (!res.ok || !/javascript|ecmascript/.test(type)) {
+    throw new Error(`EE bundle not available at ${url}`);
+  }
+  await new Promise<void>((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = url;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`EE bundle failed to load from ${url}`));
+    document.head.appendChild(script);
+  });
+};
+```
+
+Update loader.test.ts mocks (it stubs the loader; add a test for the new probe path with a mocked `fetch` 404 ⇒ resolves null, no throw to caller).
+- [ ] **Step 13.2:** `check-csp-hash.mjs`: extract the first inline `<script>` body from `index.html`, compute `sha256-` base64, compare to the hash in `nginx-security-headers.conf`; exit 1 with both values printed on mismatch. Run it; if it reports mismatch, update the conf hash to the computed value. Add `"prebuild": "node scripts/check-csp-hash.mjs"` to frontend package.json.
+- [ ] **Step 13.3:** Run `node scripts/check-csp-hash.mjs` (must pass) and `npx vitest run src/shared/enterprise/loader.test.ts` → PASS. Commit: `git commit -m "fix(enterprise): probe EE bundle silently; guard CSP hash at build time"`.
+
+---
+
+### Task 14: Quality gates + EE rebuild + live visual verification
+
+- [ ] **Step 14.1:** CE gates: `npm run lint && npm run typecheck && npm test` from the CE root — all green.
+- [ ] **Step 14.2:** Point the EE submodule at the branch: in `/home/simon/Documents/Compendiq/compendiq-ee/ce`, `git fetch /home/simon/Documents/Compendiq/compendiq-ce feature/ux-review-fixes && git checkout FETCH_HEAD`. Rebuild + restart: `./scripts/build-enterprise.sh --skip-obfuscate`, `cd build && docker build -f docker/Dockerfile.enterprise -t ghcr.io/compendiq/compendiq-ee-backend:dev . && cd ..`, `docker compose --env-file .env -f docker/docker-compose.ee.yml up -d --force-recreate backend`. **The frontend container runs the registry CE image — for frontend verification run the Vite dev server against the EE backend** (`cd compendiq-ce && npm run dev -w frontend` with proxy to :3053) or build the frontend image locally; choose whichever the compose/vite config makes cheaper (check `frontend/vite.config.ts` proxy target env var).
+- [ ] **Step 14.3:** Playwright pass mirroring the review: license page shows "expired on May 15 2026"; banner says `LLM provider "LMStudio" is unreachable`; AI page 403 → visible chat error (test with a fresh `user`-role account); models error chip; tree no longer lists other users' private pages; deleted page appears in Trash and restores; `__system__` absent from Access Control; no console errors on page load (CSP + enterprise.js gone); registration confirm-password; "1 page in TESTING" pluralized. Screenshot each.
+- [ ] **Step 14.4:** Run the overlay suites per EE CLAUDE.md (`cd build/backend && npm test && npm run test:overlay`) to prove the CE changes don't break EE.
+- [ ] **Step 14.5:** Final commit of any verification fixes; do not push (user pushes per global config).
+
+---
+
+### Task 15: Confluence integration test container
+
+Infra exists: `docker/docker-compose.confluence.yml` (Confluence DC 9.2.14 + Postgres 16, ports 127.0.0.1:8090/8091) and `e2e/confluence-sync.spec.ts` (skips unless `E2E_CONFLUENCE_URL` + `E2E_CONFLUENCE_PAT`). Confluence DC requires a license to finish setup — use an Atlassian **DC timebomb license** (developer.atlassian.com → "Timebomb licenses for testing Data Center apps"; the 72-hour DC license is fine for dev).
+
+- [ ] **Step 15.1:** `docker network inspect compendiq_backend-net >/dev/null 2>&1 || docker network create compendiq_backend-net` (compose declares it external), then `docker compose -f docker/docker-compose.confluence.yml up -d` and wait for `curl -fsS http://localhost:8090/status` to return `{"state":"FIRST_RUN"}` (startup takes minutes; JVM 2 GB).
+- [ ] **Step 15.2:** Drive the setup wizard at `http://localhost:8090` with Playwright (non-clustered "Production installation", paste timebomb license, built-in user directory, admin user `admin`/dev-only password from `docker/.env` — add `CONFLUENCE_ADMIN_PASSWORD=` entry, never commit a real secret). If the wizard markup resists automation, document the 5 manual clicks in the doc from Step 15.4 and continue manually once.
+- [ ] **Step 15.3:** In Confluence: create space `TEST` with 2-3 pages (one with a code block + task list to exercise the content pipeline), then create a PAT: profile → Personal Access Tokens → "compendiq-e2e". Export `E2E_CONFLUENCE_URL=http://localhost:8090 E2E_CONFLUENCE_PAT=<token>` and run `npx playwright test e2e/confluence-sync.spec.ts` — expect green.
+- [ ] **Step 15.4:** Write `docs/confluence-test-container.md`: how to start/stop, license note, PAT creation, env vars, what the e2e covers, and that the backend container reaches it via `compendiq_backend-net` as `http://confluence:8090`. Mention `e2e/confluence-sync-mock.spec.ts` as the CI-safe variant. Commit: `git commit -m "docs(e2e): Confluence test container runbook + verified sync e2e"`.
+- [ ] **Step 15.5:** Use the live instance for one end-to-end verification of Task 1: connect the PAT in the app, sync space TEST, confirm synced pages appear in tree/search/stats consistently for the syncing user.
+
+---
+
+## Self-review notes
+
+- Spec coverage: license expiry (T6), AI silent 403 + models spinner + summary promise (T9), provider banner naming + compactness (T8), tree/search/stats consistency (T1, T2; search already filters), trash triple-contradiction (T3, T5, T11 copy), `__system__` (T4), embedding-dimensions 404 (T10), enterprise.js + CSP console noise (T13), confirm()/selects/tooltip (T11), terminology/locale/plural/truncation/email-column/helpful-widget/settings-404/registration (T12), edition labels (T7), Confluence container (T15), live verification incl. heartbeat-404 check (T14). Post-delete heartbeat noise: navigation in Task 11's new flow happens after the mutation resolves and presence unmounts — verify in T14.3; if 404s persist, stop the heartbeat on 404 response in the presence hook (one-line guard).
+- The provider Test button already has toast feedback per code; T14.3 re-checks it live — only fix if reproducibly silent.
+- Type consistency: `TrashItem` (T5) matches T3's response; `isError` message flag (T9) is local to the AI feature types.

--- a/e2e/confluence-sync.spec.ts
+++ b/e2e/confluence-sync.spec.ts
@@ -122,46 +122,38 @@ test.describe('Confluence sync flow', () => {
       page.getByText(/saved|success/i).first(),
     ).toBeVisible({ timeout: 10_000 });
 
-    // Switch to the Sync tab to trigger sync
-    await page.getByText('Sync').first().click();
-    await page.waitForLoadState('domcontentloaded');
+    // Go to Knowledge → Spaces & Sync and discover spaces from Confluence
+    await page.goto('/settings/knowledge/spaces');
+    await page.getByRole('button', { name: /Fetch Spaces/i }).click();
 
-    // Look for a sync trigger button
-    const syncBtn = page
-      .getByRole('button', { name: /sync now|start sync|trigger sync/i })
-      .or(page.getByTestId('sync-trigger-btn'));
+    // At least one remote space appears as a selectable row ("Select <name>")
+    const selectSpaceBtn = page.getByRole('button', { name: /^Select / });
+    await expect(selectSpaceBtn.first()).toBeVisible({ timeout: 15_000 });
 
-    if (await syncBtn.first().waitFor({ state: 'visible', timeout: 5_000 }).then(() => true).catch(() => false)) {
-      await syncBtn.first().click();
+    // Select the first discovered space and persist the selection
+    await selectSpaceBtn.first().click();
+    await page.getByRole('button', { name: /Save Selection/i }).click();
 
-      // Verify that sync started (status changes or progress indicator appears)
-      const syncStatus = page
-        .getByText(/syncing|in progress|started/i)
-        .or(page.locator('[data-testid="sync-status"]'));
+    // Trigger the first sync for the selected space
+    const syncSelected = page.getByRole('button', { name: /Sync Selected/i });
+    await expect(syncSelected).toBeEnabled({ timeout: 10_000 });
+    await syncSelected.click();
 
-      await expect(syncStatus.first()).toBeVisible({ timeout: 10_000 });
-    }
+    // Sync completion is reflected by the space row gaining a "Synced: <date>"
+    // stamp (sync of the small fixture space takes seconds)
+    await expect(
+      page.getByText(/Synced: \d/).first(),
+    ).toBeVisible({ timeout: 60_000 });
 
-    // Switch to the Spaces tab to verify spaces were discovered
-    await page.getByText('Spaces').first().click();
-    await page.waitForLoadState('networkidle');
-
-    // After a successful connection, at least one Confluence space should appear
-    // Allow extra time because space fetching may be async
-    const spaceItem = page
-      .locator('[data-testid="space-item"]')
-      .or(page.getByRole('checkbox'))
-      .or(page.locator('label').filter({ hasText: /.+/ }));
-
-    const hasSpaces = await spaceItem
-      .first()
-      .waitFor({ state: 'visible', timeout: 10_000 })
-      .then(() => true)
-      .catch(() => false);
-
-    // Spaces appearing confirms the connection is working end-to-end.
-    // If the Confluence instance has spaces, at least one must be visible.
-    expect(hasSpaces).toBe(true);
+    // End-to-end proof: synced Confluence pages are served to the user
+    const pages = await page.request.get('/api/pages?source=confluence', {
+      headers: { Authorization: `Bearer ${authToken}` },
+    });
+    expect(pages.ok()).toBe(true);
+    const body = await pages.json();
+    const items = body.items ?? body.pages ?? [];
+    expect(Array.isArray(items)).toBe(true);
+    expect(items.length).toBeGreaterThan(0);
   });
 
   test('saves Confluence URL and displays it after page reload', async ({ page }) => {

--- a/e2e/pdf-export.spec.ts
+++ b/e2e/pdf-export.spec.ts
@@ -81,7 +81,7 @@ test.describe('PDF export', () => {
     // The Export PDF button is in the article right pane (ArticleRightPane)
     // It may be in a collapsed sidebar; expand it if needed
     const expandBtn = page
-      .getByLabel('Expand article sidebar')
+      .getByLabel('Expand page sidebar')
       .or(page.getByTestId('article-right-pane-rail'));
 
     if (await expandBtn.waitFor({ state: 'visible', timeout: 3_000 }).then(() => true).catch(() => false)) {
@@ -167,7 +167,7 @@ test.describe('PDF export', () => {
 
     // Expand sidebar if collapsed
     const expandBtn = page
-      .getByLabel('Expand article sidebar')
+      .getByLabel('Expand page sidebar')
       .or(page.getByTestId('article-right-pane-rail'));
 
     if (await expandBtn.waitFor({ state: 'visible', timeout: 3_000 }).then(() => true).catch(() => false)) {

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,6 +25,11 @@ RUN --mount=type=cache,target=/root/.npm npm ci -w frontend -w @compendiq/contra
 COPY packages/contracts/ ./packages/contracts/
 RUN npm run build -w @compendiq/contracts
 COPY frontend/index.html frontend/vite.config.ts frontend/tsconfig.json frontend/tsconfig.node.json ./frontend/
+# The prebuild CSP-hash guard (scripts/check-csp-hash.mjs) compares the
+# index.html inline script against nginx-security-headers.conf, so both
+# must exist in the builder stage, not just the runtime image.
+COPY frontend/scripts/ frontend/scripts/
+COPY frontend/nginx-security-headers.conf ./frontend/
 COPY frontend/public/ frontend/public/
 COPY frontend/src/ frontend/src/
 # Build-time metadata (edition + commit hash). Ships as a committed

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -21,6 +21,16 @@ export default tseslint.config(
     },
   },
   {
+    // Build-time Node scripts (e.g. the CSP hash prebuild guard).
+    files: ['scripts/**/*.mjs'],
+    languageOptions: {
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+      },
+    },
+  },
+  {
     ignores: ['dist/', 'node_modules/', '*.config.*'],
   },
 );

--- a/frontend/nginx-security-headers.conf
+++ b/frontend/nginx-security-headers.conf
@@ -9,4 +9,4 @@ add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 # CSP: style-src 'unsafe-inline' required by Tailwind/Framer Motion runtime styles.
 # frame-src 'self' allows the self-hosted draw.io editor iframe.
 # script-src hash allows the inline FOUC-prevention theme script in index.html.
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-eudeDuhgMa9OYhabnxIyl2MR8PrzSHEAZOfLayvWRGI='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; font-src 'self' data:; frame-src 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-ObJ5XWyIAGJaK9GxB9+uDb//dIlE11VIM8RlldPLYIw='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; font-src 'self' data:; frame-src 'self';" always;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/check-csp-hash.mjs",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "lint": "eslint --max-warnings=0 src/",

--- a/frontend/scripts/check-csp-hash.mjs
+++ b/frontend/scripts/check-csp-hash.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Build guard: verify that the CSP script-src hash in
+ * nginx-security-headers.conf matches the inline FOUC-prevention script in
+ * index.html.
+ *
+ * The hash is hand-maintained in the nginx conf; if the inline script changes
+ * without a hash update, browsers silently refuse to run it in production
+ * (no FOUC protection, no console hint). This script fails the build instead.
+ *
+ * CSP hashes cover the EXACT bytes between <script> and </script> — no
+ * trimming or normalization. Wired as the `prebuild` npm script.
+ */
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const frontendDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const indexHtmlPath = resolve(frontendDir, 'index.html');
+const nginxConfPath = resolve(frontendDir, 'nginx-security-headers.conf');
+
+const html = readFileSync(indexHtmlPath, 'utf8');
+
+// First inline <script> (no src attribute) — the FOUC-prevention theme script.
+const inlineScript = /<script(?![^>]*\bsrc\s*=)[^>]*>([\s\S]*?)<\/script>/.exec(html);
+if (!inlineScript) {
+  console.error(`ERROR: no inline <script> found in ${indexHtmlPath}`);
+  process.exit(1);
+}
+
+const expected = `sha256-${createHash('sha256').update(inlineScript[1], 'utf8').digest('base64')}`;
+
+// Drop nginx comment lines so "script-src" in prose doesn't shadow the directive.
+const conf = readFileSync(nginxConfPath, 'utf8')
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('#'))
+  .join('\n');
+const scriptSrc = /script-src[^;]*/.exec(conf);
+if (!scriptSrc) {
+  console.error(`ERROR: no script-src directive found in ${nginxConfPath}`);
+  process.exit(1);
+}
+
+const found = /'(sha256-[A-Za-z0-9+/=]+)'/.exec(scriptSrc[0]);
+if (!found) {
+  console.error(`ERROR: no 'sha256-...' token in the script-src directive of ${nginxConfPath}`);
+  process.exit(1);
+}
+
+if (found[1] !== expected) {
+  console.error('ERROR: CSP script-src hash is stale — the inline script in index.html changed.');
+  console.error(`  expected (computed from index.html): '${expected}'`);
+  console.error(`  found (nginx-security-headers.conf): '${found[1]}'`);
+  console.error(`Update the hash in ${nginxConfPath} to the expected value.`);
+  process.exit(1);
+}
+
+console.log(`OK: CSP script-src hash matches index.html inline script ('${expected}')`);

--- a/frontend/scripts/check-csp-hash.mjs
+++ b/frontend/scripts/check-csp-hash.mjs
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 /**
- * Build guard: verify that the CSP script-src hash in
- * nginx-security-headers.conf matches the inline FOUC-prevention script in
- * index.html.
+ * Build guard: verify that the CSP script-src hashes in
+ * nginx-security-headers.conf match the inline <script> blocks in index.html
+ * (currently only the FOUC-prevention theme script).
  *
- * The hash is hand-maintained in the nginx conf; if the inline script changes
- * without a hash update, browsers silently refuse to run it in production
- * (no FOUC protection, no console hint). This script fails the build instead.
+ * The hashes are hand-maintained in the nginx conf; if an inline script
+ * changes without a hash update, browsers silently refuse to run it in
+ * production (no FOUC protection, no console hint). This script fails the
+ * build instead. It checks both directions: every inline script must have a
+ * matching hash in the conf, and the conf must carry no orphan (stale)
+ * hashes.
  *
  * CSP hashes cover the EXACT bytes between <script> and </script> — no
  * trimming or normalization. Wired as the `prebuild` npm script.
@@ -22,14 +25,18 @@ const nginxConfPath = resolve(frontendDir, 'nginx-security-headers.conf');
 
 const html = readFileSync(indexHtmlPath, 'utf8');
 
-// First inline <script> (no src attribute) — the FOUC-prevention theme script.
-const inlineScript = /<script(?![^>]*\bsrc\s*=)[^>]*>([\s\S]*?)<\/script>/.exec(html);
-if (!inlineScript) {
+// All inline <script> blocks (no src attribute).
+const inlineScripts = [...html.matchAll(/<script(?![^>]*\bsrc\s*=)[^>]*>([\s\S]*?)<\/script>/g)].map(
+  (m) => m[1],
+);
+if (inlineScripts.length === 0) {
   console.error(`ERROR: no inline <script> found in ${indexHtmlPath}`);
   process.exit(1);
 }
 
-const expected = `sha256-${createHash('sha256').update(inlineScript[1], 'utf8').digest('base64')}`;
+const expectedHashes = inlineScripts.map(
+  (body) => `sha256-${createHash('sha256').update(body, 'utf8').digest('base64')}`,
+);
 
 // Drop nginx comment lines so "script-src" in prose doesn't shadow the directive.
 const conf = readFileSync(nginxConfPath, 'utf8')
@@ -42,18 +49,42 @@ if (!scriptSrc) {
   process.exit(1);
 }
 
-const found = /'(sha256-[A-Za-z0-9+/=]+)'/.exec(scriptSrc[0]);
-if (!found) {
+const confHashes = [...scriptSrc[0].matchAll(/'(sha256-[A-Za-z0-9+/=]+)'/g)].map((m) => m[1]);
+if (confHashes.length === 0) {
   console.error(`ERROR: no 'sha256-...' token in the script-src directive of ${nginxConfPath}`);
   process.exit(1);
 }
 
-if (found[1] !== expected) {
-  console.error('ERROR: CSP script-src hash is stale — the inline script in index.html changed.');
-  console.error(`  expected (computed from index.html): '${expected}'`);
-  console.error(`  found (nginx-security-headers.conf): '${found[1]}'`);
-  console.error(`Update the hash in ${nginxConfPath} to the expected value.`);
+let failed = false;
+
+// Every inline script needs a hash in the conf.
+expectedHashes.forEach((hash, i) => {
+  if (!confHashes.includes(hash)) {
+    failed = true;
+    const preview = inlineScripts[i].trim().split('\n')[0].slice(0, 70);
+    console.error(
+      `ERROR: inline script #${i + 1} in index.html (starts: ${JSON.stringify(preview)}) has no matching CSP hash.`,
+    );
+    console.error(`  expected in script-src: '${hash}'`);
+  }
+});
+
+// Every conf hash must correspond to an inline script (no stale leftovers).
+const orphans = confHashes.filter((hash) => !expectedHashes.includes(hash));
+if (orphans.length > 0) {
+  failed = true;
+  console.error(
+    `ERROR: script-src in ${nginxConfPath} contains hash(es) matching no inline script in index.html (stale): ${orphans
+      .map((h) => `'${h}'`)
+      .join(', ')}`,
+  );
+}
+
+if (failed) {
+  console.error(`Update the 'sha256-...' token(s) in ${nginxConfPath} to match index.html.`);
   process.exit(1);
 }
 
-console.log(`OK: CSP script-src hash matches index.html inline script ('${expected}')`);
+console.log(
+  `OK: ${inlineScripts.length} inline script hash(es) in index.html match script-src in nginx-security-headers.conf`,
+);

--- a/frontend/src/features/admin/LicenseStatusCard.test.tsx
+++ b/frontend/src/features/admin/LicenseStatusCard.test.tsx
@@ -220,8 +220,9 @@ describe('LicenseStatusCard', () => {
     expect(screen.getAllByText('Expired').length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText('Free')).not.toBeInTheDocument();
 
-    // Banner explains the expiry with the locale-formatted date
-    const expiredDateText = new Date('2026-05-15T23:59:59.999Z').toLocaleDateString();
+    // Banner explains the expiry with the locale-formatted date (UTC — the
+    // key string encodes a UTC date, so the display must not shift by TZ)
+    const expiredDateText = new Date('2026-05-15T23:59:59.999Z').toLocaleDateString(undefined, { timeZone: 'UTC' });
     const banner = screen.getByTestId('license-expired-banner');
     expect(banner.textContent).toContain('expired on');
     expect(banner.textContent).toContain(expiredDateText);

--- a/frontend/src/features/admin/LicenseStatusCard.test.tsx
+++ b/frontend/src/features/admin/LicenseStatusCard.test.tsx
@@ -91,6 +91,26 @@ describe('LicenseStatusCard', () => {
     expect(screen.getByText('50')).toBeInTheDocument();
   });
 
+  it('renders the stats-grid expiry date formatted in UTC', async () => {
+    // '2027-12-31T23:59:59.999Z' is Jan 1 in east-of-UTC locales when
+    // formatted in local time — the card must format in UTC.
+    mockFetch({
+      edition: 'enterprise',
+      tier: 'enterprise',
+      seats: 50,
+      expiresAt: '2027-12-31T23:59:59.999Z',
+      features: ['oidc'],
+      valid: true,
+      canUpdate: true,
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    await screen.findByText('Enterprise Edition');
+    const utcDateText = new Date('2027-12-31T23:59:59.999Z').toLocaleDateString(undefined, { timeZone: 'UTC' });
+    expect(screen.getByText(utcDateText)).toBeInTheDocument();
+  });
+
   it('shows feature availability based on license', async () => {
     mockFetch({
       edition: 'enterprise',

--- a/frontend/src/features/admin/LicenseStatusCard.test.tsx
+++ b/frontend/src/features/admin/LicenseStatusCard.test.tsx
@@ -198,6 +198,101 @@ describe('LicenseStatusCard', () => {
     expect(screen.getByTestId('license-key-clear-btn')).toBeInTheDocument();
   });
 
+  it('surfaces expired state when stored key is invalid with past expiry', async () => {
+    // Real EE response shape: stored key expired → tier falls back to
+    // community but displayKey/expiresAt are still reported.
+    mockFetch({
+      edition: 'community',
+      tier: 'community',
+      seats: 10,
+      expiresAt: '2026-05-15T23:59:59.999Z',
+      features: [],
+      valid: false,
+      canUpdate: true,
+      displayKey: 'ATM-enterprise-10-20260515-CPQ6ddb3390.****',
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    await screen.findByText('Community Edition');
+
+    // Badge reads "Expired", not the misleading "Free"
+    expect(screen.getAllByText('Expired').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('Free')).not.toBeInTheDocument();
+
+    // Banner explains the expiry with the locale-formatted date
+    const expiredDateText = new Date('2026-05-15T23:59:59.999Z').toLocaleDateString();
+    const banner = screen.getByTestId('license-expired-banner');
+    expect(banner.textContent).toContain('expired on');
+    expect(banner.textContent).toContain(expiredDateText);
+
+    // Stats grid stays visible despite the community fallback tier so the
+    // admin can see what the stored key granted (seats + expiry date).
+    expect(screen.getByText('Licensed Seats')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+    // Date appears in both the banner and the stats grid
+    expect(screen.getAllByText(expiredDateText).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('surfaces invalid state when stored key is invalid but not expired', async () => {
+    mockFetch({
+      edition: 'community',
+      tier: 'community',
+      seats: 10,
+      expiresAt: '2099-12-31T23:59:59.999Z',
+      features: [],
+      valid: false,
+      canUpdate: true,
+      displayKey: 'ATM-enterprise-10-20991231-CPQ6ddb3390.****',
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    await screen.findByText('Community Edition');
+
+    expect(screen.getByText('Invalid')).toBeInTheDocument();
+    expect(screen.queryByText('Free')).not.toBeInTheDocument();
+
+    const banner = screen.getByTestId('license-expired-banner');
+    expect(banner.textContent).toContain('invalid');
+    expect(banner.textContent).not.toContain('expired on');
+  });
+
+  it('does not show invalid-key banner for a valid enterprise license', async () => {
+    mockFetch({
+      edition: 'enterprise',
+      tier: 'enterprise',
+      seats: 50,
+      expiresAt: '2027-12-31T23:59:59.999Z',
+      features: ['oidc'],
+      valid: true,
+      canUpdate: true,
+      displayKey: 'ATM-enterprise-50-20271231-CPQ1a2b3c4d.****',
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    await screen.findByText('Enterprise Edition');
+    expect(screen.getAllByText('Active').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByTestId('license-expired-banner')).not.toBeInTheDocument();
+  });
+
+  it('shows Free badge and no banner for community with no stored key', async () => {
+    mockFetch({
+      edition: 'community',
+      tier: 'community',
+      features: [],
+      valid: false,
+      canUpdate: true,
+    });
+
+    render(<LicenseStatusCard />, { wrapper: createWrapper() });
+
+    await screen.findByText('Community Edition');
+    expect(screen.getByText('Free')).toBeInTheDocument();
+    expect(screen.queryByTestId('license-expired-banner')).not.toBeInTheDocument();
+  });
+
   it('sends PUT /admin/license when Save is clicked', async () => {
     const savedLicense = {
       edition: 'enterprise',

--- a/frontend/src/features/admin/LicenseStatusCard.tsx
+++ b/frontend/src/features/admin/LicenseStatusCard.tsx
@@ -202,8 +202,10 @@ export function LicenseStatusCard() {
             key string. */}
         {storedKeyInvalid && (
           <div className="border-t border-destructive/30 bg-destructive/10 px-5 py-3 text-sm" data-testid="license-expired-banner">
+            {/* The key encodes the expiry as a UTC date — format in UTC so
+                east-of-UTC locales don't display a day-late date. */}
             {isExpired ? (
-              <>Your stored license key expired on <strong>{expiredDate!.toLocaleDateString()}</strong>. Enterprise features are locked until a new key is saved.</>
+              <>Your stored license key expired on <strong>{expiredDate!.toLocaleDateString(undefined, { timeZone: 'UTC' })}</strong>. Enterprise features are locked until a new key is saved.</>
             ) : (
               <>The stored license key is invalid. Enterprise features are locked until a valid key is saved.</>
             )}
@@ -227,7 +229,7 @@ export function LicenseStatusCard() {
                 {isExpired ? 'Expired' : 'Expires'}
               </div>
               <div className="mt-1 text-xl font-semibold">
-                {data?.expiresAt ? new Date(data.expiresAt).toLocaleDateString() : 'N/A'}
+                {data?.expiresAt ? new Date(data.expiresAt).toLocaleDateString(undefined, { timeZone: 'UTC' }) : 'N/A'}
               </div>
             </div>
           </div>

--- a/frontend/src/features/admin/LicenseStatusCard.tsx
+++ b/frontend/src/features/admin/LicenseStatusCard.tsx
@@ -95,6 +95,12 @@ export function LicenseStatusCard() {
   const isValid = data?.valid === true;
   const canUpdate = data?.canUpdate === true;
   const hasStoredKey = Boolean(data?.displayKey && data.displayKey.length > 0);
+  // A stored key that the backend rejects deserves a loud explanation —
+  // otherwise the admin sees "Community — Free" and has to decode the
+  // expiry date out of the masked key string.
+  const storedKeyInvalid = hasStoredKey && !isValid;
+  const expiredDate = data?.expiresAt ? new Date(data.expiresAt) : null;
+  const isExpired = storedKeyInvalid && expiredDate !== null && expiredDate.getTime() < Date.now();
 
   const handleSave = () => {
     const trimmed = keyInput.trim();
@@ -109,7 +115,7 @@ export function LicenseStatusCard() {
     <div className="space-y-6" data-testid="license-status">
       <PanelHeader
         title="License"
-        subtitle="Current tier and the enterprise features each tier unlocks."
+        subtitle="License tier and the enterprise features each tier unlocks."
       />
 
       {/* Community-upgrade CTA promoted to top: in CE the admin is most
@@ -164,11 +170,17 @@ export function LicenseStatusCard() {
                 <span className="text-lg font-semibold">{config.label} Edition</span>
                 <span className={cn(
                   'inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium',
-                  config.borderColor,
-                  config.bgColor,
-                  config.color,
+                  storedKeyInvalid
+                    ? 'border-destructive/30 bg-destructive/10 text-destructive'
+                    : [config.borderColor, config.bgColor, config.color],
                 )}>
-                  {isValid ? 'Active' : isCommunity ? 'Free' : 'Inactive'}
+                  {isValid
+                    ? 'Active'
+                    : storedKeyInvalid
+                      ? (isExpired ? 'Expired' : 'Invalid')
+                      : isCommunity
+                        ? 'Free'
+                        : 'Inactive'}
                 </span>
               </div>
               {isCommunity && !canUpdate && (
@@ -185,8 +197,22 @@ export function LicenseStatusCard() {
           </div>
         </div>
 
-        {/* Stats */}
-        {!isCommunity && (
+        {/* Invalid stored key — explain WHY the tier fell back to community
+            instead of leaving the admin to decode the date from the masked
+            key string. */}
+        {storedKeyInvalid && (
+          <div className="border-t border-destructive/30 bg-destructive/10 px-5 py-3 text-sm" data-testid="license-expired-banner">
+            {isExpired ? (
+              <>Your stored license key expired on <strong>{expiredDate!.toLocaleDateString()}</strong>. Enterprise features are locked until a new key is saved.</>
+            ) : (
+              <>The stored license key is invalid. Enterprise features are locked until a valid key is saved.</>
+            )}
+          </div>
+        )}
+
+        {/* Stats — also shown when an (invalid) key is stored so the admin
+            can see what that key granted. */}
+        {(!isCommunity || hasStoredKey) && (
           <div className="grid grid-cols-2 gap-px border-t border-border/40 bg-border/40">
             <div className="bg-card p-4">
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -198,7 +224,7 @@ export function LicenseStatusCard() {
             <div className="bg-card p-4">
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <Calendar size={12} />
-                Expires
+                {isExpired ? 'Expired' : 'Expires'}
               </div>
               <div className="mt-1 text-xl font-semibold">
                 {data?.expiresAt ? new Date(data.expiresAt).toLocaleDateString() : 'N/A'}

--- a/frontend/src/features/admin/SyncConflictPolicyTab.tsx
+++ b/frontend/src/features/admin/SyncConflictPolicyTab.tsx
@@ -91,7 +91,7 @@ const POLICY_OPTIONS: readonly PolicyOption[] = [
     value: 'confluence-wins',
     label: 'Confluence wins',
     description:
-      'When a Confluence-side change differs from a local edit, the Confluence version is applied and the local change is discarded. This is the legacy behaviour.',
+      'When a Confluence-side change differs from a local edit, the Confluence version is applied and the local change is discarded. This is the legacy behavior.',
     warning:
       'Local edits made between syncs will be silently overwritten on the next sync.',
   },

--- a/frontend/src/features/admin/UsersAdminPage.test.tsx
+++ b/frontend/src/features/admin/UsersAdminPage.test.tsx
@@ -144,7 +144,7 @@ describe('UsersAdminPage', () => {
 
     fireEvent.click(screen.getByText('Delete'));
 
-    // ConfirmDialog replaces window.confirm — user deletion really IS permanent.
+    // ConfirmDialog replaces native confirm() — user deletion really IS permanent.
     expect(await screen.findByText('Permanently delete "bob"?')).toBeInTheDocument();
     expect(screen.getByText('This cannot be undone.')).toBeInTheDocument();
     expect(screen.getByTestId('confirm-dialog-confirm')).toHaveTextContent('Delete user');

--- a/frontend/src/features/admin/UsersAdminPage.test.tsx
+++ b/frontend/src/features/admin/UsersAdminPage.test.tsx
@@ -60,11 +60,16 @@ const mockUsers = [
   },
 ];
 
+// Mutable list returned by the fetch mock — tests can override before render
+// (e.g. to simulate an instance where no user has an email address).
+let mockUsersList: typeof mockUsers = mockUsers;
+
 describe('UsersAdminPage', () => {
   beforeEach(() => {
     // Default: bulk feature OFF. Tests that need the bulk UI flip this
     // before render.
     mockHasFeature = () => false;
+    mockUsersList = mockUsers;
 
     // Pretend we're logged in as alice so self-actions are hidden.
     useAuthStore.setState({
@@ -79,7 +84,7 @@ describe('UsersAdminPage', () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
       const url = typeof input === 'string' ? input : (input as Request).url;
       if (url.endsWith('/api/admin/users') && (input as Request).method !== 'POST') {
-        return new Response(JSON.stringify({ users: mockUsers }), {
+        return new Response(JSON.stringify({ users: mockUsersList }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         });
@@ -189,6 +194,24 @@ describe('UsersAdminPage', () => {
     expect(roleSelect.tagName).toBe('SELECT');
     expect(roleSelect.className).toContain('nm-select-md');
     expect(roleSelect).toHaveValue('user');
+  });
+
+  it('shows the Email column when at least one user has an email', async () => {
+    render(<UsersAdminPage />, { wrapper: createWrapper() });
+    await waitFor(() => screen.getByText('alice'));
+
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+  });
+
+  it('hides the Email column entirely when no user has an email', async () => {
+    mockUsersList = mockUsers.map((u) => ({ ...u, email: null })) as unknown as typeof mockUsers;
+    render(<UsersAdminPage />, { wrapper: createWrapper() });
+    await waitFor(() => screen.getByText('alice'));
+
+    // Neither the header nor the "—" placeholder cells render.
+    expect(screen.queryByText('Email')).not.toBeInTheDocument();
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
   });
 
   // ── EE #116 — bulk UI gating ───────────────────────────────────────────

--- a/frontend/src/features/admin/UsersAdminPage.test.tsx
+++ b/frontend/src/features/admin/UsersAdminPage.test.tsx
@@ -133,6 +133,64 @@ describe('UsersAdminPage', () => {
     expect(screen.getByText('Create', { selector: 'button[type="submit"]' })).toBeInTheDocument();
   });
 
+  it('delete opens a ConfirmDialog naming the user; confirming sends the DELETE', async () => {
+    render(<UsersAdminPage />, { wrapper: createWrapper() });
+    await waitFor(() => screen.getByText('bob'));
+
+    fireEvent.click(screen.getByText('Delete'));
+
+    // ConfirmDialog replaces window.confirm — user deletion really IS permanent.
+    expect(await screen.findByText('Permanently delete "bob"?')).toBeInTheDocument();
+    expect(screen.getByText('This cannot be undone.')).toBeInTheDocument();
+    expect(screen.getByTestId('confirm-dialog-confirm')).toHaveTextContent('Delete user');
+
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+
+    await waitFor(() => {
+      const deleteCall = vi
+        .mocked(globalThis.fetch)
+        .mock.calls.find(
+          ([input, init]) =>
+            String(input).includes('/api/admin/users/bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb') &&
+            init?.method === 'DELETE',
+        );
+      expect(deleteCall).toBeDefined();
+    });
+    // Dialog closes after confirm
+    await waitFor(() => {
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('cancelling the delete ConfirmDialog does not send a DELETE', async () => {
+    render(<UsersAdminPage />, { wrapper: createWrapper() });
+    await waitFor(() => screen.getByText('bob'));
+
+    fireEvent.click(screen.getByText('Delete'));
+    await screen.findByTestId('confirm-dialog');
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+    });
+    const deleteCall = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.find(([, init]) => init?.method === 'DELETE');
+    expect(deleteCall).toBeUndefined();
+  });
+
+  it('styles the role select with the design-system nm-select-md utility', async () => {
+    render(<UsersAdminPage />, { wrapper: createWrapper() });
+    await waitFor(() => screen.getByText('bob'));
+
+    const roleSelect = screen.getByTestId(
+      'user-role-select-bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb',
+    );
+    expect(roleSelect.tagName).toBe('SELECT');
+    expect(roleSelect.className).toContain('nm-select-md');
+    expect(roleSelect).toHaveValue('user');
+  });
+
   // ── EE #116 — bulk UI gating ───────────────────────────────────────────
 
   it('does not show bulk import or select checkboxes when feature is off', async () => {

--- a/frontend/src/features/admin/UsersAdminPage.tsx
+++ b/frontend/src/features/admin/UsersAdminPage.tsx
@@ -144,6 +144,10 @@ export function UsersAdminPage() {
 
   const clearSelection = () => setSelectedUserIds(new Set());
 
+  // Hide the Email column when no user has an email address (common on
+  // instances without SMTP) — a column of "—" placeholders is just noise.
+  const showEmailColumn = (data?.users ?? []).some((u) => !!u.email);
+
   return (
     <section className="space-y-6">
       <header className="flex items-start justify-between gap-4">
@@ -223,7 +227,7 @@ export function UsersAdminPage() {
                   </th>
                 )}
                 <th className="p-3">Username</th>
-                <th className="p-3">Email</th>
+                {showEmailColumn && <th className="p-3">Email</th>}
                 <th className="p-3">Role</th>
                 <th className="p-3">Status</th>
                 <th className="p-3 text-right">Actions</th>
@@ -249,7 +253,9 @@ export function UsersAdminPage() {
                     <div className="font-medium">{u.username}</div>
                     {u.displayName && <div className="text-xs text-muted-foreground">{u.displayName}</div>}
                   </td>
-                  <td className="p-3 text-muted-foreground">{u.email ?? '—'}</td>
+                  {showEmailColumn && (
+                    <td className="p-3 text-muted-foreground">{u.email ?? '—'}</td>
+                  )}
                   <td className="p-3">
                     <select
                       className="nm-select-md"

--- a/frontend/src/features/admin/UsersAdminPage.tsx
+++ b/frontend/src/features/admin/UsersAdminPage.tsx
@@ -40,7 +40,7 @@ export function UsersAdminPage() {
   const [showBulkImport, setShowBulkImport] = useState(false);
   const [showBulkAction, setShowBulkAction] = useState(false);
   const [selectedUserIds, setSelectedUserIds] = useState<Set<string>>(new Set());
-  // User awaiting delete confirmation (ConfirmDialog replaces window.confirm).
+  // User awaiting delete confirmation (ConfirmDialog replaces native confirm()).
   const [pendingDelete, setPendingDelete] = useState<AdminUser | null>(null);
 
   const { data, isLoading } = useQuery<AdminUserListResponse>({

--- a/frontend/src/features/admin/UsersAdminPage.tsx
+++ b/frontend/src/features/admin/UsersAdminPage.tsx
@@ -13,6 +13,7 @@ import { apiFetch } from '../../shared/lib/api';
 import type { AdminUser, AdminUserRole } from '@compendiq/contracts';
 import { useAuthStore } from '../../stores/auth-store';
 import { useEnterprise } from '../../shared/enterprise/use-enterprise';
+import { ConfirmDialog } from '../../shared/components/ConfirmDialog';
 import { BulkUserImportModal } from './BulkUserImportModal';
 import { UserBulkActionDialog } from './UserBulkActionDialog';
 
@@ -39,6 +40,8 @@ export function UsersAdminPage() {
   const [showBulkImport, setShowBulkImport] = useState(false);
   const [showBulkAction, setShowBulkAction] = useState(false);
   const [selectedUserIds, setSelectedUserIds] = useState<Set<string>>(new Set());
+  // User awaiting delete confirmation (ConfirmDialog replaces window.confirm).
+  const [pendingDelete, setPendingDelete] = useState<AdminUser | null>(null);
 
   const { data, isLoading } = useQuery<AdminUserListResponse>({
     queryKey: ['admin', 'users'],
@@ -249,12 +252,13 @@ export function UsersAdminPage() {
                   <td className="p-3 text-muted-foreground">{u.email ?? '—'}</td>
                   <td className="p-3">
                     <select
-                      className="rounded-md border bg-background px-2 py-1 text-xs"
+                      className="nm-select-md"
                       value={u.role}
                       disabled={u.id === currentUserId || updateRole.isPending}
                       onChange={(e) =>
                         updateRole.mutate({ id: u.id, role: e.target.value as AdminUserRole })
                       }
+                      data-testid={`user-role-select-${u.id}`}
                     >
                       <option value="user">user</option>
                       <option value="admin">admin</option>
@@ -299,11 +303,7 @@ export function UsersAdminPage() {
                       <button
                         type="button"
                         className="text-xs text-red-700 underline dark:text-red-400"
-                        onClick={() => {
-                          if (window.confirm(`Permanently delete "${u.username}"? This cannot be undone.`)) {
-                            remove.mutate(u.id);
-                          }
-                        }}
+                        onClick={() => setPendingDelete(u)}
                         disabled={remove.isPending}
                       >
                         Delete
@@ -316,6 +316,21 @@ export function UsersAdminPage() {
           </table>
         </div>
       )}
+
+      {/* Unlike page deletion (30-day trash), user deletion is permanent —
+          the copy keeps the hard "cannot be undone" warning. */}
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title={`Permanently delete "${pendingDelete?.username ?? ''}"?`}
+        description="This cannot be undone."
+        confirmLabel="Delete user"
+        destructive
+        onConfirm={() => {
+          if (pendingDelete) remove.mutate(pendingDelete.id);
+          setPendingDelete(null);
+        }}
+        onCancel={() => setPendingDelete(null)}
+      />
 
       {showCreate && (
         <UserCreateDialog

--- a/frontend/src/features/ai/AiAssistantPage.test.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.test.tsx
@@ -10,14 +10,11 @@ import { useAuthStore } from '../../stores/auth-store';
 // scrollIntoView is not available in jsdom
 Element.prototype.scrollIntoView = vi.fn();
 
-// Keep reference to original apiFetch mock to control per-test. Spread the
-// real module so the ApiError class stays available — runStream branches on
-// `err instanceof ApiError` for 403 handling.
+// Replace apiFetch with a controllable mock but keep the real ApiError class
+// available — runStream branches on `err instanceof ApiError` for 403 handling.
 const apiFetchMock = vi.fn();
-vi.mock('../../shared/lib/api', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../shared/lib/api')>()),
-  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
-}));
+vi.mock('../../shared/lib/api', async () =>
+  (await import('../../test-utils')).apiModuleMock(() => apiFetchMock));
 
 // Mock SSE module so we can control streaming behavior
 const streamSSEMock = vi.fn();

--- a/frontend/src/features/ai/AiAssistantPage.test.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.test.tsx
@@ -538,7 +538,7 @@ describe('AiAssistantPage', () => {
 
       // Verify success toast
       await waitFor(() => {
-        expect(toastSuccessMock).toHaveBeenCalledWith('Article updated and synced to Confluence');
+        expect(toastSuccessMock).toHaveBeenCalledWith('Page updated and synced to Confluence');
       });
     });
 
@@ -750,8 +750,8 @@ describe('AiAssistantPage', () => {
     });
   });
 
-  describe('diagram mode - Use in article', () => {
-    it('shows "Use in article" button after diagram generation when page is selected', async () => {
+  describe('diagram mode - Use in page', () => {
+    it('shows "Use in page" button after diagram generation when page is selected', async () => {
       mockPageData = {
         data: { id: 'p1', title: 'My Article', bodyHtml: '<p>Content</p>', bodyText: 'Content', version: 3 },
       };
@@ -794,11 +794,11 @@ describe('AiAssistantPage', () => {
 
       // Wait for stream to complete and button to appear
       await waitFor(() => {
-        expect(screen.getByText('Use in article')).toBeInTheDocument();
+        expect(screen.getByText('Use in page')).toBeInTheDocument();
       });
     });
 
-    it('does not show "Use in article" button when no page is selected', async () => {
+    it('does not show "Use in page" button when no page is selected', async () => {
       mockPageData = { data: undefined };
 
       apiFetchMock.mockImplementation((path: string) => {
@@ -820,10 +820,10 @@ describe('AiAssistantPage', () => {
       fireEvent.click(screen.getByText('Diagram'));
 
       // The button should not appear (no page context)
-      expect(screen.queryByText('Use in article')).not.toBeInTheDocument();
+      expect(screen.queryByText('Use in page')).not.toBeInTheDocument();
     });
 
-    it('calls apiFetch with PUT when "Use in article" is clicked in diagram mode', async () => {
+    it('calls apiFetch with PUT when "Use in page" is clicked in diagram mode', async () => {
       mockPageData = {
         data: { id: 'p1', title: 'My Article', bodyHtml: '<p>Content</p>', bodyText: 'Content', version: 3 },
       };
@@ -866,13 +866,13 @@ describe('AiAssistantPage', () => {
       const diagramBtn = btns.find((b) => b.textContent?.includes('Generate Diagram'))!;
       fireEvent.click(diagramBtn);
 
-      // Wait for "Use in article" button
+      // Wait for "Use in page" button
       await waitFor(() => {
-        expect(screen.getByText('Use in article')).toBeInTheDocument();
+        expect(screen.getByText('Use in page')).toBeInTheDocument();
       });
 
-      // Click "Use in article"
-      fireEvent.click(screen.getByText('Use in article'));
+      // Click "Use in page"
+      fireEvent.click(screen.getByText('Use in page'));
 
       // Verify the PUT call was made
       await waitFor(() => {
@@ -890,7 +890,7 @@ describe('AiAssistantPage', () => {
 
       // Verify success toast
       await waitFor(() => {
-        expect(toastSuccessMock).toHaveBeenCalledWith('Diagram inserted into article');
+        expect(toastSuccessMock).toHaveBeenCalledWith('Diagram inserted into page');
       });
     });
   });
@@ -1111,7 +1111,7 @@ describe('AiAssistantPage', () => {
       // Should NOT show Q&A message
       expect(screen.queryByText('Ask questions about your knowledge base')).not.toBeInTheDocument();
       // Should NOT show "Open a page first" from other modes bleeding through
-      expect(screen.queryByText('AI will create a full article based on your prompt')).not.toBeInTheDocument();
+      expect(screen.queryByText('AI will create a full page based on your prompt')).not.toBeInTheDocument();
     });
 
     it('shows only Q&A empty state in ask mode', () => {

--- a/frontend/src/features/ai/AiAssistantPage.test.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.test.tsx
@@ -4,14 +4,18 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LazyMotion, domAnimation } from 'framer-motion';
 import { AiAssistantPage } from './AiAssistantPage';
+import { ApiError } from '../../shared/lib/api';
 import { useAuthStore } from '../../stores/auth-store';
 
 // scrollIntoView is not available in jsdom
 Element.prototype.scrollIntoView = vi.fn();
 
-// Keep reference to original apiFetch mock to control per-test
+// Keep reference to original apiFetch mock to control per-test. Spread the
+// real module so the ApiError class stays available — runStream branches on
+// `err instanceof ApiError` for 403 handling.
 const apiFetchMock = vi.fn();
-vi.mock('../../shared/lib/api', () => ({
+vi.mock('../../shared/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../shared/lib/api')>()),
   apiFetch: (...args: unknown[]) => apiFetchMock(...args),
 }));
 
@@ -162,6 +166,76 @@ describe('AiAssistantPage', () => {
     render(<AiAssistantPage />, { wrapper: createWrapper() });
 
     await waitFor(() => {
+      expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('models error chip (degraded LLM provider)', () => {
+    it('shows "Models unavailable — retry" instead of the loading spinner when the models fetch fails', async () => {
+      apiFetchMock.mockImplementation((path: string) => {
+        if (path === '/settings') {
+          return Promise.resolve({ llmProvider: 'ollama', ollamaModel: '', openaiModel: null });
+        }
+        if (path.startsWith('/ollama/models')) {
+          return Promise.reject(new Error('LLM provider unreachable'));
+        }
+        if (path === '/llm/conversations') {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+
+      render(<AiAssistantPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByText('Models unavailable — retry')).toBeInTheDocument();
+      });
+      // The infinite spinner must not keep rendering once the fetch has failed.
+      expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
+    });
+
+    it('refetches models when the retry chip is clicked and recovers to the dropdown', async () => {
+      let modelsDown = true;
+      apiFetchMock.mockImplementation((path: string) => {
+        if (path === '/settings') {
+          return Promise.resolve({ llmProvider: 'ollama', ollamaModel: '', openaiModel: null });
+        }
+        if (path.startsWith('/ollama/models')) {
+          return modelsDown
+            ? Promise.reject(new Error('LLM provider unreachable'))
+            : Promise.resolve([{ name: 'llama3' }]);
+        }
+        if (path === '/llm/conversations') {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+
+      render(<AiAssistantPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByText('Models unavailable — retry')).toBeInTheDocument();
+      });
+
+      const modelsCalls = () => apiFetchMock.mock.calls
+        .map((args) => args[0])
+        .filter((p): p is string => typeof p === 'string' && p.startsWith('/ollama/models'))
+        .length;
+      const callsBefore = modelsCalls();
+
+      // Provider comes back up; clicking the chip must fire another fetch.
+      modelsDown = false;
+      fireEvent.click(screen.getByText('Models unavailable — retry'));
+
+      await waitFor(() => {
+        expect(modelsCalls()).toBeGreaterThan(callsBefore);
+      });
+
+      // Recovered: the chip is replaced by the model dropdown.
+      await waitFor(() => {
+        expect(document.querySelector('select')).not.toBeNull();
+      });
+      expect(screen.queryByText('Models unavailable — retry')).not.toBeInTheDocument();
       expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
     });
   });
@@ -537,7 +611,7 @@ describe('AiAssistantPage', () => {
       }
     });
 
-    it('removes empty assistant message when ask stream throws an error', async () => {
+    it('replaces the placeholder assistant message with an inline error when the ask stream throws', async () => {
       apiFetchMock.mockImplementation((path: string) => {
         if (path === '/settings') {
           return Promise.resolve({ llmProvider: 'ollama', ollamaModel: 'llama3', openaiModel: null });
@@ -574,7 +648,7 @@ describe('AiAssistantPage', () => {
 
       fireEvent.keyDown(input, { key: 'Enter' });
 
-      // Wait for the error toast
+      // The toast still fires for generic (non-403) errors
       await waitFor(() => {
         expect(toastErrorMock).toHaveBeenCalledWith('Connection lost');
       });
@@ -582,17 +656,63 @@ describe('AiAssistantPage', () => {
       // The user message should still be visible
       expect(screen.getByText('What is Confluence?')).toBeInTheDocument();
 
-      // The empty assistant message should have been removed.
-      // AskMode adds the user message directly via setMessages (not via runStream's
-      // userMessage option), so this test specifically verifies the fix: runStream
-      // must always remove the placeholder assistant message on error.
-      // If there were an assistant bubble, it would contain a Bot icon or typing indicator.
-      expect(screen.queryByTestId('typing-indicator')).not.toBeInTheDocument();
+      // The placeholder assistant message must NOT be silently removed: it is
+      // replaced with a visible inline error bubble carrying destructive styling.
+      const errorBubble = screen.getByTestId('message-error');
+      expect(errorBubble.textContent).toContain('Connection lost');
+      expect(errorBubble.className).toContain('destructive');
 
-      // Verify there is exactly 1 message bubble (the user message), not 2
-      // User messages have "justify-end" class on their container
-      const messageBubbles = document.querySelectorAll('.max-w-\\[80\\%\\]');
-      expect(messageBubbles.length).toBe(1);
+      // No lingering typing indicator
+      expect(screen.queryByTestId('typing-indicator')).not.toBeInTheDocument();
+    });
+
+    it('shows an inline permission explanation without a toast when ask is rejected with 403', async () => {
+      apiFetchMock.mockImplementation((path: string) => {
+        if (path === '/settings') {
+          return Promise.resolve({ llmProvider: 'ollama', ollamaModel: 'llama3', openaiModel: null });
+        }
+        if (path.startsWith('/ollama/models')) {
+          return Promise.resolve([{ name: 'llama3' }]);
+        }
+        if (path === '/llm/conversations') {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+
+      // Backend rejects POST /api/llm/ask with 403 when the user lacks the
+      // llm:query RBAC permission — streamSSE surfaces it as an ApiError.
+      // eslint-disable-next-line require-yield
+      async function* fakeForbiddenStream() {
+        throw new ApiError(403, 'Permission "llm:query" required');
+      }
+      streamSSEMock.mockReturnValue(fakeForbiddenStream());
+
+      render(<AiAssistantPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText('Ask a question...');
+      fireEvent.change(input, { target: { value: 'What is Confluence?' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      // The chat shows what happened inline, in the assistant's bubble.
+      await waitFor(() => {
+        expect(screen.getByTestId('message-error')).toBeInTheDocument();
+      });
+      const errorBubble = screen.getByTestId('message-error');
+      expect(errorBubble.textContent).toContain('permission');
+      expect(errorBubble.textContent).toContain('llm:query');
+      expect(errorBubble.textContent).toContain('administrator');
+      expect(errorBubble.className).toContain('destructive');
+
+      // 403 is fully explained inline — no redundant toast.
+      expect(toastErrorMock).not.toHaveBeenCalled();
+
+      // The user message stays visible above the explanation.
+      expect(screen.getByText('What is Confluence?')).toBeInTheDocument();
     });
 
     it('enables send button when model is loaded and input is provided', async () => {

--- a/frontend/src/features/ai/AiAssistantPage.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 import { m, useReducedMotion } from 'framer-motion';
 import {
-  Bot, User, Loader2, MessageSquare, Brain,
+  Bot, User, Loader2, MessageSquare, Brain, AlertTriangle,
   Wand2, ListCollapse, Sparkles, GitBranch, FileText, ShieldCheck, Network,
 } from 'lucide-react';
 import Markdown from 'react-markdown';
@@ -94,8 +94,11 @@ const MessageBubble = memo(function MessageBubble({
           'max-w-[80%] rounded-2xl px-4 py-3 text-sm xl:max-w-2xl',
           msg.role === 'user'
             ? 'bg-primary/10 text-foreground'
-            : 'bg-foreground/5',
+            : msg.isError
+              ? 'border border-destructive/40 bg-destructive/10'
+              : 'bg-foreground/5',
         )}
+        data-testid={msg.isError ? 'message-error' : undefined}
       >
         {showThinkingBlob && <AIThinkingBlob active />}
         {showTypingIndicator && <TypingIndicator />}
@@ -110,6 +113,10 @@ const MessageBubble = memo(function MessageBubble({
               <TypingIndicator />
             </div>
           ) : null)
+        ) : msg.isError ? (
+          // Error messages render as plain text (not Markdown) so the
+          // destructive color isn't overridden by the prose styles.
+          <p className="text-destructive">{msg.content}</p>
         ) : (
           <div className={cn('prose prose-sm max-w-none', !isLight && 'prose-invert')}>
             {msg.content ? (
@@ -144,6 +151,7 @@ const MessageBubble = memo(function MessageBubble({
   // Completed messages (not last or not streaming) will never re-render.
   if (prev.msg.id !== next.msg.id) return false;
   if (prev.msg.content !== next.msg.content) return false;
+  if (prev.msg.isError !== next.msg.isError) return false;
   if (prev.msg.sources !== next.msg.sources) return false;
   if (prev.isLast !== next.isLast) return false;
   if (prev.isStreaming !== next.isStreaming) return false;
@@ -203,7 +211,7 @@ function AiAssistantInner() {
     mode, setMode, page, pageHasChildren,
     messages, messagesEndRef, isStreaming, isThinking, thinkingElapsed,
     streamingContent,
-    model, models, setModel, isLight,
+    model, models, setModel, modelsError, refetchModels, isLight,
     includeSubPages, setIncludeSubPages,
     thinkingMode, setThinkingMode,
   } = ctx;
@@ -290,7 +298,18 @@ function AiAssistantInner() {
             the model dropdown and the toggles separates "infrastructure" the
             user sets once from "context flags" they flip per question. */}
         <div className="flex flex-wrap items-center gap-1.5">
-          {models.length === 0 ? (
+          {modelsError ? (
+            // Models fetch failed (LLM provider down / unreachable): surface
+            // the failure with a retry affordance instead of spinning forever.
+            <button
+              type="button"
+              onClick={() => refetchModels()}
+              title="Failed to load models from the LLM provider — click to retry"
+              className="flex h-7 items-center gap-1.5 rounded-md border border-destructive/40 px-2.5 text-xs text-destructive transition-colors hover:bg-destructive/10"
+            >
+              <AlertTriangle size={12} /> Models unavailable — retry
+            </button>
+          ) : models.length === 0 ? (
             <span className="flex h-7 items-center gap-1.5 rounded-md border border-border/40 px-2.5 text-xs text-muted-foreground">
               <Loader2 size={12} className="animate-spin" /> Loading models...
             </span>

--- a/frontend/src/features/ai/AiContext.tsx
+++ b/frontend/src/features/ai/AiContext.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext, useState, useRef, useEffect, useCallback, ty
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { UsecaseDefault } from '@compendiq/contracts';
-import { apiFetch } from '../../shared/lib/api';
+import { apiFetch, ApiError } from '../../shared/lib/api';
 import { streamSSE } from '../../shared/lib/sse';
 import { usePage, useEmbeddingStatus, type EmbeddingStatusData } from '../../shared/hooks/use-pages';
 import { useIsLightTheme } from '../../shared/hooks/use-is-light-theme';
@@ -26,6 +26,9 @@ export interface Message {
   role: 'user' | 'assistant';
   content: string;
   sources?: Source[];
+  /** True when this assistant message reports a failed request (rendered with
+   * destructive styling instead of the regular bubble). */
+  isError?: boolean;
 }
 
 interface Conversation {
@@ -73,6 +76,10 @@ interface AiContextValue {
   model: string;
   setModel: (m: string) => void;
   models: Array<{ name: string }>;
+  /** True when the models fetch failed (e.g. LLM provider down) — the UI must
+   * surface a retry affordance instead of spinning forever. */
+  modelsError: boolean;
+  refetchModels: () => void;
 
   // Streaming state
   input: string;
@@ -524,10 +531,23 @@ export function AiProvider({ children }: { children: ReactNode }) {
         commitToMessages();
         return;
       }
-      toast.error(err instanceof Error ? err.message : 'Request failed');
-      // Always remove the empty assistant message on error — runStream unconditionally
-      // adds a placeholder assistant message, regardless of whether userMessage was passed.
-      setMessages((prev) => prev.slice(0, -1));
+      // Surface the failure INLINE: replace the placeholder assistant message
+      // with an error message instead of silently removing it (the user
+      // previously saw a bubble appear and then vanish with no explanation).
+      const isForbidden = err instanceof ApiError && err.statusCode === 403;
+      const friendly = isForbidden
+        ? 'You don\'t have permission to use AI features (permission "llm:query"). Ask an administrator to assign you a role that includes it.'
+        : err instanceof Error ? err.message : 'Request failed';
+      // 403 is fully explained inline — keep the toast only for other errors.
+      if (!isForbidden) toast.error(friendly);
+      setMessages((prev) => {
+        const updated = [...prev];
+        const lastMsg = updated[updated.length - 1];
+        if (lastMsg && lastMsg.role === 'assistant') {
+          updated[updated.length - 1] = { ...lastMsg, content: friendly, isError: true };
+        }
+        return updated;
+      });
     } finally {
       streamingFinish();
       isStreamingRef.current = false;
@@ -556,6 +576,8 @@ export function AiProvider({ children }: { children: ReactNode }) {
     model,
     setModel,
     models,
+    modelsError: modelsQuery.isError,
+    refetchModels: modelsQuery.refetch,
     input,
     setInput,
     isStreaming,

--- a/frontend/src/features/ai/modes/AskMode.test.tsx
+++ b/frontend/src/features/ai/modes/AskMode.test.tsx
@@ -10,10 +10,11 @@ import { useAuthStore } from '../../../stores/auth-store';
 
 Element.prototype.scrollIntoView = vi.fn();
 
+// Replace apiFetch with a controllable mock but keep the real ApiError class
+// available — runStream branches on `err instanceof ApiError` for 403 handling.
 const apiFetchMock = vi.fn();
-vi.mock('../../../shared/lib/api', () => ({
-  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
-}));
+vi.mock('../../../shared/lib/api', async () =>
+  (await import('../../../test-utils')).apiModuleMock(() => apiFetchMock));
 
 const streamSSEMock = vi.fn();
 vi.mock('../../../shared/lib/sse', () => ({

--- a/frontend/src/features/ai/modes/DiagramMode.test.tsx
+++ b/frontend/src/features/ai/modes/DiagramMode.test.tsx
@@ -9,13 +9,11 @@ import { useAuthStore } from '../../../stores/auth-store';
 
 Element.prototype.scrollIntoView = vi.fn();
 
-// Spread the real module so the ApiError class stays available — runStream
-// branches on `err instanceof ApiError` for 403 handling.
+// Replace apiFetch with a controllable mock but keep the real ApiError class
+// available — runStream branches on `err instanceof ApiError` for 403 handling.
 const apiFetchMock = vi.fn();
-vi.mock('../../../shared/lib/api', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../../shared/lib/api')>()),
-  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
-}));
+vi.mock('../../../shared/lib/api', async () =>
+  (await import('../../../test-utils')).apiModuleMock(() => apiFetchMock));
 
 const streamSSEMock = vi.fn();
 vi.mock('../../../shared/lib/sse', () => ({

--- a/frontend/src/features/ai/modes/DiagramMode.test.tsx
+++ b/frontend/src/features/ai/modes/DiagramMode.test.tsx
@@ -9,8 +9,11 @@ import { useAuthStore } from '../../../stores/auth-store';
 
 Element.prototype.scrollIntoView = vi.fn();
 
+// Spread the real module so the ApiError class stays available — runStream
+// branches on `err instanceof ApiError` for 403 handling.
 const apiFetchMock = vi.fn();
-vi.mock('../../../shared/lib/api', () => ({
+vi.mock('../../../shared/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../shared/lib/api')>()),
   apiFetch: (...args: unknown[]) => apiFetchMock(...args),
 }));
 

--- a/frontend/src/features/ai/modes/DiagramMode.tsx
+++ b/frontend/src/features/ai/modes/DiagramMode.tsx
@@ -69,7 +69,7 @@ export function DiagramTypeSelector() {
 
 /**
  * Rendered after a diagram stream completes: shows the Mermaid preview
- * and an "Use in article" button.
+ * and an "Use in page" button.
  */
 export function DiagramPreview() {
   const { page, pageId, isStreaming, queryClient, diagramCode, isInsertingDiagram, setIsInsertingDiagram } = useAiContext();
@@ -88,7 +88,7 @@ export function DiagramPreview() {
           version: page.version,
         }),
       });
-      toast.success('Diagram inserted into article');
+      toast.success('Diagram inserted into page');
       queryClient.invalidateQueries({ queryKey: ['pages', pageId] });
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to insert diagram');
@@ -111,7 +111,7 @@ export function DiagramPreview() {
           {isInsertingDiagram ? (
             <><Loader2 size={14} className="animate-spin" /> Inserting...</>
           ) : (
-            <><FileInput size={14} /> Use in article</>
+            <><FileInput size={14} /> Use in page</>
           )}
         </button>
       )}

--- a/frontend/src/features/ai/modes/GenerateMode.test.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.test.tsx
@@ -9,13 +9,11 @@ import { useAuthStore } from '../../../stores/auth-store';
 
 Element.prototype.scrollIntoView = vi.fn();
 
-// Spread the real module so the ApiError class stays available — runStream
-// branches on `err instanceof ApiError` for 403 handling.
+// Replace apiFetch with a controllable mock but keep the real ApiError class
+// available — runStream branches on `err instanceof ApiError` for 403 handling.
 const apiFetchMock = vi.fn();
-vi.mock('../../../shared/lib/api', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../../shared/lib/api')>()),
-  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
-}));
+vi.mock('../../../shared/lib/api', async () =>
+  (await import('../../../test-utils')).apiModuleMock(() => apiFetchMock));
 
 const streamSSEMock = vi.fn();
 vi.mock('../../../shared/lib/sse', () => ({

--- a/frontend/src/features/ai/modes/GenerateMode.test.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.test.tsx
@@ -127,15 +127,15 @@ describe('GenerateMode', () => {
   });
 
   it('exports correct empty state constants', () => {
-    expect(GENERATE_EMPTY_TITLE).toBe('Describe the article you want to generate');
-    expect(GENERATE_EMPTY_SUBTITLE).toBe('AI will create a full article based on your prompt');
+    expect(GENERATE_EMPTY_TITLE).toBe('Describe the page you want to generate');
+    expect(GENERATE_EMPTY_SUBTITLE).toBe('AI will create a full page based on your prompt');
   });
 
   describe('GenerateModeInput', () => {
     it('renders the prompt input, send button, and PDF upload zone', () => {
       render(<GenerateModeInput />, { wrapper: createWrapper() });
 
-      expect(screen.getByPlaceholderText('Describe the article to generate...')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Describe the page to generate...')).toBeInTheDocument();
       expect(screen.getByTestId('pdf-upload-zone')).toBeInTheDocument();
       expect(getSendButton()).toBeInTheDocument();
     });
@@ -153,7 +153,7 @@ describe('GenerateMode', () => {
 
       render(<GenerateModeInput />, { wrapper: createWrapper() });
 
-      const input = screen.getByPlaceholderText('Describe the article to generate...');
+      const input = screen.getByPlaceholderText('Describe the page to generate...');
       fireEvent.change(input, { target: { value: 'Write a guide about Docker' } });
 
       await waitFor(() => {
@@ -182,7 +182,7 @@ describe('GenerateMode', () => {
 
       render(<GenerateModeInput />, { wrapper: createWrapper() });
 
-      const input = screen.getByPlaceholderText('Describe the article to generate...');
+      const input = screen.getByPlaceholderText('Describe the page to generate...');
       fireEvent.change(input, { target: { value: 'Write about Docker' } });
 
       await waitFor(() => {
@@ -209,7 +209,7 @@ describe('GenerateMode', () => {
 
       render(<GenerateModeInput />, { wrapper: createWrapper() });
 
-      const input = screen.getByPlaceholderText('Describe the article to generate...');
+      const input = screen.getByPlaceholderText('Describe the page to generate...');
       fireEvent.change(input, { target: { value: 'Write about Docker' } });
 
       await waitFor(() => {
@@ -236,7 +236,7 @@ describe('GenerateMode', () => {
 
       render(<GenerateModeInput />, { wrapper: createWrapper() });
 
-      const input = screen.getByPlaceholderText('Describe the article to generate...');
+      const input = screen.getByPlaceholderText('Describe the page to generate...');
       fireEvent.change(input, { target: { value: 'Write article' } });
 
       await waitFor(() => {
@@ -368,7 +368,7 @@ describe('GenerateMode', () => {
 
       render(<GenerateModeInput />, { wrapper: createWrapper() });
 
-      const input = screen.getByPlaceholderText('Describe the article to generate...');
+      const input = screen.getByPlaceholderText('Describe the page to generate...');
       fireEvent.change(input, { target: { value: 'Write about testing' } });
 
       await waitFor(() => {
@@ -435,7 +435,7 @@ describe('GenerateMode', () => {
       render(<GenerateModeInput />, { wrapper: createWrapper() });
 
       // Before upload: standard placeholder
-      expect(screen.getByPlaceholderText('Describe the article to generate...')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Describe the page to generate...')).toBeInTheDocument();
 
       const fileInput = screen.getByTestId('pdf-file-input');
       const pdfFile = new File(['%PDF-1.4'], 'doc.pdf', { type: 'application/pdf' });

--- a/frontend/src/features/ai/modes/GenerateMode.test.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.test.tsx
@@ -9,8 +9,11 @@ import { useAuthStore } from '../../../stores/auth-store';
 
 Element.prototype.scrollIntoView = vi.fn();
 
+// Spread the real module so the ApiError class stays available — runStream
+// branches on `err instanceof ApiError` for 403 handling.
 const apiFetchMock = vi.fn();
-vi.mock('../../../shared/lib/api', () => ({
+vi.mock('../../../shared/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../shared/lib/api')>()),
   apiFetch: (...args: unknown[]) => apiFetchMock(...args),
 }));
 

--- a/frontend/src/features/ai/modes/GenerateMode.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.tsx
@@ -392,7 +392,7 @@ export function GenerateSavePanel({
     >
       <div className="flex items-center gap-2 text-sm font-medium text-primary">
         <FolderOpen size={16} />
-        Save Article
+        Save Page
       </div>
 
       <div className="space-y-3">
@@ -593,7 +593,7 @@ export function GenerateModeInput() {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && handleSubmit()}
-            placeholder={pdfData ? 'Instructions for generating from PDF...' : 'Describe the article to generate...'}
+            placeholder={pdfData ? 'Instructions for generating from PDF...' : 'Describe the page to generate...'}
             disabled={isStreaming}
             className="flex-1 bg-transparent px-2 py-1.5 text-sm outline-none placeholder:text-muted-foreground/70 disabled:opacity-50"
           />
@@ -611,5 +611,5 @@ export function GenerateModeInput() {
   );
 }
 
-export const GENERATE_EMPTY_TITLE = 'Describe the article you want to generate';
-export const GENERATE_EMPTY_SUBTITLE = 'AI will create a full article based on your prompt';
+export const GENERATE_EMPTY_TITLE = 'Describe the page you want to generate';
+export const GENERATE_EMPTY_SUBTITLE = 'AI will create a full page based on your prompt';

--- a/frontend/src/features/ai/modes/ImproveMode.test.tsx
+++ b/frontend/src/features/ai/modes/ImproveMode.test.tsx
@@ -9,10 +9,11 @@ import { useAuthStore } from '../../../stores/auth-store';
 
 Element.prototype.scrollIntoView = vi.fn();
 
+// Replace apiFetch with a controllable mock but keep the real ApiError class
+// available — runStream branches on `err instanceof ApiError` for 403 handling.
 const apiFetchMock = vi.fn();
-vi.mock('../../../shared/lib/api', () => ({
-  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
-}));
+vi.mock('../../../shared/lib/api', async () =>
+  (await import('../../../test-utils')).apiModuleMock(() => apiFetchMock));
 
 const streamSSEMock = vi.fn();
 vi.mock('../../../shared/lib/sse', () => ({

--- a/frontend/src/features/ai/modes/ImproveMode.tsx
+++ b/frontend/src/features/ai/modes/ImproveMode.tsx
@@ -76,7 +76,7 @@ export function ImproveDiffView() {
           title: page.title,
         }),
       });
-      toast.success('Article updated and synced to Confluence');
+      toast.success('Page updated and synced to Confluence');
       queryClient.invalidateQueries({ queryKey: ['pages', pageId] });
       navigate(`/pages/${pageId}`);
     } catch (err) {

--- a/frontend/src/features/ai/modes/QualityMode.test.tsx
+++ b/frontend/src/features/ai/modes/QualityMode.test.tsx
@@ -9,10 +9,11 @@ import { useAuthStore } from '../../../stores/auth-store';
 
 Element.prototype.scrollIntoView = vi.fn();
 
+// Replace apiFetch with a controllable mock but keep the real ApiError class
+// available — runStream branches on `err instanceof ApiError` for 403 handling.
 const apiFetchMock = vi.fn();
-vi.mock('../../../shared/lib/api', () => ({
-  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
-}));
+vi.mock('../../../shared/lib/api', async () =>
+  (await import('../../../test-utils')).apiModuleMock(() => apiFetchMock));
 
 const streamSSEMock = vi.fn();
 vi.mock('../../../shared/lib/sse', () => ({

--- a/frontend/src/features/ai/modes/QualityMode.test.tsx
+++ b/frontend/src/features/ai/modes/QualityMode.test.tsx
@@ -100,7 +100,7 @@ describe('QualityMode', () => {
   });
 
   it('exports correct empty state constants', () => {
-    expect(QUALITY_EMPTY_TITLE).toBe('Analyze article quality across multiple dimensions');
+    expect(QUALITY_EMPTY_TITLE).toBe('Analyze page quality across multiple dimensions');
     expect(qualityEmptySubtitle(undefined)).toContain('Navigate to a page');
     expect(qualityEmptySubtitle({ title: 'My Article' })).toContain('My Article');
   });

--- a/frontend/src/features/ai/modes/QualityMode.tsx
+++ b/frontend/src/features/ai/modes/QualityMode.tsx
@@ -53,7 +53,7 @@ export function QualityModeInput() {
   );
 }
 
-export const QUALITY_EMPTY_TITLE = 'Analyze article quality across multiple dimensions';
+export const QUALITY_EMPTY_TITLE = 'Analyze page quality across multiple dimensions';
 export function qualityEmptySubtitle(page: { title: string } | undefined): string {
   return page
     ? `Ready to analyze: ${page.title}`

--- a/frontend/src/features/ai/modes/SummarizeMode.test.tsx
+++ b/frontend/src/features/ai/modes/SummarizeMode.test.tsx
@@ -9,10 +9,11 @@ import { useAuthStore } from '../../../stores/auth-store';
 
 Element.prototype.scrollIntoView = vi.fn();
 
+// Replace apiFetch with a controllable mock but keep the real ApiError class
+// available — runStream branches on `err instanceof ApiError` for 403 handling.
 const apiFetchMock = vi.fn();
-vi.mock('../../../shared/lib/api', () => ({
-  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
-}));
+vi.mock('../../../shared/lib/api', async () =>
+  (await import('../../../test-utils')).apiModuleMock(() => apiFetchMock));
 
 const streamSSEMock = vi.fn();
 vi.mock('../../../shared/lib/sse', () => ({

--- a/frontend/src/features/ai/modes/ask-example-prompts.ts
+++ b/frontend/src/features/ai/modes/ask-example-prompts.ts
@@ -6,7 +6,7 @@
 // Each prompt fills the input rather than auto-submits — auto-submit would
 // surprise the user.
 export const ASK_EXAMPLE_PROMPTS: readonly string[] = [
-  'Summarise the most-edited pages in the last 30 days',
+  'Summarize the most-edited pages in the last 30 days',
   'Find pages that look like duplicates of each other',
   'Draft a how-to from pages tagged "onboarding"',
   'What changed in the engineering space in the last 7 days?',

--- a/frontend/src/features/graph/GraphPage.test.tsx
+++ b/frontend/src/features/graph/GraphPage.test.tsx
@@ -99,7 +99,7 @@ describe('GraphPage', () => {
     });
 
     // Should display node/edge counts
-    expect(screen.getByText(/2 articles, 1 connections/)).toBeInTheDocument();
+    expect(screen.getByText(/2 pages, 1 connections/)).toBeInTheDocument();
 
     // Should render ForceGraph2D
     expect(screen.getByTestId('mock-force-graph')).toBeInTheDocument();

--- a/frontend/src/features/graph/GraphPage.tsx
+++ b/frontend/src/features/graph/GraphPage.tsx
@@ -272,7 +272,7 @@ export function GraphPage() {
         const badgeFontSize = Math.max(9 / globalScale, 1.2);
         ctx.font = `${badgeFontSize}px Inter, system-ui, sans-serif`;
         ctx.fillStyle = 'rgba(255,255,255,0.7)';
-        ctx.fillText(`${node.articleCount} articles`, x, y + fontSize);
+        ctx.fillText(`${node.articleCount} pages`, x, y + fontSize);
         return;
       }
 
@@ -402,7 +402,7 @@ export function GraphPage() {
         <div>
           <h1 className="text-xl font-semibold">Knowledge Graph</h1>
           <p className="text-sm text-muted-foreground">
-            {data.nodes.length} {viewMode === 'clustered' ? 'clusters' : 'articles'}, {data.edges.length} connections
+            {data.nodes.length} {viewMode === 'clustered' ? 'clusters' : 'pages'}, {data.edges.length} connections
             {focusPageId && ' (local view)'}
             {filterSpaces.length > 0 && ` in ${filterSpaces.join(', ')}`}
           </p>
@@ -419,7 +419,7 @@ export function GraphPage() {
                 )}
                 aria-label="Individual view"
                 data-testid="graph-view-individual"
-                title="Individual articles"
+                title="Individual pages"
               >
                 <Grid3x3 size={16} />
               </button>
@@ -580,7 +580,7 @@ export function GraphPage() {
             </p>
             {isClusterNode(hoveredNode) ? (
               <p className="text-muted-foreground">
-                Articles: {hoveredNode.articleCount}
+                Pages: {hoveredNode.articleCount}
               </p>
             ) : (
               <>
@@ -638,10 +638,10 @@ function ArticlePickerLanding({ onPick, onShowFullGraph }: ArticlePickerLandingP
   return (
     <div className="flex h-full items-center justify-center p-6">
       <div className="nm-card w-full max-w-xl p-6" data-testid="graph-picker-landing">
-        <h2 className="mb-1 text-lg font-semibold">Pick an article to explore</h2>
+        <h2 className="mb-1 text-lg font-semibold">Pick a page to explore</h2>
         <p className="mb-4 text-sm text-muted-foreground">
-          The knowledge graph is large — start from one article and expand from
-          there. The default view shows that article and its closest neighbours.
+          The knowledge graph is large — start from one page and expand from
+          there. The default view shows that page and its closest neighbors.
         </p>
 
         <div className="relative mb-3">
@@ -651,7 +651,7 @@ function ArticlePickerLanding({ onPick, onShowFullGraph }: ArticlePickerLandingP
             type="text"
             value={q}
             onChange={(e) => setQ(e.target.value)}
-            placeholder="Search articles by title…"
+            placeholder="Search pages by title…"
             className="w-full rounded-lg border border-border/40 bg-foreground/5 py-2 pl-9 pr-3 text-sm outline-none focus:ring-1 focus:ring-primary"
             data-testid="graph-picker-input"
           />
@@ -665,7 +665,7 @@ function ArticlePickerLanding({ onPick, onShowFullGraph }: ArticlePickerLandingP
           <p className="py-6 text-center text-xs text-muted-foreground">Searching…</p>
         ) : items.length === 0 ? (
           <p className="py-6 text-center text-xs text-muted-foreground" data-testid="graph-picker-no-results">
-            No articles match “{q}”.
+            No pages match “{q}”.
           </p>
         ) : (
           <ul role="listbox" aria-label="Search results" className="max-h-72 space-y-1 overflow-y-auto" data-testid="graph-picker-results">
@@ -844,7 +844,7 @@ export function GraphFilterSidebar({
           type="button"
           onClick={onClearFocus}
           className="rounded p-1 text-muted-foreground hover:bg-foreground/5"
-          title="Pick a different article"
+          title="Pick a different page"
           data-testid="graph-clear-focus-btn"
         >
           <X size={12} />

--- a/frontend/src/features/knowledge-requests/KnowledgeRequestsPage.tsx
+++ b/frontend/src/features/knowledge-requests/KnowledgeRequestsPage.tsx
@@ -323,7 +323,7 @@ export function KnowledgeRequestsPage() {
                   <textarea
                     value={newDescription}
                     onChange={(e) => setNewDescription(e.target.value)}
-                    placeholder="Describe what the article should cover..."
+                    placeholder="Describe what the page should cover..."
                     rows={3}
                     className="w-full rounded-md bg-foreground/5 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary resize-none"
                     data-testid="request-description-input"
@@ -378,7 +378,7 @@ export function KnowledgeRequestsPage() {
               <div className="border-b border-border/50 px-5 py-4">
                 <h2 className="font-semibold">Fulfill Request</h2>
                 <p className="text-xs text-muted-foreground mt-1">
-                  Link an existing article to fulfill this request
+                  Link an existing page to fulfill this request
                 </p>
               </div>
               <div className="p-5">
@@ -407,7 +407,7 @@ export function KnowledgeRequestsPage() {
                   data-testid="submit-fulfill"
                 >
                   {fulfillMutation.isPending && <Loader2 size={14} className="animate-spin" />}
-                  Link Article
+                  Link Page
                 </button>
               </div>
             </div>

--- a/frontend/src/features/pages/FlowchartGenerator.test.tsx
+++ b/frontend/src/features/pages/FlowchartGenerator.test.tsx
@@ -72,13 +72,13 @@ describe('FlowchartGenerator', () => {
 
   it('renders the Diagram button when closed', () => {
     render(<FlowchartGenerator pageId="page-1" bodyHtml="<p>Test</p>" pageTitle="Test Page" pageVersion={1} />, { wrapper: createWrapper() });
-    expect(screen.getByTitle('Generate diagram from article')).toBeInTheDocument();
+    expect(screen.getByTitle('Generate diagram from page')).toBeInTheDocument();
   });
 
   it('expands panel when button is clicked', async () => {
     render(<FlowchartGenerator pageId="page-1" bodyHtml="<p>Test</p>" pageTitle="Test Page" pageVersion={1} />, { wrapper: createWrapper() });
 
-    fireEvent.click(screen.getByTitle('Generate diagram from article'));
+    fireEvent.click(screen.getByTitle('Generate diagram from page'));
 
     await waitFor(() => {
       expect(screen.getByText('Generate Diagram')).toBeInTheDocument();
@@ -90,7 +90,7 @@ describe('FlowchartGenerator', () => {
       <FlowchartGenerator pageId="page-1" bodyHtml="<p>Test</p>" pageTitle="Test Page" pageVersion={1} renderTriggerOnly />,
       { wrapper: createWrapper() },
     );
-    expect(screen.getByTitle('Generate diagram from article')).toBeInTheDocument();
+    expect(screen.getByTitle('Generate diagram from page')).toBeInTheDocument();
     expect(screen.queryByText('Generate Diagram')).not.toBeInTheDocument();
   });
 
@@ -115,7 +115,7 @@ describe('FlowchartGenerator', () => {
       <FlowchartGenerator pageId="page-1" bodyHtml="<p>Test</p>" pageTitle="Test Page" pageVersion={1} renderTriggerOnly />,
       { wrapper: createWrapper() },
     );
-    const btn = screen.getByTitle('Generate diagram from article');
+    const btn = screen.getByTitle('Generate diagram from page');
     const label = btn.querySelector('span');
     expect(label).toHaveClass('hidden', 'sm:inline');
   });
@@ -219,11 +219,11 @@ describe('FlowchartGenerator', () => {
   it('shows generate button with title tooltip', () => {
     render(<FlowchartGenerator pageId="page-1" bodyHtml="<p>Test</p>" pageTitle="Test Page" pageVersion={1} />, { wrapper: createWrapper() });
 
-    const btn = screen.getByTitle('Generate diagram from article');
+    const btn = screen.getByTitle('Generate diagram from page');
     expect(btn).toBeInTheDocument();
   });
 
-  it('shows "Use in article" button after diagram generation completes', async () => {
+  it('shows "Use in page" button after diagram generation completes', async () => {
     async function* fakeStream() {
       yield { content: 'graph TD\n  A --> B' };
     }
@@ -240,11 +240,11 @@ describe('FlowchartGenerator', () => {
     fireEvent.click(screen.getByText('Generate'));
 
     await waitFor(() => {
-      expect(screen.getByText('Use in article')).toBeInTheDocument();
+      expect(screen.getByText('Use in page')).toBeInTheDocument();
     });
   });
 
-  it('does not show "Use in article" button while streaming', async () => {
+  it('does not show "Use in page" button while streaming', async () => {
     // Create a stream that never resolves
     let resolveStream: () => void;
     const streamPromise = new Promise<void>((resolve) => { resolveStream = resolve; });
@@ -265,17 +265,17 @@ describe('FlowchartGenerator', () => {
 
     fireEvent.click(screen.getByText('Generate'));
 
-    // Should show "Generating..." but not "Use in article"
+    // Should show "Generating..." but not "Use in page"
     await waitFor(() => {
       expect(screen.getByText('Generating...')).toBeInTheDocument();
     });
-    expect(screen.queryByText('Use in article')).not.toBeInTheDocument();
+    expect(screen.queryByText('Use in page')).not.toBeInTheDocument();
 
     // Clean up: resolve the promise so the generator finishes
     resolveStream!();
   });
 
-  it('calls PUT /api/pages/:id when "Use in article" is clicked', async () => {
+  it('calls PUT /api/pages/:id when "Use in page" is clicked', async () => {
     async function* fakeStream() {
       yield { content: 'graph TD\n  A --> B' };
     }
@@ -303,10 +303,10 @@ describe('FlowchartGenerator', () => {
     fireEvent.click(screen.getByText('Generate'));
 
     await waitFor(() => {
-      expect(screen.getByText('Use in article')).toBeInTheDocument();
+      expect(screen.getByText('Use in page')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText('Use in article'));
+    fireEvent.click(screen.getByText('Use in page'));
 
     await waitFor(() => {
       const putCall = apiFetchMock.mock.calls.find(
@@ -324,7 +324,7 @@ describe('FlowchartGenerator', () => {
 
     // Verify success toast
     await waitFor(() => {
-      expect(toastSuccessMock).toHaveBeenCalledWith('Diagram inserted into article');
+      expect(toastSuccessMock).toHaveBeenCalledWith('Diagram inserted into page');
     });
   });
 
@@ -355,10 +355,10 @@ describe('FlowchartGenerator', () => {
     fireEvent.click(screen.getByText('Generate'));
 
     await waitFor(() => {
-      expect(screen.getByText('Use in article')).toBeInTheDocument();
+      expect(screen.getByText('Use in page')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText('Use in article'));
+    fireEvent.click(screen.getByText('Use in page'));
 
     await waitFor(() => {
       expect(toastErrorMock).toHaveBeenCalledWith('Version conflict');

--- a/frontend/src/features/pages/FlowchartGenerator.tsx
+++ b/frontend/src/features/pages/FlowchartGenerator.tsx
@@ -122,7 +122,7 @@ export function FlowchartGenerator({
           version: pageVersion,
         }),
       });
-      toast.success('Diagram inserted into article');
+      toast.success('Diagram inserted into page');
       queryClient.invalidateQueries({ queryKey: ['pages', pageId] });
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to insert diagram');
@@ -135,7 +135,7 @@ export function FlowchartGenerator({
     <button
       onClick={toggleOpen}
       className="nm-card flex items-center gap-1.5 px-3 py-1.5 text-sm hover:bg-foreground/5"
-      title="Generate diagram from article"
+      title="Generate diagram from page"
     >
       <GitBranch size={14} /> <span className="hidden sm:inline">Diagram</span>
     </button>
@@ -212,7 +212,7 @@ export function FlowchartGenerator({
             {isInserting ? (
               <><Loader2 size={14} className="animate-spin" /> Inserting...</>
             ) : (
-              <><FileInput size={14} /> Use in article</>
+              <><FileInput size={14} /> Use in page</>
             )}
           </button>
         </>

--- a/frontend/src/features/pages/KPICards.test.tsx
+++ b/frontend/src/features/pages/KPICards.test.tsx
@@ -53,7 +53,7 @@ describe('KPICards', () => {
     );
 
     const card = screen.getByTestId('kpi-total-articles');
-    expect(card).toHaveTextContent('Total Articles');
+    expect(card).toHaveTextContent('Total Pages');
     // AnimatedCounter animates from 0 to target via spring physics
     await waitFor(() => {
       expect(card).toHaveTextContent('100');

--- a/frontend/src/features/pages/KPICards.tsx
+++ b/frontend/src/features/pages/KPICards.tsx
@@ -120,7 +120,7 @@ export function KPICards({ embeddingStatus, spacesCount, lastSynced }: KPICardsP
   const cards: KPICard[] = [
     {
       icon: FileText,
-      label: 'Total Articles',
+      label: 'Total Pages',
       value: embeddingStatus ? String(totalPages) : '--',
       numericValue: embeddingStatus ? totalPages : undefined,
       color: 'text-success',
@@ -171,7 +171,7 @@ export function KPICards({ embeddingStatus, spacesCount, lastSynced }: KPICardsP
                 <Icon size={16} />
               </div>
               <div className="min-w-0">
-                <p className="truncate text-xs text-muted-foreground">{label}</p>
+                <p className="line-clamp-2 text-xs text-muted-foreground" title={label}>{label}</p>
                 <p className="text-base font-semibold">
                   {numericValue != null ? (
                     <AnimatedCounter value={numericValue} suffix={suffix} />
@@ -197,7 +197,7 @@ export function KPICards({ embeddingStatus, spacesCount, lastSynced }: KPICardsP
               isProcessing={embeddingStatus?.isProcessing ?? false}
             />
             <div className="min-w-0">
-              <p className="truncate text-xs text-muted-foreground">Embedding Coverage</p>
+              <p className="line-clamp-2 text-xs text-muted-foreground" title="Embedding Coverage">Embedding Coverage</p>
               <p className="text-base font-semibold">
                 {embeddingStatus ? `${coveragePercent}%` : '--'}
               </p>

--- a/frontend/src/features/pages/NewPagePage.test.tsx
+++ b/frontend/src/features/pages/NewPagePage.test.tsx
@@ -217,6 +217,27 @@ describe('NewPagePage', () => {
     });
   });
 
+  it('explains the disabled Create Page button via a hover hint', () => {
+    render(<NewPagePage />, { wrapper: createWrapper() });
+    const createBtn = screen.getByText('Create Page').closest('button')!;
+    expect(createBtn).toBeDisabled();
+    // nm-button-primary sets pointer-events:none on :disabled, which swallows
+    // a title tooltip placed on the button itself — the wrapping span carries it.
+    const hintCarrier = createBtn.closest('[title]');
+    expect(hintCarrier).not.toBeNull();
+    expect(hintCarrier).toHaveAttribute('title', 'Enter a title and select a space first');
+  });
+
+  it('drops the hover hint once the Create Page button is enabled', async () => {
+    render(<NewPagePage />, { wrapper: createWrapper() });
+    fireEvent.change(screen.getByTestId('title-input'), { target: { value: 'My Page' } });
+    fireEvent.change(screen.getByTestId('space-selector'), { target: { value: '__local__' } });
+    await waitFor(() => {
+      expect(screen.getByText('Create Page').closest('button')).not.toBeDisabled();
+    });
+    expect(screen.getByText('Create Page').closest('[title]')).toBeNull();
+  });
+
   it('submit uses the selected local spaceKey (not hardcoded __local__)', async () => {
     mockCreateMutateAsync.mockResolvedValueOnce({ id: 'new-page-id', title: 'My Notes Page', version: 1 });
 

--- a/frontend/src/features/pages/NewPagePage.tsx
+++ b/frontend/src/features/pages/NewPagePage.tsx
@@ -162,13 +162,25 @@ export function NewPagePage() {
                 <LayoutTemplate size={14} />
                 Use Template
               </button>
-              <button
-                onClick={handleCreate}
-                disabled={isCreateDisabled}
-                className="nm-button-primary"
+              {/* The hint span (not the button) carries the title: nm-button-primary
+                  sets pointer-events:none on :disabled, so a tooltip on the button
+                  itself would never show while it is disabled — exactly when the
+                  user needs to know why. */}
+              <span
+                title={
+                  isCreateDisabled && !createMutation.isPending
+                    ? 'Enter a title and select a space first'
+                    : undefined
+                }
               >
-                <Save size={14} /> {createMutation.isPending ? 'Creating...' : 'Create Page'}
-              </button>
+                <button
+                  onClick={handleCreate}
+                  disabled={isCreateDisabled}
+                  className="nm-button-primary"
+                >
+                  <Save size={14} /> {createMutation.isPending ? 'Creating...' : 'Create Page'}
+                </button>
+              </span>
             </div>
           </div>
 

--- a/frontend/src/features/pages/NewPagePage.tsx
+++ b/frontend/src/features/pages/NewPagePage.tsx
@@ -318,7 +318,7 @@ export function NewPagePage() {
             <Editor
               content=""
               onChange={setBodyHtml}
-              placeholder="Start writing your article..."
+              placeholder="Start writing your page..."
               draftKey={NEW_PAGE_DRAFT_KEY}
               naked
               hideToolbar

--- a/frontend/src/features/pages/PageViewPage.test.tsx
+++ b/frontend/src/features/pages/PageViewPage.test.tsx
@@ -64,6 +64,9 @@ vi.mock('../../shared/components/article/ArticleViewer', async () => {
   };
 });
 
+// Configurable draft content so tests can exercise the restore-draft dialog.
+let mockDraftContent: string | null = null;
+
 vi.mock('../../shared/components/article/Editor', () => ({
   Editor: ({
     content,
@@ -80,7 +83,7 @@ vi.mock('../../shared/components/article/Editor', () => ({
   ),
   EditorToolbar: () => null,
   TableContextToolbar: () => null,
-  getDraft: () => null,
+  getDraft: () => mockDraftContent,
   clearDraft: vi.fn(),
 }));
 
@@ -245,6 +248,7 @@ describe('PageViewPage', () => {
     mockPinMutate.mockReset();
     mockUnpinMutate.mockReset();
     mockDeleteMutateAsync.mockReset().mockResolvedValue(undefined);
+    mockDraftContent = null;
     vi.mocked(apiFetch).mockClear();
     vi.mocked(apiFetch).mockResolvedValue({} as never);
     localStorage.clear();
@@ -616,7 +620,7 @@ describe('PageViewPage', () => {
       deleteShortcut!.action();
     });
 
-    // ConfirmDialog replaces window.confirm — copy must reflect the 30-day
+    // ConfirmDialog replaces native confirm() — copy must reflect the 30-day
     // soft-delete trash, not the old (false) "cannot be undone" claim.
     expect(await screen.findByText('Move page to trash?')).toBeInTheDocument();
     expect(
@@ -722,6 +726,78 @@ describe('PageViewPage', () => {
     } finally {
       currentMockPage = mockPage;
     }
+  });
+
+  // ConfirmDialog replaces the native confirm() draft-restore prompt. Drafts are
+  // autosaved to localStorage on this device; restoring is non-destructive, and
+  // declining simply opens the editor on the published content (matching the
+  // old confirm() semantics — both paths enter edit mode).
+  describe('draft restore dialog', () => {
+    it('opens a restore-draft dialog instead of entering edit mode when a differing draft exists', async () => {
+      mockDraftContent = '<p>Draft content</p>';
+      render(<PageViewPage />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByText('Edit'));
+
+      expect(await screen.findByText('Restore draft?')).toBeInTheDocument();
+      // Honest copy: drafts live in this browser; no false destruction claims.
+      expect(screen.getByText(/unsaved draft of this page was found/i)).toBeInTheDocument();
+      // Edit mode is NOT entered until the user decides.
+      expect(screen.queryByLabelText('Article editor')).not.toBeInTheDocument();
+
+      // Close the portal dialog before teardown — this file's afterEach wipes
+      // document.body, which races React's portal unmount if it's still open.
+      fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      });
+    });
+
+    it('confirming restores the draft into the editor', async () => {
+      mockDraftContent = '<p>Draft content</p>';
+      render(<PageViewPage />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByText('Edit'));
+      await screen.findByTestId('confirm-dialog');
+      fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Article editor')).toHaveValue('<p>Draft content</p>');
+      });
+    });
+
+    it('cancelling opens the editor on the published content instead', async () => {
+      mockDraftContent = '<p>Draft content</p>';
+      render(<PageViewPage />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByText('Edit'));
+      await screen.findByTestId('confirm-dialog');
+      fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Article editor')).toHaveValue(mockPage.bodyHtml);
+      });
+    });
+
+    it('enters edit mode directly when no draft exists', () => {
+      mockDraftContent = null;
+      render(<PageViewPage />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByText('Edit'));
+
+      expect(screen.getByLabelText('Article editor')).toBeInTheDocument();
+      expect(screen.queryByText('Restore draft?')).not.toBeInTheDocument();
+    });
+
+    it('enters edit mode directly when the draft matches the published content', () => {
+      mockDraftContent = mockPage.bodyHtml;
+      render(<PageViewPage />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByText('Edit'));
+
+      expect(screen.getByLabelText('Article editor')).toBeInTheDocument();
+      expect(screen.queryByText('Restore draft?')).not.toBeInTheDocument();
+    });
   });
 
 });

--- a/frontend/src/features/pages/PageViewPage.test.tsx
+++ b/frontend/src/features/pages/PageViewPage.test.tsx
@@ -192,6 +192,9 @@ const mockPage = {
   summaryGeneratedAt: null,
   summaryModel: null,
   summaryError: null,
+  source: 'confluence' as string,
+  visibility: 'shared' as string,
+  createdByUserId: null as string | number | null,
 };
 
 let currentMockPage: typeof mockPage | undefined = mockPage;
@@ -266,6 +269,32 @@ describe('PageViewPage', () => {
 
     expect(screen.getByText('Engineering Handbook')).toBeInTheDocument();
     expect(screen.getByText('ENG')).toBeInTheDocument();
+  });
+
+  describe('feedback widget visibility', () => {
+    it('hides "Was this page helpful?" on a standalone page created by the current user', () => {
+      // Auth user id is '1' (set in beforeEach).
+      currentMockPage = { ...mockPage, source: 'standalone', visibility: 'private', createdByUserId: '1' };
+      render(<PageViewPage />, { wrapper: createWrapper() });
+
+      expect(screen.queryByTestId('feedback-widget')).not.toBeInTheDocument();
+      expect(screen.queryByText('Was this page helpful?')).not.toBeInTheDocument();
+    });
+
+    it('shows the widget on a standalone page created by another user', () => {
+      currentMockPage = { ...mockPage, source: 'standalone', visibility: 'shared', createdByUserId: '2' };
+      render(<PageViewPage />, { wrapper: createWrapper() });
+
+      expect(screen.getByTestId('feedback-widget')).toBeInTheDocument();
+      expect(screen.getByText('Was this page helpful?')).toBeInTheDocument();
+    });
+
+    it('shows the widget on Confluence-synced pages', () => {
+      currentMockPage = { ...mockPage, source: 'confluence', createdByUserId: null };
+      render(<PageViewPage />, { wrapper: createWrapper() });
+
+      expect(screen.getByTestId('feedback-widget')).toBeInTheDocument();
+    });
   });
 
   it('renders the Edit button in the header (action buttons moved to right pane)', () => {

--- a/frontend/src/features/pages/PageViewPage.test.tsx
+++ b/frontend/src/features/pages/PageViewPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -579,14 +579,44 @@ describe('PageViewPage', () => {
     expect(deleteShortcut!.category).toBe('actions');
   });
 
-  it('Alt+Shift+D action triggers delete confirmation', async () => {
-    vi.spyOn(window, 'confirm').mockReturnValueOnce(true);
+  it('Alt+Shift+D opens the move-to-trash dialog; confirming soft-deletes the page', async () => {
     render(<PageViewPage />, { wrapper: createWrapper() });
     const deleteShortcut = capturedShortcuts.find((s) => s.key === 'Alt+Shift+D');
     expect(deleteShortcut).toBeDefined();
-    await deleteShortcut!.action();
-    expect(window.confirm).toHaveBeenCalledWith('Delete this article? This cannot be undone.');
-    expect(mockDeleteMutateAsync).toHaveBeenCalledWith('page-1');
+    act(() => {
+      deleteShortcut!.action();
+    });
+
+    // ConfirmDialog replaces window.confirm — copy must reflect the 30-day
+    // soft-delete trash, not the old (false) "cannot be undone" claim.
+    expect(await screen.findByText('Move page to trash?')).toBeInTheDocument();
+    expect(
+      screen.getByText('It can be restored from Trash for 30 days, then it is permanently deleted.'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+
+    await waitFor(() => {
+      expect(mockDeleteMutateAsync).toHaveBeenCalledWith('page-1');
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('cancelling the move-to-trash dialog does not delete', async () => {
+    render(<PageViewPage />, { wrapper: createWrapper() });
+    const deleteShortcut = capturedShortcuts.find((s) => s.key === 'Alt+Shift+D');
+    expect(deleteShortcut).toBeDefined();
+    act(() => {
+      deleteShortcut!.action();
+    });
+
+    await screen.findByTestId('confirm-dialog');
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+    });
+    expect(mockDeleteMutateAsync).not.toHaveBeenCalled();
   });
 
   it('registers an Alt+I shortcut for AI Improve', () => {

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -157,6 +157,9 @@ export function PageViewPage() {
   const [drawioEditingDiagram, setDrawioEditingDiagram] = useState<string | null>(null);
   const [drawioXml, setDrawioXml] = useState<string>('');
   const [confirmTrashOpen, setConfirmTrashOpen] = useState(false);
+  // Draft awaiting a restore decision (ConfirmDialog replaces native confirm()).
+  // While non-null, edit mode is deferred until the user picks a side.
+  const [pendingDraft, setPendingDraft] = useState<string | null>(null);
 
   // Vim mode state — lifted here so we can pass it to the external toolbar
   const [vimEnabled, setVimEnabled] = useState(() =>
@@ -217,13 +220,29 @@ export function PageViewPage() {
     setEditTitle(page.title);
     const draft = getDraft(`page-${id}`);
     if (draft && draft !== page.bodyHtml) {
-      const restoreDraft = window.confirm('A draft was found for this page. Restore it?');
-      setEditHtml(restoreDraft ? draft : page.bodyHtml);
-    } else {
-      setEditHtml(page.bodyHtml);
+      // Defer edit mode until the user decides in the ConfirmDialog below.
+      // Matches the old native confirm() semantics: either choice enters edit
+      // mode — confirm restores the draft, cancel edits the published copy.
+      setPendingDraft(draft);
+      return;
     }
+    setEditHtml(page.bodyHtml);
     setEditing(true);
   }, [id, page]);
+
+  const handleRestoreDraft = useCallback(() => {
+    if (pendingDraft === null) return;
+    setEditHtml(pendingDraft);
+    setPendingDraft(null);
+    setEditing(true);
+  }, [pendingDraft]);
+
+  const handleDeclineDraft = useCallback(() => {
+    setPendingDraft(null);
+    if (!page) return;
+    setEditHtml(page.bodyHtml);
+    setEditing(true);
+  }, [page]);
 
   const handleCancelEditing = useCallback(() => {
     if (draftKey) clearDraft(draftKey);
@@ -368,7 +387,7 @@ export function PageViewPage() {
 
   // Deleting soft-deletes into the 30-day trash, so the confirm copy must
   // not claim the action "cannot be undone". ConfirmDialog replaces the
-  // native window.confirm to match the neumorphic design system.
+  // native confirm() to match the neumorphic design system.
   const handleDeletePage = useCallback(() => {
     if (!id) return;
     setConfirmTrashOpen(true);
@@ -784,6 +803,21 @@ export function PageViewPage() {
         destructive
         onConfirm={handleConfirmMoveToTrash}
         onCancel={() => setConfirmTrashOpen(false)}
+      />
+
+      {/* Draft restore — drafts are autosaved to localStorage on this device
+          while editing. Restoring is non-destructive; declining opens the
+          editor on the published content (same as the old native confirm()
+          flow, where Cancel also entered edit mode). No destructive styling:
+          the draft is only overwritten by continued editing, never deleted
+          here. */}
+      <ConfirmDialog
+        open={pendingDraft !== null}
+        title="Restore draft?"
+        description="An unsaved draft of this page was found in this browser. Restore it to continue where you left off, or cancel to edit the published version instead (the draft is overwritten as you edit)."
+        confirmLabel="Restore draft"
+        onConfirm={handleRestoreDraft}
+        onCancel={handleDeclineDraft}
       />
     </m.div>
   );

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -206,7 +206,7 @@ export function PageViewPage() {
     setEditTitle(page.title);
     const draft = getDraft(`page-${id}`);
     if (draft && draft !== page.bodyHtml) {
-      const restoreDraft = window.confirm('A draft was found for this article. Restore it?');
+      const restoreDraft = window.confirm('A draft was found for this page. Restore it?');
       setEditHtml(restoreDraft ? draft : page.bodyHtml);
     } else {
       setEditHtml(page.bodyHtml);
@@ -246,9 +246,9 @@ export function PageViewPage() {
       });
       if (draftKey) clearDraft(draftKey);
       setEditing(false);
-      toast.success('Article saved.');
+      toast.success('Page saved.');
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to save article.';
+      const message = error instanceof Error ? error.message : 'Failed to save page.';
       if (message.includes('modified since you loaded')) {
         toast.error('Version conflict detected.', {
           action: {
@@ -381,7 +381,7 @@ export function PageViewPage() {
       key: 'Ctrl+S',
       keys: ['s'],
       mod: true,
-      description: 'Save current article',
+      description: 'Save current page',
       category: 'editor',
       action: () => {
         if (editing) handleSave();
@@ -454,7 +454,7 @@ export function PageViewPage() {
     return (
       <div className="nm-card flex min-h-[18rem] flex-col items-center justify-center gap-3 py-16 text-center">
         <FileText size={42} className="text-muted-foreground" />
-        <h1 className="text-xl font-semibold text-foreground">Article not found</h1>
+        <h1 className="text-xl font-semibold text-foreground">Page not found</h1>
         <p className="max-w-md text-sm text-muted-foreground">
           The selected page is unavailable or no longer accessible in the synced space tree.
         </p>
@@ -657,7 +657,7 @@ export function PageViewPage() {
                   value={editTitle}
                   onChange={(event) => setEditTitle(event.target.value)}
                   className="w-full bg-transparent text-3xl font-bold leading-tight tracking-[-0.02em] text-foreground outline-none placeholder:text-muted-foreground/40"
-                  placeholder="Article title…"
+                  placeholder="Page title…"
                 />
               </div>
             </div>
@@ -728,7 +728,7 @@ export function PageViewPage() {
               />
             )}
 
-            <FeatureErrorBoundary featureName="Article Viewer">
+            <FeatureErrorBoundary featureName="Page Viewer">
               <ArticleViewer
                 content={page.bodyHtml}
                 confluenceUrl={settings?.confluenceUrl}
@@ -804,7 +804,7 @@ function FeedbackWidget({ pageId }: { pageId: string | undefined }) {
 
   return (
     <div className="mt-12 border-t border-border/25 pt-6" data-testid="feedback-widget">
-      <p className="mb-3 text-sm font-medium text-muted-foreground">Was this article helpful?</p>
+      <p className="mb-3 text-sm font-medium text-muted-foreground">Was this page helpful?</p>
       <div className="flex gap-2">
         <button
           onClick={() => handleFeedback(true)}

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -33,6 +33,7 @@ import type { TocHeading } from '../../shared/components/article/TableOfContents
 import { PageViewSkeleton } from '../../shared/components/feedback/Skeleton';
 import { TagEditor } from '../../shared/components/TagEditor';
 import { ShortcutHint } from '../../shared/components/ShortcutHint';
+import { ConfirmDialog } from '../../shared/components/ConfirmDialog';
 import { usePresence } from './use-presence';
 import { PresenceAvatarStack } from './PresenceAvatarStack';
 
@@ -144,6 +145,7 @@ export function PageViewPage() {
   const [lightboxSrc, setLightboxSrc] = useState<{ alt: string; src: string } | null>(null);
   const [drawioEditingDiagram, setDrawioEditingDiagram] = useState<string | null>(null);
   const [drawioXml, setDrawioXml] = useState<string>('');
+  const [confirmTrashOpen, setConfirmTrashOpen] = useState(false);
 
   // Vim mode state — lifted here so we can pass it to the external toolbar
   const [vimEnabled, setVimEnabled] = useState(() =>
@@ -353,14 +355,23 @@ export function PageViewPage() {
     });
   }, [id, isPinned, page, pinMutation, unpinMutation]);
 
-  const handleDeletePage = useCallback(async () => {
-    if (!id || !window.confirm('Delete this article? This cannot be undone.')) return;
+  // Deleting soft-deletes into the 30-day trash, so the confirm copy must
+  // not claim the action "cannot be undone". ConfirmDialog replaces the
+  // native window.confirm to match the neumorphic design system.
+  const handleDeletePage = useCallback(() => {
+    if (!id) return;
+    setConfirmTrashOpen(true);
+  }, [id]);
+
+  const handleConfirmMoveToTrash = useCallback(async () => {
+    if (!id) return;
+    setConfirmTrashOpen(false);
     try {
       await deleteMutation_page.mutateAsync(id);
       navigate('/');
-      toast.success('Article deleted.');
+      toast.success('Page moved to trash.');
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to delete article.');
+      toast.error(error instanceof Error ? error.message : 'Failed to move page to trash.');
     }
   }, [deleteMutation_page, id, navigate]);
 
@@ -753,6 +764,16 @@ export function PageViewPage() {
           drawioUrl={drawioSettings?.drawioEmbedUrl}
         />
       )}
+
+      <ConfirmDialog
+        open={confirmTrashOpen}
+        title="Move page to trash?"
+        description="It can be restored from Trash for 30 days, then it is permanently deleted."
+        confirmLabel="Move to trash"
+        destructive
+        onConfirm={handleConfirmMoveToTrash}
+        onCancel={() => setConfirmTrashOpen(false)}
+      />
     </m.div>
   );
 }

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -19,6 +19,7 @@ import { useAuthenticatedSrc } from '../../shared/hooks/use-authenticated-src';
 import { useSettings } from '../../shared/hooks/use-settings';
 import { useKeyboardShortcuts, type ShortcutDefinition } from '../../shared/hooks/use-keyboard-shortcuts';
 import { useArticleViewStore } from '../../stores/article-view-store';
+import { useAuthStore } from '../../stores/auth-store';
 import { cn } from '../../shared/lib/cn';
 import { FeatureErrorBoundary } from '../../shared/components/feedback/FeatureErrorBoundary';
 import { QualityScoreBadge } from '../../shared/components/badges/QualityScoreBadge';
@@ -121,6 +122,16 @@ export function PageViewPage() {
   const deleteMutation_page = useDeletePage();
 
   const isPinned = pinnedData?.items.some((item) => item.id === id) ?? false;
+
+  // Hide the helpfulness widget on standalone pages the current user authored
+  // — rating your own page is noise. Confluence-synced pages (createdByUserId
+  // is null) and other users' pages keep the widget.
+  const currentUserId = useAuthStore((s) => s.user?.id);
+  const isOwnStandalonePage =
+    page?.source === 'standalone' &&
+    page.createdByUserId != null &&
+    currentUserId != null &&
+    String(page.createdByUserId) === String(currentUserId);
 
 
   // Fetch the configured draw.io embed URL (falls back to default inside DrawioEditor if undefined)
@@ -740,8 +751,8 @@ export function PageViewPage() {
               />
             </FeatureErrorBoundary>
 
-            {/* Feedback widget */}
-            <FeedbackWidget pageId={id} />
+            {/* Feedback widget — hidden on the author's own standalone pages */}
+            {!isOwnStandalonePage && <FeedbackWidget pageId={id} />}
           </div>
         )}
       </div>

--- a/frontend/src/features/pages/PagesPage.test.tsx
+++ b/frontend/src/features/pages/PagesPage.test.tsx
@@ -427,7 +427,7 @@ describe('PagesPage', () => {
 
     const section = await screen.findByTestId('pinned-articles-section');
     expect(section).toBeInTheDocument();
-    expect(screen.getByText('Pinned Articles')).toBeInTheDocument();
+    expect(screen.getByText('Pinned Pages')).toBeInTheDocument();
     expect(screen.getByText('Getting Started Guide')).toBeInTheDocument();
     expect(screen.getByText('Deployment Runbook')).toBeInTheDocument();
   });

--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -408,7 +408,7 @@ export function PagesPage() {
         </div>
       )}
 
-      {/* Pinned Articles */}
+      {/* Pinned Pages */}
       <PinnedArticlesSection />
 
       {/* Filters */}

--- a/frontend/src/features/pages/PinnedArticlesSection.test.tsx
+++ b/frontend/src/features/pages/PinnedArticlesSection.test.tsx
@@ -68,7 +68,7 @@ describe('PinnedArticlesSection', () => {
 
     const section = await screen.findByTestId('pinned-articles-section');
     expect(section).toBeInTheDocument();
-    expect(screen.getByText('Pinned Articles')).toBeInTheDocument();
+    expect(screen.getByText('Pinned Pages')).toBeInTheDocument();
     expect(screen.getByText('Getting Started Guide')).toBeInTheDocument();
     expect(screen.getByText('Deployment Runbook')).toBeInTheDocument();
   });

--- a/frontend/src/features/pages/PinnedArticlesSection.tsx
+++ b/frontend/src/features/pages/PinnedArticlesSection.tsx
@@ -35,7 +35,7 @@ export function PinnedArticlesSection() {
       <div className="mb-3 flex items-center gap-2">
         <Pin size={16} className="text-action" />
         <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
-          Pinned Articles
+          Pinned Pages
         </h2>
       </div>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">

--- a/frontend/src/features/pages/QualityAnalysisPanel.test.tsx
+++ b/frontend/src/features/pages/QualityAnalysisPanel.test.tsx
@@ -67,7 +67,7 @@ describe('QualityAnalysisPanel', () => {
       <QualityAnalysisPanel pageId="page-1" bodyHtml="<p>Test</p>" pageTitle="Test Page" />,
       { wrapper: createWrapper() },
     );
-    expect(screen.getByTitle('Analyze article quality')).toBeInTheDocument();
+    expect(screen.getByTitle('Analyze page quality')).toBeInTheDocument();
   });
 
   it('expands panel when button is clicked', async () => {
@@ -76,7 +76,7 @@ describe('QualityAnalysisPanel', () => {
       { wrapper: createWrapper() },
     );
 
-    fireEvent.click(screen.getByTitle('Analyze article quality'));
+    fireEvent.click(screen.getByTitle('Analyze page quality'));
 
     await waitFor(() => {
       expect(screen.getByText('Quality Analysis')).toBeInTheDocument();
@@ -88,7 +88,7 @@ describe('QualityAnalysisPanel', () => {
       <QualityAnalysisPanel pageId="page-1" bodyHtml="<p>Test</p>" pageTitle="Test Page" renderTriggerOnly />,
       { wrapper: createWrapper() },
     );
-    expect(screen.getByTitle('Analyze article quality')).toBeInTheDocument();
+    expect(screen.getByTitle('Analyze page quality')).toBeInTheDocument();
     expect(screen.queryByText('Quality Analysis')).not.toBeInTheDocument();
   });
 
@@ -113,7 +113,7 @@ describe('QualityAnalysisPanel', () => {
       <QualityAnalysisPanel pageId="page-1" bodyHtml="<p>Test</p>" pageTitle="Test Page" renderTriggerOnly />,
       { wrapper: createWrapper() },
     );
-    const btn = screen.getByTitle('Analyze article quality');
+    const btn = screen.getByTitle('Analyze page quality');
     const label = btn.querySelector('span');
     expect(label).toHaveClass('hidden', 'sm:inline');
   });
@@ -124,7 +124,7 @@ describe('QualityAnalysisPanel', () => {
       { wrapper: createWrapper() },
     );
 
-    fireEvent.click(screen.getByTitle('Analyze article quality'));
+    fireEvent.click(screen.getByTitle('Analyze page quality'));
 
     await waitFor(() => {
       expect(screen.getByText('Analyzing: My Article')).toBeInTheDocument();
@@ -137,7 +137,7 @@ describe('QualityAnalysisPanel', () => {
       { wrapper: createWrapper() },
     );
 
-    fireEvent.click(screen.getByTitle('Analyze article quality'));
+    fireEvent.click(screen.getByTitle('Analyze page quality'));
 
     await waitFor(() => {
       expect(apiFetchMock).toHaveBeenCalledWith('/ollama/models');
@@ -150,7 +150,7 @@ describe('QualityAnalysisPanel', () => {
       { wrapper: createWrapper() },
     );
 
-    fireEvent.click(screen.getByTitle('Analyze article quality'));
+    fireEvent.click(screen.getByTitle('Analyze page quality'));
     await waitFor(() => {
       expect(screen.getByText('Quality Analysis')).toBeInTheDocument();
     });
@@ -160,7 +160,7 @@ describe('QualityAnalysisPanel', () => {
     fireEvent.click(closeBtn);
 
     expect(screen.queryByText('Quality Analysis')).not.toBeInTheDocument();
-    expect(screen.getByTitle('Analyze article quality')).toBeInTheDocument();
+    expect(screen.getByTitle('Analyze page quality')).toBeInTheDocument();
   });
 
   it('sends correct payload when analyzing', async () => {
@@ -174,7 +174,7 @@ describe('QualityAnalysisPanel', () => {
       { wrapper: createWrapper() },
     );
 
-    fireEvent.click(screen.getByTitle('Analyze article quality'));
+    fireEvent.click(screen.getByTitle('Analyze page quality'));
 
     await waitFor(() => {
       expect(screen.getByText('Analyze')).toBeInTheDocument();
@@ -205,7 +205,7 @@ describe('QualityAnalysisPanel', () => {
       { wrapper: createWrapper() },
     );
 
-    fireEvent.click(screen.getByTitle('Analyze article quality'));
+    fireEvent.click(screen.getByTitle('Analyze page quality'));
 
     await waitFor(() => {
       expect(screen.getByText('Analyze')).toBeInTheDocument();
@@ -229,7 +229,7 @@ describe('QualityAnalysisPanel', () => {
       { wrapper: createWrapper() },
     );
 
-    fireEvent.click(screen.getByTitle('Analyze article quality'));
+    fireEvent.click(screen.getByTitle('Analyze page quality'));
 
     await waitFor(() => {
       expect(screen.getByText('Analyze')).toBeInTheDocument();
@@ -257,7 +257,7 @@ describe('QualityAnalysisPanel', () => {
       { wrapper: createWrapper() },
     );
 
-    fireEvent.click(screen.getByTitle('Analyze article quality'));
+    fireEvent.click(screen.getByTitle('Analyze page quality'));
 
     await waitFor(() => {
       expect(screen.getByText('Analyze')).toBeInTheDocument();
@@ -279,7 +279,7 @@ describe('QualityAnalysisPanel', () => {
       { wrapper: createWrapper() },
     );
 
-    const btn = screen.getByTitle('Analyze article quality');
+    const btn = screen.getByTitle('Analyze page quality');
     expect(btn).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/pages/QualityAnalysisPanel.tsx
+++ b/frontend/src/features/pages/QualityAnalysisPanel.tsx
@@ -95,7 +95,7 @@ export function QualityAnalysisPanel({
     <button
       onClick={toggleOpen}
       className="nm-card flex items-center gap-1.5 px-3 py-1.5 text-sm hover:bg-foreground/5"
-      title="Analyze article quality"
+      title="Analyze page quality"
     >
       <ShieldCheck size={14} /> <span className="hidden sm:inline">Quality</span>
     </button>
@@ -157,7 +157,7 @@ export function QualityAnalysisPanel({
       {/* Streaming indicator without result yet */}
       {isStreaming && !result && (
         <div className="flex items-center gap-2 rounded-lg border border-border/50 bg-foreground/5 p-4 text-xs text-muted-foreground">
-          <Loader2 size={12} className="animate-spin" /> Analyzing article quality...
+          <Loader2 size={12} className="animate-spin" /> Analyzing page quality...
         </div>
       )}
     </div>

--- a/frontend/src/features/pages/TrashPage.test.tsx
+++ b/frontend/src/features/pages/TrashPage.test.tsx
@@ -86,7 +86,7 @@ describe('TrashPage', () => {
     render(<TrashPage />, { wrapper: createWrapper() });
     const empty = await screen.findByTestId('trash-empty');
     expect(empty).toBeInTheDocument();
-    expect(screen.getByText('No articles in trash')).toBeInTheDocument();
+    expect(screen.getByText('No pages in trash')).toBeInTheDocument();
   });
 
   it('renders trash items fetched from GET /api/pages/trash', async () => {

--- a/frontend/src/features/pages/TrashPage.test.tsx
+++ b/frontend/src/features/pages/TrashPage.test.tsx
@@ -19,32 +19,54 @@ function createWrapper() {
   };
 }
 
-const mockTrashItems = {
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Mirrors the GET /api/pages/trash response shape from
+// backend/src/routes/knowledge/pages-crud.ts (id is a STRING).
+const mockTrashData = {
   items: [
     {
-      id: 1,
+      id: '3',
       title: 'Deleted Article',
-      deletedAt: '2026-03-10T00:00:00Z',
-      deletedBy: 'alice',
-      autoPurgeAt: '2026-04-09T00:00:00Z',
-    },
-    {
-      id: 2,
-      title: 'Another Deleted',
-      deletedAt: '2026-03-12T00:00:00Z',
-      deletedBy: 'bob',
-      autoPurgeAt: '2026-04-11T00:00:00Z',
+      source: 'standalone',
+      visibility: 'private',
+      deletedAt: new Date(Date.now() - DAY_MS).toISOString(),
+      createdAt: new Date(Date.now() - 10 * DAY_MS).toISOString(),
+      deletedBy: 'simon',
+      autoPurgeAt: new Date(Date.now() + 29 * DAY_MS).toISOString(),
     },
   ],
-  total: 2,
+  total: 1,
 };
 
-function mockFetch(data: unknown) {
-  return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(JSON.stringify(data), {
+/**
+ * Mocks fetch at the network boundary, answering only the real backend
+ * endpoints: GET /api/pages/trash and POST /api/pages/:id/restore.
+ * Everything else (e.g. the old /api/trash path) gets a 404.
+ */
+function mockApi(trashData: unknown) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    const method = init?.method ?? 'GET';
+
+    if (url === '/api/pages/trash' && method === 'GET') {
+      return new Response(JSON.stringify(trashData), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    const restoreMatch = url.match(/^\/api\/pages\/([^/]+)\/restore$/);
+    if (restoreMatch && method === 'POST') {
+      return new Response(
+        JSON.stringify({ id: restoreMatch[1], title: 'Deleted Article', restored: true }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    return new Response(JSON.stringify({ message: 'Not found' }), {
+      status: 404,
       headers: { 'Content-Type': 'application/json' },
-    }),
-  );
+    });
+  });
 }
 
 describe('TrashPage', () => {
@@ -53,70 +75,60 @@ describe('TrashPage', () => {
   });
 
   it('renders the page title and description', () => {
-    mockFetch({ items: [], total: 0 });
+    mockApi({ items: [], total: 0 });
     render(<TrashPage />, { wrapper: createWrapper() });
     expect(screen.getByText('Trash')).toBeInTheDocument();
     expect(screen.getByText(/automatically purged/)).toBeInTheDocument();
   });
 
   it('shows empty state when no items in trash', async () => {
-    mockFetch({ items: [], total: 0 });
+    mockApi({ items: [], total: 0 });
     render(<TrashPage />, { wrapper: createWrapper() });
     const empty = await screen.findByTestId('trash-empty');
     expect(empty).toBeInTheDocument();
     expect(screen.getByText('No articles in trash')).toBeInTheDocument();
   });
 
-  it('renders trash items with title and metadata', async () => {
-    mockFetch(mockTrashItems);
+  it('renders trash items fetched from GET /api/pages/trash', async () => {
+    mockApi(mockTrashData);
     render(<TrashPage />, { wrapper: createWrapper() });
 
     const list = await screen.findByTestId('trash-list');
     expect(list).toBeInTheDocument();
 
     expect(screen.getByText('Deleted Article')).toBeInTheDocument();
-    expect(screen.getByText('Another Deleted')).toBeInTheDocument();
-    expect(screen.getByText(/by alice/)).toBeInTheDocument();
-    expect(screen.getByText(/by bob/)).toBeInTheDocument();
-  });
-
-  it('shows restore button for each trash item', async () => {
-    mockFetch(mockTrashItems);
-    render(<TrashPage />, { wrapper: createWrapper() });
-    await screen.findByTestId('trash-list');
-    expect(screen.getByTestId('restore-btn-1')).toBeInTheDocument();
-    expect(screen.getByTestId('restore-btn-2')).toBeInTheDocument();
-  });
-
-  it('calls restore API when restore button is clicked', async () => {
-    const fetchSpy = mockFetch(mockTrashItems);
-    render(<TrashPage />, { wrapper: createWrapper() });
-    await screen.findByTestId('trash-list');
-
-    // Reset the mock to track the restore call
-    fetchSpy.mockResolvedValue(
-      new Response(JSON.stringify({ message: 'restored' }), {
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    );
-
-    fireEvent.click(screen.getByTestId('restore-btn-1'));
-
-    await waitFor(() => {
-      const calls = fetchSpy.mock.calls;
-      const restoreCall = calls.find(([url]) =>
-        typeof url === 'string' && url.includes('/trash/1/restore'),
-      );
-      expect(restoreCall).toBeTruthy();
-    });
+    expect(screen.getByText(/by simon/)).toBeInTheDocument();
   });
 
   it('shows days until auto-purge for each item', async () => {
-    mockFetch(mockTrashItems);
+    mockApi(mockTrashData);
     render(<TrashPage />, { wrapper: createWrapper() });
     await screen.findByTestId('trash-list');
-    // Should show auto-purge information
-    const purgeTexts = screen.getAllByText(/days until auto-purge/);
-    expect(purgeTexts).toHaveLength(2);
+    expect(screen.getByText(/29 days until auto-purge/)).toBeInTheDocument();
+  });
+
+  it('shows a restore button for each trash item', async () => {
+    mockApi(mockTrashData);
+    render(<TrashPage />, { wrapper: createWrapper() });
+    await screen.findByTestId('trash-list');
+    expect(screen.getByTestId('restore-btn-3')).toBeInTheDocument();
+  });
+
+  it('issues POST /api/pages/3/restore when restore is clicked', async () => {
+    const fetchSpy = mockApi(mockTrashData);
+    render(<TrashPage />, { wrapper: createWrapper() });
+    await screen.findByTestId('trash-list');
+
+    fireEvent.click(screen.getByTestId('restore-btn-3'));
+
+    await waitFor(() => {
+      const restoreCall = fetchSpy.mock.calls.find(
+        ([url, init]) =>
+          typeof url === 'string' &&
+          url === '/api/pages/3/restore' &&
+          init?.method === 'POST',
+      );
+      expect(restoreCall).toBeTruthy();
+    });
   });
 });

--- a/frontend/src/features/pages/TrashPage.tsx
+++ b/frontend/src/features/pages/TrashPage.tsx
@@ -35,7 +35,7 @@ export function TrashPage() {
         <div>
           <h1 className="text-2xl font-bold">Trash</h1>
           <p className="text-sm text-muted-foreground">
-            Deleted articles are automatically purged after 30 days
+            Deleted pages are automatically purged 30 days after deletion
           </p>
         </div>
       </div>
@@ -50,9 +50,9 @@ export function TrashPage() {
       ) : !trashData?.items.length ? (
         <div className="nm-card flex flex-col items-center justify-center py-16 text-center" data-testid="trash-empty">
           <Trash2 size={48} className="mb-4 text-muted-foreground" />
-          <p className="text-lg font-medium">No articles in trash</p>
+          <p className="text-lg font-medium">No pages in trash</p>
           <p className="text-sm text-muted-foreground">
-            Deleted standalone articles will appear here
+            Deleted local pages will appear here
           </p>
         </div>
       ) : (

--- a/frontend/src/features/pages/TrashPage.tsx
+++ b/frontend/src/features/pages/TrashPage.tsx
@@ -9,7 +9,7 @@ export function TrashPage() {
   const { data: trashData, isLoading } = useTrash();
   const restoreMutation = useRestorePage();
 
-  const handleRestore = async (pageId: number) => {
+  const handleRestore = async (pageId: string) => {
     try {
       await restoreMutation.mutateAsync(pageId);
       toast.success('Page restored');

--- a/frontend/src/features/pages/VersionHistory.test.tsx
+++ b/frontend/src/features/pages/VersionHistory.test.tsx
@@ -392,8 +392,7 @@ describe('VersionHistory', () => {
     expect(restoreButtons).toHaveLength(2);
   });
 
-  it('restores a version: confirms, POSTs to the restore endpoint with the current version guard', async () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+  it('restores a version through the ConfirmDialog: POSTs to the restore endpoint with the current version guard', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url.includes('/restore')) {
@@ -426,7 +425,14 @@ describe('VersionHistory', () => {
     const restoreButtons = screen.getAllByTitle('Restore this version');
     fireEvent.click(restoreButtons[0]!);
 
-    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Restore v2?'));
+    // ConfirmDialog replaces native confirm(). The copy must reflect the
+    // backend reality (pages-versions.ts): Confluence-style non-destructive
+    // restore — current content is replaced but stays in version history.
+    expect(await screen.findByText('Restore v2?')).toBeInTheDocument();
+    expect(screen.getByText(/saved as a new version/i)).toBeInTheDocument();
+    expect(screen.getByText(/stays in version history/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
 
     await waitFor(() => {
       const restoreCall = fetchSpy.mock.calls.find(
@@ -441,8 +447,7 @@ describe('VersionHistory', () => {
     });
   });
 
-  it('does not POST when the restore confirm is cancelled', async () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(false);
+  it('does not POST when the restore dialog is cancelled, and keeps the history dialog open', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockVersionsResponse());
 
     render(
@@ -454,6 +459,15 @@ describe('VersionHistory', () => {
     await waitFor(() => expect(screen.getByText('v2')).toBeInTheDocument());
 
     fireEvent.click(screen.getAllByTitle('Restore this version')[0]!);
+    await screen.findByTestId('confirm-dialog');
+
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+    });
+    // The outer Version History dialog must survive the nested cancel.
+    expect(screen.getByText('Version History')).toBeInTheDocument();
 
     const restoreCall = fetchSpy.mock.calls.find(
       ([input]) => (typeof input === 'string' ? input : String(input)).includes('/restore'),

--- a/frontend/src/features/pages/VersionHistory.tsx
+++ b/frontend/src/features/pages/VersionHistory.tsx
@@ -10,6 +10,7 @@ import type {
 } from '@compendiq/contracts';
 import { apiFetch, ApiError } from '../../shared/lib/api';
 import { DiffView } from '../../shared/components/article/DiffView';
+import { ConfirmDialog } from '../../shared/components/ConfirmDialog';
 import { cn } from '../../shared/lib/cn';
 import { useIsLightTheme } from '../../shared/hooks/use-is-light-theme';
 
@@ -84,6 +85,8 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
   const [selectedVersion, setSelectedVersion] = useState<number | null>(null);
   const [compareVersions, setCompareVersions] = useState<[number, number] | null>(null);
   const [showSemanticDiff, setShowSemanticDiff] = useState(false);
+  // Version awaiting restore confirmation (ConfirmDialog replaces native confirm()).
+  const [pendingRestore, setPendingRestore] = useState<number | null>(null);
 
   const { data: versionsData, isLoading, isError, error, refetch } = useVersionHistory(pageId, open);
   const { data: selectedVersionData } = useVersionDetail(
@@ -139,13 +142,14 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
 
   const handleRestore = (version: number) => {
     if (restoreMutation.isPending) return;
-    if (!window.confirm(
-      `Restore v${version}? This creates a new version containing the old content. ` +
-      `The current version stays in history.`,
-    )) {
-      return;
+    setPendingRestore(version);
+  };
+
+  const handleConfirmRestore = () => {
+    if (pendingRestore !== null) {
+      restoreMutation.mutate({ version: pendingRestore, expected: currentVersionNumber });
     }
-    restoreMutation.mutate({ version, expected: currentVersionNumber });
+    setPendingRestore(null);
   };
 
   // Reset state when dialog closes
@@ -154,6 +158,7 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
       setSelectedVersion(null);
       setCompareVersions(null);
       setShowSemanticDiff(false);
+      setPendingRestore(null);
     }
   }, [open]);
 
@@ -472,6 +477,22 @@ export function VersionHistory({ pageId, currentBodyText: _currentBodyText, mode
           </div>
         </Dialog.Content>
       </Dialog.Portal>
+
+      {/* Restore confirmation — nested Radix dialog (renders via its own
+          portal above the history dialog). Copy mirrors the backend reality
+          (POST /pages/:id/versions/:version/restore): Confluence-style
+          non-destructive restore — the target snapshot is applied as a NEW
+          live version and the replaced content stays in version history.
+          Destructive styling because the visible page content is replaced. */}
+      <ConfirmDialog
+        open={pendingRestore !== null}
+        title={`Restore v${pendingRestore ?? ''}?`}
+        description={`The current page content will be replaced with the content of v${pendingRestore ?? ''}, saved as a new version. The replaced content stays in version history; Confluence-synced pages are updated in Confluence as well.`}
+        confirmLabel="Restore version"
+        destructive
+        onConfirm={handleConfirmRestore}
+        onCancel={() => setPendingRestore(null)}
+      />
     </Dialog.Root>
   );
 }

--- a/frontend/src/features/search/SearchPage.tsx
+++ b/frontend/src/features/search/SearchPage.tsx
@@ -228,7 +228,7 @@ export function SearchPage() {
       <div>
         <h1 className="text-2xl font-bold">Search</h1>
         <p className="text-sm text-muted-foreground">
-          Find articles across your knowledge base
+          Find pages across your knowledge base
         </p>
       </div>
 
@@ -246,7 +246,7 @@ export function SearchPage() {
             <input
               ref={inputRef}
               type="text"
-              placeholder="Search articles by title, content, or keywords..."
+              placeholder="Search pages by title, content, or keywords..."
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               className="w-full rounded-lg bg-foreground/5 py-3 pl-11 pr-4 text-sm outline-none placeholder:text-muted-foreground focus:ring-2 focus:ring-primary/50"
@@ -486,7 +486,7 @@ export function SearchPage() {
           </div>
           <p className="text-lg font-medium" data-testid="no-results-title">No results found</p>
           <p className="mt-1 text-sm text-muted-foreground">
-            No articles match &ldquo;{activeQuery}&rdquo;
+            No pages match &ldquo;{activeQuery}&rdquo;
           </p>
           <button
             onClick={() => navigate(`/knowledge-requests?title=${encodeURIComponent(activeQuery)}`)}

--- a/frontend/src/features/settings/LoginPage.test.tsx
+++ b/frontend/src/features/settings/LoginPage.test.tsx
@@ -178,6 +178,33 @@ describe('LoginPage', () => {
       expect(registerCall).toBeUndefined();
     });
 
+    it('clears the mismatch error as soon as the user retypes either password field', async () => {
+      const { apiFetch } = await import('../../shared/lib/api');
+      vi.mocked(apiFetch).mockRejectedValue(new Error('no oidc'));
+
+      renderLoginPage();
+      switchToRegister();
+
+      fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'newuser' } });
+      fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+      fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'password124' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+
+      expect(await screen.findByText("Passwords don't match")).toBeInTheDocument();
+
+      // Correcting the confirm field must dismiss the stale error immediately.
+      fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'password123' } });
+      expect(screen.queryByText("Passwords don't match")).not.toBeInTheDocument();
+
+      // Same when editing the password field after a fresh mismatch.
+      fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'password124' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+      expect(await screen.findByText("Passwords don't match")).toBeInTheDocument();
+
+      fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password124' } });
+      expect(screen.queryByText("Passwords don't match")).not.toBeInTheDocument();
+    });
+
     it('submits the registration when the passwords match', async () => {
       const { apiFetch } = await import('../../shared/lib/api');
       vi.mocked(apiFetch).mockImplementation(async (url: string) => {

--- a/frontend/src/features/settings/LoginPage.test.tsx
+++ b/frontend/src/features/settings/LoginPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { LazyMotion, domAnimation } from 'framer-motion';
 import { LoginPage } from './LoginPage';
@@ -134,5 +134,77 @@ describe('LoginPage', () => {
 
     renderLoginPage();
     expect(await screen.findByRole('button', { name: 'Sign in with OrgSSO' })).toBeInTheDocument();
+  });
+
+  describe('registration confirm password', () => {
+    function switchToRegister() {
+      fireEvent.click(screen.getByRole('button', { name: 'Create one' }));
+    }
+
+    it('shows the confirm-password input and the 8-char hint in register mode only', async () => {
+      const { apiFetch } = await import('../../shared/lib/api');
+      vi.mocked(apiFetch).mockRejectedValue(new Error('no oidc'));
+
+      renderLoginPage();
+
+      // Login mode: neither the confirm field nor the hint is rendered.
+      expect(screen.queryByLabelText('Confirm password')).not.toBeInTheDocument();
+      expect(screen.queryByText('At least 8 characters')).not.toBeInTheDocument();
+
+      switchToRegister();
+
+      expect(screen.getByLabelText('Confirm password')).toBeInTheDocument();
+      expect(screen.getByText('At least 8 characters')).toBeInTheDocument();
+    });
+
+    it('blocks submit and shows an error when the passwords do not match', async () => {
+      const { apiFetch } = await import('../../shared/lib/api');
+      vi.mocked(apiFetch).mockRejectedValue(new Error('no oidc'));
+
+      renderLoginPage();
+      switchToRegister();
+
+      fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'newuser' } });
+      fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+      fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'password124' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+
+      expect(await screen.findByText("Passwords don't match")).toBeInTheDocument();
+
+      // No registration request was fired.
+      const registerCall = vi
+        .mocked(apiFetch)
+        .mock.calls.find(([url]) => String(url).includes('/auth/register'));
+      expect(registerCall).toBeUndefined();
+    });
+
+    it('submits the registration when the passwords match', async () => {
+      const { apiFetch } = await import('../../shared/lib/api');
+      vi.mocked(apiFetch).mockImplementation(async (url: string) => {
+        if (String(url).includes('/auth/register')) {
+          return {
+            accessToken: 'tok',
+            user: { id: 'u1', username: 'newuser', role: 'user' },
+          } as never;
+        }
+        throw new Error('no oidc');
+      });
+
+      renderLoginPage();
+      switchToRegister();
+
+      fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'newuser' } });
+      fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+      fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'password123' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+
+      await waitFor(() => {
+        const registerCall = vi
+          .mocked(apiFetch)
+          .mock.calls.find(([url]) => String(url).includes('/auth/register'));
+        expect(registerCall).toBeDefined();
+      });
+      expect(screen.queryByText("Passwords don't match")).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/features/settings/LoginPage.tsx
+++ b/frontend/src/features/settings/LoginPage.tsx
@@ -27,6 +27,8 @@ export function LoginPage() {
   const [isRegister, setIsRegister] = useState(false);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [confirmError, setConfirmError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [oidcConfig, setOidcConfig] = useState<OidcConfig | null>(null);
 
@@ -55,6 +57,14 @@ export function LoginPage() {
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
+
+    // Client-side confirmation check (register mode only) — block the
+    // request entirely on mismatch.
+    if (isRegister && password !== confirmPassword) {
+      setConfirmError("Passwords don't match");
+      return;
+    }
+    setConfirmError(null);
     setLoading(true);
 
     try {
@@ -135,7 +145,29 @@ export function LoginPage() {
               className="nm-input"
               placeholder="Enter password"
             />
+            {isRegister && (
+              <p className="mt-1.5 text-xs text-muted-foreground">At least 8 characters</p>
+            )}
           </div>
+
+          {isRegister && (
+            <div>
+              <label htmlFor="login-confirm-password" className="mb-1.5 block text-sm font-medium">Confirm password</label>
+              <input
+                id="login-confirm-password"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                minLength={8}
+                className="nm-input"
+                placeholder="Re-enter password"
+              />
+              {confirmError && (
+                <p role="alert" className="mt-1.5 text-xs text-red-500">{confirmError}</p>
+              )}
+            </div>
+          )}
 
           <button
             type="submit"
@@ -149,7 +181,11 @@ export function LoginPage() {
         <p className="mt-6 text-center text-sm text-muted-foreground">
           {isRegister ? 'Already have an account?' : "Don't have an account?"}{' '}
           <button
-            onClick={() => setIsRegister(!isRegister)}
+            onClick={() => {
+              setIsRegister(!isRegister);
+              setConfirmPassword('');
+              setConfirmError(null);
+            }}
             className="text-action hover:underline"
           >
             {isRegister ? 'Sign in' : 'Create one'}

--- a/frontend/src/features/settings/LoginPage.tsx
+++ b/frontend/src/features/settings/LoginPage.tsx
@@ -139,7 +139,10 @@ export function LoginPage() {
               id="login-password"
               type="password"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                setConfirmError(null);
+              }}
               required
               minLength={8}
               className="nm-input"
@@ -157,7 +160,10 @@ export function LoginPage() {
                 id="login-confirm-password"
                 type="password"
                 value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
+                onChange={(e) => {
+                  setConfirmPassword(e.target.value);
+                  setConfirmError(null);
+                }}
                 required
                 minLength={8}
                 className="nm-input"

--- a/frontend/src/features/settings/SettingsLayout.test.tsx
+++ b/frontend/src/features/settings/SettingsLayout.test.tsx
@@ -190,12 +190,28 @@ describe('SettingsPanelRoute — gating via direct URL', () => {
     });
   });
 
-  it('bounces unknown /settings/foo/bar URLs to the default panel', async () => {
+  it('renders a not-found panel (no redirect) for unknown /settings/foo/bar URLs', async () => {
     renderLayoutAt('/settings/foo/bar');
+
+    expect(await screen.findByText("This settings page doesn't exist.")).toBeInTheDocument();
+
+    // Offers a way back to the first visible panel instead of silently bouncing.
+    const link = screen.getByRole('link', { name: 'Go to Settings' });
+    expect(link).toHaveAttribute('href', '/settings/personal/confluence');
+
+    // No redirect happened — the default panel is not marked active.
+    expect(screen.getByTestId('nav-settings-confluence')).not.toHaveAttribute('aria-current', 'page');
+  });
+
+  it('keeps the redirect for a registered item hidden from the user (admin-only, non-admin)', async () => {
+    // ai/models exists in the nav config but is admin-only — a non-admin must
+    // be bounced to the first visible panel, NOT shown the not-found panel.
+    renderLayoutAt('/settings/ai/models');
 
     await waitFor(() => {
       expect(screen.getByTestId('nav-settings-confluence')).toHaveAttribute('aria-current', 'page');
     });
+    expect(screen.queryByText("This settings page doesn't exist.")).not.toBeInTheDocument();
   });
 });
 
@@ -239,12 +255,10 @@ describe('SettingsPanelRoute — EE deep-link loading race', () => {
     });
   });
 
-  it('still bounces unknown URLs immediately even while license is loading', async () => {
+  it('renders the not-found panel immediately for unknown URLs even while license is loading', async () => {
     enterpriseState.isLoading = true;
     renderLayoutAt('/settings/foo/bar');
 
-    await waitFor(() => {
-      expect(screen.getByTestId('nav-settings-confluence')).toHaveAttribute('aria-current', 'page');
-    });
+    expect(await screen.findByText("This settings page doesn't exist.")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/settings/SettingsPanelRoute.tsx
+++ b/frontend/src/features/settings/SettingsPanelRoute.tsx
@@ -1,5 +1,5 @@
 import { lazy, type ComponentType, type ReactElement } from 'react';
-import { Navigate, useOutletContext, useParams } from 'react-router-dom';
+import { Link, Navigate, useOutletContext, useParams } from 'react-router-dom';
 import { SETTINGS_NAV, canSeeItem, firstVisiblePath } from './settings-nav';
 import type { AccessContextWithLoading } from './SettingsLayout';
 import { useSettings, useUpdateSettings } from '../../shared/hooks/use-settings';
@@ -106,9 +106,25 @@ export function SettingsPanelRoute() {
       ? SETTINGS_NAV.find((g) => g.id === groupId)?.items.find((i) => i.id === itemId)
       : undefined;
 
-  // Unknown path — bounce immediately (nothing to load, nothing to wait for).
+  // Unknown path — no registered nav item matches (regardless of role).
+  // Render a small not-found panel instead of silently redirecting, so a
+  // typoed or stale bookmark is visible rather than confusing. Registered
+  // items the user merely cannot see (adminOnly / EE-gated) keep the
+  // redirect below.
   if (!navItem || !PANELS[key]) {
-    return <Navigate to={firstVisiblePath(ctx)} replace />;
+    return (
+      <section className="space-y-3" data-testid="settings-panel-not-found">
+        <h2 className="text-xl font-semibold tracking-[-0.01em]">
+          {"This settings page doesn't exist."}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          The address may be mistyped, or the panel may have moved.
+        </p>
+        <Link to={firstVisiblePath(ctx)} className="inline-block text-sm font-medium text-action underline">
+          Go to Settings
+        </Link>
+      </section>
+    );
   }
 
   // Defer the EE-gated redirect until the /admin/license fetch resolves.

--- a/frontend/src/features/settings/SpacesTab.test.tsx
+++ b/frontend/src/features/settings/SpacesTab.test.tsx
@@ -230,7 +230,7 @@ describe('SpacesTab', () => {
     expect(screen.getByRole('button', { name: /remove engineering/i })).toBeInTheDocument();
   });
 
-  it('calls DELETE /api/spaces/:key when a space is removed and confirmed (#721)', async () => {
+  it('calls DELETE /api/spaces/:key after confirming the remove dialog (#721)', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(
         new Response(
@@ -246,8 +246,6 @@ describe('SpacesTab', () => {
         }),
       );
 
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
-
     render(<SpacesTab onSave={mockOnSave} />, { wrapper: createWrapper() });
 
     await waitFor(() => {
@@ -255,6 +253,15 @@ describe('SpacesTab', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: /remove engineering/i }));
+
+    // ConfirmDialog replaces native confirm(). The copy must reflect the backend
+    // reality (DELETE /spaces/:key → unsyncSpace): the local purge is permanent
+    // (pages cascade to embeddings + version history), Confluence is untouched.
+    expect(await screen.findByText('Remove "Engineering" from Compendiq?')).toBeInTheDocument();
+    expect(screen.getByText(/permanently deletes its synced pages/i)).toBeInTheDocument();
+    expect(screen.getByText(/nothing is deleted in confluence/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
 
     await waitFor(() => {
       const deleteCalled = fetchSpy.mock.calls.some(
@@ -265,5 +272,90 @@ describe('SpacesTab', () => {
       );
       expect(deleteCalled).toBe(true);
     });
+  });
+
+  it('does not DELETE when the remove dialog is cancelled (#721)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          { key: 'ENG', name: 'Engineering', lastSynced: '2026-03-01T00:00:00Z', pageCount: 5 },
+        ]),
+        { headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(<SpacesTab onSave={mockOnSave} />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /remove engineering/i }));
+    await screen.findByTestId('confirm-dialog');
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+    });
+    const deleteCalled = fetchSpy.mock.calls.some(
+      ([, opts]) => (opts as RequestInit | undefined)?.method === 'DELETE',
+    );
+    expect(deleteCalled).toBe(false);
+  });
+
+  // ---------- #721: empty-selection save confirmation ----------
+
+  it('asks for confirmation before saving an empty selection, then saves on confirm', async () => {
+    render(<SpacesTab onSave={mockOnSave} />, { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByText('Save Selection (0)'));
+
+    // Dialog instead of native confirm(); copy must not claim local pages are
+    // deleted (the settings handler only clears the sync selection).
+    expect(await screen.findByText('Remove all spaces from your selection?')).toBeInTheDocument();
+    expect(screen.getByText(/stops syncing/i)).toBeInTheDocument();
+    expect(mockOnSave).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+
+    await waitFor(() => {
+      expect(mockOnSave).toHaveBeenCalledWith({ selectedSpaces: [] });
+    });
+  });
+
+  it('does not save when the empty-selection dialog is cancelled', async () => {
+    render(<SpacesTab onSave={mockOnSave} />, { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByText('Save Selection (0)'));
+    await screen.findByTestId('confirm-dialog');
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+    });
+    expect(mockOnSave).not.toHaveBeenCalled();
+  });
+
+  it('saves a non-empty selection without any confirmation dialog', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          { key: 'DEV', name: 'Development', lastSynced: '2026-03-01T00:00:00Z', pageCount: 42 },
+        ]),
+        { headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(<SpacesTab onSave={mockOnSave} />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Development')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Development'));
+    fireEvent.click(screen.getByText('Save Selection (1)'));
+
+    expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+    expect(mockOnSave).toHaveBeenCalledWith({ selectedSpaces: ['DEV'] });
   });
 });

--- a/frontend/src/features/settings/SpacesTab.tsx
+++ b/frontend/src/features/settings/SpacesTab.tsx
@@ -4,6 +4,7 @@ import { RefreshCw, CheckSquare, Square, Loader2, Trash2 } from 'lucide-react';
 import { apiFetch } from '../../shared/lib/api';
 import { cn } from '../../shared/lib/cn';
 import { toast } from 'sonner';
+import { ConfirmDialog } from '../../shared/components/ConfirmDialog';
 import { SpaceHomePicker } from './SpaceHomePicker';
 
 interface AvailableSpace {
@@ -34,6 +35,10 @@ const EMPTY_SPACES: string[] = [];
 export function SpacesTab({ selectedSpaces: initialSelected = EMPTY_SPACES, showSpaceHomeContent = true, onSave }: SpacesTabProps) {
   const queryClient = useQueryClient();
   const [selected, setSelected] = useState<Set<string>>(new Set(initialSelected));
+  // Space awaiting remove confirmation (#721; ConfirmDialog replaces native confirm()).
+  const [pendingRemove, setPendingRemove] = useState<{ key: string; name: string } | null>(null);
+  // Guard for saving an empty selection (#721).
+  const [confirmClearOpen, setConfirmClearOpen] = useState(false);
 
   // Re-sync local selection when the incoming prop's *contents* change. Keying
   // the effect on a primitive (its JSON serialization) means it only re-runs on real
@@ -101,20 +106,12 @@ export function SpacesTab({ selectedSpaces: initialSelected = EMPTY_SPACES, show
   };
 
   const handleRemoveSpace = (key: string, name: string) => {
-    if (
-      window.confirm(
-        `Remove "${name}"? This deletes its synced pages locally. It does NOT delete anything in Confluence.`,
-      )
-    ) {
-      removeSpace.mutate(key);
-    }
+    setPendingRemove({ key, name });
   };
 
   const handleSave = async () => {
-    if (
-      selected.size === 0 &&
-      !window.confirm('Remove all synced spaces from your selection?')
-    ) {
+    if (selected.size === 0) {
+      setConfirmClearOpen(true);
       return;
     }
     await onSave({ selectedSpaces: Array.from(selected) });
@@ -267,6 +264,39 @@ export function SpacesTab({ selectedSpaces: initialSelected = EMPTY_SPACES, show
           Sync Selected
         </button>
       </div>
+
+      {/* #721 remove confirmation. Copy mirrors the backend reality
+          (DELETE /spaces/:key → unsyncSpace): the local purge is permanent —
+          pages cascade-delete their embeddings and version history, cached
+          attachments are removed — but Confluence itself is read-only here
+          and the space can be synced again later. */}
+      <ConfirmDialog
+        open={pendingRemove !== null}
+        title={`Remove "${pendingRemove?.name ?? ''}" from Compendiq?`}
+        description="This permanently deletes its synced pages, embeddings and version history stored in Compendiq. Nothing is deleted in Confluence — you can sync the space again later."
+        confirmLabel="Remove space"
+        destructive
+        onConfirm={() => {
+          if (pendingRemove) removeSpace.mutate(pendingRemove.key);
+          setPendingRemove(null);
+        }}
+        onCancel={() => setPendingRemove(null)}
+      />
+
+      {/* Empty-selection save guard. Saving [] only clears the sync selection
+          (settings.ts removes the per-space editor assignments) — already
+          synced pages are NOT deleted, so the copy must not claim they are. */}
+      <ConfirmDialog
+        open={confirmClearOpen}
+        title="Remove all spaces from your selection?"
+        description="Saving an empty selection stops syncing every space for you. Already-synced pages are not deleted; re-select a space to resume syncing it."
+        confirmLabel="Save empty selection"
+        onConfirm={() => {
+          setConfirmClearOpen(false);
+          void onSave({ selectedSpaces: [] });
+        }}
+        onCancel={() => setConfirmClearOpen(false)}
+      />
     </div>
   );
 }

--- a/frontend/src/features/settings/SyncTab.test.tsx
+++ b/frontend/src/features/settings/SyncTab.test.tsx
@@ -165,6 +165,12 @@ describe('Settings SyncTab', () => {
         });
       }
 
+      if (path.includes('/api/pages/bulk/sync') && options?.method === 'POST') {
+        return new Response(JSON.stringify({ succeeded: 2, failed: 0, errors: [] }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
       return new Response('{}', {
         headers: { 'Content-Type': 'application/json' },
       });
@@ -306,5 +312,57 @@ describe('Settings SyncTab', () => {
     });
 
     expect(screen.getByTestId('summary-force-rescan')).toBeInTheDocument();
+  });
+
+  // ConfirmDialog replaces the native confirm() guard on Force Re-sync All.
+  describe('Force Re-sync All confirmation dialog', () => {
+    function bulkSyncCalls() {
+      return fetchSpy.mock.calls.filter(([url, opts]) => {
+        const path = typeof url === 'string' ? url : '';
+        return path.includes('/api/pages/bulk/sync') && (opts as RequestInit | undefined)?.method === 'POST';
+      });
+    }
+
+    it('opens a dialog and only POSTs /pages/bulk/sync after confirming', async () => {
+      authState = { user: { role: 'admin' }, accessToken: 'test-token', setAuth: vi.fn(), clearAuth: vi.fn() };
+      mockFetchResponses();
+      await navigateToSyncTab();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('sync-overview-force-resync-all')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('sync-overview-force-resync-all'));
+
+      // Honest copy: heavy re-fetch + embeddings marked dirty; nothing deleted.
+      expect(await screen.findByText('Force re-sync every Confluence page?')).toBeInTheDocument();
+      expect(screen.getByText(/even if its Confluence version is unchanged/i)).toBeInTheDocument();
+      expect(bulkSyncCalls()).toHaveLength(0);
+
+      fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+
+      await waitFor(() => {
+        expect(bulkSyncCalls().length).toBeGreaterThan(0);
+      });
+    });
+
+    it('cancelling does not start the re-sync', async () => {
+      authState = { user: { role: 'admin' }, accessToken: 'test-token', setAuth: vi.fn(), clearAuth: vi.fn() };
+      mockFetchResponses();
+      await navigateToSyncTab();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('sync-overview-force-resync-all')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('sync-overview-force-resync-all'));
+      await screen.findByTestId('confirm-dialog');
+      fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      });
+      expect(bulkSyncCalls()).toHaveLength(0);
+    });
   });
 });

--- a/frontend/src/features/settings/WorkersTab.test.tsx
+++ b/frontend/src/features/settings/WorkersTab.test.tsx
@@ -311,4 +311,79 @@ describe('WorkersTab', () => {
       expect(within(qualityCard).getByText('Error')).toBeInTheDocument();
     });
   });
+
+  // ConfirmDialog replaces the native confirm() guard on Rescan All. Each card
+  // carries copy matching its backend reality (knowledge-admin.ts routes).
+  describe('Rescan All confirmation dialog', () => {
+    function rescanPostCalls(endpoint: string) {
+      return fetchSpy.mock.calls.filter(([url, opts]) => {
+        const path = typeof url === 'string' ? url : '';
+        return path.includes(endpoint) && (opts as RequestInit | undefined)?.method === 'POST';
+      });
+    }
+
+    it('opens a dialog instead of firing the rescan POST immediately', async () => {
+      render(<WorkersTab />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('quality-rescan')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('quality-rescan'));
+
+      expect(await screen.findByTestId('confirm-dialog')).toBeInTheDocument();
+      // forceQualityRescan() NULLs quality_score — the copy must say scores
+      // are cleared, and must not invent a false "cannot be undone".
+      expect(screen.getByText(/existing quality scores are cleared/i)).toBeInTheDocument();
+      expect(rescanPostCalls('quality-rescan')).toHaveLength(0);
+    });
+
+    it('confirming fires the rescan POST', async () => {
+      render(<WorkersTab />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('quality-rescan')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('quality-rescan'));
+      await screen.findByTestId('confirm-dialog');
+      fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+
+      await waitFor(() => {
+        expect(rescanPostCalls('quality-rescan').length).toBeGreaterThan(0);
+      });
+    });
+
+    it('cancelling does not fire the rescan POST', async () => {
+      render(<WorkersTab />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('summary-rescan')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('summary-rescan'));
+      await screen.findByTestId('confirm-dialog');
+      fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      });
+      expect(rescanPostCalls('summary-rescan')).toHaveLength(0);
+    });
+
+    it('embedding rescan copy warns that stored embeddings are deleted and search is degraded meanwhile', async () => {
+      render(<WorkersTab />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('embedding-rescan')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('embedding-rescan'));
+
+      // reEmbedAll() runs DELETE FROM page_embeddings before re-queueing.
+      expect(await screen.findByTestId('confirm-dialog')).toBeInTheDocument();
+      expect(screen.getByText(/embeddings are deleted/i)).toBeInTheDocument();
+      expect(screen.getByText(/semantic search/i)).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/features/settings/WorkersTab.tsx
+++ b/frontend/src/features/settings/WorkersTab.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { Play, RotateCcw, AlertTriangle, CheckCircle, Clock, Loader2 } from 'lucide-react';
 import { m, useReducedMotion } from 'framer-motion';
 import { apiFetch } from '../../shared/lib/api';
 import { AnimatedCounter } from '../../shared/components/effects/AnimatedCounter';
+import { ConfirmDialog } from '../../shared/components/ConfirmDialog';
 import { cn } from '../../shared/lib/cn';
 
 // ---------------------------------------------------------------------------
@@ -217,12 +219,14 @@ function ProgressBar({ completed, total }: { completed: number; total: number })
 // Worker card
 // ---------------------------------------------------------------------------
 
-function WorkerCard({ title, statusKey, statusEndpoint, runEndpoint, rescanEndpoint, resetFailedEndpoint, normalize }: {
+function WorkerCard({ title, statusKey, statusEndpoint, runEndpoint, rescanEndpoint, rescanDescription, resetFailedEndpoint, normalize }: {
   title: string;
   statusKey: string;
   statusEndpoint: string;
   runEndpoint: string;
   rescanEndpoint: string;
+  /** Per-worker ConfirmDialog copy — must match what the backend rescan route actually does. */
+  rescanDescription: string;
   resetFailedEndpoint?: string;
   normalize: StatusNormalizer;
 }) {
@@ -231,6 +235,8 @@ function WorkerCard({ title, statusKey, statusEndpoint, runEndpoint, rescanEndpo
   const rescan = useWorkerAction(rescanEndpoint, `${title} rescan started`);
   const resetFailed = useWorkerAction(resetFailedEndpoint ?? '', 'Failed items reset to pending');
   const hasResetFailed = !!resetFailedEndpoint;
+  // Rescan-all guard (ConfirmDialog replaces native confirm()).
+  const [confirmRescanOpen, setConfirmRescanOpen] = useState(false);
 
   const workerState = status ? deriveWorkerState(status) : 'idle';
 
@@ -254,11 +260,7 @@ function WorkerCard({ title, statusKey, statusEndpoint, runEndpoint, rescanEndpo
             Run Now
           </button>
           <button
-            onClick={() => {
-              if (window.confirm(`Reset all pages for ${title.toLowerCase()} re-processing?`)) {
-                rescan.mutate();
-              }
-            }}
+            onClick={() => setConfirmRescanOpen(true)}
             disabled={rescan.isPending}
             className="flex items-center gap-1 rounded-lg bg-foreground/5 px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:bg-foreground/10 transition-colors disabled:opacity-50"
             title="Reset all pages to re-process"
@@ -319,6 +321,20 @@ function WorkerCard({ title, statusKey, statusEndpoint, runEndpoint, rescanEndpo
           </div>
         </>
       ) : null}
+
+      {/* Rescan-all guard. No destructive styling: everything the rescan
+          clears is recomputed automatically by the background worker. */}
+      <ConfirmDialog
+        open={confirmRescanOpen}
+        title={`Reset all pages for ${title.toLowerCase()}?`}
+        description={rescanDescription}
+        confirmLabel="Rescan all"
+        onConfirm={() => {
+          setConfirmRescanOpen(false);
+          rescan.mutate();
+        }}
+        onCancel={() => setConfirmRescanOpen(false)}
+      />
     </div>
   );
 }
@@ -337,12 +353,18 @@ export function WorkersTab() {
         </p>
       </div>
 
+      {/* rescanDescription strings mirror the backend routes in
+          knowledge-admin.ts — keep them in sync:
+          - quality-rescan → forceQualityRescan(): quality_score = NULL + pending
+          - summary-rescan → rescanAllSummaries(): pending; old summary_html kept
+          - embedding-rescan → reEmbedAll(): DELETE FROM page_embeddings + dirty */}
       <WorkerCard
         title="Quality Analysis"
         statusKey="quality"
         statusEndpoint="/llm/quality-status"
         runEndpoint="/llm/quality-run-now"
         rescanEndpoint="/llm/quality-rescan"
+        rescanDescription="Every page is reset to pending and existing quality scores are cleared, then the background worker re-analyzes all pages. This can take a while and uses LLM capacity."
         normalize={normalizeQuality}
       />
 
@@ -352,6 +374,7 @@ export function WorkersTab() {
         statusEndpoint="/llm/summary-status"
         runEndpoint="/llm/summary-run-now"
         rescanEndpoint="/llm/summary-rescan"
+        rescanDescription="Every page is reset to pending and re-summarized by the background worker. Existing summaries stay visible until they are replaced. This can take a while and uses LLM capacity."
         normalize={normalizeSummary}
       />
 
@@ -361,6 +384,7 @@ export function WorkersTab() {
         statusEndpoint="/llm/embedding-status"
         runEndpoint="/llm/embedding-run-now"
         rescanEndpoint="/llm/embedding-rescan"
+        rescanDescription="All stored embeddings are deleted and every page is re-embedded by the background worker. Semantic search results are degraded until re-embedding completes."
         resetFailedEndpoint="/llm/embedding-reset-failed"
         normalize={normalizeEmbedding}
       />

--- a/frontend/src/features/settings/panels/LlmTab.test.tsx
+++ b/frontend/src/features/settings/panels/LlmTab.test.tsx
@@ -78,8 +78,23 @@ const assignments = {
   },
 };
 
-function mockRoutes(options?: { concurrentStreamsCap?: number }) {
+function mockRoutes(options?: {
+  concurrentStreamsCap?: number;
+  /** `null` → field omitted from the settings payload (legacy backend). */
+  embeddingDimensions?: number | null;
+  probeDimensions?: number;
+}) {
   const cap = options?.concurrentStreamsCap ?? 3;
+  const settingsBody: Record<string, unknown> = {
+    ftsLanguage: 'simple',
+    embeddingChunkSize: 500,
+    embeddingChunkOverlap: 50,
+    drawioEmbedUrl: null,
+    llmMaxConcurrentStreamsPerUser: cap,
+  };
+  if (options?.embeddingDimensions !== null) {
+    settingsBody.embeddingDimensions = options?.embeddingDimensions ?? 1024;
+  }
   return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init = {}) => {
     const url = typeof input === 'string' ? input : (input as URL).toString();
     if (url.endsWith('/admin/llm-providers') && (init as RequestInit).method !== 'POST') {
@@ -98,25 +113,17 @@ function mockRoutes(options?: { concurrentStreamsCap?: number }) {
       });
     }
     if (url.endsWith('/admin/settings') && (init as RequestInit).method !== 'PUT') {
-      return new Response(
-        JSON.stringify({
-          embeddingDimensions: 1024,
-          ftsLanguage: 'simple',
-          embeddingChunkSize: 500,
-          embeddingChunkOverlap: 50,
-          drawioEmbedUrl: null,
-          llmMaxConcurrentStreamsPerUser: cap,
-        }),
-        { headers: { 'Content-Type': 'application/json' } },
-      );
+      return new Response(JSON.stringify(settingsBody), {
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
     if (url.endsWith('/admin/settings') && (init as RequestInit).method === 'PUT') {
       return new Response(JSON.stringify({ message: 'Admin settings updated' }), {
         headers: { 'Content-Type': 'application/json' },
       });
     }
-    if (url.includes('/admin/embedding/dimensions')) {
-      return new Response(JSON.stringify({ dimensions: 1024 }), {
+    if (url.endsWith('/admin/embedding/probe') && (init as RequestInit).method === 'POST') {
+      return new Response(JSON.stringify({ dimensions: options?.probeDimensions ?? 1024 }), {
         headers: { 'Content-Type': 'application/json' },
       });
     }
@@ -270,11 +277,6 @@ describe('LlmTab', () => {
           { headers: { 'Content-Type': 'application/json' } },
         );
       }
-      if (url.endsWith('/admin/embedding/dimensions')) {
-        return new Response(JSON.stringify({ dimensions: 1024 }), {
-          headers: { 'Content-Type': 'application/json' },
-        });
-      }
       return new Response(JSON.stringify([]), { headers: { 'Content-Type': 'application/json' } });
     });
 
@@ -307,5 +309,45 @@ describe('LlmTab', () => {
       const body = JSON.parse((putCall![1] as RequestInit).body as string);
       expect(body.llmMaxConcurrentStreamsPerUser).toBe(8);
     });
+  });
+
+  // ── Embedding dimensions source (UX fix, Task 10) ──
+  // GET /api/admin/embedding/dimensions does not exist on the backend, so the
+  // old dedicated query 404'd on every visit to Settings → AI Models. The
+  // value must come from the shared /admin/settings payload instead.
+
+  it('reads embedding dimensions from /admin/settings and never requests /admin/embedding/dimensions', async () => {
+    const Wrapper = createWrapper();
+    const spy = mockRoutes({ embeddingDimensions: 768, probeDimensions: 768 });
+    render(<LlmTab />, { wrapper: Wrapper });
+    await screen.findByText('Use case assignments');
+
+    // Reveal the re-embed banner and probe so currentDimensions is displayed.
+    fireEvent.change(screen.getByTestId('usecase-embedding-provider'), {
+      target: { value: providerB.id },
+    });
+    fireEvent.click(await screen.findByRole('button', { name: /probe/i }));
+    // Probe returns the same dims → confirm copy renders the settings value.
+    await screen.findByText(/dimension stays at 768/i);
+
+    // The dead endpoint must never be requested.
+    const deadCalls = spy.mock.calls.filter(([input]) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      return url.includes('/admin/embedding/dimensions');
+    });
+    expect(deadCalls).toHaveLength(0);
+  });
+
+  it('falls back to 1024 dimensions when the settings payload omits embeddingDimensions', async () => {
+    const Wrapper = createWrapper();
+    mockRoutes({ embeddingDimensions: null, probeDimensions: 1024 });
+    render(<LlmTab />, { wrapper: Wrapper });
+    await screen.findByText('Use case assignments');
+
+    fireEvent.change(screen.getByTestId('usecase-embedding-provider'), {
+      target: { value: providerB.id },
+    });
+    fireEvent.click(await screen.findByRole('button', { name: /probe/i }));
+    await screen.findByText(/dimension stays at 1024/i);
   });
 });

--- a/frontend/src/features/settings/panels/LlmTab.tsx
+++ b/frontend/src/features/settings/panels/LlmTab.tsx
@@ -31,16 +31,11 @@ export function LlmTab() {
     queryKey: ['llm-usecases'],
     queryFn: () => apiFetch('/admin/llm-usecases'),
   });
-  const { data: dims } = useQuery<{ dimensions: number }>({
-    queryKey: ['embedding-dimensions'],
-    queryFn: () => apiFetch('/admin/embedding/dimensions'),
-    // This endpoint may not exist in every deployment; on 404 fall back to
-    // the legacy 1024-dim default rather than blocking the tab.
-    retry: false,
-  });
-  // Runtime limits — only reads fields we own from the shared admin-settings
-  // document. Other fields (embedding, rate limits, AI safety) are managed
-  // elsewhere and are left untouched when we PUT.
+  // Shared admin-settings document (same ['admin-settings'] cache entry as
+  // EmbeddingTab). Read-only source for `embeddingDimensions` (current vector
+  // width shown in the re-embed banner) and `llmMaxConcurrentStreamsPerUser`.
+  // Other fields (rate limits, AI safety) are managed elsewhere and are left
+  // untouched when we PUT.
   const { data: adminSettings } = useQuery<AdminSettings>({
     queryKey: ['admin-settings'],
     queryFn: () => apiFetch('/admin/settings'),
@@ -145,7 +140,9 @@ export function LlmTab() {
       </div>
       <ProviderListSection />
       <EmbeddingReembedBanner
-        currentDimensions={dims?.dimensions ?? 1024}
+        // Legacy 1024-dim default while settings load or on older backends
+        // whose payload predates the field.
+        currentDimensions={adminSettings?.embeddingDimensions ?? 1024}
         pending={embeddingPending}
       />
       <UsecaseAssignmentsSection

--- a/frontend/src/features/settings/panels/SyncTab.tsx
+++ b/frontend/src/features/settings/panels/SyncTab.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import type { SyncOverviewResponse, SyncOverviewSpace } from '@compendiq/contracts';
 import { apiFetch } from '../../../shared/lib/api';
 import { useAuthStore } from '../../../stores/auth-store';
 import { useSync, useForceResyncAll } from '../../../shared/hooks/use-spaces';
+import { ConfirmDialog } from '../../../shared/components/ConfirmDialog';
 import { SkeletonFormFields } from '../../../shared/components/feedback/Skeleton';
 
 interface QualityStatusResponse {
@@ -32,6 +34,8 @@ export function SyncTab() {
 
   const syncMutation = useSync();
   const forceResyncMutation = useForceResyncAll();
+  // Force Re-sync All guard (ConfirmDialog replaces native confirm()).
+  const [confirmForceResyncOpen, setConfirmForceResyncOpen] = useState(false);
   const { data, isLoading, isFetching, refetch } = useQuery<SyncOverviewResponse>({
     queryKey: ['settings', 'sync-overview'],
     queryFn: () => apiFetch('/settings/sync-overview'),
@@ -98,12 +102,11 @@ export function SyncTab() {
       );
       return;
     }
-    const ok = window.confirm(
-      'Force re-sync every Confluence page?\n\n' +
-        'This re-fetches every page even if its Confluence version is ' +
-        'unchanged, and marks all embeddings dirty. It may take several minutes.',
-    );
-    if (!ok) return;
+    // Heavy-but-safe operation: confirmation via ConfirmDialog below.
+    setConfirmForceResyncOpen(true);
+  };
+
+  const runForceResyncAll = () => {
     forceResyncMutation.mutate(totalPages, {
       onSuccess: (res) => {
         if (res.failed === 0) {
@@ -443,6 +446,22 @@ export function SyncTab() {
           </div>
         )}
       </section>
+
+      {/* Force Re-sync All guard. Copy mirrors POST /pages/bulk/sync with
+          { source: 'confluence' }: a re-fetch of every Confluence page plus
+          embedding_dirty = TRUE — heavy, but nothing is deleted, so no
+          destructive styling and no false destruction claims. */}
+      <ConfirmDialog
+        open={confirmForceResyncOpen}
+        title="Force re-sync every Confluence page?"
+        description="This re-fetches every page from Confluence even if its Confluence version is unchanged, and marks all embeddings for re-embedding. It may take several minutes."
+        confirmLabel="Force re-sync"
+        onConfirm={() => {
+          setConfirmForceResyncOpen(false);
+          runForceResyncAll();
+        }}
+        onCancel={() => setConfirmForceResyncOpen(false)}
+      />
     </div>
   );
 }

--- a/frontend/src/features/settings/panels/SyncTab.tsx
+++ b/frontend/src/features/settings/panels/SyncTab.tsx
@@ -331,7 +331,7 @@ export function SyncTab() {
               )}
             </div>
             <p className="text-sm text-muted-foreground">
-              Background worker that scores each article on completeness, clarity, structure, accuracy, and readability.
+              Background worker that scores each page on completeness, clarity, structure, accuracy, and readability.
             </p>
           </div>
 
@@ -388,7 +388,7 @@ export function SyncTab() {
         <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
           <div className="space-y-1">
             <div className="flex flex-wrap items-center gap-2">
-              <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-muted-foreground">Article Summaries</h2>
+              <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-muted-foreground">Page Summaries</h2>
               {summaryStatus && (
                 <StatusBadge
                   label={summaryStatus.isProcessing ? 'Summarizing' : 'Idle'}
@@ -398,7 +398,7 @@ export function SyncTab() {
               )}
             </div>
             <p className="text-sm text-muted-foreground">
-              Background worker that generates concise summaries for each article using the LLM.
+              Background worker that generates concise summaries for each page using the LLM.
             </p>
           </div>
 

--- a/frontend/src/features/settings/panels/SystemTab.tsx
+++ b/frontend/src/features/settings/panels/SystemTab.tsx
@@ -63,7 +63,7 @@ export function SystemTab() {
             <span className="font-mono" data-testid="app-version">{__APP_VERSION__}</span>
           </div>
           <div className="flex items-center justify-between">
-            <span>Edition</span>
+            <span>Build edition</span>
             <span className="font-mono" data-testid="app-edition">{editionLabel}</span>
           </div>
           <div className="flex items-center justify-between">

--- a/frontend/src/features/setup/steps/CompleteStep.tsx
+++ b/frontend/src/features/setup/steps/CompleteStep.tsx
@@ -6,7 +6,7 @@ export function CompleteStep() {
   const navigate = useNavigate();
 
   const links = [
-    { label: 'Go to Pages', description: 'Start creating and managing articles', path: '/', testId: 'goto-pages' },
+    { label: 'Go to Pages', description: 'Start creating and managing pages', path: '/', testId: 'goto-pages' },
     { label: 'Admin Settings', description: 'Configure advanced options', path: '/settings', testId: 'goto-settings' },
   ];
 

--- a/frontend/src/features/setup/steps/ConfluenceStep.tsx
+++ b/frontend/src/features/setup/steps/ConfluenceStep.tsx
@@ -50,7 +50,7 @@ export function ConfluenceStep({ onNext, onBack }: ConfluenceStepProps) {
     >
       <h2 className="text-xl font-semibold">Connect Confluence</h2>
       <p className="mt-1 text-sm text-muted-foreground">
-        Connect to your Confluence Data Center instance to sync knowledge base articles. This step is optional
+        Connect to your Confluence Data Center instance to sync knowledge base pages. This step is optional
         -- you can always configure it later.
       </p>
 

--- a/frontend/src/features/spaces/NewSpacePage.tsx
+++ b/frontend/src/features/spaces/NewSpacePage.tsx
@@ -82,7 +82,7 @@ export function NewSpacePage() {
           <div>
             <h1 className="text-lg font-semibold text-foreground">Create Local Space</h1>
             <p className="text-xs text-muted-foreground">
-              Organize standalone articles in a local space
+              Organize standalone pages in a local space
             </p>
           </div>
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -143,6 +143,10 @@ h1, h2, h3, h4, h5, h6,
   --color-accent: #2a2925;
   --color-accent-foreground: #f5efe0;
   --color-destructive: #e88888;
+  /* Text/icon color on a solid destructive fill. #e88888 is a light red, so
+     near-black ink gives ~8:1 — comfortably AA. (Token was previously
+     undefined; text-destructive-foreground utilities need it to compile.) */
+  --color-destructive-foreground: #0a0a0a;
   --color-border: #3a3831;
   --color-ring: #f9c74f;
   --color-success: #79c088;
@@ -303,6 +307,8 @@ h1, h2, h3, h4, h5, h6,
   --color-accent: #f1f0ec;
   --color-accent-foreground: #0a0a0a;
   --color-destructive: #b0322e;
+  /* White ink on the dark red fill — ~6.9:1, AA-pass. */
+  --color-destructive-foreground: #ffffff;
   --color-border: #dedcd4;
   --color-ring: #f9c74f;
   --color-success: #2f7a3a;
@@ -578,6 +584,77 @@ h1, h2, h3, h4, h5, h6,
   }
 }
 
+/* Destructive sibling of nm-button-primary — identical box metrics
+   (padding, 1px border, radius, type scale) so it lines up with
+   nm-button-ghost in dialog footers, with the destructive palette:
+   solid red fill, theme-tuned readable ink, hover darken instead of
+   the honey glow. Press/disabled/focus follow the shared conventions. */
+@utility nm-button-destructive {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid oklch(from var(--color-destructive) calc(l - 0.06) c h);
+  /* Solid background-color under the gradient overlay, same reasoning as
+     nm-button-primary: contrast auditors only read background-color. */
+  background-color: var(--color-destructive);
+  background-image: linear-gradient(
+    145deg,
+    oklch(from var(--color-destructive) calc(l + 0.04) c h),
+    var(--color-destructive)
+  );
+  color: var(--color-destructive-foreground);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  outline: 2px solid transparent;
+  outline-offset: 3px;
+  box-shadow:
+    4px 4px 10px var(--nm-shadow-out-strong),
+    -2px -2px 6px var(--nm-highlight-strong),
+    inset 0 1px 0 oklch(1 0 0 / 0.25);
+  transition:
+    background-color 0.2s ease-out,
+    box-shadow 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+
+  &:hover {
+    /* Darken on hover (vs primary's glow) — red glow reads as an error
+       state, a simple value shift reads as affordance. */
+    background-color: oklch(from var(--color-destructive) calc(l - 0.05) c h);
+    background-image: linear-gradient(
+      145deg,
+      oklch(from var(--color-destructive) calc(l - 0.01) c h),
+      oklch(from var(--color-destructive) calc(l - 0.05) c h)
+    );
+    box-shadow:
+      6px 6px 16px var(--nm-shadow-out-strong),
+      -3px -3px 10px var(--nm-highlight-strong),
+      inset 0 1px 0 oklch(1 0 0 / 0.3);
+    transform: translateY(-2px);
+  }
+
+  &:active {
+    box-shadow:
+      inset 3px 3px 6px oklch(0 0 0 / 0.3),
+      inset -1px -1px 3px oklch(1 0 0 / 0.2);
+    transform: translateY(0) scale(0.97);
+    transition-duration: 0.1s;
+  }
+
+  &:focus-visible {
+    outline-color: var(--color-destructive);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+}
+
 @utility nm-button-ghost {
   display: inline-flex;
   align-items: center;
@@ -830,12 +907,14 @@ h1, h2, h3, h4, h5, h6,
   .nm-header,
   .nm-pill-active,
   .nm-button-primary,
+  .nm-button-destructive,
   .nm-button-ghost,
   .nm-icon-button,
   .nm-input {
     border: 2px solid ButtonText;
   }
-  .nm-button-primary {
+  .nm-button-primary,
+  .nm-button-destructive {
     background: ButtonFace;
     color: ButtonText;
   }
@@ -851,12 +930,14 @@ h1, h2, h3, h4, h5, h6,
 @media (prefers-reduced-motion: reduce) {
   .nm-card-interactive,
   .nm-button-primary,
+  .nm-button-destructive,
   .nm-button-ghost,
   .nm-icon-button {
     transition: border-color 0.2s ease-out, color 0.2s ease-out;
   }
   .nm-card-interactive:hover,
   .nm-button-primary:hover,
+  .nm-button-destructive:hover,
   .nm-button-ghost:hover,
   .nm-icon-button:hover {
     transform: none;
@@ -867,6 +948,7 @@ h1, h2, h3, h4, h5, h6,
   }
   .nm-card-interactive:active,
   .nm-button-primary:active,
+  .nm-button-destructive:active,
   .nm-button-ghost:active,
   .nm-icon-button:active {
     transform: none;

--- a/frontend/src/shared/components/ConfirmDialog.test.tsx
+++ b/frontend/src/shared/components/ConfirmDialog.test.tsx
@@ -64,13 +64,16 @@ describe('ConfirmDialog', () => {
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
-  it('applies destructive styling to the confirm button when destructive', () => {
+  it('applies the design-system destructive button when destructive', () => {
     renderDialog({ destructive: true, confirmLabel: 'Delete user' });
 
+    // nm-button-destructive (index.css @utility) replaces the old ad-hoc
+    // bg-destructive recipe so the confirm button matches nm-button-ghost
+    // (Cancel) in height/padding/press behavior.
     const confirmBtn = screen.getByTestId('confirm-dialog-confirm');
-    expect(confirmBtn.className).toContain('bg-destructive');
-    expect(confirmBtn.className).toContain('text-destructive-foreground');
+    expect(confirmBtn.className).toContain('nm-button-destructive');
     expect(confirmBtn.className).not.toContain('nm-button-primary');
+    expect(confirmBtn.className).not.toContain('bg-destructive');
   });
 
   it('uses the primary design-system button when not destructive', () => {
@@ -78,7 +81,7 @@ describe('ConfirmDialog', () => {
 
     const confirmBtn = screen.getByTestId('confirm-dialog-confirm');
     expect(confirmBtn.className).toContain('nm-button-primary');
-    expect(confirmBtn.className).not.toContain('bg-destructive');
+    expect(confirmBtn.className).not.toContain('nm-button-destructive');
   });
 
   it('moves focus inside the dialog on open (focus trap entry)', () => {

--- a/frontend/src/shared/components/ConfirmDialog.test.tsx
+++ b/frontend/src/shared/components/ConfirmDialog.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ConfirmDialog } from './ConfirmDialog';
+import type { ConfirmDialogProps } from './ConfirmDialog';
+
+function renderDialog(overrides: Partial<ConfirmDialogProps> = {}) {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+  const props: ConfirmDialogProps = {
+    open: true,
+    title: 'Move page to trash?',
+    description: 'It can be restored from Trash for 30 days.',
+    confirmLabel: 'Move to trash',
+    onConfirm,
+    onCancel,
+    ...overrides,
+  };
+  const utils = render(<ConfirmDialog {...props} />);
+  return { onConfirm, onCancel, ...utils };
+}
+
+describe('ConfirmDialog', () => {
+  it('renders title and description when open', () => {
+    renderDialog();
+
+    expect(screen.getByText('Move page to trash?')).toBeInTheDocument();
+    expect(
+      screen.getByText('It can be restored from Trash for 30 days.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('renders nothing when closed', () => {
+    renderDialog({ open: false });
+
+    expect(screen.queryByText('Move page to trash?')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders the confirm button with the given label and fires onConfirm', () => {
+    const { onConfirm, onCancel } = renderDialog();
+
+    const confirmBtn = screen.getByTestId('confirm-dialog-confirm');
+    expect(confirmBtn).toHaveTextContent('Move to trash');
+
+    fireEvent.click(confirmBtn);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('fires onCancel when Cancel is clicked', () => {
+    const { onConfirm, onCancel } = renderDialog();
+
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('fires onCancel when Escape is pressed', () => {
+    const { onConfirm, onCancel } = renderDialog();
+
+    fireEvent.keyDown(screen.getByTestId('confirm-dialog'), { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('applies destructive styling to the confirm button when destructive', () => {
+    renderDialog({ destructive: true, confirmLabel: 'Delete user' });
+
+    const confirmBtn = screen.getByTestId('confirm-dialog-confirm');
+    expect(confirmBtn.className).toContain('bg-destructive');
+    expect(confirmBtn.className).toContain('text-destructive-foreground');
+    expect(confirmBtn.className).not.toContain('nm-button-primary');
+  });
+
+  it('uses the primary design-system button when not destructive', () => {
+    renderDialog();
+
+    const confirmBtn = screen.getByTestId('confirm-dialog-confirm');
+    expect(confirmBtn.className).toContain('nm-button-primary');
+    expect(confirmBtn.className).not.toContain('bg-destructive');
+  });
+
+  it('moves focus inside the dialog on open (focus trap entry)', () => {
+    renderDialog();
+
+    const dialog = screen.getByTestId('confirm-dialog');
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+});

--- a/frontend/src/shared/components/ConfirmDialog.tsx
+++ b/frontend/src/shared/components/ConfirmDialog.tsx
@@ -1,5 +1,5 @@
 /**
- * Shared confirmation dialog — replaces native `window.confirm()` so
+ * Shared confirmation dialog — replaces the browser-native confirm() prompt so
  * confirmations match the neumorphic design system (ADR-010) instead of
  * the OS-styled browser dialog.
  *
@@ -8,10 +8,9 @@
  * and overlay-click-to-dismiss for free. Both dismissal paths route
  * through `onCancel` via `onOpenChange(false)`.
  *
- * The confirm button uses the codebase's established destructive recipe
- * (`bg-destructive text-destructive-foreground hover:bg-destructive/90`,
- * cf. DataRetentionTab / WebhooksTab) when `destructive`, otherwise the
- * design-system `nm-button-primary` utility.
+ * The confirm button uses the design-system `nm-button-destructive`
+ * utility when `destructive` (same box metrics as `nm-button-primary` /
+ * `nm-button-ghost`, destructive palette), otherwise `nm-button-primary`.
  */
 
 import * as Dialog from '@radix-ui/react-dialog';
@@ -69,11 +68,7 @@ export function ConfirmDialog({
             <button
               type="button"
               onClick={onConfirm}
-              className={
-                destructive
-                  ? 'inline-flex items-center justify-center gap-2 rounded-md bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground transition-colors hover:bg-destructive/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50'
-                  : 'nm-button-primary'
-              }
+              className={destructive ? 'nm-button-destructive' : 'nm-button-primary'}
               data-testid="confirm-dialog-confirm"
             >
               {confirmLabel}

--- a/frontend/src/shared/components/ConfirmDialog.tsx
+++ b/frontend/src/shared/components/ConfirmDialog.tsx
@@ -1,0 +1,86 @@
+/**
+ * Shared confirmation dialog — replaces native `window.confirm()` so
+ * confirmations match the neumorphic design system (ADR-010) instead of
+ * the OS-styled browser dialog.
+ *
+ * Built on @radix-ui/react-dialog (same primitive as UserBulkActionDialog
+ * et al.), which provides focus trapping, initial focus, Escape-to-dismiss
+ * and overlay-click-to-dismiss for free. Both dismissal paths route
+ * through `onCancel` via `onOpenChange(false)`.
+ *
+ * The confirm button uses the codebase's established destructive recipe
+ * (`bg-destructive text-destructive-foreground hover:bg-destructive/90`,
+ * cf. DataRetentionTab / WebhooksTab) when `destructive`, otherwise the
+ * design-system `nm-button-primary` utility.
+ */
+
+import * as Dialog from '@radix-ui/react-dialog';
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  destructive = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onCancel();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay
+          className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
+          data-testid="confirm-dialog-overlay"
+        />
+        <Dialog.Content
+          className="nm-card fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 p-6 outline-none"
+          data-testid="confirm-dialog"
+        >
+          <Dialog.Title className="text-base font-semibold text-foreground">
+            {title}
+          </Dialog.Title>
+          <Dialog.Description className="mt-2 text-sm text-muted-foreground">
+            {description}
+          </Dialog.Description>
+          <div className="mt-6 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="nm-button-ghost"
+              data-testid="confirm-dialog-cancel"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              className={
+                destructive
+                  ? 'inline-flex items-center justify-center gap-2 rounded-md bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground transition-colors hover:bg-destructive/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50'
+                  : 'nm-button-primary'
+              }
+              data-testid="confirm-dialog-confirm"
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/src/shared/components/article/ArticleOutline.tsx
+++ b/frontend/src/shared/components/article/ArticleOutline.tsx
@@ -334,7 +334,7 @@ export function ArticleOutline({
         />
       </div>
 
-      <nav aria-label="Article outline">
+      <nav aria-label="Page outline">
         <ul className="space-y-1">
           {tree.map((node) => (
             <OutlineItem

--- a/frontend/src/shared/components/article/ArticleRightPane.test.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.test.tsx
@@ -422,14 +422,14 @@ describe('ArticleRightPane', () => {
     expect(await screen.findByTestId('auto-tagger')).toBeInTheDocument();
   });
 
-  // --- Delete via ConfirmDialog (replaces window.confirm) ---
+  // --- Delete via ConfirmDialog (replaces native confirm()) ---
   it('Delete opens the move-to-trash dialog; confirming soft-deletes and navigates home', async () => {
     render(<ArticleRightPane />, { wrapper: createWrapper() });
 
     fireEvent.click(screen.getByText('Delete'));
 
     // Copy must reflect the 30-day soft-delete trash, not the old (false)
-    // "cannot be undone" claim from window.confirm.
+    // "cannot be undone" claim from native confirm().
     expect(await screen.findByText('Move page to trash?')).toBeInTheDocument();
     expect(
       screen.getByText('It can be restored from Trash for 30 days, then it is permanently deleted.'),

--- a/frontend/src/shared/components/article/ArticleRightPane.test.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.test.tsx
@@ -422,6 +422,56 @@ describe('ArticleRightPane', () => {
     expect(await screen.findByTestId('auto-tagger')).toBeInTheDocument();
   });
 
+  // --- Delete via ConfirmDialog (replaces window.confirm) ---
+  it('Delete opens the move-to-trash dialog; confirming soft-deletes and navigates home', async () => {
+    render(<ArticleRightPane />, { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByText('Delete'));
+
+    // Copy must reflect the 30-day soft-delete trash, not the old (false)
+    // "cannot be undone" claim from window.confirm.
+    expect(await screen.findByText('Move page to trash?')).toBeInTheDocument();
+    expect(
+      screen.getByText('It can be restored from Trash for 30 days, then it is permanently deleted.'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('confirm-dialog-confirm')).toHaveTextContent('Move to trash');
+
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+
+    await waitFor(() => {
+      expect(mockDeletePage).toHaveBeenCalledWith('page-1');
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('cancelling the move-to-trash dialog does not delete', async () => {
+    render(<ArticleRightPane />, { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByText('Delete'));
+    await screen.findByTestId('confirm-dialog');
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+    });
+    expect(mockDeletePage).not.toHaveBeenCalled();
+  });
+
+  it('rail Delete button drives the same move-to-trash dialog', async () => {
+    useUiStore.setState({ articleSidebarCollapsed: true });
+
+    render(<ArticleRightPane />, { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByLabelText('Delete article'));
+
+    expect(await screen.findByText('Move page to trash?')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+
+    await waitFor(() => {
+      expect(mockDeletePage).toHaveBeenCalledWith('page-1');
+    });
+  });
+
   // --- PDF Export ---
   it('renders the Export PDF button', () => {
     render(<ArticleRightPane />, { wrapper: createWrapper() });

--- a/frontend/src/shared/components/article/ArticleRightPane.test.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.test.tsx
@@ -166,7 +166,7 @@ describe('ArticleRightPane', () => {
   it('collapses to a slim rail when the collapse button is clicked', () => {
     render(<ArticleRightPane />, { wrapper: createWrapper() });
 
-    fireEvent.click(screen.getByLabelText('Collapse article sidebar'));
+    fireEvent.click(screen.getByLabelText('Collapse page sidebar'));
 
     expect(screen.getByTestId('article-right-pane-rail')).toBeInTheDocument();
     expect(screen.queryByTestId('article-right-pane')).not.toBeInTheDocument();
@@ -179,7 +179,7 @@ describe('ArticleRightPane', () => {
 
     expect(screen.getByTestId('article-right-pane-rail')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByLabelText('Expand article sidebar'));
+    fireEvent.click(screen.getByLabelText('Expand page sidebar'));
 
     expect(screen.getByTestId('article-right-pane')).toBeInTheDocument();
   });
@@ -363,7 +363,7 @@ describe('ArticleRightPane', () => {
   it('shows empty message when there are no headings', () => {
     render(<ArticleRightPane />, { wrapper: createWrapper() });
 
-    expect(screen.getByText('No headings in this article.')).toBeInTheDocument();
+    expect(screen.getByText('No headings on this page.')).toBeInTheDocument();
   });
 
   it('renders version and space key in the footer', () => {
@@ -376,7 +376,7 @@ describe('ArticleRightPane', () => {
   it('has a resize handle', () => {
     render(<ArticleRightPane />, { wrapper: createWrapper() });
 
-    expect(screen.getByRole('separator', { name: 'Resize article sidebar' })).toBeInTheDocument();
+    expect(screen.getByRole('separator', { name: 'Resize page sidebar' })).toBeInTheDocument();
   });
 
   it('renders QualityScoreBadge in properties when quality score is present', () => {
@@ -462,7 +462,7 @@ describe('ArticleRightPane', () => {
 
     render(<ArticleRightPane />, { wrapper: createWrapper() });
 
-    fireEvent.click(screen.getByLabelText('Delete article'));
+    fireEvent.click(screen.getByLabelText('Delete page'));
 
     expect(await screen.findByText('Move page to trash?')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));

--- a/frontend/src/shared/components/article/ArticleRightPane.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.tsx
@@ -392,7 +392,7 @@ export function ArticleRightPane() {
 
   // Deleting soft-deletes into the 30-day trash, so the confirm copy must
   // not claim the action "cannot be undone". ConfirmDialog replaces the
-  // native window.confirm to match the neumorphic design system. Same flow
+  // native confirm() to match the neumorphic design system. Same flow
   // and copy as PageViewPage's Alt+Shift+D shortcut.
   const handleDelete = useCallback(() => {
     if (!id) return;

--- a/frontend/src/shared/components/article/ArticleRightPane.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.tsx
@@ -45,6 +45,7 @@ import { useExportPdf } from '../../hooks/use-standalone';
 import { useSettings } from '../../hooks/use-settings';
 import { apiFetch } from '../../lib/api';
 import { cn } from '../../lib/cn';
+import { ConfirmDialog } from '../ConfirmDialog';
 import type { TocHeading } from './TableOfContents';
 
 // ---------- Outline tree helpers ----------
@@ -244,6 +245,7 @@ export function ArticleRightPane() {
   const [collapsedIds, setCollapsedIds] = useState(() => readCollapsedIds(storageKey));
   const [readingProgress, setReadingProgress] = useState(0);
   const [isResizing, setIsResizing] = useState(false);
+  const [confirmTrashOpen, setConfirmTrashOpen] = useState(false);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const sidebarRef = useRef<HTMLElement>(null);
 
@@ -388,14 +390,24 @@ export function ArticleRightPane() {
     });
   }, [id, isPinned, page, pinMutation, unpinMutation]);
 
-  const handleDelete = useCallback(async () => {
-    if (!id || !window.confirm('Delete this article? This cannot be undone.')) return;
+  // Deleting soft-deletes into the 30-day trash, so the confirm copy must
+  // not claim the action "cannot be undone". ConfirmDialog replaces the
+  // native window.confirm to match the neumorphic design system. Same flow
+  // and copy as PageViewPage's Alt+Shift+D shortcut.
+  const handleDelete = useCallback(() => {
+    if (!id) return;
+    setConfirmTrashOpen(true);
+  }, [id]);
+
+  const handleConfirmMoveToTrash = useCallback(async () => {
+    if (!id) return;
+    setConfirmTrashOpen(false);
     try {
       await deleteMutation.mutateAsync(id);
       navigate('/');
-      toast.success('Article deleted.');
+      toast.success('Page moved to trash.');
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to delete article.');
+      toast.error(error instanceof Error ? error.message : 'Failed to move page to trash.');
     }
   }, [deleteMutation, id, navigate]);
 
@@ -473,11 +485,26 @@ export function ArticleRightPane() {
 
   if (!id) return null;
 
+  // Shared between the collapsed-rail and expanded returns — Radix portals
+  // the dialog to <body>, so its position in the tree only matters for state.
+  const confirmTrashDialog = (
+    <ConfirmDialog
+      open={confirmTrashOpen}
+      title="Move page to trash?"
+      description="It can be restored from Trash for 30 days, then it is permanently deleted."
+      confirmLabel="Move to trash"
+      destructive
+      onConfirm={handleConfirmMoveToTrash}
+      onCancel={() => setConfirmTrashOpen(false)}
+    />
+  );
+
   // Collapsed rail — glass pill style
   if (collapsed) {
     const railIconBtn =
       'rounded-lg p-1.5 text-muted-foreground hover:bg-[var(--glass-pill-hover)] hover:text-foreground transition-colors disabled:opacity-50';
     return (
+      <>
       <AnimatePresence mode="wait">
         <m.div
           key="collapsed-rail"
@@ -624,10 +651,13 @@ export function ArticleRightPane() {
           )}
         </m.div>
       </AnimatePresence>
+      {confirmTrashDialog}
+      </>
     );
   }
 
   return (
+    <>
     <m.aside
       ref={sidebarRef}
       key="expanded-sidebar"
@@ -927,5 +957,7 @@ export function ArticleRightPane() {
         )}
       />
     </m.aside>
+    {confirmTrashDialog}
+    </>
   );
 }

--- a/frontend/src/shared/components/article/ArticleRightPane.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.tsx
@@ -231,7 +231,7 @@ export function ArticleRightPane() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `${page?.title?.replace(/[^a-zA-Z0-9-_ ]/g, '').replace(/\s+/g, '-').toLowerCase() ?? 'article'}.pdf`;
+      a.download = `${page?.title?.replace(/[^a-zA-Z0-9-_ ]/g, '').replace(/\s+/g, '-').toLowerCase() ?? 'page'}.pdf`;
       a.click();
       URL.revokeObjectURL(url);
     } catch (err) {

--- a/frontend/src/shared/components/article/ArticleRightPane.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.tsx
@@ -519,7 +519,7 @@ export function ArticleRightPane() {
             <button
               onClick={toggleSidebar}
               className={railIconBtn}
-              aria-label="Expand article sidebar"
+              aria-label="Expand page sidebar"
               title="Expand sidebar (.)"
             >
               <PanelRight size={16} />
@@ -641,7 +641,7 @@ export function ArticleRightPane() {
                 <button
                   onClick={handleDelete}
                   className="rounded-lg p-1.5 text-destructive/80 transition-colors hover:bg-destructive/8 hover:text-destructive"
-                  aria-label="Delete article"
+                  aria-label="Delete page"
                   title={`Delete (${formatKeysForPlatform(getShortcutHint('delete-page') ?? '', detectMac())})`}
                 >
                   <Trash2 size={16} />
@@ -676,7 +676,7 @@ export function ArticleRightPane() {
         <button
           onClick={toggleSidebar}
           className="flex items-center gap-0.5 rounded-lg p-1 text-muted-foreground hover:bg-[var(--glass-pill-hover)] hover:text-foreground transition-colors"
-          aria-label="Collapse article sidebar"
+          aria-label="Collapse page sidebar"
           title="Collapse sidebar (.)"
         >
           <PanelRightClose size={14} />
@@ -927,7 +927,7 @@ export function ArticleRightPane() {
       <div className="flex-1 overflow-y-auto p-1.5 scroll-mask" data-testid="article-outline-tree">
         {headings.length === 0 ? (
           <div className="px-3 py-6 text-center text-xs text-muted-foreground">
-            No headings in this article.
+            No headings on this page.
           </div>
         ) : (
           <div className="space-y-0.5">
@@ -948,7 +948,7 @@ export function ArticleRightPane() {
       {/* Resize handle */}
       <div
         role="separator"
-        aria-label="Resize article sidebar"
+        aria-label="Resize page sidebar"
         aria-orientation="vertical"
         onMouseDown={handleResizeStart}
         className={cn(

--- a/frontend/src/shared/components/article/ArticleSummary.test.tsx
+++ b/frontend/src/shared/components/article/ArticleSummary.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ArticleSummary } from './ArticleSummary';
@@ -102,6 +102,87 @@ describe('ArticleSummary', () => {
     );
     expect(screen.getByTestId('article-summary-pending')).toBeInTheDocument();
     expect(screen.getByText('Generating AI summary...')).toBeInTheDocument();
+  });
+
+  // The pending banner promises "AI summary will be generated shortly" — a
+  // promise that can't be kept while the LLM provider is down. When /api/health
+  // reports services.llm === false, show a muted offline note instead.
+  describe('LLM offline while summary pending', () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+      fetchMock.mockReset();
+      vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    function renderWithStatus(summaryStatus: 'pending' | 'summarizing') {
+      return render(
+        <ArticleSummary
+          pageId="p1"
+          summaryHtml={null}
+          summaryStatus={summaryStatus}
+          summaryGeneratedAt={null}
+          summaryModel={null}
+          summaryError={null}
+        />,
+        { wrapper: createWrapper() },
+      );
+    }
+
+    it('shows the offline note instead of the pending promise when health reports llm: false', async () => {
+      fetchMock.mockResolvedValue({
+        json: () => Promise.resolve({ status: 'degraded', services: { llm: false } }),
+      });
+
+      renderWithStatus('pending');
+
+      expect(await screen.findByTestId('article-summary-offline')).toBeInTheDocument();
+      expect(screen.getByText('AI summary unavailable — LLM provider offline')).toBeInTheDocument();
+      expect(screen.queryByText('AI summary will be generated shortly')).not.toBeInTheDocument();
+      expect(fetchMock).toHaveBeenCalledWith('/api/health');
+    });
+
+    it('keeps the pending text when health reports llm: true', async () => {
+      fetchMock.mockResolvedValue({
+        json: () => Promise.resolve({ status: 'ok', services: { llm: true } }),
+      });
+
+      renderWithStatus('pending');
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith('/api/health');
+      });
+      expect(screen.getByText('AI summary will be generated shortly')).toBeInTheDocument();
+      expect(screen.queryByTestId('article-summary-offline')).not.toBeInTheDocument();
+    });
+
+    it('keeps the pending text when the health endpoint is unavailable', async () => {
+      fetchMock.mockRejectedValue(new Error('network down'));
+
+      renderWithStatus('pending');
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith('/api/health');
+      });
+      expect(screen.getByText('AI summary will be generated shortly')).toBeInTheDocument();
+      expect(screen.queryByTestId('article-summary-offline')).not.toBeInTheDocument();
+    });
+
+    it('keeps "Generating AI summary..." while actively summarizing even if llm is reported down', () => {
+      fetchMock.mockResolvedValue({
+        json: () => Promise.resolve({ services: { llm: false } }),
+      });
+
+      renderWithStatus('summarizing');
+
+      // An in-flight generation already left the queue — don't contradict it.
+      expect(screen.getByText('Generating AI summary...')).toBeInTheDocument();
+      expect(screen.queryByTestId('article-summary-offline')).not.toBeInTheDocument();
+    });
   });
 
   it('renders failed state with error message and retry button (admin)', () => {

--- a/frontend/src/shared/components/article/ArticleSummary.tsx
+++ b/frontend/src/shared/components/article/ArticleSummary.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
-import { ChevronDown, ChevronRight, Sparkles, RefreshCw, AlertCircle, Clock } from 'lucide-react';
+import { ChevronDown, ChevronRight, Sparkles, RefreshCw, AlertCircle, Clock, CloudOff } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { cn } from '../../lib/cn';
 import { formatRelativeTime } from '../../lib/format-relative-time';
@@ -15,6 +16,12 @@ interface ArticleSummaryProps {
   summaryGeneratedAt: string | null;
   summaryModel: string | null;
   summaryError: string | null;
+}
+
+interface HealthStatus {
+  services?: {
+    llm?: boolean;
+  };
 }
 
 const COLLAPSE_KEY = 'article-summary-collapsed';
@@ -50,6 +57,18 @@ export function ArticleSummary({
   // visible-but-403ing control to viewers.
   const isAdmin = useAuthStore((s) => s.user?.role === 'admin');
 
+  // While a summary is pending we promise it "will be generated shortly" —
+  // a promise that can't be kept when the LLM provider is down. /api/health
+  // is public and carries the services payload on both 200 (ok) and 503
+  // (degraded), so parse the body regardless of status.
+  const { data: health } = useQuery<HealthStatus>({
+    queryKey: ['health'],
+    queryFn: () => fetch('/api/health').then((r) => r.json() as Promise<HealthStatus>),
+    staleTime: 30_000,
+    retry: false,
+    enabled: summaryStatus === 'pending',
+  });
+
   const toggleCollapse = useCallback(() => {
     setCollapsed((prev) => {
       const next = !prev;
@@ -80,6 +99,22 @@ export function ArticleSummary({
 
   // Pending / summarizing states: show a subtle indicator
   if (summaryStatus === 'pending' || summaryStatus === 'summarizing') {
+    // Pending + LLM provider down: "will be generated shortly" never
+    // materializes — say so instead of dangling the promise. An in-flight
+    // generation ('summarizing') already left the queue, so keep its text.
+    if (summaryStatus === 'pending' && health?.services?.llm === false) {
+      return (
+        <div
+          className="mb-6 flex items-center gap-2 rounded-lg border border-border/40 bg-foreground/[0.03] px-4 py-3"
+          data-testid="article-summary-offline"
+        >
+          <CloudOff size={16} className="text-muted-foreground" />
+          <span className="text-sm text-muted-foreground">
+            AI summary unavailable — LLM provider offline
+          </span>
+        </div>
+      );
+    }
     return (
       <div
         className="mb-6 flex items-center gap-2 rounded-lg border border-purple-500/20 bg-purple-500/5 px-4 py-3"

--- a/frontend/src/shared/components/article/Editor.test.tsx
+++ b/frontend/src/shared/components/article/Editor.test.tsx
@@ -864,7 +864,7 @@ describe('EditorToolbar — header numbering toggle', () => {
   it('exposes the toolbar landmark with an accessible name (#353)', () => {
     const editor = createMockEditor();
     render(<EditorToolbar editor={editor} />);
-    const toolbar = screen.getByRole('toolbar', { name: 'Article editor toolbar' });
+    const toolbar = screen.getByRole('toolbar', { name: 'Page editor toolbar' });
     expect(toolbar).toBeInTheDocument();
   });
 });

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -500,7 +500,7 @@ export function EditorToolbar({ editor, headerNumbering, onToggleHeaderNumbering
     // overflow into article content).
     <div
       role="toolbar"
-      aria-label="Article editor toolbar"
+      aria-label="Page editor toolbar"
       className="flex flex-wrap items-center gap-0.5 px-2 py-1.5"
     >
       <ToolbarGroup name="inline">

--- a/frontend/src/shared/components/badges/ServiceStatus.test.tsx
+++ b/frontend/src/shared/components/badges/ServiceStatus.test.tsx
@@ -97,6 +97,10 @@ describe('ServiceStatus', () => {
     await waitFor(() => {
       expect(screen.getByText('Redis is unavailable')).toBeInTheDocument();
     });
+
+    // Unlike the LLM alert, the Redis alert has no settings page to link to —
+    // it must render without any link.
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('shows network error when fetch fails', async () => {

--- a/frontend/src/shared/components/badges/ServiceStatus.test.tsx
+++ b/frontend/src/shared/components/badges/ServiceStatus.test.tsx
@@ -1,18 +1,23 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { ServiceStatus } from './ServiceStatus';
 
 // Wrap in LazyMotion for framer-motion
 import { LazyMotion, domAnimation } from 'framer-motion';
 
 function Wrapper({ children }: { children: React.ReactNode }) {
-  return <LazyMotion features={domAnimation}>{children}</LazyMotion>;
+  return (
+    <MemoryRouter>
+      <LazyMotion features={domAnimation}>{children}</LazyMotion>
+    </MemoryRouter>
+  );
 }
 
 describe('ServiceStatus', () => {
   beforeEach(() => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ status: 'ok', llmProvider: 'ollama', services: { postgres: true, redis: true, llm: true } }), {
+      new Response(JSON.stringify({ status: 'ok', llmProvider: 'LMStudio', services: { postgres: true, redis: true, llm: true } }), {
         headers: { 'Content-Type': 'application/json' },
       }),
     );
@@ -31,17 +36,16 @@ describe('ServiceStatus', () => {
     });
 
     // No alerts should be visible
-    expect(screen.queryByText('Ollama server is down')).not.toBeInTheDocument();
-    expect(screen.queryByText('LLM server is unreachable')).not.toBeInTheDocument();
+    expect(screen.queryByText(/LLM provider/)).not.toBeInTheDocument();
     expect(screen.queryByText('Redis is unavailable')).not.toBeInTheDocument();
   });
 
-  it('shows alert when Ollama is disconnected', async () => {
+  it('names the configured provider when the LLM is unreachable', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
         JSON.stringify({
           status: 'degraded',
-          llmProvider: 'ollama',
+          llmProvider: 'LMStudio',
           services: { postgres: true, redis: true, llm: false },
         }),
         { headers: { 'Content-Type': 'application/json' } },
@@ -51,16 +55,18 @@ describe('ServiceStatus', () => {
     render(<ServiceStatus />, { wrapper: Wrapper });
 
     await waitFor(() => {
-      expect(screen.getByText('Ollama server is down')).toBeInTheDocument();
+      expect(screen.getByText('LLM provider "LMStudio" is unreachable')).toBeInTheDocument();
     });
+
+    const settingsLink = screen.getByRole('link', { name: 'Check LLM settings' });
+    expect(settingsLink).toHaveAttribute('href', '/settings/ai/models');
   });
 
-  it('shows provider-aware alert when OpenAI provider is disconnected', async () => {
+  it('falls back to a generic label when no provider name is reported', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
         JSON.stringify({
           status: 'degraded',
-          llmProvider: 'openai',
           services: { postgres: true, redis: true, llm: false },
         }),
         { headers: { 'Content-Type': 'application/json' } },
@@ -70,9 +76,8 @@ describe('ServiceStatus', () => {
     render(<ServiceStatus />, { wrapper: Wrapper });
 
     await waitFor(() => {
-      expect(screen.getByText('LLM server is unreachable')).toBeInTheDocument();
+      expect(screen.getByText('LLM provider is unreachable')).toBeInTheDocument();
     });
-    expect(screen.queryByText('Ollama server is down')).not.toBeInTheDocument();
   });
 
   it('shows alert when Redis is disconnected', async () => {
@@ -80,7 +85,7 @@ describe('ServiceStatus', () => {
       new Response(
         JSON.stringify({
           status: 'degraded',
-          llmProvider: 'ollama',
+          llmProvider: 'LMStudio',
           services: { postgres: true, redis: false, llm: true },
         }),
         { headers: { 'Content-Type': 'application/json' } },
@@ -109,7 +114,7 @@ describe('ServiceStatus', () => {
       new Response(
         JSON.stringify({
           status: 'degraded',
-          llmProvider: 'ollama',
+          llmProvider: 'LMStudio',
           services: { postgres: true, redis: false, llm: false },
         }),
         { headers: { 'Content-Type': 'application/json' } },
@@ -119,7 +124,7 @@ describe('ServiceStatus', () => {
     render(<ServiceStatus />, { wrapper: Wrapper });
 
     await waitFor(() => {
-      expect(screen.getByText('Ollama server is down')).toBeInTheDocument();
+      expect(screen.getByText('LLM provider "LMStudio" is unreachable')).toBeInTheDocument();
       expect(screen.getByText('Redis is unavailable')).toBeInTheDocument();
     });
   });
@@ -129,7 +134,7 @@ describe('ServiceStatus', () => {
       new Response(
         JSON.stringify({
           status: 'degraded',
-          llmProvider: 'ollama',
+          llmProvider: 'LMStudio',
           services: { postgres: true, redis: true, llm: false },
         }),
         { headers: { 'Content-Type': 'application/json' } },
@@ -139,14 +144,14 @@ describe('ServiceStatus', () => {
     render(<ServiceStatus />, { wrapper: Wrapper });
 
     await waitFor(() => {
-      expect(screen.getByText('Ollama server is down')).toBeInTheDocument();
+      expect(screen.getByText('LLM provider "LMStudio" is unreachable')).toBeInTheDocument();
     });
 
-    const dismissBtn = screen.getByLabelText('Dismiss ollama alert');
+    const dismissBtn = screen.getByLabelText('Dismiss LLM provider alert');
     fireEvent.click(dismissBtn);
 
     await waitFor(() => {
-      expect(screen.queryByText('Ollama server is down')).not.toBeInTheDocument();
+      expect(screen.queryByText('LLM provider "LMStudio" is unreachable')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/shared/components/badges/ServiceStatus.tsx
+++ b/frontend/src/shared/components/badges/ServiceStatus.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
+import { Link } from 'react-router-dom';
 import { m, AnimatePresence } from 'framer-motion';
 import { AlertTriangle, X, Wifi, WifiOff, Server } from 'lucide-react';
 import { cn } from '../../lib/cn';
@@ -20,6 +21,7 @@ interface ServiceAlert {
   icon: typeof AlertTriangle;
   colorClass: string;
   bgClass: string;
+  link?: { to: string; label: string };
 }
 
 const HEALTH_CHECK_INTERVAL = 30_000;
@@ -52,16 +54,18 @@ export function ServiceStatus() {
         if (fullRes.ok) {
           const data: HealthStatus = await fullRes.json();
           if (data.services?.llm === false) {
-            const label = data.llmProvider === 'openai'
-              ? 'LLM server is unreachable'
-              : 'Ollama server is down';
+            const label = data.llmProvider
+              ? `LLM provider "${data.llmProvider}" is unreachable`
+              : 'LLM provider is unreachable';
             newAlerts.push({
+              // id stays 'ollama' for dismissal-state compatibility
               id: 'ollama',
-              service: 'ollama',
+              service: 'LLM provider',
               label,
               icon: Server,
               colorClass: 'text-warning',
               bgClass: 'bg-warning/15 border-warning/30',
+              link: { to: '/settings/ai/models', label: 'Check LLM settings' },
             });
           }
           if (data.services?.redis === false) {
@@ -126,7 +130,7 @@ export function ServiceStatus() {
               exit={{ opacity: 0, height: 0, marginBottom: 0 }}
               transition={{ duration: 0.2 }}
               className={cn(
-                'flex items-center justify-between rounded-lg border px-4 py-2.5',
+                'flex items-center justify-between rounded-lg border px-4 py-2',
                 alert.bgClass,
               )}
             >
@@ -135,6 +139,14 @@ export function ServiceStatus() {
                 <span className={cn('text-sm font-medium', alert.colorClass)}>
                   {alert.label}
                 </span>
+                {alert.link && (
+                  <Link
+                    to={alert.link.to}
+                    className={cn('text-sm underline', alert.colorClass)}
+                  >
+                    {alert.link.label}
+                  </Link>
+                )}
               </div>
               <button
                 onClick={() => dismissAlert(alert.id)}

--- a/frontend/src/shared/components/diagrams/DrawioEditor.test.tsx
+++ b/frontend/src/shared/components/diagrams/DrawioEditor.test.tsx
@@ -19,8 +19,6 @@ describe('DrawioEditor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    // Mock window.confirm for unsaved changes dialog
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -244,11 +242,15 @@ describe('DrawioEditor', () => {
     });
 
     expect(defaultOnClose).toHaveBeenCalled();
-    // Should not show confirm dialog when no unsaved changes
-    expect(window.confirm).not.toHaveBeenCalled();
+    // No discard dialog when there is nothing to discard.
+    expect(screen.queryByTestId('confirm-dialog')).toBeNull();
   });
 
-  it('shows confirm dialog on Escape key when there are unsaved changes', async () => {
+  // Escape with unsaved changes opens the shared ConfirmDialog (replaces
+  // native confirm()). Crucially, the dialog must NOT unmount the editor —
+  // the iframe (and the user's unsaved diagram state) stays alive while the
+  // dialog is open.
+  it('shows the discard ConfirmDialog on Escape when there are unsaved changes, keeping the editor mounted', async () => {
     const postMessageSpy = vi.fn();
     render(
       <DrawioEditor xml={defaultXml} onSave={defaultOnSave} onClose={defaultOnClose} />,
@@ -272,14 +274,14 @@ describe('DrawioEditor', () => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     });
 
-    expect(window.confirm).toHaveBeenCalledWith(
-      expect.stringContaining('unsaved changes'),
-    );
+    expect(screen.getByTestId('confirm-dialog')).toBeTruthy();
+    expect(screen.getByText('Discard unsaved changes?')).toBeTruthy();
+    // Editor (and its iframe) must remain mounted behind the dialog.
+    expect(screen.getByTestId('drawio-iframe')).toBeTruthy();
+    expect(defaultOnClose).not.toHaveBeenCalled();
   });
 
-  it('does not close when confirm is cancelled on Escape with unsaved changes', async () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(false);
-
+  it('confirming the discard dialog closes the editor', async () => {
     const postMessageSpy = vi.fn();
     render(
       <DrawioEditor xml={defaultXml} onSave={defaultOnSave} onClose={defaultOnClose} />,
@@ -297,12 +299,46 @@ describe('DrawioEditor', () => {
     await act(async () => {
       postFromDrawio({ event: 'autosave' });
     });
-
     await act(async () => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     });
 
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+    });
+
+    expect(defaultOnClose).toHaveBeenCalled();
+  });
+
+  it('does not close when the discard dialog is cancelled; editor stays usable', async () => {
+    const postMessageSpy = vi.fn();
+    render(
+      <DrawioEditor xml={defaultXml} onSave={defaultOnSave} onClose={defaultOnClose} />,
+    );
+
+    const iframe = screen.getByTestId('drawio-iframe') as HTMLIFrameElement;
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: { postMessage: postMessageSpy },
+      writable: true,
+    });
+
+    await act(async () => {
+      postFromDrawio({ event: 'init' });
+    });
+    await act(async () => {
+      postFromDrawio({ event: 'autosave' });
+    });
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+    });
+
     expect(defaultOnClose).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('confirm-dialog')).toBeNull();
+    expect(screen.getByTestId('drawio-iframe')).toBeTruthy();
   });
 
   it('renders iframe with self-hosted draw.io URL', () => {

--- a/frontend/src/shared/components/diagrams/DrawioEditor.tsx
+++ b/frontend/src/shared/components/diagrams/DrawioEditor.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AlertTriangle, Loader2, RefreshCw, X } from 'lucide-react';
+import { ConfirmDialog } from '../ConfirmDialog';
 
 /** Self-hosted draw.io served from /drawio/ by the same nginx.
  *  offline=1&stealth=1 disables all cloud integrations (Drive, OneDrive, etc.). */
@@ -41,6 +42,10 @@ export function DrawioEditor({ xml, onSave, onClose, drawioUrl }: DrawioEditorPr
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [phase, setPhase] = useState<EditorPhase>('loading');
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  // Escape-with-unsaved-changes guard (ConfirmDialog replaces native confirm()).
+  // The dialog renders via portal ON TOP of the overlay — the iframe (and the
+  // user's unsaved diagram state) stays mounted while the dialog is open.
+  const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
   // Key used to force-remount the iframe on retry
   const [iframeKey, setIframeKey] = useState(0);
 
@@ -172,11 +177,12 @@ export function DrawioEditor({ xml, onSave, onClose, drawioUrl }: DrawioEditorPr
 
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === 'Escape') {
+        // While the discard dialog is open, Escape belongs to the dialog
+        // (Radix routes it to onCancel) — don't re-open it from here.
+        if (confirmDiscardOpen) return;
         if (hasUnsavedChanges) {
-          const leave = window.confirm(
-            'You have unsaved changes in the diagram editor. Discard changes and close?',
-          );
-          if (!leave) return;
+          setConfirmDiscardOpen(true);
+          return;
         }
         onClose();
       }
@@ -188,7 +194,7 @@ export function DrawioEditor({ xml, onSave, onClose, drawioUrl }: DrawioEditorPr
       window.removeEventListener('beforeunload', handleBeforeUnload);
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [hasUnsavedChanges, onClose]);
+  }, [hasUnsavedChanges, confirmDiscardOpen, onClose]);
 
   const handleRetry = useCallback(() => {
     setPhase('loading');
@@ -252,6 +258,23 @@ export function DrawioEditor({ xml, onSave, onClose, drawioUrl }: DrawioEditorPr
         title="Draw.io Diagram Editor"
         data-testid="drawio-iframe"
         sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-modals allow-downloads"
+      />
+
+      {/* Discard guard for Escape with unsaved changes. Rendered alongside
+          the iframe (the dialog portals to <body>), so the editor never
+          unmounts while the user decides — cancelling returns to the live
+          editor with the diagram state intact. */}
+      <ConfirmDialog
+        open={confirmDiscardOpen}
+        title="Discard unsaved changes?"
+        description="The diagram has unsaved changes. Closing the editor now discards them; use draw.io's Save button to keep them."
+        confirmLabel="Discard and close"
+        destructive
+        onConfirm={() => {
+          setConfirmDiscardOpen(false);
+          onClose();
+        }}
+        onCancel={() => setConfirmDiscardOpen(false)}
       />
     </div>
   );

--- a/frontend/src/shared/components/layout/AppLayout.test.tsx
+++ b/frontend/src/shared/components/layout/AppLayout.test.tsx
@@ -123,7 +123,7 @@ describe('AppLayout', () => {
       </AppLayout>,
       { wrapper: createWrapper('/') },
     );
-    expect(screen.getByText('Search pages, articles, commands...')).toBeInTheDocument();
+    expect(screen.getByText('Search pages, commands...')).toBeInTheDocument();
   });
 
   it('search bar has role="search" landmark and distinct aria-labels', () => {

--- a/frontend/src/shared/components/layout/AppLayout.tsx
+++ b/frontend/src/shared/components/layout/AppLayout.tsx
@@ -74,7 +74,7 @@ export function AppLayout({ children }: { children: ReactNode }) {
     {
       key: '.',
       keys: ['.'],
-      description: 'Toggle right panel (article outline)',
+      description: 'Toggle right panel (page outline)',
       category: 'panels',
       action: toggleArticleSidebar,
     },
@@ -221,7 +221,7 @@ export function AppLayout({ children }: { children: ReactNode }) {
             className="pointer-events-auto flex w-full max-w-xl items-center gap-2 rounded-lg border border-border/50 bg-foreground/5 px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:border-border"
           >
             <Search size={16} className="shrink-0" />
-            <span className="truncate">Search pages, articles, commands...</span>
+            <span className="truncate">Search pages, commands...</span>
             <span className="ml-auto shrink-0">
               <ShortcutHint shortcutId="search" />
             </span>

--- a/frontend/src/shared/components/layout/KeyboardShortcutsModal.test.tsx
+++ b/frontend/src/shared/components/layout/KeyboardShortcutsModal.test.tsx
@@ -43,7 +43,7 @@ describe('KeyboardShortcutsModal', () => {
     expect(screen.getByText('Toggle Right Panel')).toBeInTheDocument();
     expect(screen.getByText('Zen Mode')).toBeInTheDocument();
     // Editor
-    expect(screen.getByText('Save article')).toBeInTheDocument();
+    expect(screen.getByText('Save page')).toBeInTheDocument();
     expect(screen.getByText('Toggle Edit Mode')).toBeInTheDocument();
   });
 
@@ -111,7 +111,7 @@ describe('KeyboardShortcutsModal', () => {
     render(<KeyboardShortcutsModal />);
 
     expect(screen.getByText('Formatting (Editor)')).toBeInTheDocument();
-    expect(screen.getByText('Active when editing an article')).toBeInTheDocument();
+    expect(screen.getByText('Active when editing a page')).toBeInTheDocument();
   });
 
   it('shows TipTap formatting shortcut labels', () => {

--- a/frontend/src/shared/components/layout/KeyboardShortcutsModal.tsx
+++ b/frontend/src/shared/components/layout/KeyboardShortcutsModal.tsx
@@ -95,7 +95,7 @@ export function KeyboardShortcutsModal() {
                 <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
                   {getCategoryLabel('formatting')}
                 </h3>
-                <p className="mb-2 text-[10px] text-muted-foreground/60">Active when editing an article</p>
+                <p className="mb-2 text-[10px] text-muted-foreground/60">Active when editing a page</p>
                 <div className="space-y-1.5">
                   {TIPTAP_SHORTCUTS.map((shortcut) => (
                     <div
@@ -133,7 +133,7 @@ export function KeyboardShortcutsModal() {
               </Switch.Root>
             </div>
             <p className="text-[11px] text-muted-foreground">
-              Shortcuts are disabled when typing in an input, textarea, or the article editor.
+              Shortcuts are disabled when typing in an input, textarea, or the page editor.
             </p>
           </div>
         </Dialog.Content>

--- a/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
@@ -889,4 +889,23 @@ describe('SidebarTreeNode memoization', () => {
       expect(screen.queryByText('Sync a Space')).not.toBeInTheDocument();
     });
   });
+
+  describe('footer stats pluralization', () => {
+    it('uses plural "pages" when total is not 1', () => {
+      render(<SidebarTreeView />, { wrapper: createWrapper() });
+      expect(screen.getByText('4 pages')).toBeInTheDocument();
+    });
+
+    it('uses singular "page" when total is 1', () => {
+      mockTreeData = { ...defaultTreeData, items: [defaultTreeData.items[0]!], total: 1 };
+      render(<SidebarTreeView />, { wrapper: createWrapper() });
+      expect(screen.getByText('1 page')).toBeInTheDocument();
+    });
+
+    it('keeps the space-key suffix when a space is selected', () => {
+      useUiStore.setState({ treeSidebarSpaceKey: 'DEV' });
+      render(<SidebarTreeView />, { wrapper: createWrapper() });
+      expect(screen.getByText('4 pages in DEV')).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -740,7 +740,7 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
       {treeData && (
         <div className="px-3 py-1.5">
           <span className="text-[10px] text-muted-foreground">
-            {treeData.total} pages{treeSidebarSpaceKey ? ` in ${treeSidebarSpaceKey}` : ''}
+            {treeData.total} {treeData.total === 1 ? 'page' : 'pages'}{treeSidebarSpaceKey ? ` in ${treeSidebarSpaceKey}` : ''}
           </span>
         </div>
       )}

--- a/frontend/src/shared/enterprise/context.test.tsx
+++ b/frontend/src/shared/enterprise/context.test.tsx
@@ -130,6 +130,81 @@ describe('EnterpriseProvider (community mode)', () => {
   });
 });
 
+describe('EnterpriseProvider EE bundle license gate', () => {
+  beforeEach(() => {
+    // Restores the default (probing) script loader — deliberately NOT
+    // replaced here, so any attempt to load the bundle would surface as a
+    // fetch of the bundle URL.
+    _resetForTesting();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('never requests the bundle URL when the license response is CE-shaped (no canUpdate)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ edition: 'community', tier: 'community', features: [], valid: false }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(
+      <EnterpriseProvider>
+        <TestConsumer />
+      </EnterpriseProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    expect(screen.getByTestId('ui').textContent).toBe('null');
+    const urls = fetchSpy.mock.calls.map(([input]) =>
+      typeof input === 'string' ? input : input instanceof Request ? input.url : String(input),
+    );
+    expect(urls).toContain('/api/admin/license');
+    expect(urls.some((u) => u.includes('/api/enterprise/frontend.js'))).toBe(false);
+  });
+
+  it('attempts the EE bundle load when the backend marks itself EE (canUpdate: true)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          edition: 'enterprise',
+          tier: 'enterprise',
+          features: ['oidc_sso'],
+          valid: true,
+          canUpdate: true,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const mockCard = () => null;
+    const loaderSpy = vi.fn(async () => {
+      // Simulate IIFE bundle registering itself
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__COMPENDIQ_UI__ = { LicenseStatusCard: mockCard, version: '1.0.0' };
+    });
+    _setScriptLoaderForTesting(loaderSpy);
+
+    render(
+      <EnterpriseProvider>
+        <TestConsumer />
+      </EnterpriseProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    expect(loaderSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('ui').textContent).toBe('loaded');
+    expect(screen.getByTestId('enterprise').textContent).toBe('true');
+  });
+});
+
 describe('useEnterprise outside provider', () => {
   it('should return default community values', () => {
     render(<TestConsumer />);

--- a/frontend/src/shared/enterprise/context.tsx
+++ b/frontend/src/shared/enterprise/context.tsx
@@ -5,12 +5,19 @@ import { loadEnterpriseUI } from './loader';
 import { apiFetch } from '../lib/api';
 
 /**
- * Provider that loads the enterprise UI module and fetches license info.
+ * Provider that fetches license info and, only on EE backends, loads the
+ * enterprise UI module.
  *
  * Always fetches /admin/license so isEnterprise is derived from the backend
  * response (edition + valid), not from whether the overlay bundle loaded.
  * In CE deployments the endpoint returns edition:'community'; in EE it returns
  * the actual tier. The fetch is silently swallowed for unauthenticated users.
+ *
+ * The license response also gates the bundle load: only the EE backend marks
+ * itself with `canUpdate: true` (the CE noop omits it), so on CE backends the
+ * bundle URL is never requested at all — zero extra requests, zero console
+ * noise. Waiting for the license response before deciding is fine because the
+ * UI is non-blocking: every consumer already handles `ui === null`.
  */
 export function EnterpriseProvider({ children }: { children: ReactNode }) {
   const [ui, setUi] = useState<EnterpriseUI | null>(null);
@@ -21,20 +28,26 @@ export function EnterpriseProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
 
     async function init() {
-      // Load enterprise UI module (fast, just a dynamic import attempt)
-      const enterpriseUi = await loadEnterpriseUI();
-      if (cancelled) return;
-      setUi(enterpriseUi);
-
-      // Always fetch license info — CE returns edition:'community', EE returns actual tier
+      // License first — CE returns edition:'community', EE returns actual
+      // tier. The response tells us whether the backend is EE at all.
+      let info: LicenseInfo | null = null;
       try {
-        const info = await apiFetch<LicenseInfo>('/admin/license');
-        if (!cancelled) setLicense(info);
+        info = await apiFetch<LicenseInfo>('/admin/license');
       } catch {
         // Not admin, or endpoint unavailable — license stays null
       }
+      if (cancelled) return;
+      if (info) setLicense(info);
 
-      if (!cancelled) setIsLoading(false);
+      // Only an EE backend (which marks itself with canUpdate: true) can
+      // serve the overlay bundle, so don't even attempt the load otherwise.
+      if (info?.canUpdate === true) {
+        const enterpriseUi = await loadEnterpriseUI();
+        if (cancelled) return;
+        setUi(enterpriseUi);
+      }
+
+      setIsLoading(false);
     }
 
     init();

--- a/frontend/src/shared/enterprise/loader.test.ts
+++ b/frontend/src/shared/enterprise/loader.test.ts
@@ -1,13 +1,29 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   loadEnterpriseUI,
   _resetForTesting,
   _setScriptLoaderForTesting,
+  _setScriptInjectorForTesting,
 } from './loader';
+
+const BUNDLE_URL = '/api/enterprise/frontend.js';
+
+/** Minimal fetch Response stand-in for the HEAD probe. */
+function probeResponse(ok: boolean, contentType: string | null) {
+  return {
+    ok,
+    status: ok ? 200 : 404,
+    headers: { get: (name: string) => (name.toLowerCase() === 'content-type' ? contentType : null) },
+  };
+}
 
 describe('Enterprise frontend loader', () => {
   beforeEach(() => {
     _resetForTesting();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('should return null when /api/enterprise/frontend.js is not available', async () => {
@@ -45,5 +61,63 @@ describe('Enterprise frontend loader', () => {
     const ui = await loadEnterpriseUI();
     expect(ui).not.toBeNull();
     expect(ui?.LicenseStatusCard).toBe(mockCard);
+  });
+
+  describe('HEAD probe (default loader)', () => {
+    it('should not inject a script tag when the probe returns 404', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(probeResponse(false, 'application/json'));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const ui = await loadEnterpriseUI();
+
+      expect(ui).toBeNull();
+      expect(fetchMock).toHaveBeenCalledWith(BUNDLE_URL, { method: 'HEAD' });
+      expect(document.head.querySelector(`script[src="${BUNDLE_URL}"]`)).toBeNull();
+    });
+
+    it('should not reach the script injector when the probe returns a non-JS content type', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(probeResponse(true, 'application/json; charset=utf-8')),
+      );
+      const injector = vi.fn().mockResolvedValue(undefined);
+      _setScriptInjectorForTesting(injector);
+
+      const ui = await loadEnterpriseUI();
+
+      expect(ui).toBeNull();
+      expect(injector).not.toHaveBeenCalled();
+      expect(document.head.querySelector(`script[src="${BUNDLE_URL}"]`)).toBeNull();
+    });
+
+    it('should proceed to script injection when the probe returns 200 with a JS content type', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(probeResponse(true, 'text/javascript; charset=utf-8')),
+      );
+      const mockCard = () => null;
+      const injector = vi.fn().mockImplementation(async () => {
+        // Simulate IIFE bundle: registers itself on window global
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).__COMPENDIQ_UI__ = {
+          LicenseStatusCard: mockCard,
+          version: '1.0.0',
+        };
+      });
+      _setScriptInjectorForTesting(injector);
+
+      const ui = await loadEnterpriseUI();
+
+      expect(injector).toHaveBeenCalledWith(BUNDLE_URL);
+      expect(ui).not.toBeNull();
+      expect(ui?.LicenseStatusCard).toBe(mockCard);
+    });
+
+    it('should resolve null when the probe itself rejects (network error)', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('network error')));
+
+      await expect(loadEnterpriseUI()).resolves.toBeNull();
+      expect(document.head.querySelector(`script[src="${BUNDLE_URL}"]`)).toBeNull();
+    });
   });
 });

--- a/frontend/src/shared/enterprise/loader.ts
+++ b/frontend/src/shared/enterprise/loader.ts
@@ -5,7 +5,7 @@ let loaded = false;
 
 // The EE backend serves the overlay bundle at this path.
 // CE nginx already proxies /api/ → backend, so no separate EE frontend image is needed.
-// In CE deployments the backend returns 404 — the script fails silently and ui stays null.
+// In CE deployments the backend returns 404 — the HEAD probe fails silently and ui stays null.
 const ENTERPRISE_BUNDLE_URL = '/api/enterprise/frontend.js';
 
 // Global name the IIFE bundle registers itself under (matches vite.lib.config.ts `name`)
@@ -17,19 +17,43 @@ const DEPS_GLOBAL = '__COMPENDIQ_DEPS__';
 // Pluggable script loader — replaced in tests
 type ScriptLoader = (url: string) => Promise<void>;
 
-const defaultScriptLoader: ScriptLoader = (url) =>
+// Script-element injection, separated from the probe so tests can stub
+// injection (which jsdom can't complete) without bypassing the probe.
+type ScriptInjector = (url: string) => Promise<void>;
+
+const defaultScriptInjector: ScriptInjector = (url) =>
   new Promise<void>((resolve, reject) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if ((window as any)[EE_UI_GLOBAL]) {
-      resolve(); // Already loaded (e.g. hot-reload)
-      return;
-    }
     const script = document.createElement('script');
     script.src = url;
     script.onload = () => resolve();
     script.onerror = () => reject(new Error(`EE bundle not available at ${url}`));
     document.head.appendChild(script);
   });
+
+let _scriptInjector: ScriptInjector = defaultScriptInjector;
+
+// The probe lives here (inside the default loader) rather than in
+// loadEnterpriseUI so the _setScriptLoaderForTesting seam keeps replacing
+// probe + injection together — tests that stub the loader never touch the
+// network, preserving the existing seam semantics.
+const defaultScriptLoader: ScriptLoader = async (url) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((window as any)[EE_UI_GLOBAL]) {
+    return; // Already loaded (e.g. hot-reload)
+  }
+
+  // Probe before injecting a <script> tag: in CE deployments the bundle URL
+  // intentionally 404s, and a failed <script src> logs a 404 plus a
+  // MIME-type refusal to the console on every navigation. fetch() of a 404
+  // logs nothing, so probing first keeps community mode silent.
+  const res = await fetch(url, { method: 'HEAD' });
+  const type = res.headers.get('content-type') ?? '';
+  if (!res.ok || !/javascript|ecmascript/.test(type)) {
+    throw new Error(`EE bundle not available at ${url}`);
+  }
+
+  await _scriptInjector(url);
+};
 
 let _scriptLoader: ScriptLoader = defaultScriptLoader;
 
@@ -94,6 +118,7 @@ export function _resetForTesting(): void {
   cached = null;
   loaded = false;
   _scriptLoader = defaultScriptLoader;
+  _scriptInjector = defaultScriptInjector;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any)[DEPS_GLOBAL];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -106,4 +131,14 @@ export function _resetForTesting(): void {
  */
 export function _setScriptLoaderForTesting(loader: ScriptLoader): void {
   _scriptLoader = loader;
+}
+
+/**
+ * Override the script injector used by the default loader, so the probe can
+ * be tested without jsdom needing to execute a real <script>. Exposed only
+ * for testing.
+ * @internal
+ */
+export function _setScriptInjectorForTesting(injector: ScriptInjector): void {
+  _scriptInjector = injector;
 }

--- a/frontend/src/shared/enterprise/loader.ts
+++ b/frontend/src/shared/enterprise/loader.ts
@@ -5,7 +5,8 @@ let loaded = false;
 
 // The EE backend serves the overlay bundle at this path.
 // CE nginx already proxies /api/ → backend, so no separate EE frontend image is needed.
-// In CE deployments the backend returns 404 — the HEAD probe fails silently and ui stays null.
+// On CE backends this URL is never requested at all: EnterpriseProvider only calls
+// loadEnterpriseUI() when the license response marks the backend EE (canUpdate: true).
 const ENTERPRISE_BUNDLE_URL = '/api/enterprise/frontend.js';
 
 // Global name the IIFE bundle registers itself under (matches vite.lib.config.ts `name`)
@@ -42,10 +43,11 @@ const defaultScriptLoader: ScriptLoader = async (url) => {
     return; // Already loaded (e.g. hot-reload)
   }
 
-  // Probe before injecting a <script> tag: in CE deployments the bundle URL
-  // intentionally 404s, and a failed <script src> logs a 404 plus a
-  // MIME-type refusal to the console on every navigation. fetch() of a 404
-  // logs nothing, so probing first keeps community mode silent.
+  // Defense-in-depth probe for EE backends that lack the bundle route:
+  // a failed <script src> logs a 404 plus a MIME-type refusal to the console,
+  // whereas a fetched 404 logs only a single network-level 404 line (browsers
+  // still log that — there is no fully silent way to request a missing URL).
+  // CE never reaches this code: the load is license-gated in context.tsx.
   const res = await fetch(url, { method: 'HEAD' });
   const type = res.headers.get('content-type') ?? '';
   if (!res.ok || !/javascript|ecmascript/.test(type)) {
@@ -62,9 +64,12 @@ let _scriptLoader: ScriptLoader = defaultScriptLoader;
  *
  * The EE overlay is compiled as an IIFE (not an ES module) so it can receive
  * shared module instances via window globals instead of requiring an import map.
- * This lets both CE and EE deployments use the same CE frontend image — in EE the
- * EE backend serves the bundle at /api/enterprise/frontend.js; in CE the backend
- * returns 404 and this function returns null silently.
+ * This lets both CE and EE deployments use the same CE frontend image — the EE
+ * backend serves the bundle at /api/enterprise/frontend.js. On CE backends this
+ * function is never called (EnterpriseProvider gates it on the license response's
+ * canUpdate flag), so CE produces no bundle traffic and no console noise. If an
+ * EE backend lacks the bundle route, the HEAD probe fails and this resolves null
+ * at the cost of a single network 404 log line.
  *
  * Shared instances (react, framer-motion, react-query) are exposed on
  * window.__COMPENDIQ_DEPS__ before the script loads so the IIFE's externals

--- a/frontend/src/shared/hooks/use-pages.ts
+++ b/frontend/src/shared/hooks/use-pages.ts
@@ -46,6 +46,8 @@ interface PageDetail extends PageSummary {
   summaryGeneratedAt: string | null;
   summaryModel: string | null;
   summaryError: string | null;
+  /** Creator's user id — set for standalone pages, null for Confluence-synced. */
+  createdByUserId?: string | number | null;
 }
 
 interface PaginatedPages {

--- a/frontend/src/shared/hooks/use-standalone.test.ts
+++ b/frontend/src/shared/hooks/use-standalone.test.ts
@@ -116,10 +116,12 @@ describe('use-standalone hooks', () => {
 
   describe('useTrash', () => {
     it('fetches trashed pages', async () => {
-      mockFetch({ items: [{ id: 1, title: 'Deleted Page' }], total: 1 });
+      const mock = mockFetch({ items: [{ id: '1', title: 'Deleted Page' }], total: 1 });
       const { result } = renderHook(() => useTrash(), { wrapper: createWrapper() });
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data?.items).toHaveLength(1);
+      const [url] = mock.mock.calls[0] as [string];
+      expect(url).toContain('/pages/trash');
     });
   });
 
@@ -127,9 +129,9 @@ describe('use-standalone hooks', () => {
     it('posts restore request', async () => {
       const mock = mockFetch({ message: 'restored' });
       const { result } = renderHook(() => useRestorePage(), { wrapper: createWrapper() });
-      await result.current.mutateAsync(7);
+      await result.current.mutateAsync('7');
       const [url, opts] = mock.mock.calls[0] as [string, RequestInit];
-      expect(url).toContain('/trash/7/restore');
+      expect(url).toContain('/pages/7/restore');
       expect(opts.method).toBe('POST');
     });
   });

--- a/frontend/src/shared/hooks/use-standalone.ts
+++ b/frontend/src/shared/hooks/use-standalone.ts
@@ -69,15 +69,15 @@ export function useComments(pageId: number) {
 export function useTrash() {
   return useQuery({
     queryKey: ['trash'],
-    queryFn: () => apiFetch<{ items: TrashItem[]; total: number }>('/trash'),
+    queryFn: () => apiFetch<{ items: TrashItem[]; total: number }>('/pages/trash'),
   });
 }
 
 export function useRestorePage() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (pageId: number) =>
-      apiFetch(`/trash/${pageId}/restore`, {
+    mutationFn: (pageId: string) =>
+      apiFetch(`/pages/${pageId}/restore`, {
         method: 'POST',
       }),
     onSuccess: () => {
@@ -364,10 +364,14 @@ interface Comment {
   reactions: { emoji: string; count: number; userReacted: boolean }[];
 }
 
+// Mirrors GET /api/pages/trash response items (backend returns id as string)
 interface TrashItem {
-  id: number;
+  id: string;
   title: string;
+  source: string;
+  visibility: string;
   deletedAt: string;
+  createdAt: string;
   deletedBy: string;
   autoPurgeAt: string;
 }

--- a/frontend/src/shared/hooks/use-standalone.ts
+++ b/frontend/src/shared/hooks/use-standalone.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { TrashListResponse } from '@compendiq/contracts';
 import { apiFetch, ApiError, refreshAccessTokenOnce } from '../lib/api';
 import { useAuthStore } from '../../stores/auth-store';
 
@@ -69,7 +70,7 @@ export function useComments(pageId: number) {
 export function useTrash() {
   return useQuery({
     queryKey: ['trash'],
-    queryFn: () => apiFetch<{ items: TrashItem[]; total: number }>('/pages/trash'),
+    queryFn: () => apiFetch<TrashListResponse>('/pages/trash'),
   });
 }
 
@@ -364,17 +365,7 @@ interface Comment {
   reactions: { emoji: string; count: number; userReacted: boolean }[];
 }
 
-// Mirrors GET /api/pages/trash response items (backend returns id as string)
-interface TrashItem {
-  id: string;
-  title: string;
-  source: string;
-  visibility: string;
-  deletedAt: string;
-  createdAt: string;
-  deletedBy: string;
-  autoPurgeAt: string;
-}
+// Trash items are typed by TrashListResponse from @compendiq/contracts.
 
 interface Notification {
   id: number;

--- a/frontend/src/shared/lib/shortcut-registry.test.ts
+++ b/frontend/src/shared/lib/shortcut-registry.test.ts
@@ -119,7 +119,7 @@ describe('shortcut-registry', () => {
       const shortcut = SHORTCUTS.find((s) => s.id === 'save');
       expect(shortcut).toBeDefined();
       expect(shortcut!.keys).toBe('ctrl+s');
-      expect(shortcut!.label).toBe('Save article');
+      expect(shortcut!.label).toBe('Save page');
       expect(shortcut!.category).toBe('editor');
     });
 

--- a/frontend/src/shared/lib/shortcut-registry.ts
+++ b/frontend/src/shared/lib/shortcut-registry.ts
@@ -54,7 +54,7 @@ export const SHORTCUTS: ShortcutRegistryEntry[] = [
   { id: 'close-modal', keys: 'esc', label: 'Close dialog / modal', category: 'panels' },
 
   // -- Editor --
-  { id: 'save', keys: 'ctrl+s', label: 'Save article', category: 'editor' },
+  { id: 'save', keys: 'ctrl+s', label: 'Save page', category: 'editor' },
   { id: 'toggle-edit', keys: 'ctrl+e', label: 'Toggle Edit Mode', category: 'editor' },
 
   // -- Editor (diagram lightbox) --

--- a/frontend/src/shared/lib/sse.ts
+++ b/frontend/src/shared/lib/sse.ts
@@ -1,4 +1,5 @@
 import { useAuthStore } from '../../stores/auth-store';
+import { ApiError } from './api';
 
 /**
  * Stream SSE events from a POST endpoint.
@@ -26,7 +27,9 @@ export async function* streamSSE<T = { content: string; done: boolean }>(
 
   if (!res.ok) {
     const errorBody = await res.json().catch(() => ({ message: res.statusText }));
-    throw new Error(errorBody.message ?? `SSE request failed: ${res.status}`);
+    // ApiError (extends Error) keeps the HTTP status so callers can branch on
+    // it — e.g. runStream renders a permission explanation for 403 responses.
+    throw new ApiError(res.status, errorBody.message ?? `SSE request failed: ${res.status}`);
   }
 
   const reader = res.body?.getReader();

--- a/frontend/src/test-utils.ts
+++ b/frontend/src/test-utils.ts
@@ -2,6 +2,36 @@
  * Shared test-only helpers. Not imported by application code.
  */
 
+import { vi } from 'vitest';
+
+/**
+ * `vi.mock` factory body for `shared/lib/api` that replaces `apiFetch` with a
+ * test-controlled mock while keeping every OTHER export real — most
+ * importantly the `ApiError` class, which `runStream` branches on
+ * (`err instanceof ApiError`) for 403 handling. A bare `{ apiFetch }` factory
+ * leaves `ApiError` undefined on the mock, making `instanceof` throw the
+ * moment a test exercises a stream-error path.
+ *
+ * `vi.mock` factories are hoisted above the test file's body, so the file's
+ * `apiFetchMock` const is still in its temporal dead zone when the factory
+ * runs — pass a lazy getter and the mock is only dereferenced at call time.
+ *
+ * Usage (path segments relative to the test file):
+ *
+ *   const apiFetchMock = vi.fn();
+ *   vi.mock('../../../shared/lib/api', async () =>
+ *     (await import('../../../test-utils')).apiModuleMock(() => apiFetchMock));
+ */
+export async function apiModuleMock(
+  getApiFetchMock: () => (...args: unknown[]) => unknown,
+) {
+  const actual = await vi.importActual<typeof import('./shared/lib/api')>('./shared/lib/api');
+  return {
+    ...actual,
+    apiFetch: (...args: unknown[]) => getApiFetchMock()(...args),
+  };
+}
+
 /**
  * Extract a balanced `{ ... }` block from `source`, starting at the first
  * occurrence of `openingLine` (e.g. `'@theme {'` or `'\nbody {'`).

--- a/packages/contracts/src/schemas/pages.test.ts
+++ b/packages/contracts/src/schemas/pages.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { TrashItemSchema, TrashListResponseSchema } from './pages.js';
+
+// Mirrors the exact wire shape of GET /api/pages/trash (backend serializes
+// dates to ISO strings and stringifies the integer page id).
+const validTrashItem = {
+  id: '42',
+  title: 'Trashed note',
+  source: 'standalone',
+  visibility: 'private',
+  deletedAt: '2026-06-01T12:00:00.000Z',
+  createdAt: '2026-05-20T08:30:00.000Z',
+  deletedBy: 'trash_owner_a',
+  autoPurgeAt: '2026-07-01T12:00:00.000Z',
+} as const;
+
+describe('TrashItemSchema', () => {
+  it('round-trips a valid wire item unchanged', () => {
+    const parsed = TrashItemSchema.parse(validTrashItem);
+    expect(parsed).toEqual(validTrashItem);
+  });
+
+  it('rejects an unknown source', () => {
+    expect(() => TrashItemSchema.parse({ ...validTrashItem, source: 'wiki' })).toThrow();
+  });
+
+  it('rejects an unknown visibility', () => {
+    expect(() => TrashItemSchema.parse({ ...validTrashItem, visibility: 'public' })).toThrow();
+  });
+
+  it('rejects a numeric id — the route stringifies the integer PK', () => {
+    expect(() => TrashItemSchema.parse({ ...validTrashItem, id: 42 })).toThrow();
+  });
+
+  it.each(['deletedAt', 'createdAt', 'deletedBy', 'autoPurgeAt'] as const)(
+    'rejects a missing %s — the Trash UI renders every field',
+    (field) => {
+      const { [field]: _omitted, ...rest } = validTrashItem;
+      expect(() => TrashItemSchema.parse(rest)).toThrow();
+    },
+  );
+});
+
+describe('TrashListResponseSchema', () => {
+  it('round-trips items + total unchanged', () => {
+    const payload = { items: [validTrashItem], total: 1 };
+    expect(TrashListResponseSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('accepts an empty trash', () => {
+    const parsed = TrashListResponseSchema.parse({ items: [], total: 0 });
+    expect(parsed.items).toEqual([]);
+    expect(parsed.total).toBe(0);
+  });
+
+  it('rejects a negative total', () => {
+    expect(() => TrashListResponseSchema.parse({ items: [], total: -1 })).toThrow();
+  });
+});

--- a/packages/contracts/src/schemas/pages.ts
+++ b/packages/contracts/src/schemas/pages.ts
@@ -174,6 +174,34 @@ export const PublishDraftSchema = z.object({
   bodyHtml: z.string().optional(),
 });
 
+// ── Trash (GET /api/pages/trash) ──────────────────────────────────────────────
+
+/**
+ * One soft-deleted standalone article as it crosses the wire. The backend
+ * stringifies the integer PK and serializes all dates to ISO strings
+ * (same convention as {@link PageVersionSummarySchema} responses).
+ * `autoPurgeAt` = `deletedAt` + the standalone-trash retention window, so the
+ * Trash UI shows the same date the maintenance purge acts on.
+ */
+export const TrashItemSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  source: PageSourceEnum,
+  visibility: PageVisibilityEnum,
+  deletedAt: z.string(),
+  createdAt: z.string(),
+  deletedBy: z.string(),
+  autoPurgeAt: z.string(),
+});
+export type TrashItem = z.infer<typeof TrashItemSchema>;
+
+/** Response shape of GET /api/pages/trash. */
+export const TrashListResponseSchema = z.object({
+  items: z.array(TrashItemSchema),
+  total: z.number().int().nonnegative(),
+});
+export type TrashListResponse = z.infer<typeof TrashListResponseSchema>;
+
 // -- Duplicates & Export validation schemas (Issue #580) --
 
 export const DuplicatesQuerySchema = z.object({


### PR DESCRIPTION
## Summary

Fixes all 20+ findings from the 2026-06-10 usability review of the running EE stack, in five themes:

### State consistency
- Pages tree, list, detail, search, and dashboard KPIs now share one visibility predicate (`core/services/page-visibility.ts`); the sidebar can no longer show another user's private page that 404s on click (#tree route), and KPI counts match what the caller can see (embedding-status scoping). All 11 legacy inline copies of the predicate migrated to the helper; the two deliberately-divergent predicates are now commented as such.
- Cross-user cache invalidation when a page's visibility changes.

### Trash (was broken end-to-end)
- Frontend called `/api/trash` + `/api/trash/:id/restore`; backend serves `/api/pages/trash` + `/api/pages/:id/restore` — the trash UI could never show anything. Paths fixed; backend now returns `deletedBy`/`autoPurgeAt`; a daily purge for standalone pages >30 days was added to the retention job (shared constant so UI copy and purge can't drift).
- Native `confirm("…cannot be undone")` (false for a soft delete) replaced by a design-system `ConfirmDialog` with honest copy, on both the primary (ArticleRightPane) and keyboard (PageViewPage) delete paths.

### Degraded-state UX (silent failures now speak)
- 403 on AI ask renders an inline error bubble naming the missing `llm:query` permission (root cause: `streamSSE` threw status-less errors — now throws `ApiError`).
- Models fetch failure shows a retry chip instead of an eternal spinner; the page summary banner says "unavailable — LLM provider offline" instead of promising a summary that can't come; the outage banner names the actual provider with a settings link instead of hardcoded "Ollama".
- License page now surfaces expired/invalid stored keys ("expired on <date>", seats/expiry grid) instead of silently showing "Community Edition — Free"; Diagnostics says "Build edition" to disambiguate.

### Security/correctness
- `__system__` sentinel hidden from admin user list and the RBAC principal picker; protected against deactivate/delete/role-change at the service layer.
- Stale CSP hash fixed (the FOUC-prevention inline script had been silently blocked in production since the rebrand) and guarded by a prebuild check; EE bundle loading is license-gated so CE deployments make zero requests for it (console errors per page load: 3 → 0 in CE, 1 benign network line in EE).

### Copy/polish sweep
article→page terminology, en-US spelling, pluralization, KPI label wrapping, hidden empty Email column, registration confirm-password with retype-clearing, settings 404 panel, disabled-Create-Page hint, feedback widget hidden on own pages (exposes `createdByUserId`), consistent selects.

Also: Confluence DC test-container runbook (`docs/confluence-test-container.md`) and the sync e2e spec aligned to the current Spaces & Sync UI (verified green against a live Confluence DC 9.2.14).

## Test plan
- Full gates green: lint, typecheck, backend 3203 / frontend 2247 / contracts+mcp-docs 71 tests
- EE merged-build suites green: CE-under-automock 3268, overlay 1137 (with the companion EE PR's exclusion fix)
- Live Playwright verification of every headline fix against rebuilt containers (incl. real expired license, real Confluence sync, trash round-trip)
- Every commit passed an individual two-stage review (spec + quality); whole-branch final review: ready to merge

Companion PR in compendiq-ee: excludes two CE community-mode tests that are structurally false inside the merged build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)