### PR TITLE
feat(llm): emit OTel spans around outbound LLM calls

### DIFF
--- a/backend/src/domains/llm/services/openai-compatible-client.tracing.test.ts
+++ b/backend/src/domains/llm/services/openai-compatible-client.tracing.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  chat,
+  streamChat,
+  generateEmbedding,
+  listModels,
+  invalidateBreaker,
+  type ProviderConfig,
+} from './openai-compatible-client.js';
+
+// ---------------------------------------------------------------------------
+// OTel span instrumentation for the LLM client.
+//
+// `withSpan` (src/telemetry.ts) reads the tracer from `globalThis.__otelTracer`
+// and is a transparent pass-through when no tracer is installed. These tests
+// install a minimal fake tracer at that seam and drive the REAL client against
+// a REAL local HTTP server (mock at the boundary, per CLAUDE.md), asserting
+// that each outbound LLM operation produces a named span with the expected
+// attributes and status.
+// ---------------------------------------------------------------------------
+
+interface RecordedSpan {
+  name: string;
+  attributes: Record<string, unknown>;
+  status: { code: number; message?: string } | null;
+  exceptions: unknown[];
+  ended: boolean;
+}
+
+let recordedSpans: RecordedSpan[];
+
+function installFakeTracer(): void {
+  recordedSpans = [];
+  const tracer = {
+    startActiveSpan<T>(name: string, fn: (span: unknown) => T): T {
+      const rec: RecordedSpan = {
+        name,
+        attributes: {},
+        status: null,
+        exceptions: [],
+        ended: false,
+      };
+      recordedSpans.push(rec);
+      const span = {
+        setAttribute(key: string, value: unknown) {
+          rec.attributes[key] = value;
+        },
+        setStatus(s: { code: number; message?: string }) {
+          rec.status = s;
+        },
+        recordException(err: unknown) {
+          rec.exceptions.push(err);
+        },
+        end() {
+          rec.ended = true;
+        },
+      };
+      return fn(span);
+    },
+  };
+  (globalThis as Record<string, unknown>).__otelTracer = tracer;
+}
+
+function spanByName(name: string): RecordedSpan | undefined {
+  return recordedSpans.find((s) => s.name === name);
+}
+
+let srv: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  srv = createServer((req, res) => {
+    if (req.url === '/v1/models') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ data: [{ id: 'm1' }] }));
+      return;
+    }
+    if (req.url === '/v1/embeddings') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ data: [{ embedding: [0.1, 0.2] }, { embedding: [0.3, 0.4] }] }));
+      return;
+    }
+    if (req.url === '/v1/chat/completions') {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        const parsed = JSON.parse(body) as { stream?: boolean; model?: string };
+        if (parsed.model === 'boom') {
+          res.writeHead(500);
+          res.end();
+          return;
+        }
+        if (parsed.stream) {
+          res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+          res.write('data: ' + JSON.stringify({ choices: [{ delta: { content: 'hi' } }] }) + '\n\n');
+          res.write('data: [DONE]\n\n');
+          res.end();
+        } else {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ choices: [{ message: { content: 'hi' } }] }));
+        }
+      });
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  await new Promise<void>((r) => srv.listen(0, r));
+  const { port } = srv.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}/v1`;
+});
+
+afterAll(() => new Promise<void>((r) => srv.close(() => r())));
+
+// Unique provider id per test so circuit-breaker state never leaks between
+// tests (3 failures trip a breaker for 30 s — far longer than this suite).
+let providerSeq = 0;
+let providerId: string;
+
+function cfg(): ProviderConfig {
+  return { providerId, baseUrl, apiKey: null, authType: 'none', verifySsl: true };
+}
+
+beforeEach(() => {
+  providerId = `trace-test-${++providerSeq}`;
+  installFakeTracer();
+});
+
+afterEach(() => {
+  invalidateBreaker(providerId);
+  delete (globalThis as Record<string, unknown>).__otelTracer;
+});
+
+describe('openai-compatible-client — OTel spans', () => {
+  it('chat creates an llm.chat span with provider/model attributes and OK status', async () => {
+    const out = await chat(cfg(), 'm1', [{ role: 'user', content: 'hi' }]);
+    expect(out).toBe('hi');
+
+    const span = spanByName('llm.chat');
+    expect(span).toBeDefined();
+    expect(span!.attributes['llm.provider_id']).toBe(providerId);
+    expect(span!.attributes['llm.model']).toBe('m1');
+    expect(span!.status).toEqual({ code: 1 });
+    expect(span!.ended).toBe(true);
+  });
+
+  it('chat records error status and exception on upstream failure', async () => {
+    await expect(chat(cfg(), 'boom', [{ role: 'user', content: 'hi' }])).rejects.toThrow(
+      'chat HTTP 500',
+    );
+
+    const span = spanByName('llm.chat');
+    expect(span).toBeDefined();
+    expect(span!.status?.code).toBe(2);
+    expect(span!.exceptions).toHaveLength(1);
+    expect(span!.ended).toBe(true);
+  });
+
+  it('generateEmbedding creates an llm.embeddings span with input count', async () => {
+    const vectors = await generateEmbedding(cfg(), 'bge-m3', ['a', 'b']);
+    expect(vectors).toHaveLength(2);
+
+    const span = spanByName('llm.embeddings');
+    expect(span).toBeDefined();
+    expect(span!.attributes['llm.provider_id']).toBe(providerId);
+    expect(span!.attributes['llm.model']).toBe('bge-m3');
+    expect(span!.attributes['llm.input_count']).toBe(2);
+    expect(span!.status).toEqual({ code: 1 });
+    expect(span!.ended).toBe(true);
+  });
+
+  it('listModels creates an llm.list_models span', async () => {
+    const models = await listModels(cfg());
+    expect(models.map((m) => m.name)).toEqual(['m1']);
+
+    const span = spanByName('llm.list_models');
+    expect(span).toBeDefined();
+    expect(span!.attributes['llm.provider_id']).toBe(providerId);
+    expect(span!.status).toEqual({ code: 1 });
+    expect(span!.ended).toBe(true);
+  });
+
+  it('streamChat creates an llm.stream_chat.dispatch span around the initial request', async () => {
+    const chunks: string[] = [];
+    for await (const c of streamChat(cfg(), 'm1', [{ role: 'user', content: 'hi' }])) {
+      chunks.push(c.content);
+    }
+    expect(chunks.filter(Boolean).join('')).toBe('hi');
+
+    // The span covers only the dispatch (breaker-wrapped initial request),
+    // not the full stream consumption — long-lived streams must not hold a
+    // span open for minutes.
+    const span = spanByName('llm.stream_chat.dispatch');
+    expect(span).toBeDefined();
+    expect(span!.attributes['llm.provider_id']).toBe(providerId);
+    expect(span!.attributes['llm.model']).toBe('m1');
+    expect(span!.status).toEqual({ code: 1 });
+    expect(span!.ended).toBe(true);
+  });
+
+  it('streamChat records error status when the dispatch fails', async () => {
+    const iterate = async () => {
+      for await (const c of streamChat(cfg(), 'boom', [{ role: 'user', content: 'hi' }])) {
+        void c;
+      }
+    };
+    await expect(iterate()).rejects.toThrow('streamChat HTTP 500');
+
+    const span = spanByName('llm.stream_chat.dispatch');
+    expect(span).toBeDefined();
+    expect(span!.status?.code).toBe(2);
+    expect(span!.ended).toBe(true);
+  });
+});

--- a/backend/src/domains/llm/services/openai-compatible-client.ts
+++ b/backend/src/domains/llm/services/openai-compatible-client.ts
@@ -5,6 +5,7 @@ import {
   invalidateProviderBreaker,
 } from '../../../core/services/circuit-breaker.js';
 import { logger } from '../../../core/utils/logger.js';
+import { withSpan } from '../../../telemetry.js';
 
 export interface ProviderConfig {
   providerId: string;
@@ -151,15 +152,19 @@ export interface StreamChatOptions {
 }
 
 export async function listModels(cfg: ProviderConfig): Promise<LlmModel[]> {
-  return enqueue(() =>
-    getProviderBreaker(cfg.providerId).execute(async () => {
-      const res = await undiciFetch(`${cfg.baseUrl}/models`, {
-        headers: headers(cfg), dispatcher: dispatcherFor(cfg),
-      });
-      if (!res.ok) throw new Error(`listModels HTTP ${res.status}`);
-      const body = await res.json() as { data?: Array<{ id: string }> };
-      return (body.data ?? []).map((m) => ({ name: m.id }));
-    }),
+  return withSpan(
+    'llm.list_models',
+    () => enqueue(() =>
+      getProviderBreaker(cfg.providerId).execute(async () => {
+        const res = await undiciFetch(`${cfg.baseUrl}/models`, {
+          headers: headers(cfg), dispatcher: dispatcherFor(cfg),
+        });
+        if (!res.ok) throw new Error(`listModels HTTP ${res.status}`);
+        const body = await res.json() as { data?: Array<{ id: string }> };
+        return (body.data ?? []).map((m) => ({ name: m.id }));
+      }),
+    ),
+    { 'llm.provider_id': cfg.providerId },
   );
 }
 
@@ -175,18 +180,26 @@ export async function checkHealth(cfg: ProviderConfig): Promise<HealthResult> {
 export async function chat(
   cfg: ProviderConfig, model: string, messages: ChatMessage[], opts?: StreamChatOptions,
 ): Promise<string> {
-  return enqueue(() =>
-    getProviderBreaker(cfg.providerId).execute(async () => {
-      const res = await undiciFetch(`${cfg.baseUrl}/chat/completions`, {
-        method: 'POST',
-        headers: headers(cfg),
-        body: JSON.stringify({ model, messages, stream: false, ...thinkingExtras(cfg.baseUrl, model, opts?.thinking) }),
-        dispatcher: dispatcherFor(cfg),
-      });
-      if (!res.ok) throw new Error(`chat HTTP ${res.status}`);
-      const body = await res.json() as { choices: Array<{ message: { content: string } }> };
-      return body.choices[0]?.message.content ?? '';
-    }),
+  // The span wraps the queue wait + breaker + HTTP round-trip. With OTel's
+  // undici auto-instrumentation enabled the HTTP call appears as a child
+  // span, so queue wait is derivable as the difference. No-op when OTel is
+  // disabled (withSpan passes straight through).
+  return withSpan(
+    'llm.chat',
+    () => enqueue(() =>
+      getProviderBreaker(cfg.providerId).execute(async () => {
+        const res = await undiciFetch(`${cfg.baseUrl}/chat/completions`, {
+          method: 'POST',
+          headers: headers(cfg),
+          body: JSON.stringify({ model, messages, stream: false, ...thinkingExtras(cfg.baseUrl, model, opts?.thinking) }),
+          dispatcher: dispatcherFor(cfg),
+        });
+        if (!res.ok) throw new Error(`chat HTTP ${res.status}`);
+        const body = await res.json() as { choices: Array<{ message: { content: string } }> };
+        return body.choices[0]?.message.content ?? '';
+      }),
+    ),
+    { 'llm.provider_id': cfg.providerId, 'llm.model': model },
   );
 }
 
@@ -202,17 +215,24 @@ export async function chat(
 export async function* streamChat(
   cfg: ProviderConfig, model: string, messages: ChatMessage[], signal?: AbortSignal, opts?: StreamChatOptions,
 ): AsyncGenerator<StreamChunk> {
-  const res = await getProviderBreaker(cfg.providerId).execute(async () => {
-    const r = await undiciFetch(`${cfg.baseUrl}/chat/completions`, {
-      method: 'POST',
-      headers: headers(cfg),
-      body: JSON.stringify({ model, messages, stream: true, ...thinkingExtras(cfg.baseUrl, model, opts?.thinking) }),
-      dispatcher: dispatcherFor(cfg),
-      signal,
-    });
-    if (!r.ok || !r.body) throw new Error(`streamChat HTTP ${r.status}`);
-    return r;
-  });
+  // The span covers only the dispatch (breaker + initial HTTP request), not
+  // the stream consumption — a span held open for the whole stream would
+  // outlive minutes-long generations and skew duration percentiles.
+  const res = await withSpan(
+    'llm.stream_chat.dispatch',
+    () => getProviderBreaker(cfg.providerId).execute(async () => {
+      const r = await undiciFetch(`${cfg.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: headers(cfg),
+        body: JSON.stringify({ model, messages, stream: true, ...thinkingExtras(cfg.baseUrl, model, opts?.thinking) }),
+        dispatcher: dispatcherFor(cfg),
+        signal,
+      });
+      if (!r.ok || !r.body) throw new Error(`streamChat HTTP ${r.status}`);
+      return r;
+    }),
+    { 'llm.provider_id': cfg.providerId, 'llm.model': model },
+  );
   const reader = res.body!.getReader();
   const dec = new TextDecoder();
   let buf = '';
@@ -241,17 +261,21 @@ export async function generateEmbedding(
   cfg: ProviderConfig, model: string, text: string | string[],
 ): Promise<number[][]> {
   const input = Array.isArray(text) ? text : [text];
-  return enqueue(() =>
-    getProviderBreaker(cfg.providerId).execute(async () => {
-      const res = await undiciFetch(`${cfg.baseUrl}/embeddings`, {
-        method: 'POST',
-        headers: headers(cfg),
-        body: JSON.stringify({ model, input }),
-        dispatcher: dispatcherFor(cfg),
-      });
-      if (!res.ok) throw new Error(`generateEmbedding HTTP ${res.status}`);
-      const body = await res.json() as { data: Array<{ embedding: number[] }> };
-      return body.data.map((d) => d.embedding);
-    }),
+  return withSpan(
+    'llm.embeddings',
+    () => enqueue(() =>
+      getProviderBreaker(cfg.providerId).execute(async () => {
+        const res = await undiciFetch(`${cfg.baseUrl}/embeddings`, {
+          method: 'POST',
+          headers: headers(cfg),
+          body: JSON.stringify({ model, input }),
+          dispatcher: dispatcherFor(cfg),
+        });
+        if (!res.ok) throw new Error(`generateEmbedding HTTP ${res.status}`);
+        const body = await res.json() as { data: Array<{ embedding: number[] }> };
+        return body.data.map((d) => d.embedding);
+      }),
+    ),
+    { 'llm.provider_id': cfg.providerId, 'llm.model': model, 'llm.input_count': input.length },
   );
 }

--- a/docs/ADMIN-GUIDE.md
+++ b/docs/ADMIN-GUIDE.md
@@ -590,6 +590,12 @@ In CE-only deployments the `/api/admin/compliance-reports` and `/api/admin/compl
 | `OTEL_SERVICE_NAME` | `compendiq-backend` | Service name reported to the OTLP collector |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | *(none)* | OTLP collector endpoint (e.g., `http://localhost:4318`) |
 
+When tracing is enabled, every outbound LLM call additionally emits a custom
+span (`llm.chat`, `llm.stream_chat.dispatch`, `llm.embeddings`,
+`llm.list_models`) tagged with the provider id and model, covering queue wait
+plus the upstream request. See `docs/PERFORMANCE.md` → "OpenTelemetry Tracing"
+for the full span reference.
+
 ### Docker Compose Only
 
 | Variable | Default | Description |

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -214,6 +214,21 @@ npm run dev
 # View traces at http://localhost:16686
 ```
 
+In addition to the HTTP/Fastify/pg/Redis auto-instrumentation, the backend
+emits custom spans around every outbound LLM call
+(`backend/src/domains/llm/services/openai-compatible-client.ts`):
+
+| Span | Covers | Attributes |
+|------|--------|------------|
+| `llm.chat` | queue wait + circuit breaker + completion request | `llm.provider_id`, `llm.model` |
+| `llm.stream_chat.dispatch` | breaker + initial streaming request (not stream consumption) | `llm.provider_id`, `llm.model` |
+| `llm.embeddings` | queue wait + breaker + embeddings request | `llm.provider_id`, `llm.model`, `llm.input_count` |
+| `llm.list_models` | queue wait + breaker + model listing | `llm.provider_id` |
+
+The undici auto-instrumentation nests the actual HTTP round-trip as a child
+span, so queue wait time is the difference between the `llm.*` span and its
+HTTP child.
+
 ## Monitoring & Alerting
 
 ### Key Indicators to Watch


### PR DESCRIPTION
## Summary

Closes the "OTel exists but the LLM domain doesn't use it" observability gap: `telemetry.ts` has shipped a `withSpan()` helper since the OTel integration landed, but no LLM call site ever used it. Every outbound LLM call in `openai-compatible-client.ts` is now wrapped in a custom span (transparent no-op unless `OTEL_ENABLED=true`):

| Span | Covers | Attributes |
|------|--------|------------|
| `llm.chat` | queue wait + circuit breaker + completion request | `llm.provider_id`, `llm.model` |
| `llm.stream_chat.dispatch` | breaker + initial streaming request only | `llm.provider_id`, `llm.model` |
| `llm.embeddings` | queue wait + breaker + embeddings request | `llm.provider_id`, `llm.model`, `llm.input_count` |
| `llm.list_models` | queue wait + breaker + model listing | `llm.provider_id` |

Design notes:
- Spans wrap the **whole** `enqueue()` + breaker + HTTP chain, so with the undici auto-instrumentation nesting the HTTP round-trip as a child span, queue-wait time is derivable as the difference.
- The streaming span deliberately covers only the dispatch, not stream consumption — a span held open across a minutes-long generation would skew duration percentiles.
- Error paths set span status ERROR and record the exception before rethrowing.

## Docs

Span reference added to `docs/PERFORMANCE.md` (OpenTelemetry Tracing section) and cross-linked from `docs/ADMIN-GUIDE.md` (Monitoring). No new env vars; no diagram-relevant structural change.

## Test plan

- New `openai-compatible-client.tracing.test.ts` (TDD, 6 tests): installs a minimal fake tracer at the real `globalThis.__otelTracer` seam and drives the real client against a real local HTTP server (mock at the boundary) — asserts span names, attributes, OK/ERROR status, exception recording, and span closure for all four operations including failure paths.
- Full backend suite green locally against real Postgres + Redis: 209 files, 3177 passed / 3 skipped. Lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)