### PR TITLE
fix(review): land PR #787 review fixes that missed the merge

### DIFF
--- a/backend/src/core/services/data-retention-service.test.ts
+++ b/backend/src/core/services/data-retention-service.test.ts
@@ -125,12 +125,14 @@ describe('data-retention-service', () => {
       expect(deniedCall[0]).toContain('LIMIT $2');
       expect(deniedCall[1]).toEqual([90, 10_000]);
 
-      // Standalone trash purge is source-scoped and parameterized on the
-      // 30-day window — never touches Confluence-synced rows.
+      // Standalone trash purge is source-scoped, parameterized on the
+      // 30-day window, and batched like the ADMIN_ACCESS_DENIED purge —
+      // never touches Confluence-synced rows.
       const trashCall = mockPool.query.mock.calls[4];
       expect(trashCall[0]).toContain('DELETE FROM pages');
       expect(trashCall[0]).toContain(`source = 'standalone'`);
-      expect(trashCall[1]).toEqual([STANDALONE_TRASH_RETENTION_DAYS]);
+      expect(trashCall[0]).toContain('LIMIT $2');
+      expect(trashCall[1]).toEqual([STANDALONE_TRASH_RETENTION_DAYS, 10_000]);
     });
 
     it('uses ROW_NUMBER for count-based page_versions cleanup', async () => {
@@ -240,6 +242,22 @@ describe('data-retention-service', () => {
     });
 
     // ─── Standalone trash purge (UX review) ──────────────────────────────
+    it('loops standalone trash purge batches until a short batch signals drained', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rowCount: 0 })      // audit_log
+        .mockResolvedValueOnce({ rowCount: 0 })      // search_analytics
+        .mockResolvedValueOnce({ rowCount: 0 })      // error_log
+        .mockResolvedValueOnce({ rowCount: 0 })      // ADMIN_ACCESS_DENIED drained
+        .mockResolvedValueOnce({ rowCount: 10_000 }) // trash batch 1 full — loop again
+        .mockResolvedValueOnce({ rowCount: 7 })      // trash batch 2 short — drained
+        .mockResolvedValueOnce({ rowCount: 0 });     // page_versions
+
+      const results = await runRetentionCleanup();
+      expect(results.pages_standalone_trash).toBe(10_007);
+      // page_versions still ran after the extra batch.
+      expect(results.page_versions).toBe(0);
+    });
+
     it('swallows errors inside the standalone trash purge and reports 0', async () => {
       mockPool.query
         .mockResolvedValueOnce({ rowCount: 0 }) // audit_log

--- a/backend/src/core/services/data-retention-service.ts
+++ b/backend/src/core/services/data-retention-service.ts
@@ -222,6 +222,13 @@ async function runAdminAccessDeniedRetention(): Promise<number> {
 export const STANDALONE_TRASH_RETENTION_DAYS = 30;
 
 /**
+ * Rows per DELETE batch — same backstop as the ADMIN_ACCESS_DENIED purge:
+ * keeps lock time and WAL volume bounded if a huge backlog ever accumulates
+ * (e.g. the maintenance job was disabled for months).
+ */
+const STANDALONE_TRASH_PURGE_BATCH_SIZE = 10_000;
+
+/**
  * Hard-delete standalone pages whose soft-delete (`pages.deleted_at`) is older
  * than the 30-day trash window (UX review: the Trash UI promised "purged after
  * 30 days" but nothing ever purged standalone pages — the only purge was
@@ -242,14 +249,27 @@ export async function purgeExpiredStandalonePages(): Promise<number> {
   let deleted = 0;
 
   try {
-    const { rowCount } = await pool.query(
-      `DELETE FROM pages
-        WHERE source = 'standalone'
-          AND deleted_at IS NOT NULL
-          AND deleted_at < NOW() - INTERVAL '1 day' * $1`,
-      [STANDALONE_TRASH_RETENTION_DAYS],
-    );
-    deleted = rowCount ?? 0;
+    for (;;) {
+      const { rowCount } = await pool.query(
+        // Explicit `deleted_at IS NOT NULL` guard instead of relying on SQL
+        // NULL-comparison semantics to protect live pages — matches the
+        // Confluence purge in sync-service.
+        `DELETE FROM pages
+          WHERE id IN (
+            SELECT id FROM pages
+             WHERE source = 'standalone'
+               AND deleted_at IS NOT NULL
+               AND deleted_at < NOW() - INTERVAL '1 day' * $1
+             LIMIT $2
+          )`,
+        [STANDALONE_TRASH_RETENTION_DAYS, STANDALONE_TRASH_PURGE_BATCH_SIZE],
+      );
+      const n = rowCount ?? 0;
+      deleted += n;
+      // A short batch signals drained — break out rather than loop again on
+      // a guaranteed-empty DELETE.
+      if (n < STANDALONE_TRASH_PURGE_BATCH_SIZE) break;
+    }
     if (deleted > 0) {
       logger.info(
         { deleted, retentionDays: STANDALONE_TRASH_RETENTION_DAYS },

--- a/docs/confluence-test-container.md
+++ b/docs/confluence-test-container.md
@@ -33,13 +33,20 @@ only asks for a license, deployment type, and an admin account:
    the volume and redo setup.
 2. Deployment type: **Non-clustered (single node)** → Empty Site →
    "Manage users and groups within Confluence".
-3. Admin account (dev-only, never reuse elsewhere): `admin` /
-   `confluence-admin-dev-2026` (email `admin@compendiq.local`).
+3. Admin account: username `admin`, email `admin@compendiq.local`, and a
+   throwaway dev-only password of your choice. Record it in the gitignored
+   `docker/.env` so the seeding commands below can read it (and so it never
+   lands in the repo or your shell history):
+
+   ```bash
+   echo 'CONFLUENCE_ADMIN_PASSWORD=<the password you typed>' >> docker/.env
+   ```
 
 ## Seed test content + PAT (REST)
 
 ```bash
-AUTH="admin:confluence-admin-dev-2026"
+source docker/.env
+AUTH="admin:${CONFLUENCE_ADMIN_PASSWORD}"
 # Space
 curl -fsS -u "$AUTH" -X POST http://localhost:8090/rest/api/space \
   -H 'Content-Type: application/json' \
@@ -89,8 +96,8 @@ selects + syncs one, and asserts synced Confluence pages are served by
 ## Notes
 
 - Ports bind to `127.0.0.1` only (8090 HTTP, 8091 Synchrony).
-- The timebomb license, the dev admin password above, and seeded PATs are
-  throwaway dev credentials for this isolated container — treat anything you
-  paste into a real instance differently.
+- The timebomb license, the dev admin password in `docker/.env`, and seeded
+  PATs are throwaway dev credentials for this isolated container — treat
+  anything you paste into a real instance differently.
 - Confluence DC 9.2 serves XHTML storage format only (see ADR-003); the
   seeded code-block/task-list page exercises the `confluenceToHtml` path.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "prebuild": "node scripts/check-csp-hash.mjs",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
-    "lint": "eslint --max-warnings=0 src/",
+    "lint": "eslint --max-warnings=0 src/ scripts/",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/frontend/src/features/ai/AiAssistantPage.test.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.test.tsx
@@ -712,6 +712,94 @@ describe('AiAssistantPage', () => {
       expect(screen.getByText('What is Confluence?')).toBeInTheDocument();
     });
 
+    it('names the permission from the backend 403 message, not a hardcoded one', async () => {
+      apiFetchMock.mockImplementation((path: string) => {
+        if (path === '/settings') {
+          return Promise.resolve({ llmProvider: 'ollama', ollamaModel: 'llama3', openaiModel: null });
+        }
+        if (path.startsWith('/ollama/models')) {
+          return Promise.resolve([{ name: 'llama3' }]);
+        }
+        if (path === '/llm/conversations') {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+
+      // Each streamed mode has its own permission (llm:improve, llm:generate,
+      // llm:summarize…) — the shared runStream catch must surface whichever
+      // one the backend named, not always "llm:query".
+      // eslint-disable-next-line require-yield
+      async function* fakeForbiddenStream() {
+        throw new ApiError(403, 'Permission "llm:improve" required');
+      }
+      streamSSEMock.mockReturnValue(fakeForbiddenStream());
+
+      render(<AiAssistantPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText('Ask a question...');
+      fireEvent.change(input, { target: { value: 'Improve this' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('message-error')).toBeInTheDocument();
+      });
+      const errorBubble = screen.getByTestId('message-error');
+      expect(errorBubble.textContent).toContain('llm:improve');
+      expect(errorBubble.textContent).not.toContain('llm:query');
+      expect(errorBubble.textContent).toContain('administrator');
+    });
+
+    it('surfaces in-band SSE error events inline instead of leaving an empty bubble', async () => {
+      apiFetchMock.mockImplementation((path: string) => {
+        if (path === '/settings') {
+          return Promise.resolve({ llmProvider: 'ollama', ollamaModel: 'llama3', openaiModel: null });
+        }
+        if (path.startsWith('/ollama/models')) {
+          return Promise.resolve([{ name: 'llama3' }]);
+        }
+        if (path === '/llm/conversations') {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+
+      // Mid-stream provider failures arrive as `data: {"error": …}` events on
+      // an already-established HTTP 200 stream — the common failure path.
+      async function* fakeErrorEventStream() {
+        yield { error: 'LLM provider exploded' };
+      }
+      streamSSEMock.mockReturnValue(fakeErrorEventStream());
+
+      render(<AiAssistantPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText('Ask a question...');
+      fireEvent.change(input, { target: { value: 'What is Confluence?' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      // Inline error bubble, same treatment as thrown errors…
+      await waitFor(() => {
+        expect(screen.getByTestId('message-error')).toBeInTheDocument();
+      });
+      const errorBubble = screen.getByTestId('message-error');
+      expect(errorBubble.textContent).toContain('LLM provider exploded');
+      expect(errorBubble.className).toContain('destructive');
+
+      // …plus the toast, matching non-403 thrown errors.
+      expect(toastErrorMock).toHaveBeenCalledWith('LLM provider exploded');
+
+      // No lingering typing indicator after the failure.
+      expect(screen.queryByTestId('typing-indicator')).not.toBeInTheDocument();
+    });
+
     it('enables send button when model is loaded and input is provided', async () => {
       apiFetchMock.mockImplementation((path: string) => {
         if (path === '/settings') {

--- a/frontend/src/features/ai/AiAssistantPage.test.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.test.tsx
@@ -712,6 +712,45 @@ describe('AiAssistantPage', () => {
       expect(screen.getByText('What is Confluence?')).toBeInTheDocument();
     });
 
+    it('announces inline error bubbles to screen readers via role="alert"', async () => {
+      apiFetchMock.mockImplementation((path: string) => {
+        if (path === '/settings') {
+          return Promise.resolve({ llmProvider: 'ollama', ollamaModel: 'llama3', openaiModel: null });
+        }
+        if (path.startsWith('/ollama/models')) {
+          return Promise.resolve([{ name: 'llama3' }]);
+        }
+        if (path === '/llm/conversations') {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+
+      // eslint-disable-next-line require-yield
+      async function* fakeForbiddenStream() {
+        throw new ApiError(403, 'Permission "llm:query" required');
+      }
+      streamSSEMock.mockReturnValue(fakeForbiddenStream());
+
+      render(<AiAssistantPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText('Ask a question...');
+      fireEvent.change(input, { target: { value: 'What is Confluence?' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('message-error')).toBeInTheDocument();
+      });
+      // The 403 path deliberately suppresses the toast, so the bubble itself
+      // must be a live region — otherwise screen-reader users get zero
+      // announcement of the permission failure.
+      expect(screen.getByRole('alert')).toBe(screen.getByTestId('message-error'));
+    });
+
     it('names the permission from the backend 403 message, not a hardcoded one', async () => {
       apiFetchMock.mockImplementation((path: string) => {
         if (path === '/settings') {

--- a/frontend/src/features/ai/AiAssistantPage.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.tsx
@@ -99,6 +99,10 @@ const MessageBubble = memo(function MessageBubble({
               : 'bg-foreground/5',
         )}
         data-testid={msg.isError ? 'message-error' : undefined}
+        // The 403 path suppresses the toast in favor of this bubble, so the
+        // bubble itself must be the live region — without it, screen-reader
+        // users get no announcement of the failure at all.
+        role={msg.isError ? 'alert' : undefined}
       >
         {showThinkingBlob && <AIThinkingBlob active />}
         {showTypingIndicator && <TypingIndicator />}

--- a/frontend/src/features/ai/AiContext.tsx
+++ b/frontend/src/features/ai/AiContext.tsx
@@ -485,10 +485,24 @@ export function AiProvider({ children }: { children: ReactNode }) {
       });
     };
 
+    // Replace the placeholder assistant message with an inline error bubble —
+    // shared by thrown errors (catch below) and in-band SSE error events.
+    const failLastMessage = (text: string) => {
+      setMessages((prev) => {
+        const updated = [...prev];
+        const lastMsg = updated[updated.length - 1];
+        if (lastMsg && lastMsg.role === 'assistant') {
+          updated[updated.length - 1] = { ...lastMsg, content: text, isError: true };
+        }
+        return updated;
+      });
+    };
+
     try {
+      let streamError: string | null = null;
       for await (const chunk of streamSSE<T>(endpoint, body, controller.signal)) {
         if (chunk.error) {
-          toast.error(chunk.error);
+          streamError = chunk.error;
           break;
         }
         // Handle finalContent from output post-processing (cleaned content replaces accumulated)
@@ -518,6 +532,14 @@ export function AiProvider({ children }: { children: ReactNode }) {
           originalMarkdown = chunk.originalMarkdown;
         }
       }
+      if (streamError) {
+        // In-band SSE error events (HTTP 200 already established — the common
+        // mid-stream provider failure) get the same inline treatment as thrown
+        // errors, plus the toast that non-403 throws keep.
+        toast.error(streamError);
+        failLastMessage(streamError);
+        return;
+      }
       commitToMessages();
       opts?.onComplete?.(
         accumulated,
@@ -535,19 +557,15 @@ export function AiProvider({ children }: { children: ReactNode }) {
       // with an error message instead of silently removing it (the user
       // previously saw a bubble appear and then vanish with no explanation).
       const isForbidden = err instanceof ApiError && err.statusCode === 403;
+      // The backend's 403 body names the exact missing permission (each
+      // streamed mode has its own: llm:query, llm:improve, llm:generate,
+      // llm:summarize) — pass it through instead of hardcoding one.
       const friendly = isForbidden
-        ? 'You don\'t have permission to use AI features (permission "llm:query"). Ask an administrator to assign you a role that includes it.'
+        ? `You don't have permission to use this AI feature (${err.message || 'permission denied'}). Ask an administrator to assign you a role that includes it.`
         : err instanceof Error ? err.message : 'Request failed';
       // 403 is fully explained inline — keep the toast only for other errors.
       if (!isForbidden) toast.error(friendly);
-      setMessages((prev) => {
-        const updated = [...prev];
-        const lastMsg = updated[updated.length - 1];
-        if (lastMsg && lastMsg.role === 'assistant') {
-          updated[updated.length - 1] = { ...lastMsg, content: friendly, isError: true };
-        }
-        return updated;
-      });
+      failLastMessage(friendly);
     } finally {
       streamingFinish();
       isStreamingRef.current = false;

--- a/frontend/src/features/pages/NewPagePage.test.tsx
+++ b/frontend/src/features/pages/NewPagePage.test.tsx
@@ -238,6 +238,32 @@ describe('NewPagePage', () => {
     expect(screen.getByText('Create Page').closest('[title]')).toBeNull();
   });
 
+  it('shows the disabled-create hint as visible text wired via aria-describedby', () => {
+    // A title tooltip is mouse-only — keyboard, touch and screen-reader users
+    // need the explanation too, so it must exist as real text in the DOM and
+    // be linked to the button for assistive tech.
+    render(<NewPagePage />, { wrapper: createWrapper() });
+    const createBtn = screen.getByText('Create Page').closest('button')!;
+    expect(createBtn).toBeDisabled();
+
+    const hint = screen.getByText('Enter a title and select a space first', {
+      selector: '#create-page-hint',
+    });
+    expect(hint).toBeInTheDocument();
+    expect(createBtn).toHaveAttribute('aria-describedby', 'create-page-hint');
+  });
+
+  it('removes the visible hint once the Create Page button is enabled', async () => {
+    render(<NewPagePage />, { wrapper: createWrapper() });
+    fireEvent.change(screen.getByTestId('title-input'), { target: { value: 'My Page' } });
+    fireEvent.change(screen.getByTestId('space-selector'), { target: { value: '__local__' } });
+    await waitFor(() => {
+      expect(screen.getByText('Create Page').closest('button')).not.toBeDisabled();
+    });
+    expect(document.querySelector('#create-page-hint')).toBeNull();
+    expect(screen.getByText('Create Page').closest('button')).not.toHaveAttribute('aria-describedby');
+  });
+
   it('submit uses the selected local spaceKey (not hardcoded __local__)', async () => {
     mockCreateMutateAsync.mockResolvedValueOnce({ id: 'new-page-id', title: 'My Notes Page', version: 1 });
 

--- a/frontend/src/features/pages/NewPagePage.tsx
+++ b/frontend/src/features/pages/NewPagePage.tsx
@@ -115,6 +115,9 @@ export function NewPagePage() {
   const isCreateDisabled = createMutation.isPending
     || !title.trim()
     || !spaceKey;
+  // Explain WHY create is disabled — but not while a create is in flight
+  // (the button already says "Creating...").
+  const showCreateHint = isCreateDisabled && !createMutation.isPending;
 
   return (
     <div>
@@ -166,16 +169,11 @@ export function NewPagePage() {
                   sets pointer-events:none on :disabled, so a tooltip on the button
                   itself would never show while it is disabled — exactly when the
                   user needs to know why. */}
-              <span
-                title={
-                  isCreateDisabled && !createMutation.isPending
-                    ? 'Enter a title and select a space first'
-                    : undefined
-                }
-              >
+              <span title={showCreateHint ? 'Enter a title and select a space first' : undefined}>
                 <button
                   onClick={handleCreate}
                   disabled={isCreateDisabled}
+                  aria-describedby={showCreateHint ? 'create-page-hint' : undefined}
                   className="nm-button-primary"
                 >
                   <Save size={14} /> {createMutation.isPending ? 'Creating...' : 'Create Page'}
@@ -183,6 +181,15 @@ export function NewPagePage() {
               </span>
             </div>
           </div>
+
+          {/* Visible variant of the tooltip hint: title attributes are
+              mouse-hover-only, so keyboard, touch and screen-reader users
+              need the explanation as real, aria-linked text. */}
+          {showCreateHint && (
+            <p id="create-page-hint" className="text-right text-xs text-muted-foreground">
+              Enter a title and select a space first
+            </p>
+          )}
 
           {/* Metadata bar */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-2">

--- a/frontend/src/features/pages/PageViewPage.test.tsx
+++ b/frontend/src/features/pages/PageViewPage.test.tsx
@@ -779,6 +779,34 @@ describe('PageViewPage', () => {
       });
     });
 
+    it('dismissing with Escape stays in view mode and keeps the draft pending', async () => {
+      // Escape must mean "do nothing": entering edit mode on the published
+      // copy would let autosave start overwriting the stored draft, which is
+      // a side effect nobody chose.
+      mockDraftContent = '<p>Draft content</p>';
+      render(<PageViewPage />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByText('Edit'));
+      await screen.findByTestId('confirm-dialog');
+      fireEvent.keyDown(screen.getByTestId('confirm-dialog'), { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      });
+      // Still in view mode — no editor mounted.
+      expect(screen.queryByLabelText('Article editor')).not.toBeInTheDocument();
+
+      // The decision was deferred, not made: Edit prompts again.
+      fireEvent.click(screen.getByText('Edit'));
+      expect(await screen.findByTestId('confirm-dialog')).toBeInTheDocument();
+
+      // Close the portal dialog before teardown (see first test in this block).
+      fireEvent.keyDown(screen.getByTestId('confirm-dialog'), { key: 'Escape' });
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      });
+    });
+
     it('enters edit mode directly when no draft exists', () => {
       mockDraftContent = null;
       render(<PageViewPage />, { wrapper: createWrapper() });

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -220,9 +220,9 @@ export function PageViewPage() {
     setEditTitle(page.title);
     const draft = getDraft(`page-${id}`);
     if (draft && draft !== page.bodyHtml) {
-      // Defer edit mode until the user decides in the ConfirmDialog below.
-      // Matches the old native confirm() semantics: either choice enters edit
-      // mode — confirm restores the draft, cancel edits the published copy.
+      // Defer edit mode until the user decides in the ConfirmDialog below:
+      // confirm restores the draft, the labeled cancel action edits the
+      // published copy, and Escape/overlay dismissal stays in view mode.
       setPendingDraft(draft);
       return;
     }
@@ -806,18 +806,21 @@ export function PageViewPage() {
       />
 
       {/* Draft restore — drafts are autosaved to localStorage on this device
-          while editing. Restoring is non-destructive; declining opens the
-          editor on the published content (same as the old native confirm()
-          flow, where Cancel also entered edit mode). No destructive styling:
-          the draft is only overwritten by continued editing, never deleted
-          here. */}
+          while editing. Restoring is non-destructive; the labeled cancel
+          action opens the editor on the published content. Escape/overlay
+          stay neutral (onDismiss): entering edit mode would let autosave
+          start overwriting the stored draft, a side effect nobody chose.
+          No destructive styling: the draft is only overwritten by continued
+          editing, never deleted here. */}
       <ConfirmDialog
         open={pendingDraft !== null}
         title="Restore draft?"
-        description="An unsaved draft of this page was found in this browser. Restore it to continue where you left off, or cancel to edit the published version instead (the draft is overwritten as you edit)."
+        description="An unsaved draft of this page was found in this browser. Restore it to continue where you left off, or edit the published version instead (the draft is overwritten as you edit)."
         confirmLabel="Restore draft"
+        cancelLabel="Edit published version"
         onConfirm={handleRestoreDraft}
         onCancel={handleDeclineDraft}
+        onDismiss={() => setPendingDraft(null)}
       />
     </m.div>
   );

--- a/frontend/src/neumorphic-themes.test.ts
+++ b/frontend/src/neumorphic-themes.test.ts
@@ -275,6 +275,7 @@ describe('Neumorphic @utility set', () => {
     'nm-pill-active',
     'nm-button-primary',
     'nm-button-ghost',
+    'nm-button-destructive',
     'nm-icon-button',
     'nm-input',
   ] as const;
@@ -291,6 +292,7 @@ describe('Neumorphic @utility set', () => {
       'nm-card-interactive',
       'nm-button-primary',
       'nm-button-ghost',
+      'nm-button-destructive',
       'nm-icon-button',
       'nm-input',
     ];
@@ -306,6 +308,7 @@ describe('Neumorphic @utility set', () => {
       'nm-card-interactive',
       'nm-button-primary',
       'nm-button-ghost',
+      'nm-button-destructive',
       'nm-icon-button',
       'nm-input',
     ];

--- a/frontend/src/shared/components/ConfirmDialog.test.tsx
+++ b/frontend/src/shared/components/ConfirmDialog.test.tsx
@@ -64,6 +64,35 @@ describe('ConfirmDialog', () => {
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
+  it('routes Escape to onDismiss instead of onCancel when onDismiss is provided', () => {
+    // When the Cancel button carries a real action (e.g. "edit the published
+    // version"), Escape/overlay must stay neutral: close without choosing.
+    const onDismiss = vi.fn();
+    const { onConfirm, onCancel } = renderDialog({ onDismiss });
+
+    fireEvent.keyDown(screen.getByTestId('confirm-dialog'), { key: 'Escape' });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('still routes the Cancel button to onCancel when onDismiss is provided', () => {
+    const onDismiss = vi.fn();
+    const { onCancel } = renderDialog({ onDismiss });
+
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('renders a custom cancel label when cancelLabel is provided', () => {
+    renderDialog({ cancelLabel: 'Edit published version' });
+
+    expect(screen.getByTestId('confirm-dialog-cancel')).toHaveTextContent(
+      'Edit published version',
+    );
+  });
+
   it('applies the design-system destructive button when destructive', () => {
     renderDialog({ destructive: true, confirmLabel: 'Delete user' });
 

--- a/frontend/src/shared/components/ConfirmDialog.tsx
+++ b/frontend/src/shared/components/ConfirmDialog.tsx
@@ -6,7 +6,10 @@
  * Built on @radix-ui/react-dialog (same primitive as UserBulkActionDialog
  * et al.), which provides focus trapping, initial focus, Escape-to-dismiss
  * and overlay-click-to-dismiss for free. Both dismissal paths route
- * through `onCancel` via `onOpenChange(false)`.
+ * through `onCancel` via `onOpenChange(false)` — unless `onDismiss` is
+ * provided, which they route to instead. Pass `onDismiss` whenever the
+ * Cancel button carries a real action (not just "close"), so Escape and
+ * overlay-click stay neutral.
  *
  * The confirm button uses the design-system `nm-button-destructive`
  * utility when `destructive` (same box metrics as `nm-button-primary` /
@@ -20,9 +23,17 @@ export interface ConfirmDialogProps {
   title: string;
   description: string;
   confirmLabel: string;
+  /** Cancel-button text. Defaults to "Cancel". */
+  cancelLabel?: string;
   destructive?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
+  /**
+   * Escape / overlay-click handler. Defaults to `onCancel`. Provide it when
+   * the Cancel button performs a real action, so dismissing the dialog means
+   * "close without choosing" rather than silently picking the cancel path.
+   */
+  onDismiss?: () => void;
 }
 
 export function ConfirmDialog({
@@ -30,15 +41,17 @@ export function ConfirmDialog({
   title,
   description,
   confirmLabel,
+  cancelLabel = 'Cancel',
   destructive = false,
   onConfirm,
   onCancel,
+  onDismiss,
 }: ConfirmDialogProps) {
   return (
     <Dialog.Root
       open={open}
       onOpenChange={(nextOpen) => {
-        if (!nextOpen) onCancel();
+        if (!nextOpen) (onDismiss ?? onCancel)();
       }}
     >
       <Dialog.Portal>
@@ -63,7 +76,7 @@ export function ConfirmDialog({
               className="nm-button-ghost"
               data-testid="confirm-dialog-cancel"
             >
-              Cancel
+              {cancelLabel}
             </button>
             <button
               type="button"

--- a/frontend/src/shared/enterprise/context.tsx
+++ b/frontend/src/shared/enterprise/context.tsx
@@ -41,6 +41,12 @@ export function EnterpriseProvider({ children }: { children: ReactNode }) {
 
       // Only an EE backend (which marks itself with canUpdate: true) can
       // serve the overlay bundle, so don't even attempt the load otherwise.
+      //
+      // CAVEAT: /admin/license is admin-gated, so non-admins get a 403 above
+      // and `ui` stays null for them even on EE — the bundle loads only in
+      // admin sessions. Fine today (every `ui` consumer is an admin surface);
+      // if a non-admin enterprise UI surface is ever added, the gate needs an
+      // unauthenticated/user-visible EE marker instead of `canUpdate`.
       if (info?.canUpdate === true) {
         const enterpriseUi = await loadEnterpriseUI();
         if (cancelled) return;

--- a/frontend/src/shared/enterprise/loader.test.ts
+++ b/frontend/src/shared/enterprise/loader.test.ts
@@ -42,9 +42,27 @@ describe('Enterprise frontend loader', () => {
     expect(first).toBe(second);
   });
 
-  it('should not throw or log errors in community mode', async () => {
+  it('should not throw when the bundle is unavailable', async () => {
     _setScriptLoaderForTesting(() => Promise.reject(new Error('404')));
     await expect(loadEnterpriseUI()).resolves.toBeNull();
+  });
+
+  it('warns once, naming the bundle URL, when loading fails (EE-only path)', async () => {
+    // loadEnterpriseUI is license-gated to EE backends (context.tsx), so a
+    // failure here means a real EE deployment lost its overlay — e.g. a proxy
+    // stripping the bundle's content-type. That must not stay silent.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    _setScriptLoaderForTesting(() =>
+      Promise.reject(new Error(`EE bundle not available at ${BUNDLE_URL}`)),
+    );
+
+    await expect(loadEnterpriseUI()).resolves.toBeNull();
+    // Second call hits the cached null — no second warning.
+    await expect(loadEnterpriseUI()).resolves.toBeNull();
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]![0])).toContain(BUNDLE_URL);
+    warnSpy.mockRestore();
   });
 
   it('should return ui when bundle registers on window.__COMPENDIQ_UI__', async () => {

--- a/frontend/src/shared/enterprise/loader.ts
+++ b/frontend/src/shared/enterprise/loader.ts
@@ -106,8 +106,17 @@ export async function loadEnterpriseUI(): Promise<EnterpriseUI | null> {
     if (ui && typeof ui.LicenseStatusCard === 'function') {
       cached = ui as EnterpriseUI;
     }
-  } catch {
-    // Not available — community mode. This is not an error.
+  } catch (err) {
+    // Only EE backends reach this code (the load is license-gated in
+    // context.tsx), so a failure here means a real EE deployment lost its
+    // overlay — e.g. a proxy stripping the bundle's content-type, or the
+    // bundle route missing. Warn once (the null result is cached for the
+    // session) so the failure is debuggable instead of silently hiding all
+    // enterprise UI.
+    console.warn(
+      `[enterprise] EE UI bundle failed to load from ${ENTERPRISE_BUNDLE_URL} — enterprise UI disabled for this session.`,
+      err,
+    );
     cached = null;
   }
 


### PR DESCRIPTION
## Summary

PR #787 merged at `a09789cf` fifteen minutes before its final review-fixes commit was pushed, so `eb5bd1c2` never reached `dev`. This PR lands that single commit — the fixes for all ten findings from the #787 review:

**Warnings**
- AI 403 errors pass through the backend's permission message instead of hardcoding `llm:query` (each streamed mode has its own permission)
- EE bundle load failure logs one `console.warn` (EE-only code path) so a proxy stripping the bundle content-type is debuggable instead of silently hiding all enterprise UI

**Info**
- In-band SSE `error` events render inline in the chat like thrown errors, not just a toast over an empty bubble
- Restore-draft dialog: Escape/overlay dismissal is neutral (stays in view mode); the labeled cancel action "Edit published version" carries the old behavior — `ConfirmDialog` grows optional `onDismiss`/`cancelLabel`
- Disabled Create Page hint is visible text wired via `aria-describedby`, not a mouse-only `title` tooltip
- Standalone trash purge runs in 10k batches like the `ADMIN_ACCESS_DENIED` purge (bounded locks/WAL); keeps the explicit `deleted_at IS NOT NULL` guard from `a09789cf`
- `nm-button-destructive` added to the design-system contract tests
- Frontend lint covers `scripts/` (the CSP guard was previously unlinted in CI)
- Admin-only EE bundle gating caveat documented in `EnterpriseProvider`
- Confluence runbook reads the dev admin password from `docker/.env` instead of hardcoding one

## Test plan
- TDD throughout: every behavior change has a test that was watched failing first
- Frontend suite 2273/2273; backend retention + trash suites green against real Postgres (including the rebased purge SQL); typecheck + lint clean in both workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)