### PR TITLE
fix(tests): fail-fast Redis probe helper; durable e2e selector for Confluence test result

### DIFF
--- a/backend/src/core/services/presence-service.test.ts
+++ b/backend/src/core/services/presence-service.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { createClient, type RedisClientType } from 'redis';
+import { isRedisAvailable } from '../../test-redis-helper.js';
 import {
   initPresenceBus,
   recordHeartbeat,
@@ -23,22 +24,7 @@ import {
   VIEWERS_TTL_SEC,
 } from './presence-service.js';
 
-async function checkRedisReachable(): Promise<boolean> {
-  const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
-  const probe = createClient({ url });
-  probe.on('error', () => { /* swallow */ });
-  try {
-    await probe.connect();
-    await probe.ping();
-    await probe.quit();
-    return true;
-  } catch {
-    try { await probe.quit(); } catch { /* best effort */ }
-    return false;
-  }
-}
-
-const redisAvailable = await checkRedisReachable();
+const redisAvailable = await isRedisAvailable();
 
 let main: RedisClientType | null = null;
 let teardown: (() => Promise<void>) | null = null;

--- a/backend/src/core/services/webhook-delivery.test.ts
+++ b/backend/src/core/services/webhook-delivery.test.ts
@@ -41,7 +41,6 @@ import {
   it,
   vi,
 } from 'vitest';
-import { createClient } from 'redis';
 
 // ─── Mock undici (hoisted before service import) ─────────────────────────
 //
@@ -81,6 +80,7 @@ import {
   teardownTestDb,
   truncateAllTables,
 } from '../../test-db-helper.js';
+import { isRedisAvailable } from '../../test-redis-helper.js';
 import { query } from '../db/postgres.js';
 import { encryptPat } from '../utils/crypto.js';
 import {
@@ -93,35 +93,8 @@ const mockFetch = vi.mocked(undiciFetch);
 
 // ─── Environment probe ──────────────────────────────────────────────────
 
-async function checkRedisReachable(): Promise<boolean> {
-  const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
-  const probe = createClient({
-    url,
-    socket: {
-      connectTimeout: 1_500,
-      reconnectStrategy: () => new Error('probe: no retries'),
-    },
-  });
-  probe.on('error', () => {
-    /* swallow — we only want to know whether connect works */
-  });
-  try {
-    await probe.connect();
-    await probe.ping();
-    await probe.quit();
-    return true;
-  } catch {
-    try {
-      await probe.disconnect();
-    } catch {
-      /* best effort */
-    }
-    return false;
-  }
-}
-
 const dbAvailable = await isDbAvailable();
-const redisAvailable = dbAvailable ? await checkRedisReachable() : false;
+const redisAvailable = dbAvailable ? await isRedisAvailable() : false;
 const canRun = dbAvailable && redisAvailable;
 
 // ─── Helpers ────────────────────────────────────────────────────────────

--- a/backend/src/core/services/webhook-outbox-poller.test.ts
+++ b/backend/src/core/services/webhook-outbox-poller.test.ts
@@ -19,7 +19,6 @@
  */
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { createClient } from 'redis';
 import { Queue } from 'bullmq';
 
 import {
@@ -28,6 +27,7 @@ import {
   teardownTestDb,
   truncateAllTables,
 } from '../../test-db-helper.js';
+import { isRedisAvailable } from '../../test-redis-helper.js';
 import { query, getPool } from '../db/postgres.js';
 import {
   initWebhookOutboxPoller,
@@ -42,38 +42,8 @@ import { getRedisConnectionOpts } from '../utils/redis-connection.js';
 
 // ─── Environment probe ───────────────────────────────────────────────────
 
-async function checkRedisReachable(): Promise<boolean> {
-  const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
-  // Use an explicit bounded reconnect strategy so ECONNREFUSED fails fast
-  // instead of letting the default retry backoff hang the suite. The redis
-  // client will otherwise wait >10s with exponential backoff per attempt.
-  const probe = createClient({
-    url,
-    socket: {
-      connectTimeout: 1_500,
-      reconnectStrategy: () => new Error('probe: no retries'),
-    },
-  });
-  probe.on('error', () => {
-    /* swallow — we only want to know whether connect works */
-  });
-  try {
-    await probe.connect();
-    await probe.ping();
-    await probe.quit();
-    return true;
-  } catch {
-    try {
-      await probe.disconnect();
-    } catch {
-      /* best effort */
-    }
-    return false;
-  }
-}
-
 const dbAvailable = await isDbAvailable();
-const redisAvailable = dbAvailable ? await checkRedisReachable() : false;
+const redisAvailable = dbAvailable ? await isRedisAvailable() : false;
 const canRun = dbAvailable && redisAvailable;
 
 // ─── Helpers ────────────────────────────────────────────────────────────

--- a/backend/src/domains/llm/services/embedding-service-reembed-all.integration.test.ts
+++ b/backend/src/domains/llm/services/embedding-service-reembed-all.integration.test.ts
@@ -66,6 +66,7 @@ vi.mock('./llm-provider-resolver.js', async () => {
 });
 
 import { setupTestDb, teardownTestDb, truncateAllTables, isDbAvailable } from '../../../test-db-helper.js';
+import { isRedisAvailable } from '../../../test-redis-helper.js';
 import { query } from '../../../core/db/postgres.js';
 import {
   setRedisClient,
@@ -75,28 +76,7 @@ import { runReembedAllJob } from './embedding-service.js';
 
 const dbAvailable = await isDbAvailable();
 
-async function checkRedisReachable(): Promise<boolean> {
-  const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
-  const probe = createClient({ url });
-  try {
-    probe.on('error', () => {
-      /* swallow — we only care whether connect works */
-    });
-    await probe.connect();
-    await probe.ping();
-    await probe.quit();
-    return true;
-  } catch {
-    try {
-      await probe.quit();
-    } catch {
-      /* best effort */
-    }
-    return false;
-  }
-}
-
-const redisAvailable = dbAvailable ? await checkRedisReachable() : false;
+const redisAvailable = dbAvailable ? await isRedisAvailable() : false;
 const canRun = dbAvailable && redisAvailable;
 
 let redis: RedisClientType | null = null;

--- a/backend/src/domains/llm/services/llm-queue.integration.test.ts
+++ b/backend/src/domains/llm/services/llm-queue.integration.test.ts
@@ -22,6 +22,7 @@ import {
   truncateAllTables,
   isDbAvailable,
 } from '../../../test-db-helper.js';
+import { isRedisAvailable } from '../../../test-redis-helper.js';
 import { query } from '../../../core/db/postgres.js';
 import {
   initCacheBus,
@@ -31,30 +32,8 @@ import {
   // subscriber simulates "Pod B".
 } from '../../../core/services/redis-cache-bus.js';
 
-async function checkRedisReachable(): Promise<boolean> {
-  const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
-  // Fail fast — if the connection isn't established within 1s, treat as
-  // unavailable. node-redis defaults to a longer reconnect loop that would
-  // otherwise hang the test runner on a workstation without a Redis dev
-  // container running on the published port.
-  const probe = createClient({
-    url,
-    socket: { connectTimeout: 1_000, reconnectStrategy: false },
-  });
-  probe.on('error', () => { /* swallow */ });
-  try {
-    await probe.connect();
-    await probe.ping();
-    await probe.quit();
-    return true;
-  } catch {
-    try { await probe.disconnect(); } catch { /* best effort */ }
-    return false;
-  }
-}
-
 const dbAvailable = await isDbAvailable();
-const redisAvailable = await checkRedisReachable();
+const redisAvailable = await isRedisAvailable();
 
 const integrationGate = dbAvailable && redisAvailable;
 

--- a/backend/src/routes/knowledge/pages-presence.test.ts
+++ b/backend/src/routes/knowledge/pages-presence.test.ts
@@ -14,7 +14,6 @@
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import type { FastifyInstance } from 'fastify';
-import { createClient } from 'redis';
 
 // Short-circuit DNS lookups performed by the SSRF guard during buildApp().
 vi.mock('node:dns/promises', () => ({
@@ -26,27 +25,13 @@ vi.mock('node:dns/promises', () => ({
 }));
 
 import { setupTestDb, truncateAllTables, teardownTestDb, isDbAvailable } from '../../test-db-helper.js';
+import { isRedisAvailable } from '../../test-redis-helper.js';
 import { query } from '../../core/db/postgres.js';
 import { buildApp } from '../../app.js';
 import { generateAccessToken } from '../../core/plugins/auth.js';
 
-async function checkRedisReachable(): Promise<boolean> {
-  const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
-  const probe = createClient({ url });
-  probe.on('error', () => { /* swallow */ });
-  try {
-    await probe.connect();
-    await probe.ping();
-    await probe.quit();
-    return true;
-  } catch {
-    try { await probe.quit(); } catch { /* best effort */ }
-    return false;
-  }
-}
-
 const dbAvailable = await isDbAvailable();
-const redisAvailable = dbAvailable ? await checkRedisReachable() : false;
+const redisAvailable = dbAvailable ? await isRedisAvailable() : false;
 const canRun = dbAvailable && redisAvailable;
 
 let app: FastifyInstance;

--- a/backend/src/test-redis-helper.test.ts
+++ b/backend/src/test-redis-helper.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { isRedisAvailable } from './test-redis-helper.js';
+
+describe('isRedisAvailable', () => {
+  it(
+    'resolves false for an unreachable Redis without hanging',
+    async () => {
+      // Port 1 is never a Redis. With node-redis defaults this would retry
+      // forever (the bug this helper exists to prevent); the helper must
+      // fail fast instead. The vitest timeout on this test IS the assertion
+      // that no infinite reconnect loop is possible.
+      await expect(isRedisAvailable('redis://127.0.0.1:1')).resolves.toBe(false);
+    },
+    10_000,
+  );
+
+  it('resolves false for a malformed URL instead of throwing', async () => {
+    await expect(isRedisAvailable('not-a-redis-url')).resolves.toBe(false);
+  });
+
+  it('returns a boolean for the default env-derived URL', async () => {
+    // CI has no Redis (false); workstations with the dev stack have one
+    // (true). Either way the call must settle quickly and never throw.
+    const result = await isRedisAvailable();
+    expect(typeof result).toBe('boolean');
+  });
+});

--- a/backend/src/test-redis-helper.ts
+++ b/backend/src/test-redis-helper.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared Redis availability probe for test suites that need a real Redis
+ * (presence, webhooks, cache-bus, re-embed jobs). Mirrors `test-db-helper.ts`'s
+ * `isDbAvailable()` contract: probe once, cache the answer, let suites gate
+ * with `describe.skipIf(!available)`.
+ *
+ * Fail-fast is the whole point. node-redis's DEFAULT reconnectStrategy
+ * retries forever, so a bare `createClient({ url }).connect()` never settles
+ * when Redis is down — a test file probing that way hangs the entire vitest
+ * run indefinitely instead of skipping. Every probe here disables reconnects
+ * and bounds the initial connect.
+ */
+
+import { createClient } from 'redis';
+
+let _redisAvailable: boolean | null = null;
+
+/**
+ * Check whether a Redis instance is reachable. Never throws, never retries,
+ * settles within ~1s on dead targets.
+ *
+ * The no-argument form probes `REDIS_URL` (default `redis://localhost:6379`)
+ * and caches the result for the lifetime of the process — vitest runs test
+ * files sequentially in one process (`fileParallelism: false`), so one probe
+ * serves every suite. Passing an explicit `url` always probes fresh.
+ */
+export async function isRedisAvailable(url?: string): Promise<boolean> {
+  if (url === undefined && _redisAvailable !== null) return _redisAvailable;
+
+  const target = url ?? process.env.REDIS_URL ?? 'redis://localhost:6379';
+  const result = await probe(target);
+  if (url === undefined) _redisAvailable = result;
+  return result;
+}
+
+async function probe(url: string): Promise<boolean> {
+  let client: ReturnType<typeof createClient>;
+  try {
+    client = createClient({
+      url,
+      socket: { connectTimeout: 1_000, reconnectStrategy: false },
+    });
+  } catch {
+    // Malformed URL — createClient throws synchronously.
+    return false;
+  }
+  client.on('error', () => { /* swallow — we only care whether connect works */ });
+  try {
+    await client.connect();
+    await client.ping();
+    await client.quit();
+    return true;
+  } catch {
+    try { await client.disconnect(); } catch { /* best effort */ }
+    return false;
+  }
+}

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
         'src/**/*.test.ts',
         'src/test-setup.ts',
         'src/test-db-helper.ts',
+        'src/test-redis-helper.ts',
         'src/core/db/migrations/**',
       ],
       // Phase 0 coverage gates. Aggregate-wide floors, not per-file. The

--- a/e2e/confluence-sync.spec.ts
+++ b/e2e/confluence-sync.spec.ts
@@ -93,21 +93,17 @@ test.describe('Confluence sync flow', () => {
     await expect(testBtn.first()).toBeVisible({ timeout: 5_000 });
     await testBtn.first().click();
 
-    // Wait for the connection test result (success or failure indicator)
-    // The result appears as a coloured box with a message
-    const resultIndicator = page
-      .locator('.bg-success\\/10')
-      .or(page.locator('.bg-destructive\\/10'))
-      .or(page.getByText(/connected|success|failed|error/i));
+    // Wait for the connection test result box. Located via data-testid +
+    // data-state (pinned by ConfluenceTab.test.tsx) rather than Tailwind
+    // utility classes, so a styling refactor can't silently hollow out
+    // this assertion.
+    const resultIndicator = page.getByTestId('confluence-test-result');
+    await expect(resultIndicator).toBeVisible({ timeout: 15_000 });
 
-    await expect(resultIndicator.first()).toBeVisible({ timeout: 15_000 });
-
-    // Verify the test succeeded (green success indicator)
-    const successIndicator = page
-      .locator('.bg-success\\/10')
-      .or(page.getByText(/connected|success/i));
-
-    await expect(successIndicator.first()).toBeVisible({ timeout: 5_000 });
+    // Verify the test succeeded.
+    await expect(resultIndicator).toHaveAttribute('data-state', 'success', {
+      timeout: 5_000,
+    });
 
     // Save the Confluence settings
     const saveBtn = page

--- a/frontend/src/features/settings/panels/ConfluenceTab.test.tsx
+++ b/frontend/src/features/settings/panels/ConfluenceTab.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { SettingsResponse } from '@compendiq/contracts';
+import { ConfluenceTab } from './ConfluenceTab';
+
+// ConfluenceTab only reads `confluenceUrl` and `hasConfluencePat`; the rest
+// of SettingsResponse is irrelevant to this component.
+const settings = {
+  confluenceUrl: 'https://confluence.example.com',
+  hasConfluencePat: false,
+} as SettingsResponse;
+
+function mockTestConnection(body: { success: boolean; message: string }) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(
+    async () =>
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ConfluenceTab — connection test result indicator', () => {
+  // The E2E suite (e2e/confluence-sync.spec.ts) locates this box via
+  // data-testid + data-state instead of Tailwind utility classes, so a
+  // styling refactor can't silently hollow out the E2E assertion. These
+  // tests pin that contract.
+  it('renders the success result with data-testid and data-state="success"', async () => {
+    mockTestConnection({ success: true, message: 'Connected to Confluence 9.2' });
+    render(<ConfluenceTab settings={settings} onSave={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /test connection/i }));
+
+    const result = await screen.findByTestId('confluence-test-result');
+    expect(result).toHaveAttribute('data-state', 'success');
+    expect(result).toHaveTextContent('Connected to Confluence 9.2');
+  });
+
+  it('renders the failure result with data-state="error"', async () => {
+    mockTestConnection({ success: false, message: 'Authentication failed' });
+    render(<ConfluenceTab settings={settings} onSave={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /test connection/i }));
+
+    const result = await screen.findByTestId('confluence-test-result');
+    expect(result).toHaveAttribute('data-state', 'error');
+    expect(result).toHaveTextContent('Authentication failed');
+  });
+
+  it('shows no result box before the test runs', async () => {
+    render(<ConfluenceTab settings={settings} onSave={vi.fn()} />);
+    expect(screen.queryByTestId('confluence-test-result')).not.toBeInTheDocument();
+    // Settle any pending microtasks so nothing leaks into the next test.
+    await waitFor(() => expect(true).toBe(true));
+  });
+});

--- a/frontend/src/features/settings/panels/ConfluenceTab.tsx
+++ b/frontend/src/features/settings/panels/ConfluenceTab.tsx
@@ -58,7 +58,11 @@ export function ConfluenceTab({ settings, onSave }: { settings: SettingsResponse
       </div>
 
       {testResult && (
-        <div className={`rounded-md p-3 text-sm ${testResult.success ? 'bg-success/10 text-success' : 'bg-destructive/10 text-destructive'}`}>
+        <div
+          data-testid="confluence-test-result"
+          data-state={testResult.success ? 'success' : 'error'}
+          className={`rounded-md p-3 text-sm ${testResult.success ? 'bg-success/10 text-success' : 'bg-destructive/10 text-destructive'}`}
+        >
           {testResult.message}
         </div>
       )}


### PR DESCRIPTION
## Summary

Fixes the two outstanding findings from this week's PR reviews.

### 1. Test suite hangs forever when Redis is down (root-caused)

Three test files probed Redis availability with a bare `createClient({ url }).connect()`. node-redis's **default reconnectStrategy retries forever**, so on a workstation/CI without Redis the probe never settles and the whole vitest run hangs (observed: a fork worker idle for 35 minutes at 0% CPU). Three other files carried their own correct-but-divergent fail-fast probes — six inline copies total.

New `backend/src/test-redis-helper.ts` exporting `isRedisAvailable()`:
- `connectTimeout: 1_000` + `reconnectStrategy: false` — settles within ~1s on dead targets, never throws
- caches the env-derived result for the process (vitest runs files sequentially), mirroring `test-db-helper.ts`'s `isDbAvailable()` contract
- all six probe sites migrated: `presence-service.test.ts`, `pages-presence.test.ts`, `embedding-service-reembed-all.integration.test.ts` (previously hang-prone), `webhook-delivery.test.ts`, `webhook-outbox-poller.test.ts`, `llm-queue.integration.test.ts` (previously safe, now consolidated)

**Proof:** with `REDIS_URL` pointed at a dead port, the three formerly-hanging files now skip in **1.76s**; with Redis up, all 43 gated tests pass.

### 2. Brittle e2e selector (review finding on #787)

`e2e/confluence-sync.spec.ts` located the connection-test result via `.bg-success\/10` — a Tailwind utility class that a design refactor could remove without changing semantics, silently hollowing out the assertion. `ConfluenceTab`'s result box now carries `data-testid="confluence-test-result"` and `data-state="success|error"`; the spec asserts on that contract, including a deterministic `data-state="success"` check (stronger than the old colour-class presence test). Three new component tests pin the contract (TDD: watched fail first).

## Test plan

- New: `test-redis-helper.test.ts` (fail-fast for dead URL, malformed URL, env default) and `ConfluenceTab.test.tsx` (success/error/absent states)
- Full gates green locally: backend 3209 passed / 3 skipped (214 files, real Postgres + Redis), frontend 2266 passed (178 files), lint + typecheck all workspaces
- Negative-path verification: `REDIS_URL=redis://127.0.0.1:6390` → affected suites skip in <2s instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)