### PR TITLE
fix(a11y): announce AI errors via a primed live region

### DIFF
--- a/frontend/src/features/ai/AiAssistantPage.test.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.test.tsx
@@ -762,6 +762,63 @@ describe('AiAssistantPage', () => {
       expect(screen.getByTestId('message-error')).not.toHaveAttribute('role', 'alert');
     });
 
+    it('re-announces when a retry fails with the byte-identical error', async () => {
+      // Ask mode APPENDS on retry (it never resets the list), so the derived
+      // announcer text stays identical across attempts — React would reconcile
+      // the same text node and AT would announce nothing, leaving a
+      // screen-reader user believing the retry succeeded. The announcer must
+      // mount a FRESH child element per error (keyed by message id): node
+      // insertion into a live region announces even when the text is equal.
+      apiFetchMock.mockImplementation((path: string) => {
+        if (path === '/settings') {
+          return Promise.resolve({ llmProvider: 'ollama', ollamaModel: 'llama3', openaiModel: null });
+        }
+        if (path.startsWith('/ollama/models')) {
+          return Promise.resolve([{ name: 'llama3' }]);
+        }
+        if (path === '/llm/conversations') {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+
+      // Fresh generator per call — a retry must not reuse the exhausted one.
+      // eslint-disable-next-line require-yield
+      async function* fakeForbiddenStream() {
+        throw new ApiError(403, 'Permission "llm:query" required');
+      }
+      streamSSEMock.mockImplementation(() => fakeForbiddenStream());
+
+      render(<AiAssistantPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText('Ask a question...');
+      fireEvent.change(input, { target: { value: 'What is Confluence?' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('message-error')).toHaveLength(1);
+      });
+      const announcer = screen.getByTestId('ai-error-announcer');
+      const firstNode = announcer.firstElementChild;
+      expect(firstNode).not.toBeNull();
+
+      // Retry the same question → same 403, byte-identical message.
+      fireEvent.change(input, { target: { value: 'What is Confluence?' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('message-error')).toHaveLength(2);
+      });
+      // Same text, but a NEW child node — that insertion is what AT announces.
+      expect(announcer).toHaveTextContent(/llm:query/);
+      expect(announcer.firstElementChild).not.toBeNull();
+      expect(announcer.firstElementChild).not.toBe(firstNode);
+    });
+
     it('names the permission from the backend 403 message, not a hardcoded one', async () => {
       apiFetchMock.mockImplementation((path: string) => {
         if (path === '/settings') {

--- a/frontend/src/features/ai/AiAssistantPage.test.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.test.tsx
@@ -712,7 +712,7 @@ describe('AiAssistantPage', () => {
       expect(screen.getByText('What is Confluence?')).toBeInTheDocument();
     });
 
-    it('announces inline error bubbles to screen readers via role="alert"', async () => {
+    it('announces errors via a live region that is primed before any error occurs', async () => {
       apiFetchMock.mockImplementation((path: string) => {
         if (path === '/settings') {
           return Promise.resolve({ llmProvider: 'ollama', ollamaModel: 'llama3', openaiModel: null });
@@ -738,6 +738,14 @@ describe('AiAssistantPage', () => {
         expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
       });
 
+      // The announcer must exist EMPTY before any error: per MDN's alert-role
+      // guidance, the role="alert" element has to be in the DOM first so AT
+      // watches it for content changes — adding the role together with the
+      // message is generally NOT announced.
+      const announcer = screen.getByTestId('ai-error-announcer');
+      expect(announcer).toHaveAttribute('role', 'alert');
+      expect(announcer).toHaveTextContent('');
+
       const input = screen.getByPlaceholderText('Ask a question...');
       fireEvent.change(input, { target: { value: 'What is Confluence?' } });
       fireEvent.keyDown(input, { key: 'Enter' });
@@ -745,10 +753,13 @@ describe('AiAssistantPage', () => {
       await waitFor(() => {
         expect(screen.getByTestId('message-error')).toBeInTheDocument();
       });
-      // The 403 path deliberately suppresses the toast, so the bubble itself
-      // must be a live region — otherwise screen-reader users get zero
-      // announcement of the permission failure.
-      expect(screen.getByRole('alert')).toBe(screen.getByTestId('message-error'));
+      // The 403 path deliberately suppresses the toast, so this primed region
+      // is the only screen-reader announcement of the permission failure.
+      expect(announcer).toHaveTextContent(/llm:query/);
+      // The visible bubble must NOT also claim role="alert": the role+content
+      // arriving together is the unreliable pattern, and two alert regions
+      // would double-announce on the AT combos where it does fire.
+      expect(screen.getByTestId('message-error')).not.toHaveAttribute('role', 'alert');
     });
 
     it('names the permission from the backend 403 message, not a hardcoded one', async () => {

--- a/frontend/src/features/ai/AiAssistantPage.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.tsx
@@ -98,11 +98,11 @@ const MessageBubble = memo(function MessageBubble({
               ? 'border border-destructive/40 bg-destructive/10'
               : 'bg-foreground/5',
         )}
+        // No role="alert" here: the role and the error content would arrive
+        // in the same render, which AT generally does not announce (MDN alert
+        // role). The primed announcer next to the message list handles SR
+        // announcement; this bubble is the visual surface only.
         data-testid={msg.isError ? 'message-error' : undefined}
-        // The 403 path suppresses the toast in favor of this bubble, so the
-        // bubble itself must be the live region — without it, screen-reader
-        // users get no announcement of the failure at all.
-        role={msg.isError ? 'alert' : undefined}
       >
         {showThinkingBlob && <AIThinkingBlob active />}
         {showTypingIndicator && <TypingIndicator />}
@@ -399,6 +399,16 @@ function AiAssistantInner() {
           they stay alongside the tabs while scrolling. */}
       {mode === 'improve' && <ImproveTypeSelector />}
       {mode === 'diagram' && <DiagramTypeSelector />}
+      </div>
+
+      {/* Primed live region for error announcements. It must exist (empty)
+          BEFORE any error so assistive tech watches it for content changes —
+          adding role="alert" together with the message in one render is
+          generally not announced (MDN alert role). The visible error bubble
+          below carries no alert role: this region is the single announcement
+          source (the 403 path suppresses its toast entirely). */}
+      <div role="alert" data-testid="ai-error-announcer" className="sr-only">
+        {[...messages].reverse().find((msg) => msg.isError)?.content ?? ''}
       </div>
 
       {/* Messages — clean document-like surface, no heavy glass.

--- a/frontend/src/features/ai/AiAssistantPage.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.tsx
@@ -405,10 +405,17 @@ function AiAssistantInner() {
           BEFORE any error so assistive tech watches it for content changes —
           adding role="alert" together with the message in one render is
           generally not announced (MDN alert role). The visible error bubble
-          below carries no alert role: this region is the single announcement
-          source (the 403 path suppresses its toast entirely). */}
+          below carries no alert role. For the toast-suppressed 403 path this
+          region is the only announcement; other errors keep their toast, so
+          they may announce twice — over-announcing beats silence.
+          The child span is keyed by message id: Ask mode appends on retry, so
+          a repeated identical failure derives byte-identical text — only a
+          freshly inserted node makes AT announce it again. */}
       <div role="alert" data-testid="ai-error-announcer" className="sr-only">
-        {[...messages].reverse().find((msg) => msg.isError)?.content ?? ''}
+        {(() => {
+          const lastError = [...messages].reverse().find((msg) => msg.isError);
+          return lastError ? <span key={lastError.id}>{lastError.content}</span> : null;
+        })()}
       </div>
 
       {/* Messages — clean document-like surface, no heavy glass.


### PR DESCRIPTION
## Summary

Follow-up to #790's `role="alert"` fix, which added the role to the error bubble in the same render as the error content. Per [MDN's alert-role guidance](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role), that pattern is generally **not announced** by assistive technology — the alert element must be present in the DOM *before* its content changes ("primed").

This PR:
- Mounts an empty, visually-hidden (`sr-only`) `role="alert"` announcer at page load and pipes the latest error message into it — the reliable MDN pattern (same mechanism sonner uses for toasts).
- Removes the alert role from the visible error bubble (role+content arriving together is the unreliable case, and two live regions would double-announce where it does fire). The bubble keeps its styling and `data-testid`.

This matters because the 403 path deliberately suppresses its toast in favor of the inline bubble, so this region is the *only* screen-reader announcement of permission failures.

## Test plan
- TDD: rewrote the announcement test to require the primed shape (announcer exists empty before the error, contains the permission text after, bubble carries no alert role) — watched it fail, then pass
- Full frontend suite 2274/2274; typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)