### PR TITLE
fix(llm): make AI Improve survive token-dropping models — anchor recovery, cache guard, sub-page tokens (#781 follow-up)

### DIFF
--- a/backend/src/core/services/content-converter.test.ts
+++ b/backend/src/core/services/content-converter.test.ts
@@ -9,6 +9,7 @@ import {
   restoreMedia,
   extractLayoutSkeleton,
   LayoutRecoveryError,
+  hasRecoverableLayoutTokens,
 } from './content-converter.js';
 import {
   SIMPLE_PAGE,
@@ -1891,10 +1892,134 @@ describe('content-converter: #781 layout-token resilience', () => {
       expect(xhtml).toMatch(/<ac:layout-cell>[\s\S]*Full width content[\s\S]*<\/ac:layout-cell>/);
     });
 
-    it('still throws for multi-slot skeletons with all tokens dropped (prose-to-cell assignment would be a guess)', async () => {
+    it('still throws for multi-slot skeletons when tokens are dropped AND the cell-leading prose was rewritten (no anchors to split by)', async () => {
       const { skeleton, md } = prepare(LAYOUT_TWO_EQUAL_PAGE);
-      const tokenFree = md.replace(/\[\[\[[^\]]+\]\]\]\n*/g, '');
+      const tokenFree = md
+        .replace(/\[\[\[[^\]]+\]\]\]\n*/g, '')
+        .replace('Left column content', 'Completely new intro')
+        .replace('Right column content', 'Another fresh paragraph');
       await expect(markdownToHtml(tokenFree, { layoutSkeleton: skeleton })).rejects.toThrow(LayoutRecoveryError);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // hasRecoverableLayoutTokens — the Improve route's cache guard predicate
+  // ------------------------------------------------------------------
+  describe('hasRecoverableLayoutTokens', () => {
+    it('is true for canonical tokens', () => {
+      expect(hasRecoverableLayoutTokens('[[[LAYOUT-CELL]]]\n\nProse')).toBe(true);
+    });
+
+    it('is true for realistically mangled tokens (recovery could still use them)', () => {
+      expect(hasRecoverableLayoutTokens('**[[[layout cell]]]**\n\nProse')).toBe(true);
+      expect(hasRecoverableLayoutTokens('[[LAYOUT CELL]]\n\nProse')).toBe(true);
+    });
+
+    it('is false for plain prose without any token-ish text', () => {
+      expect(hasRecoverableLayoutTokens('Just improved prose, nothing else.')).toBe(false);
+    });
+
+    it('is false when token text only appears inside code constructs (data, not structure)', () => {
+      expect(hasRecoverableLayoutTokens('```\n[[[LAYOUT-CELL]]]\n```')).toBe(false);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Anchor-based multi-cell recovery: all tokens dropped, but each cell's
+  // leading prose survives — re-slot deterministically instead of rejecting.
+  // (Observed in prod/dev: small local models return the improved prose with
+  // every [[[…]]] token gone while cell-leading headings/markers survive.)
+  // ------------------------------------------------------------------
+  describe('anchor-based recovery when the model dropped every token (multi-cell)', () => {
+    const dropAllTokens = (md: string): string => md.replace(/\[\[\[[^\]]+\]\]\]\n*/g, '');
+
+    it('recovers a two_equal layout by splitting prose at the surviving cell anchors', async () => {
+      const { skeleton, md } = prepare(LAYOUT_TWO_EQUAL_PAGE);
+      const tokenFree = dropAllTokens(md);
+      expect(tokenFree).not.toContain('[[[');
+      const html = await markdownToHtml(tokenFree, { layoutSkeleton: skeleton });
+      const xhtml = htmlToConfluence(html);
+      expect(xhtml).toContain('ac:type="two_equal"');
+      expect((xhtml.match(/<ac:layout-cell>/g) ?? []).length).toBe(2);
+      // Each cell's prose must land in ITS OWN cell, in order.
+      expect(xhtml).toMatch(/<ac:layout-cell>[\s\S]*Left column content[\s\S]*<\/ac:layout-cell>\s*<ac:layout-cell>[\s\S]*Right column content[\s\S]*<\/ac:layout-cell>/);
+    });
+
+    it('keeps prose preceding the layout at top level (not pulled into the first cell)', async () => {
+      const { skeleton, md } = prepare(LAYOUT_TWO_EQUAL_PAGE);
+      const html = await markdownToHtml(dropAllTokens(md), { layoutSkeleton: skeleton });
+      const xhtml = htmlToConfluence(html);
+      // The fixture's "Two Column Layout" h2 sits before <ac:layout> in storage.
+      expect(xhtml).toMatch(/Two Column Layout[\s\S]*<ac:layout>/);
+      expect(xhtml).not.toMatch(/<ac:layout-cell>[\s\S]*Two Column Layout/);
+    });
+
+    it('recovers the real-world failure shape: grammar-corrected prose, bold anchors stripped to plain text, no tokens', async () => {
+      // Mirrors the observed model output: **ALPHA-LEFT** → ALPHA-LEFT (bold
+      // dropped), prose grammar-corrected, every token gone.
+      const storage =
+        '<ac:layout><ac:layout-section ac:type="two_equal">' +
+        '<ac:layout-cell><p><strong>ALPHA-LEFT</strong></p><p>Der Bereitstellungsprozess beginnt mit der Compilierung des Backends. Danach werden die Migrationen ausgefuehrt.</p></ac:layout-cell>' +
+        '<ac:layout-cell><p><strong>BRAVO-RIGHT</strong></p><p>Rollbacks erfolgen durch Wiederherstellen des vorherigen Builds.</p></ac:layout-cell>' +
+        '</ac:layout-section></ac:layout>';
+      const { skeleton } = prepare(storage);
+      const modelOutput =
+        'ALPHA-LEFT\n\nDer Bereitstellungsprozess beginnt mit der Compilierung des Backends. Anschließend werden die Migrationen ausgeführt.\n\n' +
+        'BRAVO-RIGHT\n\nRollbacks erfolgen durch Wiederherstellen des vorherigen Builds.';
+      const html = await markdownToHtml(modelOutput, { layoutSkeleton: skeleton });
+      const xhtml = htmlToConfluence(html);
+      expect((xhtml.match(/<ac:layout-cell>/g) ?? []).length).toBe(2);
+      expect(xhtml).toMatch(/<ac:layout-cell>[\s\S]*Anschließend[\s\S]*<\/ac:layout-cell>\s*<ac:layout-cell>[\s\S]*Rollbacks[\s\S]*<\/ac:layout-cell>/);
+    });
+
+    it('recovers a five-cell three_with_sidebars page when every token was dropped', async () => {
+      const { skeleton, md } = prepare(LAYOUT_THREE_WITH_SIDEBARS_PAGE);
+      const html = await markdownToHtml(dropAllTokens(md), { layoutSkeleton: skeleton });
+      const xhtml = htmlToConfluence(html);
+      expect(xhtml).toContain('ac:type="three_with_sidebars"');
+      expect((xhtml.match(/<ac:layout-cell>/g) ?? []).length).toBe(5);
+      expect(xhtml).toMatch(/<ac:layout-cell>[\s\S]*Left sidebar nav[\s\S]*<\/ac:layout-cell>\s*<ac:layout-cell>[\s\S]*Wide middle content[\s\S]*<\/ac:layout-cell>/);
+      expect(xhtml).toMatch(/<ac:layout-cell>[\s\S]*Footer text\.[\s\S]*<\/ac:layout-cell>/);
+    });
+
+    it('matches anchors case-insensitively and through markdown emphasis', async () => {
+      const { skeleton, md } = prepare(LAYOUT_TWO_EQUAL_PAGE);
+      const mangled = dropAllTokens(md)
+        .replace('Left column content', '**left COLUMN content**')
+        .replace('Right column content', '_Right column content_');
+      const html = await markdownToHtml(mangled, { layoutSkeleton: skeleton });
+      const xhtml = htmlToConfluence(html);
+      expect((xhtml.match(/<ac:layout-cell>/g) ?? []).length).toBe(2);
+      expect(xhtml).toMatch(/left COLUMN content[\s\S]*<\/ac:layout-cell>\s*<ac:layout-cell>[\s\S]*Right column content/);
+    });
+
+    it('throws when an anchor would match ambiguously (same text appears twice)', async () => {
+      const storage =
+        '<ac:layout><ac:layout-section ac:type="two_equal">' +
+        '<ac:layout-cell><p>Notes</p><p>First details.</p></ac:layout-cell>' +
+        '<ac:layout-cell><p>Summary</p><p>Notes</p></ac:layout-cell>' +
+        '</ac:layout-section></ac:layout>';
+      const { skeleton, md } = prepare(storage);
+      await expect(markdownToHtml(dropAllTokens(md), { layoutSkeleton: skeleton })).rejects.toThrow(LayoutRecoveryError);
+    });
+
+    it('throws when the anchors come back out of order (cells swapped)', async () => {
+      const { skeleton, md } = prepare(LAYOUT_TWO_EQUAL_PAGE);
+      const swapped = dropAllTokens(md)
+        .replace('Left column content', 'TEMP-MARKER')
+        .replace('Right column content', 'Left column content')
+        .replace('TEMP-MARKER', 'Right column content');
+      await expect(markdownToHtml(swapped, { layoutSkeleton: skeleton })).rejects.toThrow(LayoutRecoveryError);
+    });
+
+    it('throws when a cell was empty in the original (no anchor to split by)', async () => {
+      const storage =
+        '<ac:layout><ac:layout-section ac:type="two_equal">' +
+        '<ac:layout-cell><p>Left column content</p></ac:layout-cell>' +
+        '<ac:layout-cell><p></p></ac:layout-cell>' +
+        '</ac:layout-section></ac:layout>';
+      const { skeleton, md } = prepare(storage);
+      await expect(markdownToHtml(dropAllTokens(md), { layoutSkeleton: skeleton })).rejects.toThrow(LayoutRecoveryError);
     });
   });
 
@@ -1922,15 +2047,29 @@ describe('content-converter: #781 layout-token resilience', () => {
       expect(err.details.expectedTokens).toBeGreaterThan(0);
     });
 
-    it('throws when the LLM merged two cells into one (a cell boundary is gone)', async () => {
+    it('throws when the LLM merged two cells AND rewrote the second cell lead (anchor recovery impossible)', async () => {
       await expectRecoveryError(LAYOUT_TWO_EQUAL_PAGE, (md) =>
-        md.replace('[[[/LAYOUT-CELL]]]\n\n[[[LAYOUT-CELL]]]', ''),
+        md
+          .replace('[[[/LAYOUT-CELL]]]\n\n[[[LAYOUT-CELL]]]', '')
+          .replace('Right column content', 'Umgeschriebener zweiter Teil'),
       );
     });
 
-    it('throws when the LLM dropped every token', async () => {
+    it('recovers a merged-cells echo via anchors when both cell leads survived', async () => {
+      const { skeleton, md } = prepare(LAYOUT_TWO_EQUAL_PAGE);
+      const merged = md.replace('[[[/LAYOUT-CELL]]]\n\n[[[LAYOUT-CELL]]]', '');
+      const html = await markdownToHtml(merged, { layoutSkeleton: skeleton });
+      const xhtml = htmlToConfluence(html);
+      expect((xhtml.match(/<ac:layout-cell>/g) ?? []).length).toBe(2);
+      expect(xhtml).toMatch(/<ac:layout-cell>[\s\S]*Left column content[\s\S]*<\/ac:layout-cell>\s*<ac:layout-cell>[\s\S]*Right column content[\s\S]*<\/ac:layout-cell>/);
+    });
+
+    it('throws when the LLM dropped every token and rewrote the cell-leading prose (anchor recovery impossible)', async () => {
       await expectRecoveryError(LAYOUT_TWO_EQUAL_PAGE, (md) =>
-        md.replace(/\[\[\[[^\]]+\]\]\]\n*/g, ''),
+        md
+          .replace(/\[\[\[[^\]]+\]\]\]\n*/g, '')
+          .replace('Left column content', 'Erste Spalte, neu formuliert')
+          .replace('Right column content', 'Zweite Spalte, neu formuliert'),
       );
     });
 

--- a/backend/src/core/services/content-converter.ts
+++ b/backend/src/core/services/content-converter.ts
@@ -1399,9 +1399,27 @@ function transformOutsideHtmlCode(html: string, transform: (segment: string) => 
 //      silently flattening the page. Exception (#785 review): a skeleton
 //      with exactly ONE prose-bearing slot is unambiguous even when every
 //      token was dropped — wrapProseInSingleSlot() places all prose in it.
+//   6. Anchor split (last resort, MULTI-slot): when the model dropped every
+//      token but each cell's LEADING PROSE (captured as `anchor` on the
+//      skeleton by extractLayoutSkeleton) survives uniquely and in order,
+//      splitProseByAnchors() re-slots the prose deterministically.
+//      All-or-nothing: any missing, duplicated, or out-of-order anchor —
+//      or unrecognized token-shaped remnants — falls through to the error.
 // ---------------------------------------------------------------------------
 
-export interface LayoutSkeletonToken { kind: string; isClose: boolean; attrs: string; }
+export interface LayoutSkeletonToken {
+  kind: string;
+  isClose: boolean;
+  attrs: string;
+  /**
+   * Leading text of a prose-bearing open (first non-empty block of the cell,
+   * whitespace-collapsed, capped). Used by the anchor-based last-resort
+   * recovery: when the model dropped EVERY token, the cells' leading prose
+   * usually survives the rewrite and marks where each cell's content starts.
+   * Absent on close tokens, pure containers, and empty cells.
+   */
+  anchor?: string;
+}
 
 export class LayoutRecoveryError extends Error {
   constructor(
@@ -1446,13 +1464,33 @@ function layoutWrapperKind(el: Element): { kind: string; attrs: string } | null 
  * markdown-constrained containers — see protectMedia) are skipped because
  * they travel opaquely, never as boundary tokens.
  */
+/** Max anchor length: long enough to be unique, short enough to survive edits. */
+const ANCHOR_MAX_CHARS = 80;
+
+/** First non-empty block text of a cell — the anchor for token-free recovery. */
+function leadingAnchorText(el: Element): string | undefined {
+  for (const child of Array.from(el.children)) {
+    const t = (child.textContent ?? '').replace(/\s+/g, ' ').trim();
+    if (t) return t.slice(0, ANCHOR_MAX_CHARS);
+  }
+  const own = (el.textContent ?? '').replace(/\s+/g, ' ').trim();
+  return own ? own.slice(0, ANCHOR_MAX_CHARS) : undefined;
+}
+
 export function extractLayoutSkeleton(html: string): LayoutSkeletonToken[] {
   const dom = new JSDOM(`<body>${html}</body>`);
   const tokens: LayoutSkeletonToken[] = [];
   const visit = (el: Element): void => {
     if (isFrozenLegacyWrapper(el)) return; // opaque-protected whole — no tokens
     const wrapper = layoutWrapperKind(el);
-    if (wrapper) tokens.push({ kind: wrapper.kind, isClose: false, attrs: wrapper.attrs });
+    if (wrapper) {
+      const open: LayoutSkeletonToken = { kind: wrapper.kind, isClose: false, attrs: wrapper.attrs };
+      if (PROSE_BEARING_KINDS.has(wrapper.kind)) {
+        const anchor = leadingAnchorText(el);
+        if (anchor) open.anchor = anchor;
+      }
+      tokens.push(open);
+    }
     for (const child of Array.from(el.children)) visit(child);
     // Close tokens carry no attrs (matching their canonical [[[/KIND]]] form).
     if (wrapper) tokens.push({ kind: wrapper.kind, isClose: true, attrs: '' });
@@ -1726,6 +1764,123 @@ function wrapProseInSingleSlot(markdown: string, skeleton: LayoutSkeletonToken[]
 }
 
 /**
+ * True when the markdown still carries layout-token text the #781 recovery
+ * could work with — canonical or realistically mangled spellings, outside
+ * code constructs. Used by the Improve route's cache guard: a response whose
+ * input had tokens but whose output has NONE must not be cached, or every
+ * "run AI Improve again" retry within the cache TTL would replay the same
+ * token-less output and the apply would keep failing.
+ */
+export function hasRecoverableLayoutTokens(markdown: string): boolean {
+  return scanLooseLayoutTokens(markdown).length > 0;
+}
+
+/**
+ * Lowercase + strip markdown decoration/escapes + collapse whitespace, with a
+ * map from each normalized char back to its original index. Both anchors and
+ * the model's prose are normalized with this before matching, so case fixes,
+ * dropped emphasis, and whitespace churn don't break anchor recovery.
+ */
+function normalizeWithMap(s: string): { norm: string; map: number[] } {
+  let norm = '';
+  const map: number[] = [];
+  let lastWasSpace = true; // swallow leading whitespace
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]!;
+    if (ch === '\\' && i + 1 < s.length && /[\\`*_{}[\]()#+\-.!>]/.test(s[i + 1]!)) continue;
+    if (/[*_~`#>]/.test(ch)) continue;
+    if (/\s/.test(ch)) {
+      if (!lastWasSpace) {
+        norm += ' ';
+        map.push(i);
+        lastWasSpace = true;
+      }
+      continue;
+    }
+    norm += ch.toLowerCase();
+    map.push(i);
+    lastWasSpace = false;
+  }
+  while (norm.endsWith(' ')) {
+    norm = norm.slice(0, -1);
+    map.pop();
+  }
+  return { norm, map };
+}
+
+/**
+ * Last-resort recovery for MULTI-slot skeletons when the model dropped every
+ * token: split the (debris-stripped) prose at each cell's surviving anchor —
+ * the leading text captured into the skeleton by extractLayoutSkeleton.
+ * Strictly conservative, all-or-nothing:
+ *   - every prose-bearing slot must have an anchor (empty cells → bail);
+ *   - every anchor must match exactly once, in skeleton order (a later
+ *     duplicate or swapped cells → bail);
+ * On any doubt returns null so the caller rejects instead of mis-assigning
+ * prose to cells. Prose before the first anchor stays at top level (it was
+ * outside the layout); prose after the last anchor belongs to the last cell.
+ */
+function splitProseByAnchors(markdown: string, skeleton: LayoutSkeletonToken[]): string | null {
+  // Alignment already failed, so every token-shaped fragment is debris.
+  const debris = scanLooseLayoutTokens(markdown);
+  let prose = '';
+  let pos = 0;
+  for (const d of debris) {
+    prose += markdown.slice(pos, d.start);
+    pos = d.end;
+  }
+  prose += markdown.slice(pos);
+  prose = prose.replace(/^\n+|\n+$/g, '');
+
+  // Unrecognized token-shaped remnants (e.g. a translated "[[[SPALTE]]]")
+  // survive debris-stripping; splitting around them would persist raw
+  // bracket text into the page. Reject — the echo is mangled, not dropped.
+  if (/\[\[\[|\]\]\]/.test(prose)) return null;
+
+  const slots = skeleton.filter((t) => !t.isClose && PROSE_BEARING_KINDS.has(t.kind));
+  const anchors = slots.map((t) => normalizeWithMap(t.anchor ?? '').norm);
+  if (anchors.some((a) => a.length < 3)) return null;
+
+  const { norm, map } = normalizeWithMap(prose);
+  const normStarts: number[] = [];
+  let from = 0;
+  for (const a of anchors) {
+    const idx = norm.indexOf(a, from);
+    if (idx === -1) return null; // anchor edited away → unrecoverable
+    if (norm.indexOf(a, idx + 1) !== -1) return null; // recurs later → ambiguous
+    normStarts.push(idx);
+    from = idx + a.length;
+  }
+
+  const origStarts = normStarts.map((n) => {
+    let s = map[n]!;
+    // Pull adjacent emphasis decoration into the segment so a **bold** anchor
+    // keeps its opening marks instead of leaking them into the prior segment.
+    while (s > 0 && /[*_~]/.test(prose[s - 1]!)) s--;
+    return s;
+  });
+
+  const pre = prose.slice(0, origStarts[0]!).replace(/^\n+|\n+$/g, '');
+  const segments = origStarts.map((s, i) =>
+    prose
+      .slice(s, i + 1 < origStarts.length ? origStarts[i + 1]! : prose.length)
+      .replace(/^\n+|\n+$/g, ''),
+  );
+
+  const out: string[] = [];
+  if (pre.trim()) out.push(`\n\n${pre}\n\n`);
+  let slotIdx = 0;
+  for (const t of skeleton) {
+    out.push(`\n\n${canonicalLayoutToken(t)}\n\n`);
+    if (!t.isClose && PROSE_BEARING_KINDS.has(t.kind)) {
+      const seg = segments[slotIdx++]!;
+      if (seg.trim()) out.push(`\n\n${seg}\n\n`);
+    }
+  }
+  return out.join('');
+}
+
+/**
  * Recover the LLM's (possibly mangled) layout tokens against the known
  * skeleton and return canonical markdown, or throw LayoutRecoveryError.
  * Strictness ladder (#785 review): candidates are evaluated with the strict
@@ -1794,6 +1949,14 @@ function recoverLayoutMarkdown(markdown: string, skeleton: LayoutSkeletonToken[]
   if (proseSlots.length === 1) {
     const wrapped = wrapProseInSingleSlot(markdown, skeleton);
     if (matchesSkeleton(wrapped, skeleton)) return wrapped;
+  }
+
+  // Anchor split: multi-slot skeleton, every token dropped, but each cell's
+  // leading prose survived the rewrite — split at the anchors instead of
+  // rejecting. All-or-nothing; any ambiguity falls through to the error.
+  if (proseSlots.length > 1) {
+    const split = splitProseByAnchors(markdown, skeleton);
+    if (split !== null && matchesSkeleton(split, skeleton)) return split;
   }
 
   throw new LayoutRecoveryError({

--- a/backend/src/core/services/content-converter.ts
+++ b/backend/src/core/services/content-converter.ts
@@ -1457,13 +1457,6 @@ function layoutWrapperKind(el: Element): { kind: string; attrs: string } | null 
   return null;
 }
 
-/**
- * Derive the expected layout-token skeleton from body HTML. Mirrors the
- * token emission rules of htmlToMarkdown({ layoutTokens: true }) exactly:
- * same kinds, same attrs validation, and frozen legacy wrappers (nested in
- * markdown-constrained containers — see protectMedia) are skipped because
- * they travel opaquely, never as boundary tokens.
- */
 /** Max anchor length: long enough to be unique, short enough to survive edits. */
 const ANCHOR_MAX_CHARS = 80;
 
@@ -1477,6 +1470,13 @@ function leadingAnchorText(el: Element): string | undefined {
   return own ? own.slice(0, ANCHOR_MAX_CHARS) : undefined;
 }
 
+/**
+ * Derive the expected layout-token skeleton from body HTML. Mirrors the
+ * token emission rules of htmlToMarkdown({ layoutTokens: true }) exactly:
+ * same kinds, same attrs validation, and frozen legacy wrappers (nested in
+ * markdown-constrained containers — see protectMedia) are skipped because
+ * they travel opaquely, never as boundary tokens.
+ */
 export function extractLayoutSkeleton(html: string): LayoutSkeletonToken[] {
   const dom = new JSDOM(`<body>${html}</body>`);
   const tokens: LayoutSkeletonToken[] = [];

--- a/backend/src/domains/confluence/services/subpage-context.test.ts
+++ b/backend/src/domains/confluence/services/subpage-context.test.ts
@@ -205,10 +205,39 @@ describe('subpage-context', () => {
       expect(result.pageCount).toBeLessThanOrEqual(3);
     });
 
-    it('never requests layout boundary tokens — sub-page context stays flattened (#765 review)', async () => {
-      // Truncated sub-page token sequences could be echoed by the model into
-      // the parent page's output, so neither the parent nor any sub-page
-      // conversion may opt in to layoutTokens here.
+    it('requests layout boundary tokens for the PARENT page only when opted in (apply needs them to preserve the layout)', async () => {
+      // Sub-page conversions must stay token-free (#765 review: truncated
+      // sub-page token sequences could be echoed by the model into the parent
+      // page's output) — but the PARENT page's tokens are exactly what the
+      // apply-time skeleton alignment needs; without them an Improve with
+      // includeSubPages on a layout page is guaranteed unrecoverable.
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          { confluence_id: 'child-1', title: 'Child 1', body_html: '<div class="confluence-layout"><p>Sub</p></div>' },
+        ],
+      });
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await assembleSubPageContext(
+        'user-1',
+        'parent-1',
+        '<div class="confluence-layout"><p>Parent</p></div>',
+        'Parent',
+        undefined,
+        { parentLayoutTokens: true },
+      );
+
+      const { htmlToMarkdown } = await import('../../../core/services/content-converter.js');
+      const calls = vi.mocked(htmlToMarkdown).mock.calls;
+      expect(calls.length).toBeGreaterThanOrEqual(2); // parent + sub-page
+      const parentCall = calls.find((c) => (c[0] as string).includes('Parent'));
+      expect(parentCall?.[1]).toEqual({ layoutTokens: true });
+      for (const call of calls.filter((c) => c !== parentCall)) {
+        expect(call[1]).toBeUndefined();
+      }
+    });
+
+    it('keeps every conversion token-free by default (no opts)', async () => {
       mockQuery.mockResolvedValueOnce({
         rows: [
           { confluence_id: 'child-1', title: 'Child 1', body_html: '<div class="confluence-layout"><p>Sub</p></div>' },
@@ -224,9 +253,7 @@ describe('subpage-context', () => {
       );
 
       const { htmlToMarkdown } = await import('../../../core/services/content-converter.js');
-      const calls = vi.mocked(htmlToMarkdown).mock.calls;
-      expect(calls.length).toBeGreaterThanOrEqual(2); // parent + sub-page
-      for (const call of calls) {
+      for (const call of vi.mocked(htmlToMarkdown).mock.calls) {
         expect(call[1]).toBeUndefined();
       }
     });

--- a/backend/src/domains/confluence/services/subpage-context.ts
+++ b/backend/src/domains/confluence/services/subpage-context.ts
@@ -119,9 +119,23 @@ export async function assembleSubPageContext(
   parentHtml: string,
   parentTitle: string,
   maxChars: number = MAX_COMBINED_CONTEXT_CHARS,
+  opts?: {
+    /**
+     * Emit #765 layout boundary tokens for the PARENT page conversion. The
+     * Improve route needs them: apply-time skeleton alignment runs against
+     * the parent page, so a token-free parent makes any Improve of a
+     * multi-cell layout page unrecoverable (guaranteed 422). Sub-page
+     * conversions NEVER opt in (#765 review: truncated sub-page token
+     * sequences could be echoed by the model into the parent's output —
+     * truncation only ever affects sub-pages, the parent always goes first).
+     */
+    parentLayoutTokens?: boolean;
+  },
 ): Promise<AssembledContext> {
   // Convert parent page to markdown
-  const parentMarkdown = htmlToMarkdown(parentHtml);
+  const parentMarkdown = opts?.parentLayoutTokens
+    ? htmlToMarkdown(parentHtml, { layoutTokens: true })
+    : htmlToMarkdown(parentHtml);
   const includedPages: string[] = [parentTitle];
   let wasTruncated = false;
 

--- a/backend/src/routes/llm/_helpers.ts
+++ b/backend/src/routes/llm/_helpers.ts
@@ -219,6 +219,13 @@ export async function streamSSE(
      * so a retry regenerates instead of replaying the unusable output.
      */
     shouldCache?: (content: string) => boolean;
+    /**
+     * Extra fields for the final SSE event that depend on the FULL streamed
+     * content (the static `extras` parameter is built before streaming).
+     * E.g. the Improve route's `layoutTokensLost` flag for the frontend's
+     * pre-Accept warning.
+     */
+    finalExtras?: (content: string) => Record<string, unknown>;
   },
 ): Promise<string> {
   const controller = new AbortController();
@@ -271,8 +278,10 @@ export async function streamSSE(
       await options.llmCache.setCachedResponse(options.cacheKey, fullContent);
     }
 
-    if (extras && !controller.signal.aborted) {
-      reply.raw.write(`data: ${JSON.stringify({ ...extras, done: true, final: true })}\n\n`);
+    if ((extras || options?.finalExtras) && !controller.signal.aborted) {
+      reply.raw.write(
+        `data: ${JSON.stringify({ ...extras, ...options?.finalExtras?.(fullContent), done: true, final: true })}\n\n`,
+      );
     }
   } catch (err) {
     if (controller.signal.aborted || (err instanceof Error && err.name === 'AbortError')) {

--- a/backend/src/routes/llm/_helpers.ts
+++ b/backend/src/routes/llm/_helpers.ts
@@ -39,6 +39,40 @@ export const MAX_PDF_TEXT_FOR_LLM = 80_000;
  *
  * Returns the markdown content and an optional multi-page prompt suffix.
  */
+export interface ResolvedPageRef {
+  id: number;
+  confluenceId: string | null;
+  title: string;
+}
+
+// pages.id is int4 — only strings that safely fit are tried as internal ids
+// (long numeric strings are Confluence ids and would overflow the cast).
+const SAFE_INT4_DIGITS = 9;
+
+/**
+ * Resolve a route-level `pageId` to the page row. The frontend passes the
+ * INTERNAL `pages.id` (its /pages/:id route param) while API callers may
+ * pass the Confluence id — both are numeric strings, so the internal id is
+ * tried first, mirroring the precedence of /llm/improvements/apply.
+ */
+export async function resolvePageRef(pageId: string): Promise<ResolvedPageRef | undefined> {
+  type Row = { id: number; confluence_id: string | null; title: string };
+  if (/^\d+$/.test(pageId) && pageId.length <= SAFE_INT4_DIGITS) {
+    const byId = await query<Row>(
+      'SELECT id, confluence_id, title FROM pages WHERE id = $1 AND deleted_at IS NULL',
+      [parseInt(pageId, 10)],
+    );
+    const row = byId.rows[0];
+    if (row) return { id: row.id, confluenceId: row.confluence_id, title: row.title };
+  }
+  const byConfluenceId = await query<Row>(
+    'SELECT id, confluence_id, title FROM pages WHERE confluence_id = $1 AND deleted_at IS NULL',
+    [pageId],
+  );
+  const row = byConfluenceId.rows[0];
+  return row ? { id: row.id, confluenceId: row.confluence_id, title: row.title } : undefined;
+}
+
 export async function assembleContextIfNeeded(
   userId: string,
   pageId: string | undefined,
@@ -47,13 +81,23 @@ export async function assembleContextIfNeeded(
   opts?: { protectMedia?: boolean; layoutTokens?: boolean },
 ): Promise<{ markdown: string; multiPageSuffix: string }> {
   if (includeSubPages && pageId) {
-    const pageResult = await query<{ title: string }>(
-      'SELECT title FROM pages WHERE confluence_id = $1',
-      [pageId],
+    // Resolve internal-vs-Confluence id: sub-page traversal is keyed on the
+    // Confluence id (pages.parent_id), so an unresolved internal id would
+    // silently fetch no children and title the parent "Untitled".
+    const resolved = await resolvePageRef(pageId);
+    const parentHtml = opts?.protectMedia ? protectMedia(content).html : content;
+    const assembled = await assembleSubPageContext(
+      userId,
+      resolved?.confluenceId ?? pageId,
+      parentHtml,
+      resolved?.title ?? 'Untitled',
+      undefined,
+      // #765: tokens for the PARENT page only — apply-time skeleton
+      // alignment runs against the parent, and without its tokens any
+      // Improve of a multi-cell layout page is guaranteed unrecoverable.
+      // Sub-page conversions stay token-free (see assembleSubPageContext).
+      { parentLayoutTokens: opts?.layoutTokens === true },
     );
-    const parentTitle = pageResult.rows[0]?.title ?? 'Untitled';
-
-    const assembled = await assembleSubPageContext(userId, pageId, content, parentTitle);
     return {
       markdown: assembled.markdown,
       multiPageSuffix: getMultiPagePromptSuffix(assembled.pageCount),
@@ -62,10 +106,8 @@ export async function assembleContextIfNeeded(
 
   const html = opts?.protectMedia ? protectMedia(content).html : content;
   return {
-    // #765: layout boundary tokens are opt-in — only the Improve route's
-    // main-page conversion requests them. The sub-page branch above never
-    // emits tokens (truncated sub-page token sequences could be echoed by
-    // the model into the parent page's output).
+    // #765: layout boundary tokens are opt-in — only the Improve route
+    // requests them.
     markdown: htmlToMarkdown(html, { layoutTokens: opts?.layoutTokens === true }),
     multiPageSuffix: '',
   };
@@ -170,6 +212,13 @@ export async function streamSSE(
     llmCache?: LlmCache;
     cacheKey?: string;
     postProcess?: (content: string) => OutputSanitizeResult;
+    /**
+     * Gate on the cache write (runs on the post-processed content). Return
+     * false to skip caching — e.g. the Improve route's layout-token guard,
+     * which refuses to cache a response that lost the page's [[[…]]] tokens
+     * so a retry regenerates instead of replaying the unusable output.
+     */
+    shouldCache?: (content: string) => boolean;
   },
 ): Promise<string> {
   const controller = new AbortController();
@@ -215,7 +264,10 @@ export async function streamSSE(
     }
 
     // Cache the (possibly cleaned) response
-    if (options?.llmCache && options?.cacheKey && fullContent && !controller.signal.aborted) {
+    if (
+      options?.llmCache && options?.cacheKey && fullContent && !controller.signal.aborted &&
+      (options.shouldCache?.(fullContent) ?? true)
+    ) {
       await options.llmCache.setCachedResponse(options.cacheKey, fullContent);
     }
 

--- a/backend/src/routes/llm/apply-improvement.test.ts
+++ b/backend/src/routes/llm/apply-improvement.test.ts
@@ -202,6 +202,50 @@ describe('POST /api/llm/improvements/apply', () => {
     expect(response.statusCode).toBe(404);
   });
 
+  it('falls back to the Confluence id when a numeric pageId matches no internal id', async () => {
+    const selects: string[] = [];
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT id, version, title, space_key, source, confluence_id')) {
+        selects.push(sql);
+        if (sql.includes('WHERE id = $1')) return Promise.resolve({ rows: [] });
+        // Standalone page owned by the requester — local-update path, no Confluence push.
+        return Promise.resolve({ rows: [{ id: 7, version: 2, title: 'Standalone', space_key: 'LOCAL', source: 'standalone', confluence_id: '1146884', body_html: '<p>Old</p>', created_by_user_id: 'user-123', visibility: 'private' }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/improvements/apply',
+      payload: { pageId: '1146884', improvedMarkdown: '## Better' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(selects[0]).toContain('WHERE id = $1');
+    expect(selects[1]).toContain('WHERE confluence_id = $1');
+  });
+
+  it('skips the int4 cast for numeric ids longer than 9 digits (404, not a cast error)', async () => {
+    const selects: string[] = [];
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT id, version, title, space_key, source, confluence_id')) {
+        selects.push(sql);
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/improvements/apply',
+      payload: { pageId: '123456789012', improvedMarkdown: '## Better' },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(selects.some((sql) => sql.includes('WHERE id = $1'))).toBe(false);
+    expect(selects.some((sql) => sql.includes('WHERE confluence_id = $1'))).toBe(true);
+  });
+
   it('returns 409 on version conflict', async () => {
     mockQuery.mockImplementation((sql: string) => {
       if (sql.includes('SELECT id, version, title, space_key, source, confluence_id')) {

--- a/backend/src/routes/llm/improve-instruction.test.ts
+++ b/backend/src/routes/llm/improve-instruction.test.ts
@@ -46,6 +46,7 @@ vi.mock('../../core/services/content-converter.js', () => ({
   markdownToHtml: vi.fn(),
   protectMedia: vi.fn((html: string) => ({ html, media: [] })),
   restoreMedia: vi.fn((html: string) => html),
+  hasRecoverableLayoutTokens: vi.fn((md: string) => /\[\[\[/.test(md)),
 }));
 
 vi.mock('../../domains/llm/services/embedding-service.js', () => ({

--- a/backend/src/routes/llm/improve-layout-cache.test.ts
+++ b/backend/src/routes/llm/improve-layout-cache.test.ts
@@ -138,7 +138,14 @@ describe('POST /api/llm/improve - layout-token cache guard', () => {
     mockGetCachedResponse.mockResolvedValue(null);
   });
 
-  async function improve(content: string, modelOutput: string): Promise<number> {
+  function parseSseEvents(body: string): Array<Record<string, unknown>> {
+    return body
+      .split('\n')
+      .filter((line) => line.startsWith('data: '))
+      .map((line) => JSON.parse(line.slice(6)) as Record<string, unknown>);
+  }
+
+  async function improve(content: string, modelOutput: string): Promise<{ status: number; finalEvent?: Record<string, unknown> }> {
     async function* mockGenerator() {
       yield { content: modelOutput, done: true };
     }
@@ -148,24 +155,55 @@ describe('POST /api/llm/improve - layout-token cache guard', () => {
       url: '/api/llm/improve',
       payload: { content, type: 'grammar', model: 'llama3' },
     });
-    return response.statusCode;
+    return { status: response.statusCode, finalEvent: parseSseEvents(response.body).find((e) => e.final === true) };
   }
 
   it('does NOT cache a response that lost the layout tokens', async () => {
-    const status = await improve(LAYOUT_CONTENT, 'Left prose improved\n\nRight prose improved');
+    const { status } = await improve(LAYOUT_CONTENT, 'Left prose improved\n\nRight prose improved');
     expect(status).toBe(200);
     expect(mockSetCachedResponse).not.toHaveBeenCalled();
   });
 
   it('caches a response that kept the layout tokens', async () => {
-    const status = await improve(LAYOUT_CONTENT, LAYOUT_CONTENT.replace('Left prose', 'Left prose improved'));
+    const { status } = await improve(LAYOUT_CONTENT, LAYOUT_CONTENT.replace('Left prose', 'Left prose improved'));
     expect(status).toBe(200);
     expect(mockSetCachedResponse).toHaveBeenCalledTimes(1);
   });
 
   it('caches normally for layout-free pages regardless of output shape', async () => {
-    const status = await improve('Plain prose without any layout.', 'Improved plain prose.');
+    const { status } = await improve('Plain prose without any layout.', 'Improved plain prose.');
     expect(status).toBe(200);
     expect(mockSetCachedResponse).toHaveBeenCalledTimes(1);
+  });
+
+  // The frontend's pre-Accept warning prefers this authoritative flag over
+  // its own `[[[` heuristic, which cannot recognize mangled-but-recoverable
+  // token spellings.
+  it('flags layoutTokensLost=true on the final SSE event when the output lost the tokens', async () => {
+    const { finalEvent } = await improve(LAYOUT_CONTENT, 'Left prose improved\n\nRight prose improved');
+    expect(finalEvent).toBeDefined();
+    expect(finalEvent!.layoutTokensLost).toBe(true);
+  });
+
+  it('flags layoutTokensLost=false when the output kept the tokens', async () => {
+    const { finalEvent } = await improve(LAYOUT_CONTENT, LAYOUT_CONTENT.replace('Left prose', 'Left prose improved'));
+    expect(finalEvent!.layoutTokensLost).toBe(false);
+  });
+
+  it('flags layoutTokensLost=false for layout-free pages', async () => {
+    const { finalEvent } = await improve('Plain prose without any layout.', 'Improved plain prose.');
+    expect(finalEvent!.layoutTokensLost).toBe(false);
+  });
+
+  it('computes the flag for cached responses too (pre-guard cache entries may be token-less)', async () => {
+    mockGetCachedResponse.mockResolvedValue({ content: 'token-less cached output' });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/improve',
+      payload: { content: LAYOUT_CONTENT, type: 'grammar', model: 'llama3' },
+    });
+    expect(response.statusCode).toBe(200);
+    const finalEvent = parseSseEvents(response.body).find((e) => e.final === true);
+    expect(finalEvent!.layoutTokensLost).toBe(true);
   });
 });

--- a/backend/src/routes/llm/improve-layout-cache.test.ts
+++ b/backend/src/routes/llm/improve-layout-cache.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+
+// Token-loss cache guard: a model response that LOST the layout boundary
+// tokens must never be written to the LLM cache. The 422 apply rejection
+// tells the user to "run AI Improve again" — with the bad response cached
+// for LLM_CACHE_TTL, every retry would serve the same token-less output and
+// the user would be stuck in a poisoned-retry loop until the TTL expired
+// (observed on the dev stack: three identical cache-hit improves in 12s).
+
+const mockResolveUsecase = vi.fn().mockResolvedValue({
+  config: {
+    providerId: 'p1', baseUrl: 'http://x/v1', apiKey: null,
+    authType: 'none', verifySsl: true, name: 'X', defaultModel: 'm',
+  },
+  model: 'm',
+});
+
+vi.mock('../../domains/llm/services/llm-provider-resolver.js', () => ({
+  resolveUsecase: (...args: unknown[]) => mockResolveUsecase(...args),
+}));
+
+const mockProviderStreamChat = vi.fn();
+
+vi.mock('../../domains/llm/services/openai-compatible-client.js', () => ({
+  streamChat: (...args: unknown[]) => mockProviderStreamChat(...args),
+  chat: vi.fn(),
+  generateEmbedding: vi.fn(),
+  listModels: vi.fn(),
+  checkHealth: vi.fn(),
+  invalidateDispatcher: vi.fn(),
+}));
+
+vi.mock('../../core/db/postgres.js', () => ({
+  query: vi.fn().mockResolvedValue({ rows: [] }),
+  runMigrations: vi.fn(),
+  closePool: vi.fn(),
+}));
+
+vi.mock('../../domains/llm/services/rag-service.js', () => ({
+  hybridSearch: vi.fn(),
+  buildRagContext: vi.fn(),
+}));
+
+// htmlToMarkdown is identity so the request `content` IS the markdown the
+// route sees — tests control token presence directly. The token predicate
+// mirrors the real implementation's contract (any recoverable token-ish
+// text counts); its real behavior is covered in content-converter.test.ts.
+vi.mock('../../core/services/content-converter.js', () => ({
+  htmlToMarkdown: vi.fn((html: string) => html),
+  confluenceToHtml: vi.fn(),
+  htmlToConfluence: vi.fn(),
+  htmlToText: vi.fn(),
+  markdownToHtml: vi.fn(),
+  protectMedia: vi.fn((html: string) => ({ html, media: [] })),
+  restoreMedia: vi.fn((html: string) => html),
+  hasRecoverableLayoutTokens: vi.fn((md: string) => /\[\[\[/.test(md)),
+}));
+
+vi.mock('../../domains/llm/services/embedding-service.js', () => ({
+  getEmbeddingStatus: vi.fn(),
+  processDirtyPages: vi.fn(),
+  reEmbedAll: vi.fn(),
+  embedPage: vi.fn(),
+  isProcessingUser: vi.fn().mockReturnValue(false),
+  resetFailedEmbeddings: vi.fn().mockResolvedValue(0),
+}));
+
+const mockGetCachedResponse = vi.fn().mockResolvedValue(null);
+const mockSetCachedResponse = vi.fn();
+
+vi.mock('../../domains/llm/services/llm-cache.js', () => {
+  class MockLlmCache {
+    getCachedResponse = mockGetCachedResponse;
+    setCachedResponse = mockSetCachedResponse;
+    acquireLock = vi.fn().mockResolvedValue(true);
+    releaseLock = vi.fn().mockResolvedValue(undefined);
+    waitForCachedResponse = vi.fn().mockResolvedValue(null);
+    clearAll = vi.fn();
+  }
+  return {
+    LlmCache: MockLlmCache,
+    buildLlmCacheKey: vi.fn().mockReturnValue('test-cache-key'),
+    buildRagCacheKey: vi.fn(),
+  };
+});
+
+vi.mock('../../core/services/audit-service.js', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
+vi.mock('../../domains/confluence/services/sync-service.js', () => ({
+  getClientForUser: vi.fn(),
+}));
+
+vi.mock('../../domains/confluence/services/subpage-context.js', () => ({
+  assembleSubPageContext: vi.fn(),
+  getMultiPagePromptSuffix: vi.fn().mockReturnValue(''),
+}));
+
+vi.mock('../../core/utils/sanitize-llm-input.js', () => ({
+  sanitizeLlmInput: vi.fn((input: string) => ({ sanitized: input, warnings: [] })),
+}));
+
+import { llmImproveRoutes } from './llm-improve.js';
+
+const LAYOUT_CONTENT =
+  '[[[LAYOUT]]]\n\n[[[LAYOUT-SECTION two_equal]]]\n\n[[[LAYOUT-CELL]]]\n\nLeft prose\n\n[[[/LAYOUT-CELL]]]\n\n' +
+  '[[[LAYOUT-CELL]]]\n\nRight prose\n\n[[[/LAYOUT-CELL]]]\n\n[[[/LAYOUT-SECTION]]]\n\n[[[/LAYOUT]]]';
+
+describe('POST /api/llm/improve - layout-token cache guard', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.decorate('authenticate', async () => {});
+    app.decorate('requireAdmin', async () => {});
+    app.decorate('redis', {});
+    app.decorateRequest('userId', '');
+    app.addHook('onRequest', async (request) => {
+      request.userId = 'test-user-123';
+      request.userCan = async () => true;
+    });
+
+    await app.register(llmImproveRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCachedResponse.mockResolvedValue(null);
+  });
+
+  async function improve(content: string, modelOutput: string): Promise<number> {
+    async function* mockGenerator() {
+      yield { content: modelOutput, done: true };
+    }
+    mockProviderStreamChat.mockReturnValue(mockGenerator());
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/improve',
+      payload: { content, type: 'grammar', model: 'llama3' },
+    });
+    return response.statusCode;
+  }
+
+  it('does NOT cache a response that lost the layout tokens', async () => {
+    const status = await improve(LAYOUT_CONTENT, 'Left prose improved\n\nRight prose improved');
+    expect(status).toBe(200);
+    expect(mockSetCachedResponse).not.toHaveBeenCalled();
+  });
+
+  it('caches a response that kept the layout tokens', async () => {
+    const status = await improve(LAYOUT_CONTENT, LAYOUT_CONTENT.replace('Left prose', 'Left prose improved'));
+    expect(status).toBe(200);
+    expect(mockSetCachedResponse).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches normally for layout-free pages regardless of output shape', async () => {
+    const status = await improve('Plain prose without any layout.', 'Improved plain prose.');
+    expect(status).toBe(200);
+    expect(mockSetCachedResponse).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/routes/llm/improve-page-id.test.ts
+++ b/backend/src/routes/llm/improve-page-id.test.ts
@@ -58,6 +58,7 @@ vi.mock('../../core/services/content-converter.js', () => ({
   markdownToHtml: vi.fn(),
   protectMedia: vi.fn((html: string) => ({ html, media: [] })),
   restoreMedia: vi.fn((html: string) => html),
+  hasRecoverableLayoutTokens: vi.fn((md: string) => /\[\[\[/.test(md)),
 }));
 
 vi.mock('../../domains/llm/services/embedding-service.js', () => ({
@@ -160,17 +161,19 @@ describe('POST /api/llm/improve — page_id resolution (regression: issue #418)'
     });
   });
 
-  it('first-click: INSERT uses page_id subquery (not confluence_id column) when pageId is provided', async () => {
-    // Arrange: INSERT returns a valid improvement id (page exists in DB)
+  it('first-click: pageId resolves to the pages row and the INSERT carries its internal id', async () => {
+    // Arrange: page resolution finds the row; INSERT returns a valid id.
     mockQuery.mockImplementation((sql: string) => {
       if (sql.includes('INSERT INTO llm_improvements')) {
         return Promise.resolve({ rows: [{ id: 'improvement-1' }] });
+      }
+      if (sql.includes('SELECT id, confluence_id, title FROM pages')) {
+        return Promise.resolve({ rows: [{ id: 42, confluence_id: 'conf-123', title: 'T' }] });
       }
       // user_settings for custom prompt lookup
       if (sql.includes('SELECT custom_prompts FROM user_settings')) {
         return Promise.resolve({ rows: [] });
       }
-      // SELECT title FROM pages (assembleContextIfNeeded without includeSubPages returns early)
       return Promise.resolve({ rows: [] });
     });
 
@@ -195,15 +198,52 @@ describe('POST /api/llm/improve — page_id resolution (regression: issue #418)'
     expect(response.statusCode).toBe(200);
     expect(response.headers['content-type']).toBe('text/event-stream');
 
-    // Assert: INSERT uses page_id with the SELECT subquery pattern (not confluence_id column directly)
+    // Assert: INSERT writes page_id with the RESOLVED internal id (the
+    // route resolves both id forms up front — see resolvePageRef).
     const insertCall = (mockQuery.mock.calls as unknown[][]).find(
       (args) => typeof args[0] === 'string' && (args[0] as string).includes('INSERT INTO llm_improvements'),
     );
     expect(insertCall).toBeDefined();
     const insertSql = insertCall![0] as string;
     expect(insertSql).toContain('page_id');
-    expect(insertSql).toContain('FROM pages p WHERE p.confluence_id');
-    expect(insertSql).not.toContain('confluence_id,'); // should not insert directly into confluence_id column
+    expect(insertSql).not.toContain('confluence_id,'); // never the confluence_id column
+    expect((insertCall![1] as unknown[])[1]).toBe(42);
+  });
+
+  it('resolves a NUMERIC pageId as the internal pages.id first (what the frontend routes pass)', async () => {
+    const selects: Array<{ sql: string; params: unknown[] }> = [];
+    mockQuery.mockImplementation((sql: string, params: unknown[]) => {
+      if (sql.includes('SELECT id, confluence_id, title FROM pages')) {
+        selects.push({ sql, params });
+        if (sql.includes('WHERE id = $1')) {
+          return Promise.resolve({ rows: [{ id: 11, confluence_id: '917505', title: 'Layout page' }] });
+        }
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('INSERT INTO llm_improvements')) {
+        return Promise.resolve({ rows: [{ id: 'improvement-2' }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    async function* mockGenerator() {
+      yield { content: 'Improved content', done: true };
+    }
+    mockProviderStreamChat.mockReturnValue(mockGenerator());
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/improve',
+      payload: { content: '<p>x</p>', type: 'grammar', model: 'llama3', pageId: '11' },
+    });
+    expect(response.statusCode).toBe(200);
+
+    expect(selects[0]!.sql).toContain('WHERE id = $1');
+    expect(selects[0]!.params).toEqual([11]);
+    const insertCall = (mockQuery.mock.calls as unknown[][]).find(
+      (args) => typeof args[0] === 'string' && (args[0] as string).includes('INSERT INTO llm_improvements'),
+    );
+    expect((insertCall![1] as unknown[])[1]).toBe(11);
   });
 
   it('persists and audits the resolved provider id and model, not the request model', async () => {
@@ -222,6 +262,9 @@ describe('POST /api/llm/improve — page_id resolution (regression: issue #418)'
     mockQuery.mockImplementation((sql: string) => {
       if (sql.includes('INSERT INTO llm_improvements')) {
         return Promise.resolve({ rows: [{ id: 'improvement-1' }] });
+      }
+      if (sql.includes('SELECT id, confluence_id, title FROM pages')) {
+        return Promise.resolve({ rows: [{ id: 42, confluence_id: 'conf-123', title: 'T' }] });
       }
       if (sql.includes('SELECT custom_prompts FROM user_settings')) {
         return Promise.resolve({ rows: [] });
@@ -253,7 +296,7 @@ describe('POST /api/llm/improve — page_id resolution (regression: issue #418)'
     expect(insertCall).toBeDefined();
     expect(insertCall![1]).toEqual([
       'user-123',
-      'conf-123',
+      42,
       'grammar',
       'resolved-model',
       '<p>Original content</p>',
@@ -267,12 +310,9 @@ describe('POST /api/llm/improve — page_id resolution (regression: issue #418)'
     );
   });
 
-  it('first-click: page not yet synced — INSERT returns 0 rows, no UPDATE attempted, stream returns 200', async () => {
-    // Arrange: INSERT returns 0 rows (page not in pages table yet — not yet synced from Confluence)
+  it('first-click: page not yet synced — resolution finds no row, no INSERT/UPDATE attempted, stream returns 200', async () => {
+    // Arrange: page resolution finds nothing (not yet synced from Confluence)
     mockQuery.mockImplementation((sql: string) => {
-      if (sql.includes('INSERT INTO llm_improvements')) {
-        return Promise.resolve({ rows: [] }); // 0 rows = page not found
-      }
       if (sql.includes('SELECT custom_prompts FROM user_settings')) {
         return Promise.resolve({ rows: [] });
       }
@@ -300,7 +340,11 @@ describe('POST /api/llm/improve — page_id resolution (regression: issue #418)'
     expect(response.statusCode).toBe(200);
     expect(response.headers['content-type']).toBe('text/event-stream');
 
-    // Assert: no UPDATE was attempted because improvementId is undefined
+    // Assert: neither INSERT nor UPDATE was attempted
+    const insertCall = (mockQuery.mock.calls as unknown[][]).find(
+      (args) => typeof args[0] === 'string' && (args[0] as string).includes('INSERT INTO llm_improvements'),
+    );
+    expect(insertCall).toBeUndefined();
     const updateCall = (mockQuery.mock.calls as unknown[][]).find(
       (args) => typeof args[0] === 'string' && (args[0] as string).includes("SET improved_content"),
     );

--- a/backend/src/routes/llm/llm-conversations.ts
+++ b/backend/src/routes/llm/llm-conversations.ts
@@ -107,18 +107,31 @@ export async function llmConversationRoutes(fastify: FastifyInstance) {
     const { pageId, improvedMarkdown, version, title } = body;
     const userId = request.userId;
 
-    // Resolve page by confluenceId or internal id (standalone pages use numeric id)
-    const isNumericId = /^\d+$/.test(pageId);
-    const existing = await query<{
+    // Resolve page by internal id or Confluence id. Both are numeric strings,
+    // so the internal id (what the frontend's /pages/:id routes pass) wins,
+    // with a Confluence-id fallback for API callers — same precedence as
+    // resolvePageRef in the improve route. The digit cap keeps long Confluence
+    // ids out of the int4 cast (a 10+ digit id would error, not 404).
+    type PageRow = {
       id: number; version: number; title: string; space_key: string;
       source: string; confluence_id: string | null; body_html: string | null;
       created_by_user_id: string | null; visibility: string;
-    }>(
-      `SELECT id, version, title, space_key, source, confluence_id, body_html,
-              created_by_user_id, visibility FROM pages
-       WHERE ${isNumericId ? 'id = $1' : 'confluence_id = $1'} AND deleted_at IS NULL`,
-      [isNumericId ? parseInt(pageId, 10) : pageId],
-    );
+    };
+    const PAGE_COLUMNS = `id, version, title, space_key, source, confluence_id, body_html,
+              created_by_user_id, visibility`;
+    let existing: { rows: PageRow[] } = { rows: [] };
+    if (/^\d{1,9}$/.test(pageId)) {
+      existing = await query<PageRow>(
+        `SELECT ${PAGE_COLUMNS} FROM pages WHERE id = $1 AND deleted_at IS NULL`,
+        [parseInt(pageId, 10)],
+      );
+    }
+    if (existing.rows.length === 0) {
+      existing = await query<PageRow>(
+        `SELECT ${PAGE_COLUMNS} FROM pages WHERE confluence_id = $1 AND deleted_at IS NULL`,
+        [pageId],
+      );
+    }
     if (existing.rows.length === 0) {
       throw fastify.httpErrors.notFound('Page not found');
     }

--- a/backend/src/routes/llm/llm-improve.ts
+++ b/backend/src/routes/llm/llm-improve.ts
@@ -116,7 +116,12 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
       // Echo back the markdown the model was given (#704) so the frontend can
       // diff like-for-like (original markdown vs improved markdown) instead of
       // comparing formatting-stripped bodyText against the markdown output.
-      sendCachedSSE(reply, cached.content, { originalMarkdown: markdown });
+      // layoutTokensLost: lossy responses are no longer cached, but entries
+      // written before that guard may still be live for one cache TTL.
+      sendCachedSSE(reply, cached.content, {
+        originalMarkdown: markdown,
+        layoutTokensLost: inputHasLayoutTokens && !hasRecoverableLayoutTokens(cached.content),
+      });
       return;
     }
 
@@ -165,6 +170,12 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
         // 422 with "run AI Improve again", and a cached token-less response
         // would replay on every retry until the TTL expires.
         shouldCache: (out) => !inputHasLayoutTokens || hasRecoverableLayoutTokens(out),
+        // Authoritative token-loss verdict for the frontend's pre-Accept
+        // warning — its own `[[[` heuristic cannot recognize mangled-but-
+        // recoverable token spellings.
+        finalExtras: (out) => ({
+          layoutTokensLost: inputHasLayoutTokens && !hasRecoverableLayoutTokens(out),
+        }),
       });
 
       // Persist the full improved content now that streaming is done

--- a/backend/src/routes/llm/llm-improve.ts
+++ b/backend/src/routes/llm/llm-improve.ts
@@ -9,8 +9,10 @@ import { ImproveRequestSchema } from '@compendiq/contracts';
 import { logAuditEvent } from '../../core/services/audit-service.js';
 import { logger } from '../../core/utils/logger.js';
 import { emitLlmAudit, estimateTokens } from '../../domains/llm/services/llm-audit-hook.js';
+import { hasRecoverableLayoutTokens } from '../../core/services/content-converter.js';
 import {
   assembleContextIfNeeded,
+  resolvePageRef,
   resolveSystemPrompt,
   checkCacheWithLock,
   sendCachedSSE,
@@ -91,7 +93,8 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
     // #765: when the markdown carries layout boundary tokens or media
     // placeholders, instruct the model to keep them verbatim. (Deterministic
     // per content, so it composes safely with the cache key below.)
-    if (/\[\[\[|CQ\\?_MEDIA\\?_PLACEHOLDER/.test(markdown)) {
+    const inputHasLayoutTokens = /\[\[\[/.test(markdown);
+    if (inputHasLayoutTokens || /CQ\\?_MEDIA\\?_PLACEHOLDER/.test(markdown)) {
       systemPrompt += `\n\n${STRUCTURE_PRESERVATION_INSTRUCTION}`;
     }
     if (sanitizedInstruction) {
@@ -117,15 +120,21 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
       return;
     }
 
-    // Pre-insert improvement record so we have the row to update after streaming
+    // Pre-insert improvement record so we have the row to update after
+    // streaming. resolvePageRef accepts both id forms — the frontend passes
+    // the INTERNAL pages.id, which the old confluence_id-only subquery never
+    // matched, so UI-driven improvements silently skipped this record.
     let improvementId: string | undefined;
     if (body.pageId) {
-      const insertResult = await query<{ id: string }>(
-        `INSERT INTO llm_improvements (user_id, page_id, improvement_type, model, original_content, improved_content, status)
-         SELECT $1, p.id, $3, $4, $5, '', 'streaming' FROM pages p WHERE p.confluence_id = $2 RETURNING id`,
-        [userId, body.pageId, type, resolvedModel, content.slice(0, 10000)],
-      );
-      improvementId = insertResult.rows[0]?.id;
+      const page = await resolvePageRef(body.pageId);
+      if (page) {
+        const insertResult = await query<{ id: string }>(
+          `INSERT INTO llm_improvements (user_id, page_id, improvement_type, model, original_content, improved_content, status)
+           VALUES ($1, $2, $3, $4, $5, '', 'streaming') RETURNING id`,
+          [userId, page.id, type, resolvedModel, content.slice(0, 10000)],
+        );
+        improvementId = insertResult.rows[0]?.id;
+      }
     }
 
     // Always echo the markdown the model was given (#704) so the frontend can
@@ -148,7 +157,15 @@ export async function llmImproveRoutes(fastify: FastifyInstance) {
 
       const generator = streamChat(chatConfig, resolvedModel, improveMessages, undefined, { thinking: body.thinking });
 
-      const accumulated = await streamSSE(request, reply, generator, improveExtras, { llmCache, cacheKey, postProcess });
+      const accumulated = await streamSSE(request, reply, generator, improveExtras, {
+        llmCache,
+        cacheKey,
+        postProcess,
+        // Never cache a response that lost the layout tokens: the apply will
+        // 422 with "run AI Improve again", and a cached token-less response
+        // would replay on every retry until the TTL expires.
+        shouldCache: (out) => !inputHasLayoutTokens || hasRecoverableLayoutTokens(out),
+      });
 
       // Persist the full improved content now that streaming is done
       if (improvementId && accumulated) {

--- a/docs/architecture/11-content-pipeline.md
+++ b/docs/architecture/11-content-pipeline.md
@@ -253,7 +253,11 @@ or media tokens, instructing the model — with a few-shot example (#781) —
 to keep them verbatim. It also refuses to **cache** a response that lost
 every token (`hasRecoverableLayoutTokens`): the 422 message tells the user
 to run Improve again, and a cached token-less response would otherwise
-replay on every retry until the LLM cache TTL expired.
+replay on every retry until the LLM cache TTL expired. The same verdict is
+sent to the frontend as `layoutTokensLost` on the final SSE event, so the
+Improve diff view can warn before the user hits Accept — authoritative
+over any client-side token heuristic, which cannot recognize
+mangled-but-recoverable spellings.
 
 ### Skeleton-guided token recovery + 422 fallback (#781)
 

--- a/docs/architecture/11-content-pipeline.md
+++ b/docs/architecture/11-content-pipeline.md
@@ -208,15 +208,19 @@ around the (still fully editable) cell content:
 [[[COLUMN width=50%]]]    … [[[/COLUMN]]]    ← legacy ac:column macro
 ```
 
-`layoutTokens` is set solely by the Improve route's main-page conversion
+`layoutTokens` is set solely by the Improve route
 (`assembleContextIfNeeded` in `routes/llm/_helpers.ts`). Every other
 `htmlToMarkdown` caller — quality scoring, auto-tagging, diagram context,
-version-compare summaries, sub-page context, page imports — keeps the
-default flattened output, so raw `[[[…]]]` tokens never leak into prompts
-or user-visible text. Sub-page context in particular must stay token-free
-even within the Improve flow: a truncated sub-page token sequence could be
+version-compare summaries, page imports — keeps the default flattened
+output, so raw `[[[…]]]` tokens never leak into prompts or user-visible
+text. In the Improve flow's sub-page mode the **parent page** conversion
+emits tokens too (apply-time skeleton alignment runs against the parent;
+without its tokens an Improve of a multi-cell layout page with
+`includeSubPages` was guaranteed unrecoverable) — but **sub-page**
+conversions stay token-free: a truncated sub-page token sequence could be
 echoed by the model into the parent page's output and build layout that
-never existed on the parent. Legacy sections/columns nested inside
+never existed on the parent (truncation only ever affects sub-pages — the
+parent always goes first). Legacy sections/columns nested inside
 markdown-constrained containers (`td`/`th`/`li`/`blockquote`/panels) never
 emit tokens either — they stay opaque-frozen via `protectMedia` (see above).
 
@@ -246,7 +250,10 @@ poison the balance validation of the real tokens.
 `/llm/improve` appends `STRUCTURE_PRESERVATION_INSTRUCTION` (from
 `prompts.ts`) to the system prompt whenever the markdown contains boundary
 or media tokens, instructing the model — with a few-shot example (#781) —
-to keep them verbatim.
+to keep them verbatim. It also refuses to **cache** a response that lost
+every token (`hasRecoverableLayoutTokens`): the 422 message tells the user
+to run Improve again, and a cached token-less response would otherwise
+replay on every retry until the LLM cache TTL expired.
 
 ### Skeleton-guided token recovery + 422 fallback (#781)
 
@@ -296,12 +303,21 @@ the LLM's echo; it aligns whatever came back against the known skeleton:
    toast by the frontend). The page is **not** modified locally and nothing
    is pushed to Confluence — a flattened body can never be saved silently.
    An empty skeleton (layout-free page) also strips any *hallucinated*
-   tokens instead of building layout that never existed. One exception:
-   a skeleton with exactly **one** prose-bearing slot (a `single`-layout
-   page) is recovered even when the model dropped every token — all prose
-   can only belong in that one cell, so it is wrapped there (debris
-   stripped, same token-for-token verification). With two or more slots the
-   assignment would be a guess, and the 422 stands.
+   tokens instead of building layout that never existed. Two exceptions
+   recover even when the model dropped **every** token:
+   - a skeleton with exactly **one** prose-bearing slot (a `single`-layout
+     page): all prose can only belong in that one cell, so it is wrapped
+     there (debris stripped, same token-for-token verification);
+   - a **multi**-slot skeleton whose cells' **leading prose survives**: the
+     skeleton carries each cell's leading text as an `anchor` (captured by
+     `extractLayoutSkeleton`), and `splitProseByAnchors()` re-slots the
+     output at the anchors — matched case-insensitively, through markdown
+     emphasis and whitespace churn. Strictly all-or-nothing: every slot
+     needs an anchor, every anchor must match exactly once and in skeleton
+     order, and any unrecognized token-shaped remnant bails; otherwise the
+     422 stands. (This is the observed real-model failure shape: small
+     local models return the improved prose with every token gone while
+     cell-leading headings/markers survive verbatim.)
 
 Note that greedy in-order alignment guards the layout **structure**, not the
 prose-to-cell **assignment**: a model that swaps two cells' content yields

--- a/frontend/src/features/ai/AiContext.tsx
+++ b/frontend/src/features/ai/AiContext.tsx
@@ -126,6 +126,14 @@ interface AiContextValue {
   /** Markdown baseline (#704) the model was fed — diffed against `improvedContent`. */
   originalMarkdown: string;
   setOriginalMarkdown: (v: string) => void;
+  /**
+   * Backend verdict from the Improve stream's final event: the output lost
+   * the page's layout boundary tokens beyond recovery. Authoritative over
+   * any client-side token heuristic; undefined when the stream ended without
+   * a final event (abort) — callers fall back to their own check then.
+   */
+  layoutTokensLost: boolean | undefined;
+  setLayoutTokensLost: (v: boolean | undefined) => void;
 
   // Diagram mode state
   diagramType: string;
@@ -159,12 +167,16 @@ interface StreamChunk {
   sources?: Source[];
   /** Improve route (#704): the original markdown the model was fed, echoed on the final event. */
   originalMarkdown?: string;
+  /** Improve route: backend verdict that the output lost the layout tokens beyond recovery. */
+  layoutTokensLost?: boolean;
 }
 
 /** Extra, non-content metadata surfaced to `onComplete` once a stream finishes. */
 export interface StreamMeta {
   /** Improve route (#704): markdown baseline for like-for-like diffing. */
   originalMarkdown?: string;
+  /** Improve route: backend verdict that the output lost the layout tokens beyond recovery. */
+  layoutTokensLost?: boolean;
 }
 
 const AiCtx = createContext<AiContextValue | null>(null);
@@ -209,6 +221,7 @@ export function AiProvider({ children }: { children: ReactNode }) {
   const [showDiffView, setShowDiffView] = useState(false);
   const [improvedContent, setImprovedContent] = useState('');
   const [originalMarkdown, setOriginalMarkdown] = useState('');
+  const [layoutTokensLost, setLayoutTokensLost] = useState<boolean | undefined>(undefined);
   const [diagramType, setDiagramType] = useState('flowchart');
   const [diagramCode, setDiagramCode] = useState('');
   const [isInsertingDiagram, setIsInsertingDiagram] = useState(false);
@@ -459,6 +472,7 @@ export function AiProvider({ children }: { children: ReactNode }) {
     let accumulated = '';
     let finalSources: Source[] = [];
     let originalMarkdown: string | undefined;
+    let streamLayoutTokensLost: boolean | undefined;
 
     // Add the placeholder assistant message with a stable ID. It stays empty
     // during the stream (#747) — the in-flight answer renders through the
@@ -531,6 +545,9 @@ export function AiProvider({ children }: { children: ReactNode }) {
         if (chunk.originalMarkdown !== undefined) {
           originalMarkdown = chunk.originalMarkdown;
         }
+        if (chunk.layoutTokensLost !== undefined) {
+          streamLayoutTokensLost = chunk.layoutTokensLost;
+        }
       }
       if (streamError) {
         // In-band SSE error events (HTTP 200 already established — the common
@@ -544,7 +561,9 @@ export function AiProvider({ children }: { children: ReactNode }) {
       opts?.onComplete?.(
         accumulated,
         finalSources.length > 0 ? finalSources : undefined,
-        originalMarkdown !== undefined ? { originalMarkdown } : undefined,
+        originalMarkdown !== undefined || streamLayoutTokensLost !== undefined
+          ? { originalMarkdown, layoutTokensLost: streamLayoutTokensLost }
+          : undefined,
       );
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') {
@@ -621,6 +640,8 @@ export function AiProvider({ children }: { children: ReactNode }) {
     setImprovedContent,
     originalMarkdown,
     setOriginalMarkdown,
+    layoutTokensLost,
+    setLayoutTokensLost,
     diagramType,
     setDiagramType,
     diagramCode,

--- a/frontend/src/features/ai/modes/ImproveMode.test.tsx
+++ b/frontend/src/features/ai/modes/ImproveMode.test.tsx
@@ -266,6 +266,56 @@ describe('ImproveMode', () => {
     });
   });
 
+  // Layout-token loss warning: when the page's markdown carried [[[…]]]
+  // layout boundary tokens but the model's output lost them all, applying
+  // will most likely be rejected (422) — warn BEFORE the user hits Accept.
+  describe('layout-token loss warning', () => {
+    const TOKEN_MD =
+      '[[[LAYOUT]]]\n\n[[[LAYOUT-SECTION two_equal]]]\n\n[[[LAYOUT-CELL]]]\n\nLeft\n\n[[[/LAYOUT-CELL]]]\n\n' +
+      '[[[LAYOUT-CELL]]]\n\nRight\n\n[[[/LAYOUT-CELL]]]\n\n[[[/LAYOUT-SECTION]]]\n\n[[[/LAYOUT]]]';
+
+    async function runImproveWith(improved: string, original: string) {
+      async function* fakeStream() {
+        yield { content: improved };
+        yield { originalMarkdown: original, done: true, final: true };
+      }
+      streamSSEMock.mockReturnValue(fakeStream());
+
+      render(
+        <>
+          <ImproveModeInput />
+          <ImproveDiffView />
+        </>,
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Improve Page/i })).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByRole('button', { name: /Improve Page/i }));
+      await waitFor(() => {
+        expect(screen.getByTestId('unified-diff')).toBeInTheDocument();
+      });
+    }
+
+    it('warns when the original markdown had layout tokens but the AI output lost them', async () => {
+      await runImproveWith('Left improved\n\nRight improved', TOKEN_MD);
+      const warning = screen.getByTestId('layout-token-loss-warning');
+      expect(warning.textContent).toMatch(/layout/i);
+      expect(warning.textContent).toMatch(/try again|run .*again|retry/i);
+    });
+
+    it('shows no warning when the AI output kept the tokens', async () => {
+      await runImproveWith(TOKEN_MD.replace('Left', 'Left improved'), TOKEN_MD);
+      expect(screen.queryByTestId('layout-token-loss-warning')).not.toBeInTheDocument();
+    });
+
+    it('shows no warning for layout-free pages', async () => {
+      await runImproveWith('Improved prose', '# Title\n\nOriginal prose');
+      expect(screen.queryByTestId('layout-token-loss-warning')).not.toBeInTheDocument();
+    });
+  });
+
   it('disables textarea while streaming', async () => {
     // Create a stream that never resolves so isStreaming stays true
     let resolveStream: () => void;

--- a/frontend/src/features/ai/modes/ImproveMode.test.tsx
+++ b/frontend/src/features/ai/modes/ImproveMode.test.tsx
@@ -314,6 +314,58 @@ describe('ImproveMode', () => {
       await runImproveWith('Improved prose', '# Title\n\nOriginal prose');
       expect(screen.queryByTestId('layout-token-loss-warning')).not.toBeInTheDocument();
     });
+
+    // The backend's final SSE event carries an authoritative layoutTokensLost
+    // verdict (it runs the real recoverability scan); the client `[[[`
+    // heuristic is only the fallback when the flag is absent (e.g. aborted
+    // stream).
+    it('trusts backend layoutTokensLost=false over the client heuristic (mangled-but-recoverable output)', async () => {
+      async function* fakeStream() {
+        // Mangled 2-bracket spelling: no literal `[[[`, but the backend's
+        // loose scanner can still recover it — so it reports false.
+        yield { content: '[[LAYOUT CELL]]\n\nLeft improved' };
+        yield { originalMarkdown: TOKEN_MD, layoutTokensLost: false, done: true, final: true };
+      }
+      streamSSEMock.mockReturnValue(fakeStream());
+      render(
+        <>
+          <ImproveModeInput />
+          <ImproveDiffView />
+        </>,
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Improve Page/i })).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByRole('button', { name: /Improve Page/i }));
+      await waitFor(() => {
+        expect(screen.getByTestId('unified-diff')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('layout-token-loss-warning')).not.toBeInTheDocument();
+    });
+
+    it('trusts backend layoutTokensLost=true even when the output happens to contain bracket text', async () => {
+      async function* fakeStream() {
+        yield { content: 'Prose mentioning [[[something]]] that is not a real token' };
+        yield { originalMarkdown: TOKEN_MD, layoutTokensLost: true, done: true, final: true };
+      }
+      streamSSEMock.mockReturnValue(fakeStream());
+      render(
+        <>
+          <ImproveModeInput />
+          <ImproveDiffView />
+        </>,
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Improve Page/i })).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByRole('button', { name: /Improve Page/i }));
+      await waitFor(() => {
+        expect(screen.getByTestId('unified-diff')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('layout-token-loss-warning')).toBeInTheDocument();
+    });
   });
 
   it('disables textarea while streaming', async () => {

--- a/frontend/src/features/ai/modes/ImproveMode.tsx
+++ b/frontend/src/features/ai/modes/ImproveMode.tsx
@@ -88,18 +88,35 @@ export function ImproveDiffView() {
 
   if (!showDiffView || !page || !improvedContent || isStreaming) return null;
 
+  // The page's markdown carried [[[…]]] layout boundary tokens but the AI
+  // output lost every one of them: applying will most likely be rejected by
+  // the backend's layout guard (422). Surface that BEFORE the user accepts.
+  const layoutTokensLost = /\[\[\[/.test(originalMarkdown) && !/\[\[\[/.test(improvedContent);
+
   return (
-    <DiffView
-      // #704: diff like-for-like — the original markdown the model was fed
-      // (echoed by /llm/improve) vs the improved markdown it returned, so only
-      // genuine wording/structure edits show. Falls back to the page body only
-      // if the backend didn't supply the baseline (e.g. an aborted stream).
-      original={originalMarkdown || page.bodyText || page.bodyHtml}
-      improved={improvedContent}
-      onAccept={handleAccept}
-      onReject={() => setShowDiffView(false)}
-      isAccepting={isApplying}
-    />
+    <div className="flex flex-col gap-3">
+      {layoutTokensLost && (
+        <div
+          data-testid="layout-token-loss-warning"
+          role="alert"
+          className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2 text-sm text-foreground"
+        >
+          The AI response dropped this page's column-layout markers. Applying may fail or
+          lose the layout — run Improve again to retry.
+        </div>
+      )}
+      <DiffView
+        // #704: diff like-for-like — the original markdown the model was fed
+        // (echoed by /llm/improve) vs the improved markdown it returned, so only
+        // genuine wording/structure edits show. Falls back to the page body only
+        // if the backend didn't supply the baseline (e.g. an aborted stream).
+        original={originalMarkdown || page.bodyText || page.bodyHtml}
+        improved={improvedContent}
+        onAccept={handleAccept}
+        onReject={() => setShowDiffView(false)}
+        isAccepting={isApplying}
+      />
+    </div>
   );
 }
 

--- a/frontend/src/features/ai/modes/ImproveMode.tsx
+++ b/frontend/src/features/ai/modes/ImproveMode.tsx
@@ -60,7 +60,10 @@ export function ImproveTypeSelector() {
  * Diff view shown after an improve stream completes.
  */
 export function ImproveDiffView() {
-  const { page, pageId, navigate, queryClient, isStreaming, showDiffView, setShowDiffView, improvedContent, originalMarkdown } = useAiContext();
+  const {
+    page, pageId, navigate, queryClient, isStreaming, showDiffView, setShowDiffView,
+    improvedContent, originalMarkdown, layoutTokensLost: backendLayoutTokensLost,
+  } = useAiContext();
   const [isApplying, setIsApplying] = useState(false);
 
   const handleAccept = useCallback(async () => {
@@ -91,7 +94,12 @@ export function ImproveDiffView() {
   // The page's markdown carried [[[…]]] layout boundary tokens but the AI
   // output lost every one of them: applying will most likely be rejected by
   // the backend's layout guard (422). Surface that BEFORE the user accepts.
-  const layoutTokensLost = /\[\[\[/.test(originalMarkdown) && !/\[\[\[/.test(improvedContent);
+  // The backend's final-event verdict is authoritative (it runs the real
+  // recoverability scan, which also recognizes mangled token spellings); the
+  // `[[[` heuristic only covers streams that ended without a final event.
+  const layoutTokensLost =
+    backendLayoutTokensLost ??
+    (/\[\[\[/.test(originalMarkdown) && !/\[\[\[/.test(improvedContent));
 
   return (
     <div className="flex flex-col gap-3">
@@ -126,7 +134,7 @@ export function ImproveDiffView() {
 export function ImproveModeInput() {
   const {
     isStreaming, page, isPageLoading, model, pageId, includeSubPages, thinkingMode, runStream,
-    improvementType, setShowDiffView, setImprovedContent, setOriginalMarkdown,
+    improvementType, setShowDiffView, setImprovedContent, setOriginalMarkdown, setLayoutTokensLost,
   } = useAiContext();
   const [instruction, setInstruction] = useState('');
   const [searchWeb, setSearchWeb] = useState(false);
@@ -155,6 +163,7 @@ export function ImproveModeInput() {
     setShowDiffView(false);
     setImprovedContent('');
     setOriginalMarkdown('');
+    setLayoutTokensLost(undefined);
 
     const body: Record<string, unknown> = {
       content: page.bodyHtml, type: improvementType, model, pageId: pageId ?? undefined, includeSubPages,
@@ -179,11 +188,12 @@ export function ImproveModeInput() {
           if (meta?.originalMarkdown !== undefined) {
             setOriginalMarkdown(meta.originalMarkdown);
           }
+          setLayoutTokensLost(meta?.layoutTokensLost);
           setShowDiffView(true);
         },
       },
     );
-  }, [page, model, improvementType, pageId, isStreaming, includeSubPages, thinkingMode, instruction, searchWeb, runStream, setShowDiffView, setImprovedContent, setOriginalMarkdown]);
+  }, [page, model, improvementType, pageId, isStreaming, includeSubPages, thinkingMode, instruction, searchWeb, runStream, setShowDiffView, setImprovedContent, setOriginalMarkdown, setLayoutTokensLost]);
 
   return (
     <div className="mt-3 flex flex-col gap-3 border-t border-border/40 pt-3">


### PR DESCRIPTION
## Problem

"AI Improve loses the page layout" still reproduces on builds that already contain #765/#781. Investigation on the dev stack found the real failure shape: small local models (observed with qwen3-vl-4b) sometimes return the improved prose with **every `[[[…]]]` boundary token gone**. The apply is then correctly rejected with 422 — but three compounding gaps kept the feature effectively unusable on layout pages:

1. **Multi-cell pages could not recover from total token loss**, even though in the captured real-world failure the cell-leading text (`ALPHA-LEFT`, `BRAVO-RIGHT`) survived verbatim and marks exactly where each cell starts.
2. **The token-less response was cached for the full LLM-cache TTL.** The 422 message says "run AI Improve again" — but the retry hit the cache and replayed the same unusable output (observed as three identical cache-hit improves within 12 s).
3. **`includeSubPages` was guaranteed unrecoverable on layout pages**: the sub-page branch never emitted layout tokens, so apply-time skeleton alignment could never succeed. It also mishandled the internal `pages.id` the frontend passes (parent title fell back to "Untitled", children were silently skipped, `llm_improvements` rows were never inserted).

## Fix

- **Anchor-based multi-cell recovery** (`content-converter.ts`): `extractLayoutSkeleton` now captures each prose-bearing cell's leading text as an `anchor`; a new last-resort ladder step `splitProseByAnchors()` re-slots token-free output at the surviving anchors (case-insensitive, tolerant of dropped emphasis/whitespace churn). Strictly all-or-nothing: missing, duplicate, or out-of-order anchors, empty cells, or unrecognized token-shaped remnants still fail closed with the 422 — never a guessed cell assignment, never silent flattening.
- **Poisoned-retry cache guard** (`llm-improve.ts` + `streamSSE` `shouldCache`): responses that lost every recoverable token are not cached, so a retry regenerates instead of replaying.
- **Sub-page mode fixed** (`_helpers.ts`, `subpage-context.ts`): the PARENT page conversion now emits layout tokens (sub-pages stay token-free per the #765 review concern — truncation only ever affects sub-pages); new `resolvePageRef()` accepts both the internal `pages.id` (what the frontend sends) and the Confluence id, fixing the parent title, child traversal, and the `llm_improvements` insert. **Side effect worth noting:** in sub-page mode the parent content now also goes through `protectMedia` (previously raw) — consistent with the non-subpage path and with apply-time skeleton derivation, and strictly safer for media.
- **Pre-Accept warning** (`ImproveMode.tsx`): when the streamed output lost the tokens, the diff view shows an alert advising a retry instead of letting the user run into the 422.

## Review follow-ups (second commit)

- Reattached the `extractLayoutSkeleton` JSDoc that the new anchor helpers had orphaned.
- `/llm/improvements/apply` now uses the same dual-form id resolution as the improve route (internal id first, Confluence-id fallback) and caps the int4 cast at 9 digits — a 10+-digit numeric id previously caused a Postgres integer-overflow 500 instead of a 404.
- The final SSE event (and the cached path) now carries an authoritative `layoutTokensLost` verdict computed with the real recoverability scan; the frontend warning prefers it over the client-side `[[[` heuristic (which false-positived on mangled-but-recoverable spellings), keeping the heuristic only as a fallback for aborted streams.

## Verification

- Replayed the **exact token-less model output captured from the failing dev-stack run** against the real page's skeleton — recovery rebuilds both cells with the corrected prose.
- End-to-end on the dev stack: Improve → Apply → Confluence storage keeps `ac:layout` (two_equal + single sections, 3 cells).
- Backend: 216 files, 3240 passed (30 new tests across converter recovery, cache guard, pageId resolution, sub-page tokens, apply fallback, SSE flag). Frontend: 178 files, 2283 passed (5 new). Lint + typecheck clean.
- `docs/architecture/11-content-pipeline.md` updated (recovery ladder step 6, cache guard, `layoutTokensLost` flag, sub-page token policy).

## Residual limitation (by design)

If the model rewrites a cell's first line **and** drops all tokens in the same response, recovery still rejects with the 422 — guessing the assignment would corrupt cell content. The pre-Accept warning + uncached retry turn that into a one-click recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)