### PR TITLE
fix(test): stabilize flaky Radix focus-scope timer (#799)

### DIFF
--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,4 +1,6 @@
 import '@testing-library/jest-dom';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
 
 // Mock IntersectionObserver for jsdom (used by TableOfContents scroll-spy)
 class MockIntersectionObserver {
@@ -106,3 +108,15 @@ if (!window.matchMedia) {
     }),
   });
 }
+
+// Radix focus-scope schedules a setTimeout(…, 0) in its unmount cleanup that
+// dispatches an event on its container (@radix-ui/react-focus-scope
+// dist/index.mjs:89). If that macrotask fires after jsdom has torn the document
+// down, dispatchEvent gets an invalid target and vitest reports an uncaught
+// TypeError — intermittently reddening a green run (#799). The leak is cross-file.
+// Unmount explicitly, then flush one real macrotask so the focus-scope timer
+// fires while the document is still attached, instead of leaking into teardown.
+afterEach(async () => {
+  cleanup();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { afterEach } from 'vitest';
+import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 
 // Mock IntersectionObserver for jsdom (used by TableOfContents scroll-spy)
@@ -116,7 +116,11 @@ if (!window.matchMedia) {
 // TypeError — intermittently reddening a green run (#799). The leak is cross-file.
 // Unmount explicitly, then flush one real macrotask so the focus-scope timer
 // fires while the document is still attached, instead of leaking into teardown.
+// Skip the flush when a test left fake timers active: a faked setTimeout would
+// never resolve (hanging the run), and a faked focus-scope timer can't leak into
+// real teardown anyway.
 afterEach(async () => {
   cleanup();
+  if (vi.isFakeTimers()) return;
   await new Promise((resolve) => setTimeout(resolve, 0));
 });


### PR DESCRIPTION
## Summary
Fixes the intermittent uncaught `TypeError: Failed to execute 'dispatchEvent'` from `@radix-ui/react-focus-scope` that occasionally reds an otherwise-green frontend run (#799).

`@radix-ui/react-focus-scope@1.1.7` schedules a `setTimeout(() => container.dispatchEvent(unmountEvent), 0)` in its unmount cleanup (`dist/index.mjs:89`). When that macrotask fires **after** jsdom has torn the document down, `dispatchEvent` gets an invalid target and vitest reports it as an uncaught exception, attributing it to whichever test was running. The leak is cross-file.

## Fix
A global `afterEach` in `frontend/src/test-setup.ts` now runs RTL `cleanup()` explicitly and then awaits **one real macrotask** (`await new Promise(r => setTimeout(r, 0))`), forcing the focus-scope timer to fire *inside* the test's own lifecycle while the document is still attached — instead of leaking into teardown. This works with real timers (unlike `vi.runAllTimers()`, which needs fake timers).

## Verification
- Full FE suite run **3×**: all exit 0, **no `dispatchEvent` errors**, 2287 tests passing (178 files).
- `lint` + `typecheck` clean.

Closes #799