### PR TITLE
feat: deep-review follow-ups (CE #798) — search filters, mcp-docs auth, hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,6 +125,7 @@ BACKEND_PORT=3051
 # MCP_DOCS_URL=http://mcp-docs:3100/mcp  # URL of the MCP docs sidecar (default in Docker)
 # MCP_LOG_LEVEL=info                       # Log level for the sidecar container
 # MCP_CACHE_TTL=3600                       # Default cache TTL in seconds
+# MCP_DOCS_TOKEN=                          # Shared secret for backend<->mcp-docs /mcp auth. Unset = no app-level auth (relies on Docker network isolation). Set the same value on backend + mcp-docs.
 # All other MCP Docs settings (enabled, domain allow/blocklist) are managed via Admin Settings UI.
 
 # --- RAG / Vector Search ---

--- a/backend/src/core/plugins/correlation-id.test.ts
+++ b/backend/src/core/plugins/correlation-id.test.ts
@@ -58,6 +58,21 @@ describe('correlation-id plugin', () => {
     expect(response.headers['x-correlation-id']).toBe(customId);
   });
 
+  it('falls back to a generated UUID when the inbound ID exceeds the length bound', async () => {
+    const tooLong = 'x'.repeat(300);
+    const response = await app.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { 'x-correlation-id': tooLong },
+    });
+
+    const body = JSON.parse(response.body);
+    expect(body.correlationId).not.toBe(tooLong);
+    expect(body.correlationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
   it('should generate unique IDs for different requests', async () => {
     const response1 = await app.inject({ method: 'GET', url: '/test' });
     const response2 = await app.inject({ method: 'GET', url: '/test' });

--- a/backend/src/core/plugins/correlation-id.ts
+++ b/backend/src/core/plugins/correlation-id.ts
@@ -31,11 +31,27 @@ export function createCorrelationLogger(correlationId: string): Logger {
   return rootLogger.child({ correlationId });
 }
 
+/** Upper bound on an accepted inbound correlation ID (generous; a UUID is 36). */
+export const MAX_CORRELATION_ID_LENGTH = 256;
+
+/**
+ * Resolve the correlation ID for a request: reuse the inbound `x-correlation-id`
+ * header when present and within {@link MAX_CORRELATION_ID_LENGTH}, otherwise
+ * mint a fresh UUID. Bounding the length stops an oversized client-supplied
+ * value from bloating every log line and the reflected response header.
+ */
+export function resolveCorrelationId(raw: string | string[] | undefined): string {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value && value.length > 0 && value.length <= MAX_CORRELATION_ID_LENGTH) {
+    return value;
+  }
+  return randomUUID();
+}
+
 export default fp(async (fastify: FastifyInstance) => {
   fastify.addHook('onRequest', async (request: FastifyRequest, reply: FastifyReply) => {
-    // Read from header or generate a new UUID
-    const correlationId =
-      (request.headers['x-correlation-id'] as string) || randomUUID();
+    // Reuse a sane inbound ID, otherwise generate a new UUID.
+    const correlationId = resolveCorrelationId(request.headers['x-correlation-id']);
 
     request.correlationId = correlationId;
 

--- a/backend/src/core/services/circuit-breaker.test.ts
+++ b/backend/src/core/services/circuit-breaker.test.ts
@@ -138,6 +138,24 @@ describe('CircuitBreaker', () => {
       expect(breaker.getStatus().state).toBe('CLOSED');
       expect(breaker.getStatus().failureCount).toBe(0);
     });
+
+    it('admits only one concurrent probe in HALF_OPEN', async () => {
+      vi.useRealTimers();
+      let started = 0;
+      const slow = () => breaker.execute(async () => {
+        started++;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return 'ok';
+      });
+
+      const results = await Promise.allSettled([slow(), slow()]);
+
+      // Exactly one probe ran; the second was rejected without invoking fn.
+      expect(started).toBe(1);
+      const rejected = results.filter((r) => r.status === 'rejected');
+      expect(rejected).toHaveLength(1);
+      expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(CircuitBreakerOpenError);
+    });
   });
 
   describe('reset', () => {

--- a/backend/src/core/services/circuit-breaker.ts
+++ b/backend/src/core/services/circuit-breaker.ts
@@ -27,6 +27,8 @@ export class CircuitBreaker {
   private failureCount = 0;
   private successCount = 0;
   private lastFailureTime: number | null = null;
+  /** True while a HALF_OPEN probe request is in flight (single-probe gate). */
+  private isProbing = false;
   private readonly config: CircuitBreakerConfig;
   readonly name: string;
 
@@ -70,6 +72,19 @@ export class CircuitBreaker {
       );
     }
 
+    // HALF_OPEN admits a single probe at a time: concurrent requests would all
+    // hit a recovering server and could each flip the breaker, defeating the
+    // probe's purpose. Reject extra probes until the first resolves.
+    const wasProbing = this.state === 'HALF_OPEN';
+    if (wasProbing) {
+      if (this.isProbing) {
+        throw new CircuitBreakerOpenError(
+          `${this.name}: probe already in flight`,
+        );
+      }
+      this.isProbing = true;
+    }
+
     try {
       const result = await fn();
       this.onSuccess();
@@ -77,6 +92,10 @@ export class CircuitBreaker {
     } catch (err) {
       this.onFailure();
       throw err;
+    } finally {
+      // onSuccess/onFailure may have flipped state to CLOSED/OPEN, so clear the
+      // probe flag unconditionally based on whether *this* call took the probe.
+      if (wasProbing) this.isProbing = false;
     }
   }
 
@@ -93,6 +112,7 @@ export class CircuitBreaker {
     this.failureCount = 0;
     this.successCount = 0;
     this.lastFailureTime = null;
+    this.isProbing = false;
     logger.info({ breaker: this.name }, 'Circuit breaker reset');
   }
 

--- a/backend/src/core/services/mcp-docs-client.test.ts
+++ b/backend/src/core/services/mcp-docs-client.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Capture the transport constructor args so we can assert the auth header.
+const { transportCtor } = vi.hoisted(() => ({ transportCtor: vi.fn() }));
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: class {
+    constructor(url: URL, opts?: unknown) {
+      transportCtor(url, opts);
+    }
+    close() {}
+  },
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class {
+    async connect() {}
+    async listTools() {
+      return { tools: [] };
+    }
+  },
+}));
+
+vi.mock('./mcp-docs-settings.js', () => ({
+  getMcpDocsSettings: vi.fn().mockResolvedValue({
+    enabled: true,
+    url: 'http://mcp-docs:3100/mcp',
+  }),
+}));
+
+describe('mcp-docs-client transport auth header', () => {
+  beforeEach(() => {
+    // Fresh module each test so the module-level connection cache is reset and
+    // the transport is reconstructed (and re-captured).
+    vi.resetModules();
+    transportCtor.mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.MCP_DOCS_TOKEN;
+  });
+
+  it('sends the shared-secret header on the transport when MCP_DOCS_TOKEN is set', async () => {
+    process.env.MCP_DOCS_TOKEN = 's3cret-token';
+    const { testConnection } = await import('./mcp-docs-client.js');
+
+    await testConnection();
+
+    expect(transportCtor).toHaveBeenCalledWith(
+      expect.any(URL),
+      { requestInit: { headers: { 'x-mcp-docs-token': 's3cret-token' } } },
+    );
+  });
+
+  it('omits the header (requestInit undefined) when no token is set', async () => {
+    const { testConnection } = await import('./mcp-docs-client.js');
+
+    await testConnection();
+
+    expect(transportCtor).toHaveBeenCalledWith(expect.any(URL), { requestInit: undefined });
+  });
+});

--- a/backend/src/core/services/mcp-docs-client.ts
+++ b/backend/src/core/services/mcp-docs-client.ts
@@ -28,7 +28,11 @@ async function ensureConnected(): Promise<Client> {
   if (client) return client;
 
   try {
-    transport = new StreamableHTTPClientTransport(new URL(settings.url));
+    // Send the shared secret (if configured) so the sidecar's /mcp guard accepts us.
+    const token = process.env.MCP_DOCS_TOKEN;
+    transport = new StreamableHTTPClientTransport(new URL(settings.url), {
+      requestInit: token ? { headers: { 'x-mcp-docs-token': token } } : undefined,
+    });
     client = new Client({ name: 'compendiq-backend', version: APP_VERSION });
     await client.connect(transport);
     connectedUrl = settings.url;

--- a/backend/src/core/services/mcp-docs-settings.test.ts
+++ b/backend/src/core/services/mcp-docs-settings.test.ts
@@ -36,6 +36,23 @@ describe('mcp-docs-settings', () => {
     expect(settings.maxContentLength).toBe(50_000);
   });
 
+  it('keeps the feature enabled when only the domain list JSON is corrupt', async () => {
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [
+        { setting_key: 'mcp_docs_enabled', setting_value: 'true' },
+        { setting_key: 'mcp_docs_allowed_domains', setting_value: '{not valid json' },
+      ],
+      rowCount: 2, command: 'SELECT', oid: 0, fields: [],
+    });
+
+    const settings = await getMcpDocsSettings();
+
+    // A corrupt domain list must not collapse the whole config to DEFAULTS
+    // (which would disable the feature) — only that field falls back.
+    expect(settings.enabled).toBe(true);
+    expect(settings.allowedDomains).toEqual(['*']);
+  });
+
   it('parses stored settings correctly', async () => {
     vi.mocked(query).mockResolvedValueOnce({
       rows: [

--- a/backend/src/core/services/mcp-docs-settings.test.ts
+++ b/backend/src/core/services/mcp-docs-settings.test.ts
@@ -53,6 +53,21 @@ describe('mcp-docs-settings', () => {
     expect(settings.allowedDomains).toEqual(['*']);
   });
 
+  it('falls back when a domain list is valid JSON but not a string array', async () => {
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [
+        { setting_key: 'mcp_docs_enabled', setting_value: 'true' },
+        { setting_key: 'mcp_docs_blocked_domains', setting_value: '[1, 2, 3]' },
+      ],
+      rowCount: 2, command: 'SELECT', oid: 0, fields: [],
+    });
+
+    const settings = await getMcpDocsSettings();
+
+    expect(settings.enabled).toBe(true);
+    expect(settings.blockedDomains).toEqual([]); // DEFAULTS.blockedDomains
+  });
+
   it('parses stored settings correctly', async () => {
     vi.mocked(query).mockResolvedValueOnce({
       rows: [

--- a/backend/src/core/services/mcp-docs-settings.ts
+++ b/backend/src/core/services/mcp-docs-settings.ts
@@ -52,6 +52,23 @@ async function getSettingsMap(): Promise<Record<string, string>> {
   return map;
 }
 
+/**
+ * Parse a stored JSON string-array setting, falling back to `fallback` (and
+ * logging) when the value is absent or corrupt. A bad domain list must not
+ * disable the whole feature, so this is scoped per-field rather than wrapping
+ * the entire settings load in one try/catch.
+ */
+function parseDomainList(raw: string | undefined, fallback: string[]): string[] {
+  if (!raw) return fallback;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : fallback;
+  } catch (err) {
+    logger.warn({ err }, 'Invalid MCP docs domain list JSON, using default for this field');
+    return fallback;
+  }
+}
+
 export async function getMcpDocsSettings(): Promise<McpDocsSettings> {
   try {
     const settings = await getSettingsMap();
@@ -59,12 +76,8 @@ export async function getMcpDocsSettings(): Promise<McpDocsSettings> {
       enabled: settings['mcp_docs_enabled'] === 'true',
       url: settings['mcp_docs_url'] ?? DEFAULTS.url,
       domainMode: (settings['mcp_docs_domain_mode'] as 'allowlist' | 'blocklist') ?? DEFAULTS.domainMode,
-      allowedDomains: settings['mcp_docs_allowed_domains']
-        ? JSON.parse(settings['mcp_docs_allowed_domains'])
-        : DEFAULTS.allowedDomains,
-      blockedDomains: settings['mcp_docs_blocked_domains']
-        ? JSON.parse(settings['mcp_docs_blocked_domains'])
-        : DEFAULTS.blockedDomains,
+      allowedDomains: parseDomainList(settings['mcp_docs_allowed_domains'], DEFAULTS.allowedDomains),
+      blockedDomains: parseDomainList(settings['mcp_docs_blocked_domains'], DEFAULTS.blockedDomains),
       cacheTtl: parseInt(settings['mcp_docs_cache_ttl'] ?? String(DEFAULTS.cacheTtl), 10),
       maxContentLength: parseInt(settings['mcp_docs_max_content_length'] ?? String(DEFAULTS.maxContentLength), 10),
     };

--- a/backend/src/core/services/mcp-docs-settings.ts
+++ b/backend/src/core/services/mcp-docs-settings.ts
@@ -62,7 +62,11 @@ function parseDomainList(raw: string | undefined, fallback: string[]): string[] 
   if (!raw) return fallback;
   try {
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : fallback;
+    if (Array.isArray(parsed) && parsed.every((d) => typeof d === 'string')) {
+      return parsed;
+    }
+    logger.warn('MCP docs domain list is not a string array, using default for this field');
+    return fallback;
   } catch (err) {
     logger.warn({ err }, 'Invalid MCP docs domain list JSON, using default for this field');
     return fallback;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       ATTACHMENTS_DIR: /app/data/attachments
       NODE_EXTRA_CA_CERTS: ${CONTAINER_CA_BUNDLE_PATH:-/etc/ssl/certs/ca-certificates.crt}
       MCP_DOCS_URL: ${MCP_DOCS_URL:-http://mcp-docs:3100/mcp}
+      MCP_DOCS_TOKEN: ${MCP_DOCS_TOKEN:-}
     depends_on:
       postgres:
         condition: service_healthy
@@ -99,6 +100,7 @@ services:
       LOG_LEVEL: ${MCP_LOG_LEVEL:-info}
       CACHE_TTL_SECONDS: ${MCP_CACHE_TTL:-3600}
       SEARXNG_URL: ${SEARXNG_URL:-http://searxng:8080}
+      MCP_DOCS_TOKEN: ${MCP_DOCS_TOKEN:-}
     depends_on:
       redis:
         condition: service_healthy

--- a/frontend/src/features/search/SearchPage.tsx
+++ b/frontend/src/features/search/SearchPage.tsx
@@ -191,6 +191,10 @@ export function SearchPage() {
     spaceKey: filters.spaceKey,
     page,
     sort,
+    author: filters.author,
+    dateFrom: filters.dateFrom,
+    dateTo: filters.dateTo,
+    labels: filters.labels,
   });
 
   // Display enhanced results if available; fall back to immediate results.

--- a/frontend/src/shared/hooks/use-search.test.ts
+++ b/frontend/src/shared/hooks/use-search.test.ts
@@ -311,4 +311,33 @@ describe('useSearch', () => {
     );
     expect(allHaveSpaceKey).toBe(true);
   });
+
+  it('passes author, date range, and labels→tags to the query URL', async () => {
+    const fetchSpy = mockFetch(makeSearchResponse(), makeSearchResponse({ mode: 'hybrid' }));
+
+    const { result } = renderHook(
+      () => useSearch({
+        query: 'docker',
+        mode: 'hybrid',
+        author: 'jane',
+        dateFrom: '2026-01-01',
+        dateTo: '2026-02-01',
+        labels: 'kb,ops',
+      }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoadingImmediate).toBe(false));
+
+    const searchCalls = fetchSpy.mock.calls.filter(([url]) =>
+      typeof url === 'string' && (url as string).includes('/search'),
+    );
+    expect(searchCalls.length).toBeGreaterThan(0);
+    const url = searchCalls[0][0] as string;
+    expect(url).toContain('author=jane');
+    expect(url).toContain('dateFrom=2026-01-01');
+    expect(url).toContain('dateTo=2026-02-01');
+    // FE field `labels` maps to backend query param `tags` (comma-encoded)
+    expect(url).toContain('tags=kb%2Cops');
+  });
 });

--- a/frontend/src/shared/hooks/use-search.ts
+++ b/frontend/src/shared/hooks/use-search.ts
@@ -47,6 +47,14 @@ interface UseSearchParams {
   page?: number;
   /** Sort order for keyword/immediate results. Semantic & hybrid ignore this (score-ordered server-side). */
   sort?: 'relevance' | 'modified' | 'title';
+  /** Filter to a single author (Confluence display name). */
+  author?: string;
+  /** Inclusive lower bound on last-modified date (YYYY-MM-DD). */
+  dateFrom?: string;
+  /** Inclusive upper bound on last-modified date (YYYY-MM-DD). */
+  dateTo?: string;
+  /** Comma-separated labels; sent to the backend as the `tags` param. */
+  labels?: string;
 }
 
 interface UseSearchResult {
@@ -83,7 +91,7 @@ const MIN_QUERY_LENGTH = 1;
  * staleTime: 0 on both — search results are query-specific and must not be
  * served from the TanStack Query cache between different search terms.
  */
-export function useSearch({ query, mode, spaceKey, page: requestedPage = 1, sort = 'relevance' }: UseSearchParams): UseSearchResult {
+export function useSearch({ query, mode, spaceKey, page: requestedPage = 1, sort = 'relevance', author, dateFrom, dateTo, labels }: UseSearchParams): UseSearchResult {
   // Debounce the query string
   const [debouncedQuery, setDebouncedQuery] = useState(query);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -107,6 +115,11 @@ export function useSearch({ query, mode, spaceKey, page: requestedPage = 1, sort
     sp.set('limit', '10');
     if (pageNum > 1) sp.set('page', String(pageNum));
     if (spaceKey) sp.set('spaceKey', spaceKey);
+    // Filters apply to every mode — the backend ANDs them into the WHERE clause.
+    if (author) sp.set('author', author);
+    if (dateFrom) sp.set('dateFrom', dateFrom);
+    if (dateTo) sp.set('dateTo', dateTo);
+    if (labels) sp.set('tags', labels); // FE field `labels` → backend query param `tags`
     // Sort only affects keyword results — semantic/hybrid are score-ordered server-side.
     if (searchMode === 'keyword' && sort !== 'relevance') sp.set('sort', sort);
     return `/search?${sp.toString()}`;
@@ -118,7 +131,7 @@ export function useSearch({ query, mode, spaceKey, page: requestedPage = 1, sort
   const enhancedHasData = useRef(false);
 
   const immediateQuery = useQuery<SearchApiResponse>({
-    queryKey: ['search', 'immediate', trimmedQuery, spaceKey, requestedPage, sort],
+    queryKey: ['search', 'immediate', trimmedQuery, spaceKey, requestedPage, sort, author, dateFrom, dateTo, labels],
     queryFn: () => apiFetch<SearchApiResponse>(buildUrl('keyword', requestedPage)),
     enabled: isQueryEnabled && !enhancedHasData.current,
     staleTime: 30_000,
@@ -128,7 +141,7 @@ export function useSearch({ query, mode, spaceKey, page: requestedPage = 1, sort
   // ── Phase 2: Enhanced semantic/hybrid results ────────────────────────────
   // Only fires when mode is not 'keyword'
   const enhancedQuery = useQuery<SearchApiResponse>({
-    queryKey: ['search', 'enhanced', trimmedQuery, mode, spaceKey],
+    queryKey: ['search', 'enhanced', trimmedQuery, mode, spaceKey, author, dateFrom, dateTo, labels],
     queryFn: () => apiFetch<SearchApiResponse>(buildUrl(mode as 'semantic' | 'hybrid')),
     enabled: isQueryEnabled && mode !== 'keyword',
     staleTime: 0,

--- a/mcp-docs/src/auth.test.ts
+++ b/mcp-docs/src/auth.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeMcpAuth, MCP_AUTH_HEADER } from './auth.js';
+
+function makeRes() {
+  return {
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) { this.statusCode = code; return this; },
+    json(b: unknown) { this.body = b; return this; },
+  };
+}
+
+describe('makeMcpAuth', () => {
+  it('passes through when no token is configured (backward compatible)', () => {
+    const next = vi.fn();
+    const res = makeRes();
+    makeMcpAuth(undefined)({ headers: {} } as never, res as never, next as never);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(0);
+  });
+
+  it('rejects a missing token with 401 when configured', () => {
+    const next = vi.fn();
+    const res = makeRes();
+    makeMcpAuth('s3cret')({ headers: {} } as never, res as never, next as never);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects a wrong token with 401', () => {
+    const next = vi.fn();
+    const res = makeRes();
+    makeMcpAuth('s3cret')(
+      { headers: { [MCP_AUTH_HEADER]: 'nope' } } as never,
+      res as never,
+      next as never,
+    );
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects a token of a different length with 401 (no length leak crash)', () => {
+    const next = vi.fn();
+    const res = makeRes();
+    makeMcpAuth('s3cret')(
+      { headers: { [MCP_AUTH_HEADER]: 'x' } } as never,
+      res as never,
+      next as never,
+    );
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('allows a correct token', () => {
+    const next = vi.fn();
+    const res = makeRes();
+    makeMcpAuth('s3cret')(
+      { headers: { [MCP_AUTH_HEADER]: 's3cret' } } as never,
+      res as never,
+      next as never,
+    );
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(0);
+  });
+});

--- a/mcp-docs/src/auth.ts
+++ b/mcp-docs/src/auth.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared-secret auth for the /mcp endpoints.
+ *
+ * The sidecar's primary control is Docker network isolation (only the backend
+ * can reach it). This adds defense-in-depth: when MCP_DOCS_TOKEN is set, every
+ * /mcp request must present it in the `x-mcp-docs-token` header. /health stays
+ * open for container probes. When the token is unset the middleware is a
+ * pass-through, so existing deployments keep working unchanged.
+ */
+
+import { timingSafeEqual } from 'node:crypto';
+import type { Request, Response, NextFunction } from 'express';
+import { logger } from './logger.js';
+
+export const MCP_AUTH_HEADER = 'x-mcp-docs-token';
+
+function constantTimeEqual(presented: string, expected: string): boolean {
+  const a = Buffer.from(presented, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  if (a.length !== b.length) {
+    // Keep timing roughly constant on a length mismatch, then fail.
+    timingSafeEqual(b, b);
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Build the Express middleware guarding /mcp. A falsy `token` yields a
+ * pass-through middleware (logs a one-time warning).
+ */
+export function makeMcpAuth(token: string | undefined) {
+  let warned = false;
+  return function mcpAuth(req: Request, res: Response, next: NextFunction): void {
+    if (!token) {
+      if (!warned) {
+        logger.warn('MCP_DOCS_TOKEN not set — /mcp is unauthenticated (relying on network isolation)');
+        warned = true;
+      }
+      next();
+      return;
+    }
+    const presented = (req.headers[MCP_AUTH_HEADER] as string | undefined) ?? '';
+    if (presented && constantTimeEqual(presented, token)) {
+      next();
+      return;
+    }
+    res.status(401).json({ error: 'Unauthorized' });
+  };
+}

--- a/mcp-docs/src/auth.ts
+++ b/mcp-docs/src/auth.ts
@@ -8,20 +8,17 @@
  * pass-through, so existing deployments keep working unchanged.
  */
 
-import { timingSafeEqual } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 import type { Request, Response, NextFunction } from 'express';
 import { logger } from './logger.js';
 
 export const MCP_AUTH_HEADER = 'x-mcp-docs-token';
 
 function constantTimeEqual(presented: string, expected: string): boolean {
-  const a = Buffer.from(presented, 'utf8');
-  const b = Buffer.from(expected, 'utf8');
-  if (a.length !== b.length) {
-    // Keep timing roughly constant on a length mismatch, then fail.
-    timingSafeEqual(b, b);
-    return false;
-  }
+  // Compare fixed-length SHA-256 digests: neither the comparison time nor an
+  // early length-mismatch branch can leak anything about the expected token.
+  const a = createHash('sha256').update(presented).digest();
+  const b = createHash('sha256').update(expected).digest();
   return timingSafeEqual(a, b);
 }
 

--- a/mcp-docs/src/index.ts
+++ b/mcp-docs/src/index.ts
@@ -18,6 +18,7 @@ import { fetchUrl } from './tools/fetch-url.js';
 import { searchWeb } from './tools/search-web.js';
 import { listCached } from './tools/list-cached.js';
 import { logger } from './logger.js';
+import { makeMcpAuth } from './auth.js';
 import { parsePort, parseCacheTtl } from './config.js';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -40,6 +41,8 @@ const PORT: number = parsedPort;
 
 const HOST = process.env.MCP_DOCS_HOST ?? '127.0.0.1';
 const REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379';
+// Optional shared secret; when set, /mcp requires it in the x-mcp-docs-token header.
+const MCP_DOCS_TOKEN = process.env.MCP_DOCS_TOKEN;
 // CACHE_TTL is non-fatal: falls back to the default when unset/malformed.
 const CACHE_TTL = parseCacheTtl(process.env.CACHE_TTL_SECONDS);
 
@@ -205,6 +208,9 @@ setInterval(() => {
 
 const app = express();
 app.use(express.json());
+
+// Shared-secret guard on /mcp (all methods); /health below stays open.
+app.use('/mcp', makeMcpAuth(MCP_DOCS_TOKEN));
 
 // MCP endpoint
 app.post('/mcp', async (req, res) => {

--- a/mcp-docs/src/index.ts
+++ b/mcp-docs/src/index.ts
@@ -207,10 +207,11 @@ setInterval(() => {
 }, SESSION_REAP_INTERVAL_MS).unref();
 
 const app = express();
-app.use(express.json());
 
-// Shared-secret guard on /mcp (all methods); /health below stays open.
+// Shared-secret guard on /mcp (all methods) — registered BEFORE express.json so
+// an unauthenticated request's body is never parsed. /health below stays open.
 app.use('/mcp', makeMcpAuth(MCP_DOCS_TOKEN));
+app.use(express.json());
 
 // MCP endpoint
 app.post('/mcp', async (req, res) => {

--- a/mcp-docs/src/tools/search-web.test.ts
+++ b/mcp-docs/src/tools/search-web.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { searchWeb } from './search-web.js';
+import { DocsCache } from '../cache/redis-cache.js';
+
+describe('searchWeb error signaling', () => {
+  let setCachedSearchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.spyOn(DocsCache.prototype, 'getCachedSearch').mockResolvedValue(null);
+    setCachedSearchSpy = vi
+      .spyOn(DocsCache.prototype, 'setCachedSearch')
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('throws on a network failure and does NOT cache it', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    await expect(searchWeb('hello world', null, {})).rejects.toThrow(/unavailable/);
+    expect(setCachedSearchSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws on a non-2xx response and does NOT cache it', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    await expect(searchWeb('hello world', null, {})).rejects.toThrow(/unavailable/);
+    expect(setCachedSearchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns [] and caches a genuinely-empty successful response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    }));
+    const out = await searchWeb('hello world', null, {});
+    expect(out).toEqual([]);
+    expect(setCachedSearchSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/mcp-docs/src/tools/search-web.ts
+++ b/mcp-docs/src/tools/search-web.ts
@@ -46,7 +46,7 @@ export async function searchWeb(
   searchUrl.searchParams.set('format', 'json');
   searchUrl.searchParams.set('categories', 'general');
 
-  let results: SearchResult[] = [];
+  let results: SearchResult[];
 
   try {
     const response = await fetch(searchUrl.toString(), {
@@ -69,12 +69,18 @@ export async function searchWeb(
       snippet: r.content ?? '',
     }));
   } catch (err) {
-    logger.warn({ err, query: sanitized }, 'SearXNG search failed');
-    // Return empty results rather than failing the tool call
-    results = [];
+    // Surface backend failures (timeout / non-2xx / DNS / parse) instead of
+    // masking them as an empty result set — and do NOT cache the failure, so a
+    // transient SearXNG outage isn't pinned for the cache TTL and a
+    // misconfigured SEARXNG_URL stays distinguishable from a genuine no-results
+    // (#798). The tool wrapper maps this to an isError MCP response.
+    logger.warn({ err, query: sanitized }, 'SearXNG search backend unavailable');
+    throw new Error(
+      `search backend unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
-  // 4. Cache results
+  // 4. Cache successful responses only — a genuinely-empty result set is cacheable.
   await cache.setCachedSearch(sanitized, {
     results, query: sanitized, fetchedAt: new Date().toISOString(),
   });


### PR DESCRIPTION
Addresses the correctness/security follow-ups from #798. The **vite 7→8 upgrade** ships as its own PR (per the issue's guidance); this PR is everything else.

## Changes
- **Search filters wired** (`use-search.ts`, `SearchPage.tsx`) — the backend search route already accepted `author/dateFrom/dateTo/tags`, but the FE only forwarded `spaceKey`. Now threads all filters through (FE `labels` → backend `tags`) and into the query keys so a filter change refetches. (`ce-fe-misc-2`)
- **mcp-docs shared-secret auth** — optional `MCP_DOCS_TOKEN` (constant-time compared from `x-mcp-docs-token`) guards `/mcp`; `/health` stays open; unset = pass-through (network-isolation only, backward compatible). Backend client sends the header via the SDK transport's `requestInit`. Wired into `.env.example` + both compose services. (`ce-contracts-mcp-2`)
- **`search_web` error signaling** — now throws on backend failure (timeout/non-2xx/DNS/parse) instead of returning `[]`, and caches only successful responses, so a misconfigured `SEARXNG_URL` is distinguishable from genuine no-results and transient outages aren't pinned for the TTL. RAG still degrades gracefully (consumer already catches). (`ce-contracts-mcp-4`)
- **Backlog items:**
  - correlation-id length bound (256) — `correlation-id.ts`
  - circuit-breaker HALF_OPEN single-probe gate — `circuit-breaker.ts`
  - mcp-docs-settings per-field domain-list parse fallback (+ non-array guard) — `mcp-docs-settings.ts`

## Scope notes
- The 4th named backlog item — **ssrf-guard `lookup(host, {all:true})`** — was **already implemented and tested on `dev`** (#583, `ssrf-guard.test.ts:482–535`); no change needed.
- The remaining **~116 unnamed low/info items** from the review aren't enumerated in the issue (no source list available), so they're not in scope here.
- Diagrams: the mcp-docs auth + `search_web` changes are security/behavior refinements on an existing backend↔mcp-docs link, not topology changes, so the architecture diagrams remain accurate (flagging here per the diagrams rule).

## Verification
- TDD for every change. `npm run typecheck` + `npm run lint` clean across contracts/backend/frontend; mcp-docs typecheck clean.
- Touched suites green: FE search 30, mcp-docs 62 (incl. new auth + search-web tests), correlation-id 8, circuit-breaker 18, mcp-docs-settings 4. Full DB-backed backend suite left to CI.

Refs #798