### PR TITLE
fix(rag): drain fire-and-forget search-analytics before DB reset (flaky deadlock #805)

### DIFF
--- a/backend/src/domains/llm/services/rag-service-analytics.test.ts
+++ b/backend/src/domains/llm/services/rag-service-analytics.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Root-cause regression test for #805: search-analytics writes are fired
+// without await from the search path, so a late INSERT can race a test's
+// TRUNCATE and deadlock. The fix tracks in-flight writes so callers can drain
+// them via flushSearchAnalytics(). This proves the drain semantics
+// deterministically (the production flake is CI-load-dependent and doesn't
+// reproduce locally), by controlling the INSERT's completion timing.
+
+const queryMock = vi.fn();
+vi.mock('../../../core/db/postgres.js', () => ({
+  query: (...args: unknown[]) => queryMock(...args),
+  getVectorPool: vi.fn(),
+  getPool: vi.fn(),
+  runMigrations: vi.fn(),
+  closePool: vi.fn(),
+  checkConnection: vi.fn(),
+}));
+
+const { trackSearchAnalytics, flushSearchAnalytics } = await import('./rag-service.js');
+
+describe('search-analytics flush (#805)', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it('flushSearchAnalytics() does not resolve until the in-flight write settles', async () => {
+    // Make the analytics INSERT hang until we explicitly release it.
+    let release!: () => void;
+    queryMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        release = () => resolve({ rows: [] });
+      }),
+    );
+
+    trackSearchAnalytics('user-1', 'q', 0, null, 'hybrid'); // fire-and-forget; query() now pending
+
+    let flushed = false;
+    const flushP = flushSearchAnalytics().then(() => {
+      flushed = true;
+    });
+
+    // Let microtasks run — flush must still be blocked on the pending INSERT.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(flushed).toBe(false);
+    expect(queryMock).toHaveBeenCalledTimes(1);
+
+    release(); // INSERT completes
+    await flushP;
+    expect(flushed).toBe(true); // flush resolved only after the write settled
+  });
+
+  it('flushSearchAnalytics() resolves immediately when nothing is in flight', async () => {
+    await expect(flushSearchAnalytics()).resolves.toBeUndefined();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/domains/llm/services/rag-service.integration.test.ts
+++ b/backend/src/domains/llm/services/rag-service.integration.test.ts
@@ -58,7 +58,7 @@ vi.mock('../../../core/enterprise/loader.js', async () => {
 });
 
 // Import the functions under test AFTER the mocks above are registered.
-const { hybridSearch, keywordSearch, vectorSearch } = await import('./rag-service.js');
+const { hybridSearch, keywordSearch, vectorSearch, flushSearchAnalytics } = await import('./rag-service.js');
 // The logger is spied on below (Phase D overfetch tests) to read the
 // `candidatesBeforeFilter` / `candidatesAfterFilter` counts without poking
 // at the internal vectorSearch/keywordSearch calls — ES module bindings
@@ -76,6 +76,10 @@ describe.skipIf(!dbAvailable)('rag-service integration — space permission enfo
     await teardownTestDb();
   });
   beforeEach(async () => {
+    // Drain any fire-and-forget search-analytics writes from the previous test
+    // before TRUNCATE, else a late INSERT (FK RowShareLock) deadlocks the reset
+    // (AccessExclusiveLock). See #805.
+    await flushSearchAnalytics();
     await truncateAllTables();
     // Re-seed system roles that migration 039 inserts on fresh install;
     // truncateAllTables wipes them, so restore the ones we reference below.
@@ -274,6 +278,8 @@ describe.skipIf(!dbAvailable)('rag-service integration — per-page ACL post-fil
     await teardownTestDb();
   });
   beforeEach(async () => {
+    // Drain fire-and-forget search-analytics writes before TRUNCATE (see #805).
+    await flushSearchAnalytics();
     await truncateAllTables();
     await query(
       `INSERT INTO roles (name, display_name, is_system, permissions) VALUES

--- a/backend/src/domains/llm/services/rag-service.ts
+++ b/backend/src/domains/llm/services/rag-service.ts
@@ -198,6 +198,39 @@ export async function recordSearchAnalytics(
   }
 }
 
+// In-flight fire-and-forget analytics writes. recordSearchAnalytics is invoked
+// WITHOUT await from the search path so it never adds latency to a user search —
+// but the INSERT can still be running after the caller returns. Track the
+// promises so callers that need a quiet point (graceful shutdown; DB reset in
+// integration tests) can drain them; otherwise a late INSERT (RowShareLock for
+// the users FK) deadlocks a concurrent TRUNCATE (AccessExclusiveLock). See #805.
+const inFlightAnalytics = new Set<Promise<void>>();
+
+/** Fire-and-forget a search-analytics write while tracking it for {@link flushSearchAnalytics}. */
+export function trackSearchAnalytics(
+  userId: string,
+  queryText: string,
+  resultCount: number,
+  maxScore: number | null,
+  searchType: string,
+): void {
+  const p = recordSearchAnalytics(userId, queryText, resultCount, maxScore, searchType)
+    .catch(() => {})
+    .finally(() => {
+      inFlightAnalytics.delete(p);
+    });
+  inFlightAnalytics.add(p);
+}
+
+/**
+ * Await all in-flight fire-and-forget search-analytics writes. Use before
+ * resetting/tearing down the database (integration tests) and during graceful
+ * shutdown, so a late INSERT never races a TRUNCATE. See #805.
+ */
+export async function flushSearchAnalytics(): Promise<void> {
+  await Promise.allSettled([...inFlightAnalytics]);
+}
+
 /**
  * Hybrid RAG search: combines vector search + keyword search using RRF.
  * Returns top results with source metadata for citations.
@@ -282,7 +315,7 @@ export async function hybridSearch(
     // Record search analytics (non-blocking)
     const searchType = vectorResults.length === 0 && keywordResults.length > 0 ? 'keyword_fallback' : 'hybrid';
     const maxScore = topResults.length > 0 ? Math.max(...topResults.map((r) => r.score)) : null;
-    recordSearchAnalytics(userId, question, topResults.length, maxScore, searchType).catch(() => {});
+    trackSearchAnalytics(userId, question, topResults.length, maxScore, searchType);
 
     return topResults;
   }
@@ -293,7 +326,7 @@ export async function hybridSearch(
   // Distinguish keyword-fallback (embedding failed) from true hybrid
   const searchType = vectorResults.length === 0 && keywordResults.length > 0 ? 'keyword_fallback' : 'hybrid';
   const maxScore = topResults.length > 0 ? Math.max(...topResults.map((r) => r.score)) : null;
-  recordSearchAnalytics(userId, question, topResults.length, maxScore, searchType).catch(() => {});
+  trackSearchAnalytics(userId, question, topResults.length, maxScore, searchType);
 
   return topResults;
 }


### PR DESCRIPTION
Fixes the flaky `rag-service.integration.test.ts` deadlock (#805) that intermittently reds "Backend Tests (CE community-mode)" (it cost 2 re-runs on EE #206).

## Root cause
`recordSearchAnalytics()` is fired **without await** from the hybrid-search path (`rag-service.ts`). Its `INSERT INTO search_analytics` takes a RowShareLock on the `users` table (FK check) and keeps running *after the search returns* — outliving the test. The next test's `beforeEach` resets the DB (`AccessExclusiveLock`), and the two collide:
- PG kills one as the deadlock victim → if it's the test's query, the **test fails**;
- if the reset removes the parent row first → **FK violation** in the late INSERT;
- many in-flight writes → pool **connect timeout**.

`fileParallelism: false` rules out cross-file parallelism — it's this in-file async leak.

## Fix
- `rag-service.ts`: track in-flight fire-and-forget analytics promises in a `Set`; export `flushSearchAnalytics()` to drain them (also useful for graceful-shutdown). Production behaviour is unchanged — writes stay non-blocking.
- `rag-service.integration.test.ts`: `await flushSearchAnalytics()` at the top of each `beforeEach`, before the reset — so no analytics INSERT is ever in flight when the reset runs. Deterministically eliminates the lock contention.

## Verification
The flake is **CI-load-dependent** — it does **not** reproduce locally (old code passed 10/10 here; the race window is too narrow on a fast box). So:
- **Deterministic unit test** (`rag-service-analytics.test.ts`): controls the INSERT's completion timing via a mock and proves `flushSearchAnalytics()` does not resolve until the in-flight write settles (and resolves immediately when nothing is in flight). This is a real regression guard regardless of timing.
- Integration suite green **8/8** locally with the fix; `typecheck` + `lint` clean.

Closes #805
