### PR TITLE
release: v0.6.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,6 +125,7 @@ BACKEND_PORT=3051
 # MCP_DOCS_URL=http://mcp-docs:3100/mcp  # URL of the MCP docs sidecar (default in Docker)
 # MCP_LOG_LEVEL=info                       # Log level for the sidecar container
 # MCP_CACHE_TTL=3600                       # Default cache TTL in seconds
+# MCP_DOCS_TOKEN=                          # Shared secret for backend<->mcp-docs /mcp auth. Unset = no app-level auth (relies on Docker network isolation). Set the same value on backend + mcp-docs.
 # All other MCP Docs settings (enabled, domain allow/blocklist) are managed via Admin Settings UI.
 
 # --- RAG / Vector Search ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-15
+
+> Patch release: deep-review follow-ups, the Vite 8 build upgrade, and test/flake hardening.
+
+### Added
+
+- Search results now apply the **Author / Date-range / Labels** filters — they were collected in the UI but never sent to the API. (#803)
+- Optional shared-secret auth (`MCP_DOCS_TOKEN`, constant-time compared) on the mcp-docs sidecar's `/mcp` endpoints, as defense-in-depth on top of Docker network isolation; `/health` stays open. (#803)
+
+### Changed
+
+- Frontend build upgraded to **Vite 8** (with `@vitejs/plugin-react` 6); `build.rollupOptions.output.manualChunks` migrated to Rolldown's function form. Lifts the temporary Vite 7 pin. (#801, #804)
+
+### Fixed
+
+- Deep-review security & correctness fixes across the backend. (#797)
+- `search_web` now surfaces a SearXNG backend failure (timeout / non-2xx / DNS / parse) instead of silently returning **and caching** empty results, so a misconfigured `SEARXNG_URL` is distinguishable from a genuine no-results. (#803)
+- Bounded the inbound `x-correlation-id` length; the LLM circuit breaker admits a single in-flight probe in `HALF_OPEN`; mcp-docs domain-list settings fall back per-field instead of disabling the feature on one corrupt value; SSRF guard validates all resolved IPs. (#803)
+- Stabilised two flaky tests: a Radix focus-scope timer firing after jsdom teardown (frontend), and a `rag-service` search-analytics write deadlocking the test DB reset (backend). (#802, #806)
+- Defense-in-depth: NaN-guarded integer parsing for the re-embed wait timeout (a garbage value previously caused a silent never-timeout) and chunk settings; mcp-docs cache listing skips a corrupted entry instead of truncating. (#807)
+
 ## [0.6.0] - 2026-06-13
 
 > Curated summary of the notable changes among ~159 PRs merged since 0.5.2.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ Feature PRs to `dev` → no bump. Release (`dev → main`) → bump all five `pa
 - `npm install` from repo root only — workspaces require a single root lockfile.
 - `pino-pretty` is a devDependency (excluded from production images).
 - Pin majors for framework deps (React 19, Fastify 5, TipTap v3).
+- **Root override `"vite": "^7.3.3"`** pins the whole tree to vite 7 (don't remove without testing `npm run dev`). vitest 4 / `@tailwindcss/vite` otherwise pull vite 8 → `rolldown@1.0.1`, whose stricter transform contract breaks `@vitejs/plugin-react@5.2.0`'s native react-refresh wrapper in the dev server (`Missing field moduleType`). Lifting the pin requires moving the app to vite 8 + `@vitejs/plugin-react` 6.x together. See #800.
 
 ## Code Quality
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Feature PRs to `dev` → no bump. Release (`dev → main`) → bump all five `pa
 - `npm install` from repo root only — workspaces require a single root lockfile.
 - `pino-pretty` is a devDependency (excluded from production images).
 - Pin majors for framework deps (React 19, Fastify 5, TipTap v3).
-- **Root override `"vite": "^7.3.3"`** pins the whole tree to vite 7 (don't remove without testing `npm run dev`). vitest 4 / `@tailwindcss/vite` otherwise pull vite 8 → `rolldown@1.0.1`, whose stricter transform contract breaks `@vitejs/plugin-react@5.2.0`'s native react-refresh wrapper in the dev server (`Missing field moduleType`). Lifting the pin requires moving the app to vite 8 + `@vitejs/plugin-react` 6.x together. See #800.
+- **Root override `"vite": "^8.0.16"`** unifies the whole tree on a single vite 8 (frontend + vitest + `@tailwindcss/vite` must not split versions). The app runs **vite 8 with `@vitejs/plugin-react` 6.x** — these move together: vite 8's `rolldown` transform contract breaks plugin-react 5.x's native react-refresh wrapper in the dev server (`Missing field moduleType`, #800), so never downgrade one without the other. Rolldown also dropped the **object** form of `build.rollupOptions.output.manualChunks` — it must be the **function** form (see `frontend/vite.config.ts`).
 
 ## Code Quality
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "//hoisting-note": "`p-limit` and `ipaddr.js` are ALSO declared in the root package.json `dependencies` block to force npm to hoist them to root node_modules. The runtime Docker stage only copies the root tree, so any version pinned here that ends up nested under backend/node_modules disappears at runtime. If you change the ranges below, update the root mirror in lockstep — the docker-build smoke step is the safety net but local repros are faster.",

--- a/backend/src/core/db/migrations/079_restore_page_embeddings_unique.sql
+++ b/backend/src/core/db/migrations/079_restore_page_embeddings_unique.sql
@@ -1,0 +1,29 @@
+-- Restore the UNIQUE (page_id, chunk_index) invariant on page_embeddings.
+--
+-- History: migration 023 added page_embeddings_confluence_id_chunk_index_key
+-- UNIQUE (confluence_id, chunk_index). Migration 030 swapped the natural key
+-- from confluence_id to a page_id FK via
+--   ALTER TABLE page_embeddings DROP COLUMN IF EXISTS confluence_id;
+-- which silently dropped that unique constraint along with the old column.
+-- Unlike page_versions (030 recreated its unique index on the new INT column),
+-- page_embeddings only got a plain, non-unique page_embeddings_page_id_idx, so
+-- the "one row per (page, chunk)" invariant has been DB-unenforced ever since.
+--
+-- The sole writer (embedPage in embedding-service.ts) replaces a page's rows
+-- inside a single transaction via DELETE-then-INSERT (no ON CONFLICT), so this
+-- index is purely a defense-in-depth backstop against duplicate (page_id,
+-- chunk_index) rows from concurrent re-embeds or any future upsert writer — it
+-- is fully compatible with the existing delete-then-insert path.
+
+-- Defensive de-dup before index creation. The DELETE-then-INSERT writer should
+-- never have produced duplicates, but the missing constraint means earlier
+-- concurrent runs could have left some behind. Keep the lowest id per
+-- (page_id, chunk_index) tuple.
+DELETE FROM page_embeddings pe
+USING page_embeddings pe2
+WHERE pe.id > pe2.id
+  AND pe.page_id = pe2.page_id
+  AND pe.chunk_index = pe2.chunk_index;
+
+CREATE UNIQUE INDEX IF NOT EXISTS page_embeddings_page_id_chunk_unique
+  ON page_embeddings(page_id, chunk_index);

--- a/backend/src/core/plugins/correlation-id.test.ts
+++ b/backend/src/core/plugins/correlation-id.test.ts
@@ -58,6 +58,21 @@ describe('correlation-id plugin', () => {
     expect(response.headers['x-correlation-id']).toBe(customId);
   });
 
+  it('falls back to a generated UUID when the inbound ID exceeds the length bound', async () => {
+    const tooLong = 'x'.repeat(300);
+    const response = await app.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { 'x-correlation-id': tooLong },
+    });
+
+    const body = JSON.parse(response.body);
+    expect(body.correlationId).not.toBe(tooLong);
+    expect(body.correlationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
   it('should generate unique IDs for different requests', async () => {
     const response1 = await app.inject({ method: 'GET', url: '/test' });
     const response2 = await app.inject({ method: 'GET', url: '/test' });

--- a/backend/src/core/plugins/correlation-id.ts
+++ b/backend/src/core/plugins/correlation-id.ts
@@ -31,11 +31,27 @@ export function createCorrelationLogger(correlationId: string): Logger {
   return rootLogger.child({ correlationId });
 }
 
+/** Upper bound on an accepted inbound correlation ID (generous; a UUID is 36). */
+export const MAX_CORRELATION_ID_LENGTH = 256;
+
+/**
+ * Resolve the correlation ID for a request: reuse the inbound `x-correlation-id`
+ * header when present and within {@link MAX_CORRELATION_ID_LENGTH}, otherwise
+ * mint a fresh UUID. Bounding the length stops an oversized client-supplied
+ * value from bloating every log line and the reflected response header.
+ */
+export function resolveCorrelationId(raw: string | string[] | undefined): string {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value && value.length > 0 && value.length <= MAX_CORRELATION_ID_LENGTH) {
+    return value;
+  }
+  return randomUUID();
+}
+
 export default fp(async (fastify: FastifyInstance) => {
   fastify.addHook('onRequest', async (request: FastifyRequest, reply: FastifyReply) => {
-    // Read from header or generate a new UUID
-    const correlationId =
-      (request.headers['x-correlation-id'] as string) || randomUUID();
+    // Reuse a sane inbound ID, otherwise generate a new UUID.
+    const correlationId = resolveCorrelationId(request.headers['x-correlation-id']);
 
     request.correlationId = correlationId;
 

--- a/backend/src/core/services/admin-user-service.rbac-invalidation.test.ts
+++ b/backend/src/core/services/admin-user-service.rbac-invalidation.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ce-svc-security-1: a role change must flush the RBAC Redis caches
+// (rbac:admin/spaces/perms/global:<id>) so a demoted admin loses the
+// system-admin bypass immediately instead of after the 60s TTL. These tests
+// mock the DB + cache layers so the invalidation call can be asserted
+// deterministically without a live Redis (the real-DB suite in
+// admin-user-service.test.ts can't observe Redis key deletion).
+
+// Fake transactional client whose query() resolves a configurable result per
+// call. updateUser issues, in order: BEGIN, SELECT ... FOR UPDATE, UPDATE,
+// COMMIT (no token delete unless roleChanged adds one).
+function makeClient(existingRole: 'admin' | 'user', newRole: 'admin' | 'user') {
+  const userRow = {
+    id: 'target-id',
+    username: 'demotee',
+    email: null,
+    display_name: null,
+    role: existingRole,
+    auth_provider: 'local',
+    deactivated_at: null,
+    deactivated_by: null,
+    deactivated_reason: null,
+    created_at: new Date(),
+  };
+  const updatedRow = { ...userRow, role: newRole };
+  const query = vi.fn(async (sql: string) => {
+    const text = String(sql);
+    if (/FOR UPDATE/.test(text)) return { rows: [userRow], rowCount: 1 };
+    if (/^\s*UPDATE users SET/.test(text)) return { rows: [updatedRow], rowCount: 1 };
+    if (/pg_advisory_xact_lock/.test(text)) return { rows: [], rowCount: 0 };
+    if (/SELECT id\s+FROM users/.test(text)) {
+      // assertNotLastActiveAdminTx: pretend another admin exists.
+      return { rows: [{ id: 'other-admin' }], rowCount: 1 };
+    }
+    // BEGIN / COMMIT / DELETE refresh_tokens / etc.
+    return { rows: [], rowCount: 0 };
+  });
+  const release = vi.fn();
+  return { query, release };
+}
+
+const fakeClient = { client: makeClient('admin', 'user') };
+
+vi.mock('../db/postgres.js', () => ({
+  query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+  getPool: vi.fn(() => ({ connect: vi.fn(async () => fakeClient.client) })),
+  runMigrations: vi.fn(),
+  closePool: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('./user-security-cache.js', () => ({
+  invalidateUserSecurityState: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./rbac-service.js', () => ({
+  invalidateRbacCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { updateUser } from './admin-user-service.js';
+import { invalidateRbacCache } from './rbac-service.js';
+import { invalidateUserSecurityState } from './user-security-cache.js';
+
+const rbacMock = invalidateRbacCache as ReturnType<typeof vi.fn>;
+const secMock = invalidateUserSecurityState as ReturnType<typeof vi.fn>;
+
+describe('updateUser RBAC cache invalidation (ce-svc-security-1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('flushes the RBAC cache for the user when the role changes (admin -> user)', async () => {
+    fakeClient.client = makeClient('admin', 'user');
+    await updateUser('target-id', { role: 'user' });
+
+    expect(rbacMock).toHaveBeenCalledTimes(1);
+    expect(rbacMock).toHaveBeenCalledWith('target-id');
+    // Existing #737 security-state invalidation must still run.
+    expect(secMock).toHaveBeenCalledWith('target-id');
+  });
+
+  it('does NOT flush the RBAC cache when the role is unchanged', async () => {
+    fakeClient.client = makeClient('user', 'user');
+    await updateUser('target-id', { displayName: 'Renamed' });
+
+    expect(rbacMock).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/core/services/admin-user-service.ts
+++ b/backend/src/core/services/admin-user-service.ts
@@ -12,6 +12,7 @@ import type { PoolClient } from 'pg';
 import { query, getPool } from '../db/postgres.js';
 import { logger } from '../utils/logger.js';
 import { invalidateUserSecurityState } from './user-security-cache.js';
+import { invalidateRbacCache } from './rbac-service.js';
 import type { AdminUser, AdminUserRole } from '@compendiq/contracts';
 
 const BCRYPT_ROUNDS = 10;
@@ -254,6 +255,14 @@ export async function updateUser(id: string, patch: UpdateUserOptions): Promise<
     await client.query('COMMIT');
     if (roleChanged) {
       await invalidateUserSecurityState(id);
+      // A role change crosses a privilege boundary — flush the RBAC caches
+      // (rbac:admin/spaces/perms/global:<id>) so a demoted admin loses the
+      // system-admin bypass immediately instead of after the 60s TTL. The
+      // per-request auth check already rejects the old-role access token;
+      // this closes the residual all-spaces/all-pages bypass that survives
+      // a forced re-login (rbac-service reads its own Redis cache, not the
+      // token claim).
+      await invalidateRbacCache(id);
     }
     return rowToAdminUser(res.rows[0]!);
   } catch (err: unknown) {

--- a/backend/src/core/services/circuit-breaker.test.ts
+++ b/backend/src/core/services/circuit-breaker.test.ts
@@ -138,6 +138,24 @@ describe('CircuitBreaker', () => {
       expect(breaker.getStatus().state).toBe('CLOSED');
       expect(breaker.getStatus().failureCount).toBe(0);
     });
+
+    it('admits only one concurrent probe in HALF_OPEN', async () => {
+      vi.useRealTimers();
+      let started = 0;
+      const slow = () => breaker.execute(async () => {
+        started++;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return 'ok';
+      });
+
+      const results = await Promise.allSettled([slow(), slow()]);
+
+      // Exactly one probe ran; the second was rejected without invoking fn.
+      expect(started).toBe(1);
+      const rejected = results.filter((r) => r.status === 'rejected');
+      expect(rejected).toHaveLength(1);
+      expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(CircuitBreakerOpenError);
+    });
   });
 
   describe('reset', () => {

--- a/backend/src/core/services/circuit-breaker.ts
+++ b/backend/src/core/services/circuit-breaker.ts
@@ -27,6 +27,8 @@ export class CircuitBreaker {
   private failureCount = 0;
   private successCount = 0;
   private lastFailureTime: number | null = null;
+  /** True while a HALF_OPEN probe request is in flight (single-probe gate). */
+  private isProbing = false;
   private readonly config: CircuitBreakerConfig;
   readonly name: string;
 
@@ -70,6 +72,19 @@ export class CircuitBreaker {
       );
     }
 
+    // HALF_OPEN admits a single probe at a time: concurrent requests would all
+    // hit a recovering server and could each flip the breaker, defeating the
+    // probe's purpose. Reject extra probes until the first resolves.
+    const wasProbing = this.state === 'HALF_OPEN';
+    if (wasProbing) {
+      if (this.isProbing) {
+        throw new CircuitBreakerOpenError(
+          `${this.name}: probe already in flight`,
+        );
+      }
+      this.isProbing = true;
+    }
+
     try {
       const result = await fn();
       this.onSuccess();
@@ -77,6 +92,10 @@ export class CircuitBreaker {
     } catch (err) {
       this.onFailure();
       throw err;
+    } finally {
+      // onSuccess/onFailure may have flipped state to CLOSED/OPEN, so clear the
+      // probe flag unconditionally based on whether *this* call took the probe.
+      if (wasProbing) this.isProbing = false;
     }
   }
 
@@ -93,6 +112,7 @@ export class CircuitBreaker {
     this.failureCount = 0;
     this.successCount = 0;
     this.lastFailureTime = null;
+    this.isProbing = false;
     logger.info({ breaker: this.name }, 'Circuit breaker reset');
   }
 

--- a/backend/src/core/services/mcp-docs-client.test.ts
+++ b/backend/src/core/services/mcp-docs-client.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Capture the transport constructor args so we can assert the auth header.
+const { transportCtor } = vi.hoisted(() => ({ transportCtor: vi.fn() }));
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: class {
+    constructor(url: URL, opts?: unknown) {
+      transportCtor(url, opts);
+    }
+    close() {}
+  },
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class {
+    async connect() {}
+    async listTools() {
+      return { tools: [] };
+    }
+  },
+}));
+
+vi.mock('./mcp-docs-settings.js', () => ({
+  getMcpDocsSettings: vi.fn().mockResolvedValue({
+    enabled: true,
+    url: 'http://mcp-docs:3100/mcp',
+  }),
+}));
+
+describe('mcp-docs-client transport auth header', () => {
+  beforeEach(() => {
+    // Fresh module each test so the module-level connection cache is reset and
+    // the transport is reconstructed (and re-captured).
+    vi.resetModules();
+    transportCtor.mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.MCP_DOCS_TOKEN;
+  });
+
+  it('sends the shared-secret header on the transport when MCP_DOCS_TOKEN is set', async () => {
+    process.env.MCP_DOCS_TOKEN = 's3cret-token';
+    const { testConnection } = await import('./mcp-docs-client.js');
+
+    await testConnection();
+
+    expect(transportCtor).toHaveBeenCalledWith(
+      expect.any(URL),
+      { requestInit: { headers: { 'x-mcp-docs-token': 's3cret-token' } } },
+    );
+  });
+
+  it('omits the header (requestInit undefined) when no token is set', async () => {
+    const { testConnection } = await import('./mcp-docs-client.js');
+
+    await testConnection();
+
+    expect(transportCtor).toHaveBeenCalledWith(expect.any(URL), { requestInit: undefined });
+  });
+});

--- a/backend/src/core/services/mcp-docs-client.ts
+++ b/backend/src/core/services/mcp-docs-client.ts
@@ -28,7 +28,11 @@ async function ensureConnected(): Promise<Client> {
   if (client) return client;
 
   try {
-    transport = new StreamableHTTPClientTransport(new URL(settings.url));
+    // Send the shared secret (if configured) so the sidecar's /mcp guard accepts us.
+    const token = process.env.MCP_DOCS_TOKEN;
+    transport = new StreamableHTTPClientTransport(new URL(settings.url), {
+      requestInit: token ? { headers: { 'x-mcp-docs-token': token } } : undefined,
+    });
     client = new Client({ name: 'compendiq-backend', version: APP_VERSION });
     await client.connect(transport);
     connectedUrl = settings.url;

--- a/backend/src/core/services/mcp-docs-settings.test.ts
+++ b/backend/src/core/services/mcp-docs-settings.test.ts
@@ -36,6 +36,38 @@ describe('mcp-docs-settings', () => {
     expect(settings.maxContentLength).toBe(50_000);
   });
 
+  it('keeps the feature enabled when only the domain list JSON is corrupt', async () => {
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [
+        { setting_key: 'mcp_docs_enabled', setting_value: 'true' },
+        { setting_key: 'mcp_docs_allowed_domains', setting_value: '{not valid json' },
+      ],
+      rowCount: 2, command: 'SELECT', oid: 0, fields: [],
+    });
+
+    const settings = await getMcpDocsSettings();
+
+    // A corrupt domain list must not collapse the whole config to DEFAULTS
+    // (which would disable the feature) — only that field falls back.
+    expect(settings.enabled).toBe(true);
+    expect(settings.allowedDomains).toEqual(['*']);
+  });
+
+  it('falls back when a domain list is valid JSON but not a string array', async () => {
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [
+        { setting_key: 'mcp_docs_enabled', setting_value: 'true' },
+        { setting_key: 'mcp_docs_blocked_domains', setting_value: '[1, 2, 3]' },
+      ],
+      rowCount: 2, command: 'SELECT', oid: 0, fields: [],
+    });
+
+    const settings = await getMcpDocsSettings();
+
+    expect(settings.enabled).toBe(true);
+    expect(settings.blockedDomains).toEqual([]); // DEFAULTS.blockedDomains
+  });
+
   it('parses stored settings correctly', async () => {
     vi.mocked(query).mockResolvedValueOnce({
       rows: [

--- a/backend/src/core/services/mcp-docs-settings.ts
+++ b/backend/src/core/services/mcp-docs-settings.ts
@@ -52,6 +52,27 @@ async function getSettingsMap(): Promise<Record<string, string>> {
   return map;
 }
 
+/**
+ * Parse a stored JSON string-array setting, falling back to `fallback` (and
+ * logging) when the value is absent or corrupt. A bad domain list must not
+ * disable the whole feature, so this is scoped per-field rather than wrapping
+ * the entire settings load in one try/catch.
+ */
+function parseDomainList(raw: string | undefined, fallback: string[]): string[] {
+  if (!raw) return fallback;
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((d) => typeof d === 'string')) {
+      return parsed;
+    }
+    logger.warn('MCP docs domain list is not a string array, using default for this field');
+    return fallback;
+  } catch (err) {
+    logger.warn({ err }, 'Invalid MCP docs domain list JSON, using default for this field');
+    return fallback;
+  }
+}
+
 export async function getMcpDocsSettings(): Promise<McpDocsSettings> {
   try {
     const settings = await getSettingsMap();
@@ -59,12 +80,8 @@ export async function getMcpDocsSettings(): Promise<McpDocsSettings> {
       enabled: settings['mcp_docs_enabled'] === 'true',
       url: settings['mcp_docs_url'] ?? DEFAULTS.url,
       domainMode: (settings['mcp_docs_domain_mode'] as 'allowlist' | 'blocklist') ?? DEFAULTS.domainMode,
-      allowedDomains: settings['mcp_docs_allowed_domains']
-        ? JSON.parse(settings['mcp_docs_allowed_domains'])
-        : DEFAULTS.allowedDomains,
-      blockedDomains: settings['mcp_docs_blocked_domains']
-        ? JSON.parse(settings['mcp_docs_blocked_domains'])
-        : DEFAULTS.blockedDomains,
+      allowedDomains: parseDomainList(settings['mcp_docs_allowed_domains'], DEFAULTS.allowedDomains),
+      blockedDomains: parseDomainList(settings['mcp_docs_blocked_domains'], DEFAULTS.blockedDomains),
       cacheTtl: parseInt(settings['mcp_docs_cache_ttl'] ?? String(DEFAULTS.cacheTtl), 10),
       maxContentLength: parseInt(settings['mcp_docs_max_content_length'] ?? String(DEFAULTS.maxContentLength), 10),
     };

--- a/backend/src/core/utils/safe-int.test.ts
+++ b/backend/src/core/utils/safe-int.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { safeIntOr } from './safe-int.js';
+
+describe('safeIntOr', () => {
+  it('parses a valid integer string', () => {
+    expect(safeIntOr('42', 7)).toBe(42);
+  });
+
+  it('falls back on undefined / null / empty', () => {
+    expect(safeIntOr(undefined, 7)).toBe(7);
+    expect(safeIntOr(null, 7)).toBe(7);
+    expect(safeIntOr('', 7)).toBe(7);
+  });
+
+  it('falls back on non-numeric garbage (would otherwise be NaN)', () => {
+    // The bug this guards: `parseInt('abc') ?? fallback` === NaN (?? ignores NaN),
+    // so a NaN would flow downstream (e.g. `elapsed > NaN` is always false).
+    expect(safeIntOr('abc', 600000)).toBe(600000);
+    expect(safeIntOr('12abc', 7)).toBe(12); // parseInt's leading-digits behaviour is fine
+  });
+
+  it('rejects values below min (default min = 1 rejects 0 and negatives)', () => {
+    expect(safeIntOr('0', 7)).toBe(7);
+    expect(safeIntOr('-5', 7)).toBe(7);
+  });
+
+  it('allows 0 when min = 0 (e.g. chunk overlap)', () => {
+    expect(safeIntOr('0', 50, 0)).toBe(0);
+    expect(safeIntOr('-1', 50, 0)).toBe(50); // still rejects negatives
+  });
+});

--- a/backend/src/core/utils/safe-int.ts
+++ b/backend/src/core/utils/safe-int.ts
@@ -1,0 +1,20 @@
+/**
+ * Parse an integer from an untrusted string (env var or admin_settings value),
+ * falling back to a default when the value is missing, non-numeric, or out of
+ * range. Plain `parseInt(x) ?? fallback` does NOT catch `NaN` (?? only catches
+ * null/undefined), and `parseInt(x) || fallback` wrongly rejects a valid `0`.
+ * This guards both: a `NaN`/garbage value can't silently flow downstream (e.g.
+ * a `NaN` timeout makes `elapsed > NaN` always false → an infinite wait).
+ *
+ * @param raw      the raw string (e.g. process.env.X or a DB setting_value)
+ * @param fallback value to use when `raw` is absent/invalid/below `min`
+ * @param min      minimum accepted value (default 1; pass 0 to allow zero)
+ */
+export function safeIntOr(
+  raw: string | undefined | null,
+  fallback: number,
+  min = 1,
+): number {
+  const n = parseInt(raw ?? '', 10);
+  return Number.isFinite(n) && n >= min ? n : fallback;
+}

--- a/backend/src/core/utils/ssrf-guard.test.ts
+++ b/backend/src/core/utils/ssrf-guard.test.ts
@@ -91,6 +91,10 @@ describe('SSRF Guard', () => {
     it('should block 0.0.0.0', () => {
       expect(() => validateUrl('http://0.0.0.0/api')).toThrow(SsrfError);
     });
+
+    it('should block 0.0.0.0/8 this-host range', () => {
+      expect(() => validateUrl('http://0.0.0.1/')).toThrow(SsrfError);
+    });
   });
 
   describe('blocked private IPv4 ranges', () => {
@@ -482,32 +486,42 @@ describe('SSRF Guard', () => {
     });
 
     it('should pass for public URLs that resolve to public IPs', async () => {
-      mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
 
       await expect(validateUrlWithDns('https://example.com/api')).resolves.toBeUndefined();
     });
 
+    it('should reject when ANY resolved record is private (mixed public+private)', async () => {
+      // Round-robin / multi-record response: first public, second internal.
+      mockLookup.mockResolvedValue([
+        { address: '93.184.216.34', family: 4 },
+        { address: '169.254.169.254', family: 4 },
+      ]);
+
+      await expect(validateUrlWithDns('https://rebind-mixed.example.com/api')).rejects.toThrow(SsrfError);
+    });
+
     it('should reject when DNS resolves to a private IP (127.x.x.x)', async () => {
-      mockLookup.mockResolvedValue({ address: '127.0.0.1', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
 
       await expect(validateUrlWithDns('https://evil-rebind.example.com/api')).rejects.toThrow(SsrfError);
       await expect(validateUrlWithDns('https://evil-rebind.example.com/api')).rejects.toThrow(/DNS resolved to blocked IP/);
     });
 
     it('should reject when DNS resolves to a private IP (10.x.x.x)', async () => {
-      mockLookup.mockResolvedValue({ address: '10.0.0.1', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '10.0.0.1', family: 4 }]);
 
       await expect(validateUrlWithDns('https://rebind.example.com/api')).rejects.toThrow(SsrfError);
     });
 
     it('should reject when DNS resolves to 169.254.x.x (link-local)', async () => {
-      mockLookup.mockResolvedValue({ address: '169.254.169.254', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
 
       await expect(validateUrlWithDns('https://metadata.example.com')).rejects.toThrow(SsrfError);
     });
 
     it('should skip DNS check for allowlisted origins', async () => {
-      mockLookup.mockResolvedValue({ address: '10.0.0.5', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
 
       addAllowedBaseUrl('http://10.0.0.5:8090');
       await expect(validateUrlWithDns('http://10.0.0.5:8090/rest/api')).resolves.toBeUndefined();

--- a/backend/src/core/utils/ssrf-guard.ts
+++ b/backend/src/core/utils/ssrf-guard.ts
@@ -182,7 +182,7 @@ const BLOCKED_IPV4_PATTERNS = [
   /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,           // 10.0.0.0/8
   /^172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}$/,  // 172.16.0.0/12
   /^192\.168\.\d{1,3}\.\d{1,3}$/,              // 192.168.0.0/16
-  /^0\.0\.0\.0$/,                                // Unspecified
+  /^0\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,             // 0.0.0.0/8 "this host" (covers 0.0.0.0)
   /^169\.254\.\d{1,3}\.\d{1,3}$/,              // Link-local
   /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}$/, // CGNAT 100.64.0.0/10
 ];
@@ -353,9 +353,14 @@ function isBlockedIp(ip: string): boolean {
  */
 async function resolveAndValidateIp(hostname: string): Promise<void> {
   try {
-    const { address } = await lookup(hostname);
-    if (isBlockedIp(address)) {
-      throw new SsrfError(`SSRF blocked: DNS resolved to blocked IP: ${hostname} -> ${address}`);
+    // Resolve ALL A/AAAA records, not just the first: a multi-record or
+    // round-robin response can mix a public address with a private one to slip
+    // past a single-address check. Block if ANY resolved address is internal.
+    const resolved = await lookup(hostname, { all: true });
+    for (const { address } of resolved) {
+      if (isBlockedIp(address)) {
+        throw new SsrfError(`SSRF blocked: DNS resolved to blocked IP: ${hostname} -> ${address}`);
+      }
     }
   } catch (err) {
     // Re-throw our own SsrfError

--- a/backend/src/domains/confluence/services/attachment-handler.test.ts
+++ b/backend/src/domains/confluence/services/attachment-handler.test.ts
@@ -36,8 +36,9 @@ vi.mock('undici', () => ({
   request: vi.fn(),
 }));
 
+const mockAssertNonSsrfUrl = vi.fn().mockResolvedValue(undefined);
 vi.mock('../../../core/utils/ssrf-guard.js', () => ({
-  validateUrl: vi.fn(),
+  assertNonSsrfUrl: (...args: unknown[]) => mockAssertNonSsrfUrl(...args),
 }));
 
 // Mock fs to avoid real filesystem operations.
@@ -94,6 +95,8 @@ describe('attachment-handler', () => {
     vi.mocked(fs.rm).mockResolvedValue(undefined);
     vi.mocked(fs.readdir as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     mockRequest.mockReset();
+    // Default: SSRF guard passes (URL is safe)
+    mockAssertNonSsrfUrl.mockResolvedValue(undefined);
     // Default: no prior failures
     mockGetAttachmentFailureCount.mockResolvedValue(0);
     mockRecordAttachmentFailure.mockResolvedValue(undefined);
@@ -391,6 +394,33 @@ describe('attachment-handler', () => {
 
       expect(result).toEqual(Buffer.from('external-image'));
       expect(mockRequest).toHaveBeenCalled();
+      expect(mockAssertNonSsrfUrl).toHaveBeenCalledWith('https://example.com/img.png');
+    });
+
+    it('rejects a content-sourced external image whose URL fails the DNS SSRF guard', async () => {
+      const client = createMockClient();
+      // Simulate a public hostname whose A record resolves to a private IP:
+      // the DNS-resolving guard rejects, and the fetch must never happen.
+      mockAssertNonSsrfUrl.mockRejectedValue(
+        new Error('SSRF blocked: DNS resolved to blocked IP'),
+      );
+
+      await expect(
+        fetchAndCachePageImage({
+          client,
+          userId: 'user-1',
+          pageId: 'page-1',
+          localFilename: getLocalFilenameForImageSource({
+            kind: 'external-url',
+            url: 'https://internal.attacker.example/x.png',
+          }),
+          bodyStorage:
+            '<ac:image><ri:url ri:value="https://internal.attacker.example/x.png" /></ac:image>',
+        }),
+      ).rejects.toThrow(/SSRF blocked/);
+
+      expect(mockAssertNonSsrfUrl).toHaveBeenCalledWith('https://internal.attacker.example/x.png');
+      expect(mockRequest).not.toHaveBeenCalled();
     });
 
     it('fetches a mirrored cross-page image using its local filename', async () => {

--- a/backend/src/domains/confluence/services/attachment-handler.ts
+++ b/backend/src/domains/confluence/services/attachment-handler.ts
@@ -5,7 +5,7 @@ import { request } from 'undici';
 import type { RedisClientType } from 'redis';
 import { ConfluenceClient, ConfluenceAttachment } from './confluence-client.js';
 import { logger } from '../../../core/utils/logger.js';
-import { validateUrl } from '../../../core/utils/ssrf-guard.js';
+import { assertNonSsrfUrl } from '../../../core/utils/ssrf-guard.js';
 import {
   extractImageReferences,
   SUPPORTED_IMAGE_EXTENSIONS,
@@ -486,7 +486,10 @@ async function cacheExternalImage(
 }
 
 async function downloadExternalImage(url: string): Promise<ExternalImageDownloadResult> {
-  validateUrl(url);
+  // Content-sourced external image URLs are untrusted (lifted verbatim from
+  // synced Confluence page bodies, never allowlisted), so use the DNS-resolving
+  // SSRF guard to block public hostnames that resolve to private/internal IPs.
+  await assertNonSsrfUrl(url);
 
   const { statusCode, headers, body } = await request(url, {
     signal: AbortSignal.timeout(15_000),

--- a/backend/src/domains/confluence/services/confluence-client.test.ts
+++ b/backend/src/domains/confluence/services/confluence-client.test.ts
@@ -249,6 +249,41 @@ describe('ConfluenceClient', () => {
       const callUrl = mockRequest.mock.calls[0][0] as string;
       expect(callUrl).toContain(encodeURIComponent('space="OPS" AND type=page AND title="Shared Assets"'));
     });
+
+    it('escapes a double-quote in the space key so it cannot break out of the CQL literal', async () => {
+      const client = new ConfluenceClient(baseUrl, pat);
+      mockRequest.mockResolvedValue({
+        statusCode: 200,
+        body: { text: async () => JSON.stringify({ results: [], start: 0, limit: 1, size: 0 }) },
+      } as never);
+
+      // ri:space-key sourced from page XHTML could contain a quote to inject CQL.
+      await client.findPageByTitle('OPS" OR space="SECRET', 'Shared Assets');
+
+      const callUrl = mockRequest.mock.calls[0][0] as string;
+      const decodedCql = decodeURIComponent(callUrl.split('cql=')[1].split('&')[0]);
+      // The quote is escaped, so the value stays inside the space="..." literal
+      // and no bare ` OR space=` clause leaks into the query.
+      expect(decodedCql).toContain('space="OPS\\" OR space=\\"SECRET" AND ');
+      expect(decodedCql).not.toContain('space="OPS" OR space="SECRET"');
+    });
+  });
+
+  describe('getModifiedPages', () => {
+    it('escapes a double-quote in the space key so it cannot break out of the CQL literal', async () => {
+      const client = new ConfluenceClient(baseUrl, pat);
+      mockRequest.mockResolvedValue({
+        statusCode: 200,
+        body: { text: async () => JSON.stringify({ results: [], start: 0, limit: 50, size: 0 }) },
+      } as never);
+
+      await client.getModifiedPages(new Date('2026-06-01T00:00:00Z'), 'OPS" OR space="SECRET');
+
+      const callUrl = mockRequest.mock.calls[0][0] as string;
+      const decodedCql = decodeURIComponent(callUrl.split('cql=')[1].split('&')[0]);
+      expect(decodedCql).toContain('space="OPS\\" OR space=\\"SECRET" AND type=page');
+      expect(decodedCql).not.toContain('space="OPS" OR space="SECRET"');
+    });
   });
 
   describe('label management', () => {

--- a/backend/src/domains/confluence/services/confluence-client.ts
+++ b/backend/src/domains/confluence/services/confluence-client.ts
@@ -613,16 +613,23 @@ export class ConfluenceClient {
     );
   }
 
+  // Escape a value before interpolating it into a double-quoted CQL string literal.
+  // Backslash first, then double-quote, so a quote in attacker-influenced input
+  // (e.g. a page's ri:space-key attribute) can't break out of the literal.
+  private escapeCqlValue(value: string): string {
+    return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  }
+
   async findPageByTitle(spaceKey: string | null | undefined, title: string): Promise<ConfluencePage | null> {
-    const escapedTitle = title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    const cql = `${spaceKey ? `space="${spaceKey}" AND ` : ''}type=page AND title="${escapedTitle}"`;
+    const escapedTitle = this.escapeCqlValue(title);
+    const cql = `${spaceKey ? `space="${this.escapeCqlValue(spaceKey)}" AND ` : ''}type=page AND title="${escapedTitle}"`;
     const response = await this.searchPages(cql, 0, 1);
     return response.results[0] ?? null;
   }
 
   async getModifiedPages(since: Date, spaceKey: string): Promise<ConfluencePage[]> {
     const dateStr = since.toISOString().split('T')[0];
-    const cql = `space="${spaceKey}" AND type=page AND lastmodified>="${dateStr}" ORDER BY lastmodified DESC`;
+    const cql = `space="${this.escapeCqlValue(spaceKey)}" AND type=page AND lastmodified>="${dateStr}" ORDER BY lastmodified DESC`;
     const pages: ConfluencePage[] = [];
     let start = 0;
     const limit = 50;

--- a/backend/src/domains/knowledge/services/duplicate-detector.integration.test.ts
+++ b/backend/src/domains/knowledge/services/duplicate-detector.integration.test.ts
@@ -164,4 +164,37 @@ describe.skipIf(!dbAvailable)('duplicate-detector integration — RBAC kNN filte
 
     expect(results.map((r) => r.title)).toContain('My private draft');
   });
+
+  it('surfaces every accessible standalone near-duplicate, each with a distinct non-null id', async () => {
+    // Two accessible standalone near-duplicates both inside the threshold. They
+    // both have confluence_id IS NULL, so keying dedup on confluence_id would
+    // collapse them into a single row (Postgres treats NULLs as equal in
+    // DISTINCT ON). Keying on the page PK keeps both.
+    const vec = fakeVec(29);
+    await seedPage({ confluenceId: 'src-1', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy guide', vec });
+    const sharedId = await seedPage({
+      confluenceId: null, source: 'standalone', spaceKey: null,
+      title: 'Standalone deploy notes', visibility: 'shared', createdBy: USER_B, vec,
+    });
+    const ownPrivateId = await seedPage({
+      confluenceId: null, source: 'standalone', spaceKey: null,
+      title: 'My private deploy draft', visibility: 'private', createdBy: USER_A, vec,
+    });
+
+    const results = await findDuplicates(USER_A, 'src-1');
+    const standalone = results.filter((r) => r.confluenceId === null);
+
+    // Both standalone duplicates surface — not collapsed into one.
+    expect(standalone).toHaveLength(2);
+    expect(standalone.map((r) => r.title).sort()).toEqual([
+      'My private deploy draft',
+      'Standalone deploy notes',
+    ]);
+    // Every candidate carries a stable, non-null id usable as a nav target.
+    expect(results.every((r) => typeof r.id === 'number' && Number.isInteger(r.id))).toBe(true);
+    const ids = standalone.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length); // distinct
+    expect(ids).toContain(sharedId);
+    expect(ids).toContain(ownPrivateId);
+  });
 });

--- a/backend/src/domains/knowledge/services/duplicate-detector.test.ts
+++ b/backend/src/domains/knowledge/services/duplicate-detector.test.ts
@@ -105,6 +105,7 @@ describe('DuplicateDetector', () => {
       mocks.mockClientQuery.mockResolvedValueOnce({
         rows: [
           {
+            id: 101,
             confluence_id: 'neighbor-1',
             title: 'Neighbor Page',
             space_key: 'DEV',
@@ -118,6 +119,7 @@ describe('DuplicateDetector', () => {
       const result = await findDuplicates('user-1', 'conf-source', { distanceThreshold: 0.15, limit: 10 });
 
       expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(101);
       expect(result[0].confluenceId).toBe('neighbor-1');
       expect(result[0].title).toBe('Neighbor Page');
       expect(result[0].spaceKey).toBe('DEV');
@@ -186,6 +188,11 @@ describe('DuplicateDetector', () => {
       expect(cteSQL).toContain('pe2.page_id = cp2.id');
       // The old broken join referenced pe2.confluence_id — verify it's gone
       expect(cteSQL).not.toContain('pe2.confluence_id');
+      // Dedup on the page PK (cp2.id), not the nullable confluence_id —
+      // otherwise standalone pages (confluence_id IS NULL) collapse into one row.
+      expect(cteSQL).toContain('DISTINCT ON (cp2.id)');
+      expect(cteSQL).not.toContain('DISTINCT ON (cp2.confluence_id)');
+      expect(cteSQL).toContain('ORDER BY cp2.id, pe2.embedding');
     });
 
     // ── #733 RBAC regressions ───────────────────────────────────────────
@@ -234,8 +241,8 @@ describe('DuplicateDetector', () => {
       // CTE returns one close match and one far one
       mocks.mockClientQuery.mockResolvedValueOnce({
         rows: [
-          { confluence_id: 'close-1', title: 'Close Neighbor', space_key: 'DEV', distance: 0.05 },
-          { confluence_id: 'far-1', title: 'Far Neighbor', space_key: 'DEV', distance: 0.50 },
+          { id: 1, confluence_id: 'close-1', title: 'Close Neighbor', space_key: 'DEV', distance: 0.05 },
+          { id: 2, confluence_id: 'far-1', title: 'Far Neighbor', space_key: 'DEV', distance: 0.50 },
         ],
       });
       mocks.mockClientQuery.mockResolvedValueOnce(undefined); // COMMIT
@@ -272,7 +279,7 @@ describe('DuplicateDetector', () => {
       mocks.mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
       // Pages scan returns one page
       mocks.mockQuery.mockResolvedValueOnce({
-        rows: [{ confluence_id: 'page-a', title: 'Page A' }],
+        rows: [{ id: 10, confluence_id: 'page-a', title: 'Page A' }],
       });
 
       // findDuplicates for 'page-a': preliminary SELECT
@@ -284,7 +291,7 @@ describe('DuplicateDetector', () => {
       mocks.mockClientQuery.mockResolvedValueOnce(undefined); // SET LOCAL
       mocks.mockClientQuery.mockResolvedValueOnce({
         rows: [
-          { confluence_id: 'page-b', title: 'Page B', space_key: 'DEV', distance: 0.08 },
+          { id: 20, confluence_id: 'page-b', title: 'Page B', space_key: 'DEV', distance: 0.08 },
         ],
       }); // CTE
       mocks.mockClientQuery.mockResolvedValueOnce(undefined); // COMMIT
@@ -301,8 +308,8 @@ describe('DuplicateDetector', () => {
       // Pages scan returns two pages
       mocks.mockQuery.mockResolvedValueOnce({
         rows: [
-          { confluence_id: 'page-a', title: 'Page A' },
-          { confluence_id: 'page-b', title: 'Page B' },
+          { id: 10, confluence_id: 'page-a', title: 'Page A' },
+          { id: 20, confluence_id: 'page-b', title: 'Page B' },
         ],
       });
 
@@ -312,7 +319,7 @@ describe('DuplicateDetector', () => {
         .mockResolvedValueOnce(undefined) // BEGIN
         .mockResolvedValueOnce(undefined) // SET LOCAL
         .mockResolvedValueOnce({
-          rows: [{ confluence_id: 'page-b', title: 'Page B', space_key: 'DEV', distance: 0.08 }],
+          rows: [{ id: 20, confluence_id: 'page-b', title: 'Page B', space_key: 'DEV', distance: 0.08 }],
         }) // CTE
         .mockResolvedValueOnce(undefined); // COMMIT
 
@@ -322,7 +329,7 @@ describe('DuplicateDetector', () => {
         .mockResolvedValueOnce(undefined) // BEGIN
         .mockResolvedValueOnce(undefined) // SET LOCAL
         .mockResolvedValueOnce({
-          rows: [{ confluence_id: 'page-a', title: 'Page A', space_key: 'DEV', distance: 0.08 }],
+          rows: [{ id: 10, confluence_id: 'page-a', title: 'Page A', space_key: 'DEV', distance: 0.08 }],
         }) // CTE
         .mockResolvedValueOnce(undefined); // COMMIT
 

--- a/backend/src/domains/knowledge/services/duplicate-detector.ts
+++ b/backend/src/domains/knowledge/services/duplicate-detector.ts
@@ -6,7 +6,10 @@ import { logger } from '../../../core/utils/logger.js';
 const RAG_EF_SEARCH = parseInt(process.env.RAG_EF_SEARCH ?? '100', 10);
 
 interface DuplicateCandidate {
-  confluenceId: string;
+  // Stable page PK — always present, used as the dedup key and as a non-null
+  // navigation target for standalone pages (confluenceId IS NULL).
+  id: number;
+  confluenceId: string | null;
   title: string;
   spaceKey: string;
   embeddingDistance: number;
@@ -85,17 +88,23 @@ export async function findDuplicates(
 
     // Find nearest neighbors using pgvector kNN on the average embedding
     const result = await client.query<{
-      confluence_id: string;
+      id: number;
+      confluence_id: string | null;
       title: string;
       space_key: string;
       distance: number;
     }>(
+      // Dedup on the page PK, not confluence_id: standalone pages have
+      // confluence_id IS NULL and Postgres DISTINCT ON treats NULLs as equal,
+      // so keying on confluence_id collapses every standalone candidate into a
+      // single row. cp2.id is always non-null and unique per page.
       `WITH source_avg AS (
          SELECT AVG(embedding) AS avg_embedding
          FROM page_embeddings
          WHERE page_id = $1
        )
-       SELECT DISTINCT ON (cp2.confluence_id)
+       SELECT DISTINCT ON (cp2.id)
+         cp2.id,
          cp2.confluence_id,
          cp2.title,
          cp2.space_key,
@@ -107,7 +116,7 @@ export async function findDuplicates(
          AND source_avg.avg_embedding IS NOT NULL
          AND cp2.deleted_at IS NULL
          AND ${visiblePagesPredicate(3, 4, 'cp2')}
-       ORDER BY cp2.confluence_id, pe2.embedding <=> source_avg.avg_embedding
+       ORDER BY cp2.id, pe2.embedding <=> source_avg.avg_embedding
        LIMIT $2`,
       // #733: over-fetch to filter later; candidates restricted to the same
       // retrieval scope as rag-service (accessible Confluence spaces +
@@ -128,6 +137,7 @@ export async function findDuplicates(
       const combinedScore = embeddingSimilarity * 0.7 + titleSim * 0.3;
 
       candidates.push({
+        id: row.id,
         confluenceId: row.confluence_id,
         title: row.title,
         spaceKey: row.space_key,
@@ -163,8 +173,8 @@ export async function scanAllDuplicates(
 
   // Get all pages with embeddings (RBAC access control)
   const dupSpaces = await getUserAccessibleSpaces(userId);
-  const pages = await query<{ confluence_id: string; title: string }>(
-    `SELECT DISTINCT cp.confluence_id, cp.title
+  const pages = await query<{ id: number; confluence_id: string; title: string }>(
+    `SELECT DISTINCT cp.id, cp.confluence_id, cp.title
      FROM pages cp
      JOIN page_embeddings pe ON pe.page_id = cp.id
      WHERE cp.space_key = ANY($1::text[])
@@ -183,14 +193,16 @@ export async function scanAllDuplicates(
       });
 
       for (const dup of duplicates) {
-        // Avoid reporting A->B and B->A
-        const pairKey = [page.confluence_id, dup.confluenceId].sort().join(':');
+        // Avoid reporting A->B and B->A. Key on the stable page PKs — standalone
+        // pages have a NULL confluenceId, which would otherwise collide.
+        const pairKey = [page.id, dup.id].sort((a, b) => a - b).join(':');
         if (seen.has(pairKey)) continue;
         seen.add(pairKey);
 
         allPairs.push({
           page1: {
             sourceId: page.confluence_id,
+            id: page.id,
             confluenceId: page.confluence_id,
             title: page.title,
             spaceKey: '', // Will be filled from the scan

--- a/backend/src/domains/llm/services/embedding-service.integration.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.integration.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../../test-db-helper.js';
+import { query } from '../../../core/db/postgres.js';
+import pgvector from 'pgvector';
+
+// Deterministic 1024-dim vector for fixtures
+function fakeVec(seed: number): number[] {
+  return Array.from({ length: 1024 }, (_, i) => Math.sin((i + 1) * seed) * 0.01);
+}
+
+const dbAvailable = await isDbAvailable();
+
+// Regression for ce-migrations-1: migration 030 silently dropped the
+// UNIQUE (confluence_id, chunk_index) constraint on page_embeddings when it
+// removed the confluence_id column, and never recreated it on the new page_id
+// column. Migration 079 restores the invariant as UNIQUE (page_id, chunk_index).
+describe.skipIf(!dbAvailable)('page_embeddings (page_id, chunk_index) uniqueness — migration 079', () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  }, 30_000);
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+  beforeEach(async () => {
+    await truncateAllTables();
+  });
+
+  async function seedPage(): Promise<number> {
+    const page = await query<{ id: number }>(
+      `INSERT INTO pages (confluence_id, source, space_key, title, body_text, body_storage, body_html)
+       VALUES (gen_random_uuid()::text, 'confluence', 'DEV', 'Page', 'body', '', '')
+       RETURNING id`,
+    );
+    return page.rows[0]!.id;
+  }
+
+  async function insertEmbedding(pageId: number, chunkIndex: number): Promise<void> {
+    await query(
+      `INSERT INTO page_embeddings (page_id, chunk_index, chunk_text, embedding, metadata)
+       VALUES ($1, $2, $3, $4, $5::jsonb)`,
+      [
+        pageId,
+        chunkIndex,
+        `chunk ${chunkIndex}`,
+        pgvector.toSql(fakeVec(chunkIndex + 1)),
+        JSON.stringify({ page_title: 'Page', section_title: 'Page', space_key: 'DEV' }),
+      ],
+    );
+  }
+
+  it('rejects a duplicate (page_id, chunk_index) row', async () => {
+    const pageId = await seedPage();
+    await insertEmbedding(pageId, 0);
+
+    await expect(insertEmbedding(pageId, 0)).rejects.toThrow(
+      /duplicate key value|unique constraint|page_embeddings_page_id_chunk_unique/i,
+    );
+  });
+
+  it('allows distinct chunk_index values for the same page', async () => {
+    const pageId = await seedPage();
+    await insertEmbedding(pageId, 0);
+    await insertEmbedding(pageId, 1);
+
+    const { rows } = await query<{ count: string }>(
+      'SELECT COUNT(*)::text AS count FROM page_embeddings WHERE page_id = $1',
+      [pageId],
+    );
+    expect(rows[0]!.count).toBe('2');
+  });
+
+  it('allows the same chunk_index across different pages', async () => {
+    const pageA = await seedPage();
+    const pageB = await seedPage();
+    await insertEmbedding(pageA, 0);
+    await insertEmbedding(pageB, 0);
+
+    const { rows } = await query<{ count: string }>(
+      'SELECT COUNT(*)::text AS count FROM page_embeddings',
+    );
+    expect(rows[0]!.count).toBe('2');
+  });
+});

--- a/backend/src/domains/llm/services/embedding-service.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.test.ts
@@ -1466,6 +1466,33 @@ describe('chunkText', () => {
       // No DB interaction at all since Phase 1 throws
       expect(mockClient.query).not.toHaveBeenCalled();
     });
+
+    it('when EVERY batch is skipped (all context-length): preserves embeddings, leaves page dirty/failed, no DELETE or embedded UPDATE', async () => {
+      mocks.htmlToText.mockReturnValue('Some content for the page that is long enough');
+
+      // Every Phase 1 batch rejects with a context-length error → allEmbeddings stays empty
+      const contextErr = new Error('HTTP 400 - input length exceeds context length');
+      mocks.providerGenerateEmbedding.mockRejectedValue(contextErr);
+
+      const count = await embedPage('user-1', 101, 'Page', 'DEV', '<p>content</p>');
+
+      // No embeddings produced
+      expect(count).toBe(0);
+
+      // Phase 2 must NOT run: no transaction opened, no DELETE that would wipe
+      // existing embeddings, no INSERT, no COMMIT.
+      expect(mockClient.query).not.toHaveBeenCalled();
+      expect(mockClient.release).not.toHaveBeenCalled();
+
+      // The page is marked failed and left dirty via the pool `query` (not the client).
+      expect(mocks.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = mocks.query.mock.calls[0]!;
+      expect(sql).toContain("embedding_status = 'failed'");
+      expect(sql).toContain('embedding_dirty = TRUE');
+      // It must NOT falsely mark the page embedded.
+      expect(sql).not.toContain("embedding_status = 'embedded'");
+      expect(params).toEqual([101, 'all chunk batches exceeded embedding context length']);
+    });
   });
 
   describe('getEmbedBreakerNextRetryTime', () => {

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -4,6 +4,7 @@ import { resolveUsecase } from './llm-provider-resolver.js';
 import { generateEmbedding } from './openai-compatible-client.js';
 import { htmlToText } from '../../../core/services/content-converter.js';
 import { logger } from '../../../core/utils/logger.js';
+import { safeIntOr } from '../../../core/utils/safe-int.js';
 import { invalidateGraphCache, acquireEmbeddingLock, releaseEmbeddingLock, isEmbeddingLocked, getRedisClient, listActiveEmbeddingLocks } from '../../../core/services/redis-cache.js';
 import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
 import { visiblePagesPredicate } from '../../../core/services/page-visibility.js';
@@ -276,14 +277,16 @@ async function getAdminChunkSettings(): Promise<{ chunkSize: number; chunkOverla
      WHERE setting_key IN ('embedding_chunk_size', 'embedding_chunk_overlap')`,
   );
 
-  const settings: Record<string, number> = {};
+  const settings: Record<string, string> = {};
   for (const row of result.rows) {
-    settings[row.setting_key] = parseInt(row.setting_value, 10);
+    settings[row.setting_key] = row.setting_value;
   }
 
+  // safeIntOr guards a NaN/garbage admin_settings value (plain `?? DEFAULT`
+  // would let a NaN through). Overlap may legitimately be 0, so allow min 0.
   return {
-    chunkSize: settings['embedding_chunk_size'] ?? CHUNK_SIZE,
-    chunkOverlap: settings['embedding_chunk_overlap'] ?? CHUNK_OVERLAP,
+    chunkSize: safeIntOr(settings['embedding_chunk_size'], CHUNK_SIZE),
+    chunkOverlap: safeIntOr(settings['embedding_chunk_overlap'], CHUNK_OVERLAP, 0),
   };
 }
 
@@ -1223,10 +1226,10 @@ export async function enqueueReembedAll(
  *     every 100 pages (or on 100%).
  */
 export async function runReembedAllJob(job: Job): Promise<string> {
-  const WAIT_LOCKS_TIMEOUT_MS = parseInt(
-    process.env.REEMBED_WAIT_LOCKS_MS ?? '600000',
-    10,
-  );
+  // Guard against a garbage env value: a NaN timeout makes the
+  // `Date.now() - waitStart > WAIT_LOCKS_TIMEOUT_MS` check below always false,
+  // so the wait loop would never time out (silent hang).
+  const WAIT_LOCKS_TIMEOUT_MS = safeIntOr(process.env.REEMBED_WAIT_LOCKS_MS, 600_000);
   const POLL_INTERVAL_MS = 3_000;
 
   // Wait-on-locks loop — exit when no per-user lock (other than our own

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -319,6 +319,11 @@ export async function embedPage(
   // remain intact in the database.
   const batchSize = 10;
   const allEmbeddings: Array<{ chunkIndex: number; text: string; embedding: number[]; metadata: ChunkMetadata }> = [];
+  // Tracks whether any batch was dropped because it exceeded the embedding
+  // model's context length. Used to distinguish "page legitimately has no
+  // embeddable content" from "every batch was skipped" so we never destroy
+  // existing embeddings or falsely mark the page embedded in the latter case.
+  let skippedBatches = false;
 
   // Resolve the `embedding` use-case once per page so we don't hit the
   // resolver cache on every batch. Rotating providers mid-page would mix
@@ -349,11 +354,31 @@ export async function embedPage(
           { pageId, batchOffset: i, batchSize: batch.length },
           'Skipping oversized embedding batch (context length exceeded)',
         );
+        skippedBatches = true;
         continue;
       }
       logger.error({ err, pageId, batch: i }, 'Failed to embed batch');
       throw err;
     }
+  }
+
+  // If every batch was skipped for exceeding the context length, no embeddings
+  // were produced. Do NOT enter Phase 2 — the unconditional DELETE there would
+  // wipe the page's existing (good) embeddings and the UPDATE would falsely mark
+  // the page 'embedded', silently dropping it from the RAG index. Instead leave
+  // existing embeddings intact, mark the page failed and keep it dirty so a
+  // future retry (or content change) can re-embed it.
+  if (allEmbeddings.length === 0 && skippedBatches) {
+    await query(
+      `UPDATE pages SET embedding_status = 'failed', embedding_dirty = TRUE, embedding_error = $2
+       WHERE id = $1`,
+      [pageId, 'all chunk batches exceeded embedding context length'],
+    );
+    logger.warn(
+      { pageId, pageTitle },
+      'All embedding batches exceeded context length — page left dirty, existing embeddings preserved',
+    );
+    return 0;
   }
 
   // ── Phase 2: Atomically replace old embeddings with new ones ─────────────────

--- a/backend/src/domains/llm/services/rag-service-analytics.test.ts
+++ b/backend/src/domains/llm/services/rag-service-analytics.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Root-cause regression test for #805: search-analytics writes are fired
+// without await from the search path, so a late INSERT can race a test's
+// TRUNCATE and deadlock. The fix tracks in-flight writes so callers can drain
+// them via flushSearchAnalytics(). This proves the drain semantics
+// deterministically (the production flake is CI-load-dependent and doesn't
+// reproduce locally), by controlling the INSERT's completion timing.
+
+const queryMock = vi.fn();
+vi.mock('../../../core/db/postgres.js', () => ({
+  query: (...args: unknown[]) => queryMock(...args),
+  getVectorPool: vi.fn(),
+  getPool: vi.fn(),
+  runMigrations: vi.fn(),
+  closePool: vi.fn(),
+  checkConnection: vi.fn(),
+}));
+
+const { trackSearchAnalytics, flushSearchAnalytics } = await import('./rag-service.js');
+
+describe('search-analytics flush (#805)', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it('flushSearchAnalytics() does not resolve until the in-flight write settles', async () => {
+    // Make the analytics INSERT hang until we explicitly release it.
+    let release!: () => void;
+    queryMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        release = () => resolve({ rows: [] });
+      }),
+    );
+
+    trackSearchAnalytics('user-1', 'q', 0, null, 'hybrid'); // fire-and-forget; query() now pending
+
+    let flushed = false;
+    const flushP = flushSearchAnalytics().then(() => {
+      flushed = true;
+    });
+
+    // Let microtasks run — flush must still be blocked on the pending INSERT.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(flushed).toBe(false);
+    expect(queryMock).toHaveBeenCalledTimes(1);
+
+    release(); // INSERT completes
+    await flushP;
+    expect(flushed).toBe(true); // flush resolved only after the write settled
+  });
+
+  it('flushSearchAnalytics() resolves immediately when nothing is in flight', async () => {
+    await expect(flushSearchAnalytics()).resolves.toBeUndefined();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/domains/llm/services/rag-service.integration.test.ts
+++ b/backend/src/domains/llm/services/rag-service.integration.test.ts
@@ -58,7 +58,7 @@ vi.mock('../../../core/enterprise/loader.js', async () => {
 });
 
 // Import the functions under test AFTER the mocks above are registered.
-const { hybridSearch, keywordSearch, vectorSearch } = await import('./rag-service.js');
+const { hybridSearch, keywordSearch, vectorSearch, flushSearchAnalytics } = await import('./rag-service.js');
 // The logger is spied on below (Phase D overfetch tests) to read the
 // `candidatesBeforeFilter` / `candidatesAfterFilter` counts without poking
 // at the internal vectorSearch/keywordSearch calls — ES module bindings
@@ -76,6 +76,10 @@ describe.skipIf(!dbAvailable)('rag-service integration — space permission enfo
     await teardownTestDb();
   });
   beforeEach(async () => {
+    // Drain any fire-and-forget search-analytics writes from the previous test
+    // before TRUNCATE, else a late INSERT (FK RowShareLock) deadlocks the reset
+    // (AccessExclusiveLock). See #805.
+    await flushSearchAnalytics();
     await truncateAllTables();
     // Re-seed system roles that migration 039 inserts on fresh install;
     // truncateAllTables wipes them, so restore the ones we reference below.
@@ -274,6 +278,8 @@ describe.skipIf(!dbAvailable)('rag-service integration — per-page ACL post-fil
     await teardownTestDb();
   });
   beforeEach(async () => {
+    // Drain fire-and-forget search-analytics writes before TRUNCATE (see #805).
+    await flushSearchAnalytics();
     await truncateAllTables();
     await query(
       `INSERT INTO roles (name, display_name, is_system, permissions) VALUES

--- a/backend/src/domains/llm/services/rag-service.ts
+++ b/backend/src/domains/llm/services/rag-service.ts
@@ -198,6 +198,39 @@ export async function recordSearchAnalytics(
   }
 }
 
+// In-flight fire-and-forget analytics writes. recordSearchAnalytics is invoked
+// WITHOUT await from the search path so it never adds latency to a user search —
+// but the INSERT can still be running after the caller returns. Track the
+// promises so callers that need a quiet point (graceful shutdown; DB reset in
+// integration tests) can drain them; otherwise a late INSERT (RowShareLock for
+// the users FK) deadlocks a concurrent TRUNCATE (AccessExclusiveLock). See #805.
+const inFlightAnalytics = new Set<Promise<void>>();
+
+/** Fire-and-forget a search-analytics write while tracking it for {@link flushSearchAnalytics}. */
+export function trackSearchAnalytics(
+  userId: string,
+  queryText: string,
+  resultCount: number,
+  maxScore: number | null,
+  searchType: string,
+): void {
+  const p = recordSearchAnalytics(userId, queryText, resultCount, maxScore, searchType)
+    .catch(() => {})
+    .finally(() => {
+      inFlightAnalytics.delete(p);
+    });
+  inFlightAnalytics.add(p);
+}
+
+/**
+ * Await all in-flight fire-and-forget search-analytics writes. Use before
+ * resetting/tearing down the database (integration tests) and during graceful
+ * shutdown, so a late INSERT never races a TRUNCATE. See #805.
+ */
+export async function flushSearchAnalytics(): Promise<void> {
+  await Promise.allSettled([...inFlightAnalytics]);
+}
+
 /**
  * Hybrid RAG search: combines vector search + keyword search using RRF.
  * Returns top results with source metadata for citations.
@@ -282,7 +315,7 @@ export async function hybridSearch(
     // Record search analytics (non-blocking)
     const searchType = vectorResults.length === 0 && keywordResults.length > 0 ? 'keyword_fallback' : 'hybrid';
     const maxScore = topResults.length > 0 ? Math.max(...topResults.map((r) => r.score)) : null;
-    recordSearchAnalytics(userId, question, topResults.length, maxScore, searchType).catch(() => {});
+    trackSearchAnalytics(userId, question, topResults.length, maxScore, searchType);
 
     return topResults;
   }
@@ -293,7 +326,7 @@ export async function hybridSearch(
   // Distinguish keyword-fallback (embedding failed) from true hybrid
   const searchType = vectorResults.length === 0 && keywordResults.length > 0 ? 'keyword_fallback' : 'hybrid';
   const maxScore = topResults.length > 0 ? Math.max(...topResults.map((r) => r.score)) : null;
-  recordSearchAnalytics(userId, question, topResults.length, maxScore, searchType).catch(() => {});
+  trackSearchAnalytics(userId, question, topResults.length, maxScore, searchType);
 
   return topResults;
 }

--- a/backend/src/routes/confluence/attachments.test.ts
+++ b/backend/src/routes/confluence/attachments.test.ts
@@ -43,7 +43,16 @@ vi.mock('node:fs/promises', () => ({
 // Mock Redis client
 const mockRedisGet = vi.fn();
 const mockRedisSetEx = vi.fn();
-const mockRedisClient = { get: mockRedisGet, setEx: mockRedisSetEx };
+const mockRedisScan = vi.fn();
+const mockRedisDel = vi.fn();
+const mockRedisKeys = vi.fn();
+const mockRedisClient = {
+  get: mockRedisGet,
+  setEx: mockRedisSetEx,
+  scan: mockRedisScan,
+  del: mockRedisDel,
+  keys: mockRedisKeys,
+};
 vi.mock('../../core/services/redis-cache.js', () => ({
   getRedisClient: () => mockRedisClient,
 }));
@@ -90,6 +99,11 @@ describe('Attachment routes', () => {
     });
     mockRedisGet.mockResolvedValue(null);
     mockRedisSetEx.mockResolvedValue('OK');
+    // Default: SCAN returns an empty page and a terminal cursor so the
+    // invalidation loop completes in one iteration.
+    mockRedisScan.mockResolvedValue({ cursor: 0, keys: [] });
+    mockRedisDel.mockResolvedValue(0);
+    mockRedisKeys.mockResolvedValue([]);
   });
 
   it('should return 404 when the page is not in the user selected spaces', async () => {
@@ -651,6 +665,57 @@ describe('Attachment routes', () => {
         'diagram.png',
         expect.any(Buffer),
       );
+    });
+
+    it('invalidates the page cache with a non-blocking SCAN loop (never KEYS)', async () => {
+      mockGetClientForUser.mockResolvedValue(mockClient);
+      mockWriteAttachmentCache.mockResolvedValue('/data/attachments/page-123/diagram.png');
+
+      // Two-page SCAN walk: first page yields matching keys + a non-terminal
+      // cursor, second page yields the terminal cursor '0' to end the loop.
+      mockRedisScan
+        .mockResolvedValueOnce({ cursor: 42, keys: ['a:page:page-123:list', 'b:page:page-123:tree'] })
+        .mockResolvedValueOnce({ cursor: 0, keys: [] });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/attachments/page-123/diagram.png',
+        payload: { dataUri: VALID_PNG_DATA_URI },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      // SCAN (cursor-based) is used, KEYS (blocking, O(N) keyspace walk) is not.
+      expect(mockRedisKeys).not.toHaveBeenCalled();
+      expect(mockRedisScan).toHaveBeenCalledTimes(2);
+      expect(mockRedisScan).toHaveBeenNthCalledWith(1, '0', {
+        MATCH: '*:page:page-123*',
+        COUNT: 100,
+      });
+      // Second call resumes from the cursor returned by the first page.
+      expect(mockRedisScan).toHaveBeenNthCalledWith(2, '42', {
+        MATCH: '*:page:page-123*',
+        COUNT: 100,
+      });
+      // Matched keys from the first page are deleted.
+      expect(mockRedisDel).toHaveBeenCalledWith(['a:page:page-123:list', 'b:page:page-123:tree']);
+    });
+
+    it('keeps cache invalidation non-fatal when SCAN throws', async () => {
+      mockGetClientForUser.mockResolvedValue(mockClient);
+      mockWriteAttachmentCache.mockResolvedValue('/data/attachments/page-123/diagram.png');
+      mockRedisScan.mockRejectedValue(new Error('Redis unavailable'));
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/attachments/page-123/diagram.png',
+        payload: { dataUri: VALID_PNG_DATA_URI },
+      });
+
+      // The PNG already uploaded — a cache-invalidation failure must not fail
+      // the request (the cache expires naturally on TTL).
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({ success: true, filename: 'diagram.png' });
     });
 
     it('should return 500 when Confluence upload fails', async () => {

--- a/backend/src/routes/confluence/attachments.ts
+++ b/backend/src/routes/confluence/attachments.ts
@@ -420,12 +420,21 @@ export async function attachmentRoutes(fastify: FastifyInstance) {
         }
       }
 
-      // Invalidate Redis page cache so other users get the updated diagram
+      // Invalidate Redis page cache so other users get the updated diagram.
+      // Uses a SCAN cursor loop (not KEYS) to avoid blocking the single-threaded
+      // Redis server — mirrors the established pattern in redis-cache.ts.
       try {
         const redis = getRedisClient();
         if (redis) {
-          const keys = await redis.keys(`*:page:${pageId}*`);
-          if (keys.length > 0) await redis.del(keys);
+          const pattern = `*:page:${pageId}*`;
+          let cursor = '0';
+          do {
+            const result = await redis.scan(cursor, { MATCH: pattern, COUNT: 100 });
+            cursor = String(result.cursor);
+            if (result.keys.length > 0) {
+              await redis.del(result.keys);
+            }
+          } while (cursor !== '0');
         }
       } catch {
         // Redis may be unavailable — non-fatal, cache will expire naturally

--- a/backend/src/routes/foundation/notifications.test.ts
+++ b/backend/src/routes/foundation/notifications.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
 import Fastify from 'fastify';
 import sensible from '@fastify/sensible';
+import { ZodError } from 'zod';
 
 // Hoisted query mock so we can reference it in tests
 vi.mock('../../core/services/rbac-service.js', () => ({
@@ -35,6 +36,18 @@ describe('Notification routes', () => {
       request.userId = 'test-user-id';
       request.username = 'testuser';
       request.userRole = 'user';
+    });
+
+    // Mirror the production app's Zod error handling (ZodError → 400)
+    app.setErrorHandler((error: Error & { statusCode?: number }, _request, reply) => {
+      if (error instanceof ZodError) {
+        return reply.status(400).send({ error: 'ValidationError', statusCode: 400 });
+      }
+      return reply.status(error.statusCode ?? 500).send({
+        error: error.name,
+        message: error.message,
+        statusCode: error.statusCode ?? 500,
+      });
     });
 
     await app.register(notificationRoutes, { prefix: '/api' });
@@ -127,6 +140,46 @@ describe('Notification routes', () => {
       const countCall = mockQuery.mock.calls[0];
       expect(countCall[0]).toContain('type = $');
       expect(countCall[1]).toContain('comment');
+    });
+
+    it('should reject an uncapped limit above the maximum', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications?limit=100000000',
+      });
+
+      expect(response.statusCode).toBe(400);
+      // No DB query should run for invalid input
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('should coerce and apply default limit/offset to the SELECT query', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ count: '0' }] });
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/notifications',
+      });
+
+      // Second call is the paginated SELECT; last two params are limit, offset
+      const selectCall = mockQuery.mock.calls[1];
+      const selectParams = selectCall[1] as unknown[];
+      expect(selectParams.slice(-2)).toEqual([50, 0]);
+    });
+
+    it('should coerce a valid limit string into a capped number', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ count: '0' }] });
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/notifications?limit=100&offset=10',
+      });
+
+      const selectCall = mockQuery.mock.calls[1];
+      const selectParams = selectCall[1] as unknown[];
+      expect(selectParams.slice(-2)).toEqual([100, 10]);
     });
   });
 

--- a/backend/src/routes/foundation/notifications.ts
+++ b/backend/src/routes/foundation/notifications.ts
@@ -1,5 +1,9 @@
 import { FastifyInstance } from 'fastify';
 import {
+  NotificationListQuerySchema,
+  NotificationPreferenceUpdateSchema,
+} from '@compendiq/contracts';
+import {
   listNotifications,
   getUnreadCount,
   markAsRead,
@@ -18,19 +22,14 @@ export async function notificationRoutes(fastify: FastifyInstance) {
 
   // GET /notifications — List notifications (filter: unread, type; paginated)
   fastify.get('/notifications', async (request) => {
-    const { unread, type, limit, offset } = request.query as {
-      unread?: string;
-      type?: string;
-      limit?: string;
-      offset?: string;
-    };
+    const { unread, type, limit, offset } = NotificationListQuerySchema.parse(request.query);
 
     return listNotifications({
       userId: request.userId,
       unreadOnly: unread === 'true',
       type,
-      limit: limit ? parseInt(limit, 10) : undefined,
-      offset: offset ? parseInt(offset, 10) : undefined,
+      limit,
+      offset,
     });
   });
 
@@ -81,16 +80,8 @@ export async function notificationRoutes(fastify: FastifyInstance) {
   });
 
   // PUT /notification-preferences — Update preferences
-  fastify.put('/notification-preferences', async (request, reply) => {
-    const { type, inApp, email } = request.body as {
-      type?: string;
-      inApp?: boolean;
-      email?: boolean;
-    };
-
-    if (!type || typeof type !== 'string') {
-      return reply.badRequest('type is required');
-    }
+  fastify.put('/notification-preferences', async (request) => {
+    const { type, inApp, email } = NotificationPreferenceUpdateSchema.parse(request.body);
 
     await updatePreference(
       request.userId,

--- a/backend/src/routes/knowledge/page-update.test.ts
+++ b/backend/src/routes/knowledge/page-update.test.ts
@@ -18,6 +18,11 @@ vi.mock('../../domains/confluence/services/sync-service.js', () => ({
   getClientForUser: (...args: unknown[]) => mockGetClientForUser(...args),
 }));
 
+const mockGetUserAccessibleSpaces = vi.fn();
+vi.mock('../../core/services/rbac-service.js', () => ({
+  getUserAccessibleSpaces: (...args: unknown[]) => mockGetUserAccessibleSpaces(...args),
+}));
+
 vi.mock('../../core/services/content-converter.js', () => ({
   confluenceToHtml: (...args: unknown[]) => mockConfluenceToHtml(...args),
   htmlToConfluence: (...args: unknown[]) => mockHtmlToConfluence(...args),
@@ -99,6 +104,8 @@ describe('PUT /api/pages/:id', () => {
     mockConfluenceToHtml.mockReturnValue('<p>converted</p>');
     mockHtmlToConfluence.mockReturnValue('<p>storage</p>');
     mockHtmlToText.mockReturnValue('converted');
+    // Default: the test user can reach the OPS space used by the Confluence fixture.
+    mockGetUserAccessibleSpaces.mockResolvedValue(['OPS']);
 
     mockQuery.mockImplementation((sql: string) => {
       if (sql.includes('SELECT id, version, space_key')) {
@@ -138,6 +145,28 @@ describe('PUT /api/pages/:id', () => {
       'page-1',
       'OPS',
     );
+  });
+
+  it('returns 403 and does not push to Confluence when the page is in a space the user cannot access', async () => {
+    // Page lives in OPS but the user only has DEV — mirrors DELETE /pages/:id RBAC.
+    mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
+    const updatePage = vi.fn();
+    mockGetClientForUser.mockResolvedValue({ updatePage });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/pages/page-1',
+      payload: {
+        title: 'Should not happen',
+        bodyHtml: '<p>unauthorized edit</p>',
+        version: 7,
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(mockGetUserAccessibleSpaces).toHaveBeenCalledWith('user-1');
+    // Critical: no upstream edit must occur for an unauthorized space.
+    expect(updatePage).not.toHaveBeenCalled();
   });
 
   describe('standalone visibility change — cache invalidation', () => {

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -1281,6 +1281,14 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     }
 
     // --- Confluence article: existing flow ---
+    // RBAC: verify user has access to this page's space before allowing edit
+    if (existingPage.space_key) {
+      const accessibleSpaces = await getUserAccessibleSpaces(userId);
+      if (!accessibleSpaces.includes(existingPage.space_key)) {
+        throw fastify.httpErrors.forbidden('Access denied to this space');
+      }
+    }
+
     const client = await getClientForUser(userId);
     if (!client) {
       throw fastify.httpErrors.badRequest('Confluence not configured');
@@ -1545,17 +1553,23 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
 
     const existing = await query<{
       id: number; source: string; created_by_user_id: string | null;
-      visibility: string; deleted_at: Date | null;
+      visibility: string; space_key: string | null; deleted_at: Date | null;
     }>(
-      'SELECT id, source, created_by_user_id, visibility, deleted_at FROM pages WHERE id = $1 AND deleted_at IS NULL',
+      'SELECT id, source, created_by_user_id, visibility, space_key, deleted_at FROM pages WHERE id = $1 AND deleted_at IS NULL',
       [pageId],
     );
     if (!existing.rows.length) throw fastify.httpErrors.notFound('Page not found');
 
     const page = existing.rows[0]!;
 
-    // Access control: standalone pages require ownership or shared visibility
-    if (page.source === 'standalone' && page.created_by_user_id !== userId && page.visibility !== 'shared') {
+    // Access control: Confluence pages require RBAC space access; standalone pages
+    // require ownership or shared visibility
+    if (page.source === 'confluence') {
+      const spaces = await getUserAccessibleSpaces(userId);
+      if (!page.space_key || !spaces.includes(page.space_key)) {
+        throw fastify.httpErrors.forbidden('Access denied to this space');
+      }
+    } else if (page.created_by_user_id !== userId && page.visibility !== 'shared') {
       throw fastify.httpErrors.forbidden('Not authorized to edit this page');
     }
 
@@ -1578,19 +1592,26 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
 
     const result = await query<{
       id: number; source: string; created_by_user_id: string | null;
-      visibility: string; draft_body_html: string | null;
+      visibility: string; space_key: string | null; draft_body_html: string | null;
       draft_body_text: string | null; draft_updated_at: Date | null;
       draft_updated_by: string | null;
     }>(
-      `SELECT id, source, created_by_user_id, visibility, draft_body_html, draft_body_text, draft_updated_at, draft_updated_by FROM pages WHERE id = $1 AND deleted_at IS NULL`,
+      `SELECT id, source, created_by_user_id, visibility, space_key, draft_body_html, draft_body_text, draft_updated_at, draft_updated_by FROM pages WHERE id = $1 AND deleted_at IS NULL`,
       [pageId],
     );
     if (!result.rows.length) throw fastify.httpErrors.notFound('Page not found');
 
     const row = result.rows[0]!;
 
-    // Access control
-    if (row.source === 'standalone' && row.created_by_user_id !== userId && row.visibility !== 'shared') {
+    // Access control: Confluence pages require RBAC space access; standalone pages
+    // require ownership or shared visibility. Use 404 (no existence oracle) to
+    // match GET /pages/:id semantics.
+    if (row.source === 'confluence') {
+      const spaces = await getUserAccessibleSpaces(userId);
+      if (!row.space_key || !spaces.includes(row.space_key)) {
+        throw fastify.httpErrors.notFound('Page not found');
+      }
+    } else if (row.created_by_user_id !== userId && row.visibility !== 'shared') {
       throw fastify.httpErrors.notFound('Page not found');
     }
 
@@ -1625,8 +1646,14 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
 
     const page = existing.rows[0]!;
 
-    // Access control
-    if (page.source === 'standalone' && page.created_by_user_id !== userId && page.visibility !== 'shared') {
+    // Access control: Confluence pages require RBAC space access; standalone pages
+    // require ownership or shared visibility
+    if (page.source === 'confluence') {
+      const spaces = await getUserAccessibleSpaces(userId);
+      if (!page.space_key || !spaces.includes(page.space_key)) {
+        throw fastify.httpErrors.forbidden('Access denied to this space');
+      }
+    } else if (page.created_by_user_id !== userId && page.visibility !== 'shared') {
       throw fastify.httpErrors.forbidden('Not authorized to publish this page');
     }
 
@@ -1713,17 +1740,23 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
 
     const existing = await query<{
       id: number; source: string; created_by_user_id: string | null;
-      visibility: string;
+      visibility: string; space_key: string | null;
     }>(
-      'SELECT id, source, created_by_user_id, visibility FROM pages WHERE id = $1 AND deleted_at IS NULL',
+      'SELECT id, source, created_by_user_id, visibility, space_key FROM pages WHERE id = $1 AND deleted_at IS NULL',
       [pageId],
     );
     if (!existing.rows.length) throw fastify.httpErrors.notFound('Page not found');
 
     const page = existing.rows[0]!;
 
-    // Access control
-    if (page.source === 'standalone' && page.created_by_user_id !== userId && page.visibility !== 'shared') {
+    // Access control: Confluence pages require RBAC space access; standalone pages
+    // require ownership or shared visibility
+    if (page.source === 'confluence') {
+      const spaces = await getUserAccessibleSpaces(userId);
+      if (!page.space_key || !spaces.includes(page.space_key)) {
+        throw fastify.httpErrors.forbidden('Access denied to this space');
+      }
+    } else if (page.created_by_user_id !== userId && page.visibility !== 'shared') {
       throw fastify.httpErrors.forbidden('Not authorized to discard this draft');
     }
 

--- a/backend/src/routes/knowledge/pages-draft.test.ts
+++ b/backend/src/routes/knowledge/pages-draft.test.ts
@@ -22,6 +22,11 @@ vi.mock('../../domains/confluence/services/sync-service.js', () => ({
   getClientForUser: (...args: unknown[]) => mockGetClientForUser(...args),
 }));
 
+const mockGetUserAccessibleSpaces = vi.fn();
+vi.mock('../../core/services/rbac-service.js', () => ({
+  getUserAccessibleSpaces: (...args: unknown[]) => mockGetUserAccessibleSpaces(...args),
+}));
+
 vi.mock('../../core/services/content-converter.js', () => ({
   confluenceToHtml: (...args: unknown[]) => mockConfluenceToHtml(...args),
   htmlToConfluence: (...args: unknown[]) => mockHtmlToConfluence(...args),
@@ -109,6 +114,8 @@ describe('Draft-while-published routes', () => {
     vi.clearAllMocks();
     mockHtmlToText.mockReturnValue('plain text');
     mockHtmlToConfluence.mockReturnValue('<p>storage</p>');
+    // Default: user can reach DEV/OPS. Confluence-branch tests override per case.
+    mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
   });
 
   // ---------- PUT /api/pages/:id/draft ----------
@@ -420,7 +427,8 @@ describe('Draft-while-published routes', () => {
               body_html: '<p>live</p>', body_text: 'live',
               body_storage: '<p>storage</p>', source: 'confluence',
               created_by_user_id: null, visibility: 'shared',
-              confluence_id: 'conf-123', draft_body_html: '<p>draft</p>',
+              confluence_id: 'conf-123', space_key: 'DEV',
+              draft_body_html: '<p>draft</p>',
               draft_body_storage: null,
             }],
           });
@@ -589,6 +597,248 @@ describe('Draft-while-published routes', () => {
       const body = response.json();
       expect(body.hasDraft).toBe(false);
       expect(body.draftUpdatedAt).toBeNull();
+    });
+  });
+
+  // ---------- Confluence-page RBAC space access (IDOR fix) ----------
+  // Confluence-sourced drafts must be gated on getUserAccessibleSpaces, exactly
+  // like GET /pages/:id and DELETE /pages/:id. Without this, any authenticated
+  // user could read/overwrite/publish/discard the draft of a page in a space
+  // they have no RBAC assignment in.
+
+  describe('Confluence-page RBAC space access', () => {
+    // PUT /draft — overwrite the draft
+    it('PUT /draft returns 403 for a Confluence page in an inaccessible space', async () => {
+      mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('SELECT id, source')) {
+          return Promise.resolve({
+            rows: [{
+              id: 10, source: 'confluence', created_by_user_id: null,
+              visibility: 'shared', space_key: 'HR', deleted_at: null,
+            }],
+          });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/10/draft',
+        payload: { title: 'Sneaky', bodyHtml: '<p>sneaky draft</p>' },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(mockGetUserAccessibleSpaces).toHaveBeenCalledWith(TEST_USER);
+      // The draft UPDATE must never run.
+      const updateCall = mockQuery.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('draft_body_html = $1'),
+      );
+      expect(updateCall).toBeUndefined();
+    });
+
+    it('PUT /draft saves the draft for a Confluence page in an accessible space', async () => {
+      mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('SELECT id, source')) {
+          return Promise.resolve({
+            rows: [{
+              id: 10, source: 'confluence', created_by_user_id: null,
+              visibility: 'shared', space_key: 'DEV', deleted_at: null,
+            }],
+          });
+        }
+        return Promise.resolve({ rows: [], rowCount: 1 });
+      });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/10/draft',
+        payload: { title: 'OK', bodyHtml: '<p>authorized draft</p>' },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    // GET /draft — read the draft (404, no existence oracle)
+    it('GET /draft returns 404 for a Confluence page in an inaccessible space', async () => {
+      mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+      mockQuery.mockResolvedValue({
+        rows: [{
+          id: 10, source: 'confluence', created_by_user_id: null,
+          visibility: 'shared', space_key: 'HR',
+          draft_body_html: '<p>secret draft</p>', draft_body_text: 'secret',
+          draft_updated_at: new Date(), draft_updated_by: 'someone',
+        }],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/pages/10/draft',
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(mockGetUserAccessibleSpaces).toHaveBeenCalledWith(TEST_USER);
+    });
+
+    it('GET /draft returns the draft for a Confluence page in an accessible space', async () => {
+      mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+      mockQuery.mockResolvedValue({
+        rows: [{
+          id: 10, source: 'confluence', created_by_user_id: null,
+          visibility: 'shared', space_key: 'OPS',
+          draft_body_html: '<p>visible draft</p>', draft_body_text: 'visible',
+          draft_updated_at: new Date('2026-01-01'), draft_updated_by: 'author',
+        }],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/pages/10/draft',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().bodyHtml).toBe('<p>visible draft</p>');
+    });
+
+    // POST /draft/publish — promote the draft to live
+    it('POST /draft/publish returns 403 for a Confluence page in an inaccessible space', async () => {
+      mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+      const txCalls: string[] = [];
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('SELECT id, version, title')) {
+          return Promise.resolve({
+            rows: [{
+              id: 10, version: 3, title: 'Secret Article',
+              body_html: '<p>live</p>', body_text: 'live',
+              body_storage: '<p>storage</p>', source: 'confluence',
+              created_by_user_id: null, visibility: 'shared',
+              confluence_id: 'conf-123', space_key: 'HR',
+              draft_body_html: '<p>draft</p>', draft_body_storage: null,
+            }],
+          });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+      mockTxQuery.mockImplementation((sql: string) => {
+        txCalls.push(sql.trim().substring(0, 30));
+        return Promise.resolve({ rows: [], rowCount: 1 });
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/10/draft/publish',
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(mockGetUserAccessibleSpaces).toHaveBeenCalledWith(TEST_USER);
+      // No content swap may occur for an unauthorized space.
+      expect(txCalls).not.toContain('BEGIN');
+    });
+
+    it('POST /draft/publish publishes for a Confluence page in an accessible space', async () => {
+      mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+      mockGetClientForUser.mockResolvedValue({ updatePage: vi.fn().mockResolvedValue({}) });
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('SELECT id, version, title')) {
+          return Promise.resolve({
+            rows: [{
+              id: 10, version: 3, title: 'Authorized Article',
+              body_html: '<p>live</p>', body_text: 'live',
+              body_storage: '<p>storage</p>', source: 'confluence',
+              created_by_user_id: null, visibility: 'shared',
+              confluence_id: 'conf-123', space_key: 'OPS',
+              draft_body_html: '<p>draft</p>', draft_body_storage: null,
+            }],
+          });
+        }
+        return Promise.resolve({ rows: [], rowCount: 1 });
+      });
+      mockTxQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages/10/draft/publish',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().published).toBe(true);
+    });
+
+    // DELETE /draft — discard the draft
+    it('DELETE /draft returns 403 for a Confluence page in an inaccessible space', async () => {
+      mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('SELECT id, source')) {
+          return Promise.resolve({
+            rows: [{
+              id: 10, source: 'confluence', created_by_user_id: null,
+              visibility: 'shared', space_key: 'HR',
+            }],
+          });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/pages/10/draft',
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(mockGetUserAccessibleSpaces).toHaveBeenCalledWith(TEST_USER);
+      // The discard UPDATE must never run.
+      const updateCall = mockQuery.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('draft_body_html = NULL'),
+      );
+      expect(updateCall).toBeUndefined();
+    });
+
+    it('DELETE /draft discards the draft for a Confluence page in an accessible space', async () => {
+      mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('SELECT id, source')) {
+          return Promise.resolve({
+            rows: [{
+              id: 10, source: 'confluence', created_by_user_id: null,
+              visibility: 'shared', space_key: 'DEV',
+            }],
+          });
+        }
+        return Promise.resolve({ rows: [], rowCount: 1 });
+      });
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/pages/10/draft',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().hasDraft).toBe(false);
+    });
+
+    // A Confluence page with no space_key is unreachable (defensive): treated as denied.
+    it('PUT /draft returns 403 for a Confluence page with a null space_key', async () => {
+      mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('SELECT id, source')) {
+          return Promise.resolve({
+            rows: [{
+              id: 10, source: 'confluence', created_by_user_id: null,
+              visibility: 'shared', space_key: null, deleted_at: null,
+            }],
+          });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/10/draft',
+        payload: { title: 'X', bodyHtml: '<p>x</p>' },
+      });
+
+      expect(response.statusCode).toBe(403);
     });
   });
 });

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       ATTACHMENTS_DIR: /app/data/attachments
       NODE_EXTRA_CA_CERTS: ${CONTAINER_CA_BUNDLE_PATH:-/etc/ssl/certs/ca-certificates.crt}
       MCP_DOCS_URL: ${MCP_DOCS_URL:-http://mcp-docs:3100/mcp}
+      MCP_DOCS_TOKEN: ${MCP_DOCS_TOKEN:-}
     depends_on:
       postgres:
         condition: service_healthy
@@ -99,6 +100,7 @@ services:
       LOG_LEVEL: ${MCP_LOG_LEVEL:-info}
       CACHE_TTL_SECONDS: ${MCP_CACHE_TTL:-3600}
       SEARXNG_URL: ${SEARXNG_URL:-http://searxng:8080}
+      MCP_DOCS_TOKEN: ${MCP_DOCS_TOKEN:-}
     depends_on:
       redis:
         condition: service_healthy

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,7 +71,7 @@
     "@testing-library/react": "^16.1.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.0.3",
-    "@vitejs/plugin-react": "^5.1.4",
+    "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.4",
     "eslint": "^9.27.0",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -80,7 +80,7 @@
     "tailwindcss": "^4.2.1",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.56.1",
-    "vite": "^7.3.2",
+    "vite": "^8.0.16",
     "vitest": "^4.1.4"
   }
 }

--- a/frontend/src/build-config.test.ts
+++ b/frontend/src/build-config.test.ts
@@ -76,25 +76,21 @@ describe('Vite build configuration', () => {
     });
 
     it('only references packages that exist in package.json dependencies', () => {
-      // Extract all quoted package names from the manualChunks section
-      const manualChunksMatch = viteConfigSource.match(
-        /manualChunks:\s*\{([\s\S]*?)\n\s{8}\}/,
-      );
-      expect(manualChunksMatch).not.toBeNull();
+      // vite 8 (Rolldown) dropped the object form of manualChunks, so the
+      // package→chunk mapping now lives in the VENDOR_CHUNKS tuple array.
+      const blockMatch = viteConfigSource.match(/VENDOR_CHUNKS[^=]*=\s*\[([\s\S]*?)\n\];/);
+      expect(blockMatch).not.toBeNull();
 
-      const chunksBlock = manualChunksMatch![1];
-      // Match package names in array values (strings inside square brackets)
-      const packageRefs = [
-        ...chunksBlock.matchAll(/'(@?[a-z][a-z0-9./-]*)'/g),
-      ]
+      const block = blockMatch![1];
+      // Chunk names are the first string of each tuple, identified by the inner
+      // array that follows them: `['chunk-name', [ ... ]]`.
+      const chunkNames = new Set(
+        [...block.matchAll(/\[\s*'([^']+)'\s*,\s*\[/g)].map((m) => m[1]),
+      );
+      // Every other quoted identifier is a package reference; verify it exists.
+      const packageRefs = [...block.matchAll(/'(@?[a-z][a-z0-9./-]*)'/g)]
         .map((m) => m[1])
-        // Filter out chunk names (keys) by only keeping values inside arrays
-        .filter((name) => {
-          // Chunk keys appear as 'key': [...], package refs appear inside [...]
-          // A simple heuristic: chunk keys are followed by a colon
-          const keyPattern = new RegExp(`'${escapeRegex(name)}'\\s*:`);
-          return !keyPattern.test(chunksBlock);
-        });
+        .filter((name) => !chunkNames.has(name));
 
       for (const pkg of packageRefs) {
         expect(deps).toContain(pkg);
@@ -102,7 +98,3 @@ describe('Vite build configuration', () => {
     });
   });
 });
-
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}

--- a/frontend/src/features/pages/DuplicateDetector.test.tsx
+++ b/frontend/src/features/pages/DuplicateDetector.test.tsx
@@ -117,6 +117,7 @@ describe('DuplicateDetector', () => {
         JSON.stringify({
           duplicates: [
             {
+              id: 2,
               confluenceId: 'page-2',
               title: 'Similar Page',
               spaceKey: 'DEV',
@@ -153,6 +154,7 @@ describe('DuplicateDetector', () => {
         JSON.stringify({
           duplicates: [
             {
+              id: 2,
               confluenceId: 'page-2',
               title: 'Similar Page',
               spaceKey: 'DEV',
@@ -181,6 +183,46 @@ describe('DuplicateDetector', () => {
 
     fireEvent.click(screen.getByText('View'));
     expect(mockNavigate).toHaveBeenCalledWith('/pages/page-2');
+  });
+
+  it('navigates via numeric id for standalone duplicates (null confluenceId)', async () => {
+    // Standalone articles have confluenceId === null; the nav target must fall
+    // back to the page's numeric id, not the literal string "null".
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          duplicates: [
+            {
+              id: 77,
+              confluenceId: null,
+              title: 'Standalone Note',
+              spaceKey: '',
+              embeddingDistance: 0.1,
+              titleSimilarity: 0.5,
+              combinedScore: 0.78,
+            },
+          ],
+          pageId: 'page-1',
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(
+      <DuplicateDetector pageId="page-1" pageTitle="Test Page" />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(screen.getByText('Duplicates'));
+    fireEvent.click(screen.getByText('Find Duplicates'));
+
+    await waitFor(() => {
+      expect(screen.getByText('View')).toBeInTheDocument();
+    });
+
+    // View navigates to the numeric id, not the literal "null".
+    fireEvent.click(screen.getByText('View'));
+    expect(mockNavigate).toHaveBeenCalledWith('/pages/77');
   });
 
   it('closes dialog via close button', async () => {

--- a/frontend/src/features/pages/DuplicateDetector.tsx
+++ b/frontend/src/features/pages/DuplicateDetector.tsx
@@ -7,7 +7,11 @@ import { apiFetch } from '../../shared/lib/api';
 import { cn } from '../../shared/lib/cn';
 
 interface DuplicateCandidate {
-  confluenceId: string;
+  // Stable page PK — always present. confluenceId is null for standalone
+  // articles, so navigation falls back to this id (the /pages/:id route
+  // resolves numeric ids too).
+  id: number;
+  confluenceId: string | null;
   title: string;
   spaceKey: string;
   embeddingDistance: number;
@@ -64,12 +68,12 @@ export function DuplicateDetector({ pageId, pageTitle }: DuplicateDetectorProps)
     refetch();
   };
 
-  const handleCompare = (duplicateId: string) => {
+  const handleCompare = (duplicateId: string | number) => {
     setOpen(false);
     navigate(`/pages/${pageId}?compare=${duplicateId}`);
   };
 
-  const handleView = (duplicateId: string) => {
+  const handleView = (duplicateId: string | number) => {
     setOpen(false);
     navigate(`/pages/${duplicateId}`);
   };
@@ -139,9 +143,12 @@ export function DuplicateDetector({ pageId, pageTitle }: DuplicateDetectorProps)
               <div className="space-y-2">
                 {data?.duplicates.map((dup) => {
                   const similarity = Math.round(dup.combinedScore * 100);
+                  // confluenceId is null for standalone articles; fall back to
+                  // the stable page id for keys and navigation targets.
+                  const navId = dup.confluenceId ?? dup.id;
                   return (
                     <div
-                      key={dup.confluenceId}
+                      key={dup.id}
                       className="flex items-center justify-between gap-3 rounded-lg bg-foreground/5 px-4 py-3"
                     >
                       <div className="min-w-0 flex-1">
@@ -161,13 +168,13 @@ export function DuplicateDetector({ pageId, pageTitle }: DuplicateDetectorProps)
                       </div>
                       <div className="flex shrink-0 gap-2">
                         <button
-                          onClick={() => handleCompare(dup.confluenceId)}
+                          onClick={() => handleCompare(navId)}
                           className="flex items-center gap-1 rounded-md border border-border/50 px-2.5 py-1 text-xs hover:bg-foreground/5 transition-colors"
                         >
                           Compare
                         </button>
                         <button
-                          onClick={() => handleView(dup.confluenceId)}
+                          onClick={() => handleView(navId)}
                           className="flex items-center gap-1 rounded-md border border-border/50 px-2.5 py-1 text-xs hover:bg-foreground/5 transition-colors"
                         >
                           <ExternalLink size={10} /> View

--- a/frontend/src/features/search/SearchPage.tsx
+++ b/frontend/src/features/search/SearchPage.tsx
@@ -191,6 +191,10 @@ export function SearchPage() {
     spaceKey: filters.spaceKey,
     page,
     sort,
+    author: filters.author,
+    dateFrom: filters.dateFrom,
+    dateTo: filters.dateTo,
+    labels: filters.labels,
   });
 
   // Display enhanced results if available; fall back to immediate results.

--- a/frontend/src/features/search/SearchPage.tsx
+++ b/frontend/src/features/search/SearchPage.tsx
@@ -190,6 +190,7 @@ export function SearchPage() {
     mode: searchMode,
     spaceKey: filters.spaceKey,
     page,
+    sort,
   });
 
   // Display enhanced results if available; fall back to immediate results.

--- a/frontend/src/shared/components/article/AttachmentsMacroView.test.tsx
+++ b/frontend/src/shared/components/article/AttachmentsMacroView.test.tsx
@@ -18,6 +18,13 @@ vi.mock('lucide-react', () => ({
   Loader2: () => <span data-testid="icon-loader" />,
 }));
 
+// Mock the shared authenticated api helper. The component must use apiFetch
+// (which attaches the Authorization header) rather than a bare fetch().
+const mockApiFetch = vi.fn();
+vi.mock('../../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
 function makeProps(overrides: Partial<NodeViewProps> = {}): NodeViewProps {
   return {
     node: {
@@ -44,27 +51,34 @@ function makeProps(overrides: Partial<NodeViewProps> = {}): NodeViewProps {
 
 describe('AttachmentsMacroView', () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('requests attachments via the authenticated api helper', async () => {
+    mockApiFetch.mockResolvedValue({ attachments: [] });
+
+    render(<AttachmentsMacroView {...makeProps()} />);
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith('/attachments/12345/list');
+    });
   });
 
   it('renders loading state initially', () => {
-    // Never resolve fetch so we stay in loading state
-    vi.spyOn(globalThis, 'fetch').mockImplementation(() => new Promise(() => {}));
+    // Never resolve so we stay in loading state
+    mockApiFetch.mockImplementation(() => new Promise(() => {}));
 
     render(<AttachmentsMacroView {...makeProps()} />);
     expect(screen.getByText('Loading attachments...')).toBeTruthy();
   });
 
   it('renders attachment list after successful fetch', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        attachments: [
-          { filename: 'diagram.png', size: 1024, url: '/api/attachments/12345/diagram.png' },
-          { filename: 'report.pdf', size: 2048576, url: '/api/attachments/12345/report.pdf' },
-        ],
-      }),
-    } as Response);
+    mockApiFetch.mockResolvedValue({
+      attachments: [
+        { filename: 'diagram.png', size: 1024, url: '/api/attachments/12345/diagram.png' },
+        { filename: 'report.pdf', size: 2048576, url: '/api/attachments/12345/report.pdf' },
+      ],
+    });
 
     render(<AttachmentsMacroView {...makeProps()} />);
 
@@ -79,10 +93,7 @@ describe('AttachmentsMacroView', () => {
   });
 
   it('renders empty state when no attachments', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => ({ attachments: [] }),
-    } as Response);
+    mockApiFetch.mockResolvedValue({ attachments: [] });
 
     render(<AttachmentsMacroView {...makeProps()} />);
 
@@ -92,27 +103,21 @@ describe('AttachmentsMacroView', () => {
   });
 
   it('renders error state on fetch failure', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: false,
-      status: 500,
-    } as Response);
+    mockApiFetch.mockRejectedValue(new Error('Failed to load attachments'));
 
     render(<AttachmentsMacroView {...makeProps()} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Failed to load attachments (500)')).toBeTruthy();
+      expect(screen.getByText('Failed to load attachments')).toBeTruthy();
     });
   });
 
   it('renders download links in read-only mode', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        attachments: [
-          { filename: 'doc.txt', size: 100, url: '/api/attachments/12345/doc.txt' },
-        ],
-      }),
-    } as Response);
+    mockApiFetch.mockResolvedValue({
+      attachments: [
+        { filename: 'doc.txt', size: 100, url: '/api/attachments/12345/doc.txt' },
+      ],
+    });
 
     render(<AttachmentsMacroView {...makeProps({ editor: { isEditable: false } as NodeViewProps['editor'] })} />);
 
@@ -124,14 +129,11 @@ describe('AttachmentsMacroView', () => {
   });
 
   it('renders plain text (not links) in edit mode', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        attachments: [
-          { filename: 'doc.txt', size: 100, url: '/api/attachments/12345/doc.txt' },
-        ],
-      }),
-    } as Response);
+    mockApiFetch.mockResolvedValue({
+      attachments: [
+        { filename: 'doc.txt', size: 100, url: '/api/attachments/12345/doc.txt' },
+      ],
+    });
 
     render(<AttachmentsMacroView {...makeProps({ editor: { isEditable: true } as NodeViewProps['editor'] })} />);
 

--- a/frontend/src/shared/components/article/AttachmentsMacroView.tsx
+++ b/frontend/src/shared/components/article/AttachmentsMacroView.tsx
@@ -2,6 +2,7 @@ import { NodeViewWrapper } from '@tiptap/react';
 import { useEffect, useState } from 'react';
 import { File, FileText, FileImage, FileArchive, FileCode, Loader2 } from 'lucide-react';
 import { useParams } from 'react-router-dom';
+import { apiFetch } from '../../lib/api';
 import type { NodeViewProps } from '@tiptap/react';
 
 interface Attachment {
@@ -56,11 +57,9 @@ export function AttachmentsMacroView({ editor }: NodeViewProps) {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(`/api/attachments/${encodeURIComponent(pageId)}/list`);
-        if (!res.ok) {
-          throw new Error(`Failed to load attachments (${res.status})`);
-        }
-        const data = await res.json();
+        const data = await apiFetch<{ attachments?: Attachment[] }>(
+          `/attachments/${encodeURIComponent(pageId)}/list`,
+        );
         if (!cancelled) {
           setAttachments(data.attachments ?? []);
         }

--- a/frontend/src/shared/hooks/use-search.test.ts
+++ b/frontend/src/shared/hooks/use-search.test.ts
@@ -311,4 +311,33 @@ describe('useSearch', () => {
     );
     expect(allHaveSpaceKey).toBe(true);
   });
+
+  it('passes author, date range, and labels→tags to the query URL', async () => {
+    const fetchSpy = mockFetch(makeSearchResponse(), makeSearchResponse({ mode: 'hybrid' }));
+
+    const { result } = renderHook(
+      () => useSearch({
+        query: 'docker',
+        mode: 'hybrid',
+        author: 'jane',
+        dateFrom: '2026-01-01',
+        dateTo: '2026-02-01',
+        labels: 'kb,ops',
+      }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoadingImmediate).toBe(false));
+
+    const searchCalls = fetchSpy.mock.calls.filter(([url]) =>
+      typeof url === 'string' && (url as string).includes('/search'),
+    );
+    expect(searchCalls.length).toBeGreaterThan(0);
+    const url = searchCalls[0][0] as string;
+    expect(url).toContain('author=jane');
+    expect(url).toContain('dateFrom=2026-01-01');
+    expect(url).toContain('dateTo=2026-02-01');
+    // FE field `labels` maps to backend query param `tags` (comma-encoded)
+    expect(url).toContain('tags=kb%2Cops');
+  });
 });

--- a/frontend/src/shared/hooks/use-search.test.ts
+++ b/frontend/src/shared/hooks/use-search.test.ts
@@ -259,6 +259,40 @@ describe('useSearch', () => {
     expect(enhancedCalls).toHaveLength(0);
   });
 
+  it('adds sort to the keyword query URL when sort is not relevance', async () => {
+    const fetchSpy = mockFetch(makeSearchResponse({ mode: 'keyword' }));
+
+    const { result } = renderHook(
+      () => useSearch({ query: 'redis', mode: 'keyword', sort: 'modified' }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoadingImmediate).toBe(false));
+
+    const searchCalls = fetchSpy.mock.calls.filter(([url]) =>
+      typeof url === 'string' && (url as string).includes('/search'),
+    );
+    const url = searchCalls[0][0] as string;
+    expect(url).toContain('sort=modified');
+  });
+
+  it('omits the sort param when sort is relevance (server default)', async () => {
+    const fetchSpy = mockFetch(makeSearchResponse({ mode: 'keyword' }));
+
+    const { result } = renderHook(
+      () => useSearch({ query: 'redis', mode: 'keyword', sort: 'relevance' }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoadingImmediate).toBe(false));
+
+    const searchCalls = fetchSpy.mock.calls.filter(([url]) =>
+      typeof url === 'string' && (url as string).includes('/search'),
+    );
+    const url = searchCalls[0][0] as string;
+    expect(url).not.toContain('sort=');
+  });
+
   it('passes spaceKey to both query URLs', async () => {
     const fetchSpy = mockFetch(makeSearchResponse(), makeSearchResponse({ mode: 'hybrid' }));
 

--- a/frontend/src/shared/hooks/use-search.ts
+++ b/frontend/src/shared/hooks/use-search.ts
@@ -45,6 +45,8 @@ interface UseSearchParams {
   mode: 'keyword' | 'semantic' | 'hybrid';
   spaceKey?: string;
   page?: number;
+  /** Sort order for keyword/immediate results. Semantic & hybrid ignore this (score-ordered server-side). */
+  sort?: 'relevance' | 'modified' | 'title';
 }
 
 interface UseSearchResult {
@@ -81,7 +83,7 @@ const MIN_QUERY_LENGTH = 1;
  * staleTime: 0 on both — search results are query-specific and must not be
  * served from the TanStack Query cache between different search terms.
  */
-export function useSearch({ query, mode, spaceKey, page: requestedPage = 1 }: UseSearchParams): UseSearchResult {
+export function useSearch({ query, mode, spaceKey, page: requestedPage = 1, sort = 'relevance' }: UseSearchParams): UseSearchResult {
   // Debounce the query string
   const [debouncedQuery, setDebouncedQuery] = useState(query);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -105,6 +107,8 @@ export function useSearch({ query, mode, spaceKey, page: requestedPage = 1 }: Us
     sp.set('limit', '10');
     if (pageNum > 1) sp.set('page', String(pageNum));
     if (spaceKey) sp.set('spaceKey', spaceKey);
+    // Sort only affects keyword results — semantic/hybrid are score-ordered server-side.
+    if (searchMode === 'keyword' && sort !== 'relevance') sp.set('sort', sort);
     return `/search?${sp.toString()}`;
   }
 
@@ -114,7 +118,7 @@ export function useSearch({ query, mode, spaceKey, page: requestedPage = 1 }: Us
   const enhancedHasData = useRef(false);
 
   const immediateQuery = useQuery<SearchApiResponse>({
-    queryKey: ['search', 'immediate', trimmedQuery, spaceKey, requestedPage],
+    queryKey: ['search', 'immediate', trimmedQuery, spaceKey, requestedPage, sort],
     queryFn: () => apiFetch<SearchApiResponse>(buildUrl('keyword', requestedPage)),
     enabled: isQueryEnabled && !enhancedHasData.current,
     staleTime: 30_000,

--- a/frontend/src/shared/hooks/use-search.ts
+++ b/frontend/src/shared/hooks/use-search.ts
@@ -47,6 +47,14 @@ interface UseSearchParams {
   page?: number;
   /** Sort order for keyword/immediate results. Semantic & hybrid ignore this (score-ordered server-side). */
   sort?: 'relevance' | 'modified' | 'title';
+  /** Filter to a single author (Confluence display name). */
+  author?: string;
+  /** Inclusive lower bound on last-modified date (YYYY-MM-DD). */
+  dateFrom?: string;
+  /** Inclusive upper bound on last-modified date (YYYY-MM-DD). */
+  dateTo?: string;
+  /** Comma-separated labels; sent to the backend as the `tags` param. */
+  labels?: string;
 }
 
 interface UseSearchResult {
@@ -83,7 +91,7 @@ const MIN_QUERY_LENGTH = 1;
  * staleTime: 0 on both — search results are query-specific and must not be
  * served from the TanStack Query cache between different search terms.
  */
-export function useSearch({ query, mode, spaceKey, page: requestedPage = 1, sort = 'relevance' }: UseSearchParams): UseSearchResult {
+export function useSearch({ query, mode, spaceKey, page: requestedPage = 1, sort = 'relevance', author, dateFrom, dateTo, labels }: UseSearchParams): UseSearchResult {
   // Debounce the query string
   const [debouncedQuery, setDebouncedQuery] = useState(query);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -107,6 +115,11 @@ export function useSearch({ query, mode, spaceKey, page: requestedPage = 1, sort
     sp.set('limit', '10');
     if (pageNum > 1) sp.set('page', String(pageNum));
     if (spaceKey) sp.set('spaceKey', spaceKey);
+    // Filters apply to every mode — the backend ANDs them into the WHERE clause.
+    if (author) sp.set('author', author);
+    if (dateFrom) sp.set('dateFrom', dateFrom);
+    if (dateTo) sp.set('dateTo', dateTo);
+    if (labels) sp.set('tags', labels); // FE field `labels` → backend query param `tags`
     // Sort only affects keyword results — semantic/hybrid are score-ordered server-side.
     if (searchMode === 'keyword' && sort !== 'relevance') sp.set('sort', sort);
     return `/search?${sp.toString()}`;
@@ -118,7 +131,7 @@ export function useSearch({ query, mode, spaceKey, page: requestedPage = 1, sort
   const enhancedHasData = useRef(false);
 
   const immediateQuery = useQuery<SearchApiResponse>({
-    queryKey: ['search', 'immediate', trimmedQuery, spaceKey, requestedPage, sort],
+    queryKey: ['search', 'immediate', trimmedQuery, spaceKey, requestedPage, sort, author, dateFrom, dateTo, labels],
     queryFn: () => apiFetch<SearchApiResponse>(buildUrl('keyword', requestedPage)),
     enabled: isQueryEnabled && !enhancedHasData.current,
     staleTime: 30_000,
@@ -128,7 +141,7 @@ export function useSearch({ query, mode, spaceKey, page: requestedPage = 1, sort
   // ── Phase 2: Enhanced semantic/hybrid results ────────────────────────────
   // Only fires when mode is not 'keyword'
   const enhancedQuery = useQuery<SearchApiResponse>({
-    queryKey: ['search', 'enhanced', trimmedQuery, mode, spaceKey],
+    queryKey: ['search', 'enhanced', trimmedQuery, mode, spaceKey, author, dateFrom, dateTo, labels],
     queryFn: () => apiFetch<SearchApiResponse>(buildUrl(mode as 'semantic' | 'hybrid')),
     enabled: isQueryEnabled && mode !== 'keyword',
     staleTime: 0,

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,4 +1,6 @@
 import '@testing-library/jest-dom';
+import { afterEach, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
 
 // Mock IntersectionObserver for jsdom (used by TableOfContents scroll-spy)
 class MockIntersectionObserver {
@@ -106,3 +108,19 @@ if (!window.matchMedia) {
     }),
   });
 }
+
+// Radix focus-scope schedules a setTimeout(…, 0) in its unmount cleanup that
+// dispatches an event on its container (@radix-ui/react-focus-scope
+// dist/index.mjs:89). If that macrotask fires after jsdom has torn the document
+// down, dispatchEvent gets an invalid target and vitest reports an uncaught
+// TypeError — intermittently reddening a green run (#799). The leak is cross-file.
+// Unmount explicitly, then flush one real macrotask so the focus-scope timer
+// fires while the document is still attached, instead of leaking into teardown.
+// Skip the flush when a test left fake timers active: a faked setTimeout would
+// never resolve (hanging the run), and a faked focus-scope timer can't leak into
+// real teardown anyway.
+afterEach(async () => {
+  cleanup();
+  if (vi.isFakeTimers()) return;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -25,6 +25,39 @@ try {
   // Use defaults; nothing to log since this runs during vite config init.
 }
 
+// Vendor chunk groups. vite 8 (Rolldown) dropped the object form of
+// `manualChunks`, so this is the function form: map a module id to its chunk
+// name by the package directory it lives in. Trailing slashes keep `react`
+// from matching `react-dom` / `react-router-dom`.
+const VENDOR_CHUNKS: Array<[chunk: string, packages: string[]]> = [
+  ['react-vendor', ['react', 'react-dom', 'react-router-dom']],
+  ['query', ['@tanstack/react-query']],
+  ['motion', ['framer-motion']],
+  ['radix-ui', [
+    '@radix-ui/react-collapsible',
+    '@radix-ui/react-dialog',
+    '@radix-ui/react-dropdown-menu',
+    '@radix-ui/react-popover',
+    '@radix-ui/react-switch',
+  ]],
+  ['ui-utils', ['lucide-react', 'clsx', 'tailwind-merge', 'sonner']],
+  ['zustand', ['zustand']],
+  ['recharts', ['recharts']],
+  ['pdf', ['pdf-lib']],
+  // The excel chunk was removed in #303 alongside the exceljs dep.
+];
+
+function manualChunks(id: string): string | undefined {
+  // Rolldown ids are normally posix, but normalize separators so a Windows dev
+  // build matches `/node_modules/<pkg>/` the same way as linux CI.
+  const normalized = id.replace(/\\/g, '/');
+  if (!normalized.includes('/node_modules/')) return undefined;
+  for (const [chunk, packages] of VENDOR_CHUNKS) {
+    if (packages.some((pkg) => normalized.includes(`/node_modules/${pkg}/`))) return chunk;
+  }
+  return undefined;
+}
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   define: {
@@ -56,28 +89,7 @@ export default defineConfig({
     sourcemap: process.env.NODE_ENV !== 'production',
     rollupOptions: {
       output: {
-        manualChunks: {
-          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
-          'query': ['@tanstack/react-query'],
-          'motion': ['framer-motion'],
-          'radix-ui': [
-            '@radix-ui/react-collapsible',
-            '@radix-ui/react-dialog',
-            '@radix-ui/react-dropdown-menu',
-            '@radix-ui/react-popover',
-            '@radix-ui/react-switch',
-          ],
-          'ui-utils': [
-            'lucide-react',
-            'clsx',
-            'tailwind-merge',
-            'sonner',
-          ],
-          'zustand': ['zustand'],
-          'recharts': ['recharts'],
-          'pdf': ['pdf-lib'],
-          // The excel chunk was removed in #303 alongside the exceljs dep.
-        },
+        manualChunks,
       },
     },
     chunkSizeWarningLimit: 600,

--- a/mcp-docs/package-lock.json
+++ b/mcp-docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compendiq-mcp-docs",
-  "version": "0.5.2",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compendiq-mcp-docs",
-      "version": "0.5.2",
+      "version": "0.6.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "express": "^5.1.0",

--- a/mcp-docs/package.json
+++ b/mcp-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq-mcp-docs",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/mcp-docs/src/auth.test.ts
+++ b/mcp-docs/src/auth.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeMcpAuth, MCP_AUTH_HEADER } from './auth.js';
+
+function makeRes() {
+  return {
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) { this.statusCode = code; return this; },
+    json(b: unknown) { this.body = b; return this; },
+  };
+}
+
+describe('makeMcpAuth', () => {
+  it('passes through when no token is configured (backward compatible)', () => {
+    const next = vi.fn();
+    const res = makeRes();
+    makeMcpAuth(undefined)({ headers: {} } as never, res as never, next as never);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(0);
+  });
+
+  it('rejects a missing token with 401 when configured', () => {
+    const next = vi.fn();
+    const res = makeRes();
+    makeMcpAuth('s3cret')({ headers: {} } as never, res as never, next as never);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects a wrong token with 401', () => {
+    const next = vi.fn();
+    const res = makeRes();
+    makeMcpAuth('s3cret')(
+      { headers: { [MCP_AUTH_HEADER]: 'nope' } } as never,
+      res as never,
+      next as never,
+    );
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects a token of a different length with 401 (no length leak crash)', () => {
+    const next = vi.fn();
+    const res = makeRes();
+    makeMcpAuth('s3cret')(
+      { headers: { [MCP_AUTH_HEADER]: 'x' } } as never,
+      res as never,
+      next as never,
+    );
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('allows a correct token', () => {
+    const next = vi.fn();
+    const res = makeRes();
+    makeMcpAuth('s3cret')(
+      { headers: { [MCP_AUTH_HEADER]: 's3cret' } } as never,
+      res as never,
+      next as never,
+    );
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(0);
+  });
+});

--- a/mcp-docs/src/auth.ts
+++ b/mcp-docs/src/auth.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared-secret auth for the /mcp endpoints.
+ *
+ * The sidecar's primary control is Docker network isolation (only the backend
+ * can reach it). This adds defense-in-depth: when MCP_DOCS_TOKEN is set, every
+ * /mcp request must present it in the `x-mcp-docs-token` header. /health stays
+ * open for container probes. When the token is unset the middleware is a
+ * pass-through, so existing deployments keep working unchanged.
+ */
+
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { Request, Response, NextFunction } from 'express';
+import { logger } from './logger.js';
+
+export const MCP_AUTH_HEADER = 'x-mcp-docs-token';
+
+function constantTimeEqual(presented: string, expected: string): boolean {
+  // Compare fixed-length SHA-256 digests: neither the comparison time nor an
+  // early length-mismatch branch can leak anything about the expected token.
+  const a = createHash('sha256').update(presented).digest();
+  const b = createHash('sha256').update(expected).digest();
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Build the Express middleware guarding /mcp. A falsy `token` yields a
+ * pass-through middleware (logs a one-time warning).
+ */
+export function makeMcpAuth(token: string | undefined) {
+  let warned = false;
+  return function mcpAuth(req: Request, res: Response, next: NextFunction): void {
+    if (!token) {
+      if (!warned) {
+        logger.warn('MCP_DOCS_TOKEN not set — /mcp is unauthenticated (relying on network isolation)');
+        warned = true;
+      }
+      next();
+      return;
+    }
+    const presented = (req.headers[MCP_AUTH_HEADER] as string | undefined) ?? '';
+    if (presented && constantTimeEqual(presented, token)) {
+      next();
+      return;
+    }
+    res.status(401).json({ error: 'Unauthorized' });
+  };
+}

--- a/mcp-docs/src/cache/redis-cache.test.ts
+++ b/mcp-docs/src/cache/redis-cache.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DocsCache, type CachedDoc } from './redis-cache.js';
+
+function makeDoc(url: string, title: string): CachedDoc {
+  return { markdown: '# ' + title, title, url, fetchedAt: '2026-06-14T00:00:00Z', contentLength: 4 };
+}
+
+describe('DocsCache.listCachedDocs', () => {
+  it('skips a corrupted cache entry instead of aborting the whole list', async () => {
+    const good = makeDoc('https://a.example/doc', 'Alpha');
+    const store: Record<string, string> = {
+      'mcp:docs:url:1': JSON.stringify(good),
+      'mcp:docs:url:2': '{not valid json', // corrupted
+      'mcp:docs:url:3': JSON.stringify(makeDoc('https://b.example/doc', 'Beta')),
+    };
+    const fakeRedis = {
+      scan: vi.fn().mockResolvedValue({ cursor: 0, keys: Object.keys(store) }),
+      get: vi.fn(async (k: string) => store[k] ?? null),
+    } as unknown as ConstructorParameters<typeof DocsCache>[0];
+
+    const cache = new DocsCache(fakeRedis);
+    const docs = await cache.listCachedDocs();
+
+    // Both well-formed docs are returned; the corrupted one is skipped (not a throw).
+    expect(docs.map((d) => d.title).sort()).toEqual(['Alpha', 'Beta']);
+  });
+
+  it('returns [] when redis is unavailable', async () => {
+    const cache = new DocsCache(null);
+    await expect(cache.listCachedDocs()).resolves.toEqual([]);
+  });
+});

--- a/mcp-docs/src/cache/redis-cache.ts
+++ b/mcp-docs/src/cache/redis-cache.ts
@@ -87,11 +87,18 @@ export class DocsCache {
         cursor = String(result.cursor);
         for (const key of result.keys) {
           const raw = await this.redis.get(key);
-          if (raw) {
-            const doc = JSON.parse(raw) as CachedDoc;
-            if (!filter || doc.url.includes(filter) || doc.title.toLowerCase().includes(filter.toLowerCase())) {
-              docs.push(doc);
-            }
+          if (!raw) continue;
+          // Skip a single corrupted entry rather than letting it abort the whole
+          // scan (the outer catch would otherwise truncate the list).
+          let doc: CachedDoc;
+          try {
+            doc = JSON.parse(raw) as CachedDoc;
+          } catch (err) {
+            logger.warn({ err, key }, 'Skipping corrupted cache entry');
+            continue;
+          }
+          if (!filter || doc.url.includes(filter) || doc.title.toLowerCase().includes(filter.toLowerCase())) {
+            docs.push(doc);
           }
         }
       } while (cursor !== '0');

--- a/mcp-docs/src/config.test.ts
+++ b/mcp-docs/src/config.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { parsePort, parseCacheTtl, DEFAULT_CACHE_TTL } from './config.js';
+
+describe('parsePort', () => {
+  it('parses a valid port', () => {
+    expect(parsePort('3100')).toBe(3100);
+    expect(parsePort('1')).toBe(1);
+    expect(parsePort('65535')).toBe(65535);
+  });
+
+  it('uses the fallback when unset', () => {
+    expect(parsePort(undefined)).toBe(3100);
+    expect(parsePort(undefined, '8080')).toBe(8080);
+  });
+
+  it('returns null for a non-numeric value (would NaN -> random port otherwise)', () => {
+    expect(parsePort('not-a-number')).toBe(null);
+    expect(parsePort('')).toBe(null);
+    expect(parsePort('   ')).toBe(null);
+    expect(parsePort('abc')).toBe(null);
+  });
+
+  it('parseInt leniency: a trailing-garbage value keeps the leading integer', () => {
+    // parseInt('3100x', 10) === 3100 — not NaN. Documenting the boundary so it
+    // is clear the guard fails fast only on a genuinely non-numeric value.
+    expect(parsePort('3100x')).toBe(3100);
+  });
+
+  it('returns null for out-of-range ports', () => {
+    expect(parsePort('0')).toBe(null);
+    expect(parsePort('-1')).toBe(null);
+    expect(parsePort('65536')).toBe(null);
+    expect(parsePort('99999')).toBe(null);
+  });
+});
+
+describe('parseCacheTtl', () => {
+  it('parses a valid TTL', () => {
+    expect(parseCacheTtl('60')).toBe(60);
+    expect(parseCacheTtl('7200')).toBe(7200);
+  });
+
+  it('falls back to the default when unset', () => {
+    expect(parseCacheTtl(undefined)).toBe(DEFAULT_CACHE_TTL);
+  });
+
+  it('falls back to the default for non-numeric or non-positive values (no NaN)', () => {
+    expect(parseCacheTtl('not-a-number')).toBe(DEFAULT_CACHE_TTL);
+    expect(parseCacheTtl('')).toBe(DEFAULT_CACHE_TTL);
+    expect(parseCacheTtl('0')).toBe(DEFAULT_CACHE_TTL);
+    expect(parseCacheTtl('-5')).toBe(DEFAULT_CACHE_TTL);
+  });
+});

--- a/mcp-docs/src/config.ts
+++ b/mcp-docs/src/config.ts
@@ -1,0 +1,30 @@
+/**
+ * Environment parsing for the MCP docs sidecar.
+ *
+ * Numeric env vars are parsed with explicit NaN/range guards so a malformed
+ * value fails fast (PORT) or falls back (CACHE_TTL) instead of silently
+ * binding a random ephemeral port or using a NaN TTL.
+ */
+
+export const DEFAULT_CACHE_TTL = 3600;
+
+/**
+ * Parse and validate a TCP port. Returns the port when it is an integer in
+ * 1..65535, otherwise null (caller should treat that as fatal).
+ */
+export function parsePort(raw: string | undefined, fallback = '3100'): number | null {
+  const port = parseInt(raw ?? fallback, 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    return null;
+  }
+  return port;
+}
+
+/**
+ * Parse a cache TTL in seconds, falling back to {@link DEFAULT_CACHE_TTL} when
+ * the value is unset, non-numeric, or non-positive.
+ */
+export function parseCacheTtl(raw: string | undefined): number {
+  const ttl = parseInt(raw ?? String(DEFAULT_CACHE_TTL), 10);
+  return Number.isInteger(ttl) && ttl > 0 ? ttl : DEFAULT_CACHE_TTL;
+}

--- a/mcp-docs/src/index.ts
+++ b/mcp-docs/src/index.ts
@@ -18,6 +18,7 @@ import { fetchUrl } from './tools/fetch-url.js';
 import { searchWeb } from './tools/search-web.js';
 import { listCached } from './tools/list-cached.js';
 import { logger } from './logger.js';
+import { parsePort, parseCacheTtl } from './config.js';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -27,10 +28,20 @@ const APP_VERSION: string = JSON.parse(
   readFileSync(resolve(__dirname, '../package.json'), 'utf-8'),
 ).version;
 
-const PORT = parseInt(process.env.PORT ?? '3100', 10);
+// A malformed PORT (e.g. empty-but-set, or non-numeric) parses to NaN;
+// app.listen(NaN) would silently bind a random ephemeral port instead of
+// failing. Fail fast. (Narrow null -> number for use inside start()'s closure.)
+const parsedPort = parsePort(process.env.PORT);
+if (parsedPort === null) {
+  logger.fatal({ port: process.env.PORT }, 'Invalid PORT — must be an integer in 1..65535');
+  process.exit(1);
+}
+const PORT: number = parsedPort;
+
 const HOST = process.env.MCP_DOCS_HOST ?? '127.0.0.1';
 const REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379';
-const CACHE_TTL = parseInt(process.env.CACHE_TTL_SECONDS ?? '3600', 10);
+// CACHE_TTL is non-fatal: falls back to the default when unset/malformed.
+const CACHE_TTL = parseCacheTtl(process.env.CACHE_TTL_SECONDS);
 
 // ── Redis connection ────────────────────────────────────────────────────
 

--- a/mcp-docs/src/index.ts
+++ b/mcp-docs/src/index.ts
@@ -18,6 +18,7 @@ import { fetchUrl } from './tools/fetch-url.js';
 import { searchWeb } from './tools/search-web.js';
 import { listCached } from './tools/list-cached.js';
 import { logger } from './logger.js';
+import { makeMcpAuth } from './auth.js';
 import { parsePort, parseCacheTtl } from './config.js';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -40,6 +41,8 @@ const PORT: number = parsedPort;
 
 const HOST = process.env.MCP_DOCS_HOST ?? '127.0.0.1';
 const REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379';
+// Optional shared secret; when set, /mcp requires it in the x-mcp-docs-token header.
+const MCP_DOCS_TOKEN = process.env.MCP_DOCS_TOKEN;
 // CACHE_TTL is non-fatal: falls back to the default when unset/malformed.
 const CACHE_TTL = parseCacheTtl(process.env.CACHE_TTL_SECONDS);
 
@@ -204,6 +207,10 @@ setInterval(() => {
 }, SESSION_REAP_INTERVAL_MS).unref();
 
 const app = express();
+
+// Shared-secret guard on /mcp (all methods) — registered BEFORE express.json so
+// an unauthenticated request's body is never parsed. /health below stays open.
+app.use('/mcp', makeMcpAuth(MCP_DOCS_TOKEN));
 app.use(express.json());
 
 // MCP endpoint

--- a/mcp-docs/src/security/ssrf-guard.test.ts
+++ b/mcp-docs/src/security/ssrf-guard.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect } from 'vitest';
-import { validateUrl, SsrfError } from './ssrf-guard.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { lookup } from 'node:dns/promises';
+import { validateUrl, validateUrlWithDns, SsrfError } from './ssrf-guard.js';
+
+// ESM named exports can't be spied with vi.spyOn, so mock the module. The
+// hoisted factory replaces dns.promises.lookup with a controllable mock fn.
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(),
+}));
+
+const lookupMock = vi.mocked(lookup);
 
 describe('ssrf-guard', () => {
   it('allows valid public URLs', () => {
@@ -61,5 +70,64 @@ describe('ssrf-guard', () => {
     const parsed = validateUrl('https://docs.example.com/api?q=test');
     expect(parsed.hostname).toBe('docs.example.com');
     expect(parsed.protocol).toBe('https:');
+  });
+});
+
+describe('validateUrlWithDns — DNS-resolving guard', () => {
+  beforeEach(() => {
+    lookupMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('blocks a public hostname whose A record points at cloud metadata', async () => {
+    // Classic SSRF: attacker-controlled domain resolves to the metadata IP.
+    lookupMock.mockResolvedValue([{ address: '169.254.169.254', family: 4 }] as never);
+
+    await expect(validateUrlWithDns('https://evil.example.com')).rejects.toThrow(SsrfError);
+    await expect(validateUrlWithDns('https://evil.example.com')).rejects.toThrow(/169\.254\.169\.254/);
+  });
+
+  it('blocks a public hostname that resolves to loopback', async () => {
+    lookupMock.mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+    await expect(validateUrlWithDns('https://rebind.example.com')).rejects.toThrow(SsrfError);
+  });
+
+  it('blocks a public hostname that resolves to an RFC1918 address', async () => {
+    lookupMock.mockResolvedValue([{ address: '10.1.2.3', family: 4 }] as never);
+    await expect(validateUrlWithDns('https://internal.example.com')).rejects.toThrow(SsrfError);
+  });
+
+  it('blocks when ANY resolved address is private (mixed A records)', async () => {
+    lookupMock.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 }, // public
+      { address: '192.168.1.5', family: 4 },   // private — must trip the guard
+    ] as never);
+    await expect(validateUrlWithDns('https://multi.example.com')).rejects.toThrow(SsrfError);
+  });
+
+  it('blocks a public hostname that resolves to an IPv6 ULA', async () => {
+    lookupMock.mockResolvedValue([{ address: 'fd00::1', family: 6 }] as never);
+    await expect(validateUrlWithDns('https://v6.example.com')).rejects.toThrow(SsrfError);
+  });
+
+  it('allows a public hostname that resolves to a public address', async () => {
+    lookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
+    const parsed = await validateUrlWithDns('https://docs.example.com/api');
+    expect(parsed.hostname).toBe('docs.example.com');
+  });
+
+  it('still enforces the sync checks before resolving (literal private IP)', async () => {
+    await expect(validateUrlWithDns('http://169.254.169.254')).rejects.toThrow(SsrfError);
+    // Literal-IP URLs are rejected by the sync pass — no DNS lookup needed.
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('does not block when DNS resolution fails (handled by the HTTP client later)', async () => {
+    lookupMock.mockRejectedValue(Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' }));
+    const parsed = await validateUrlWithDns('https://does-not-resolve.example.com');
+    expect(parsed.hostname).toBe('does-not-resolve.example.com');
   });
 });

--- a/mcp-docs/src/security/ssrf-guard.ts
+++ b/mcp-docs/src/security/ssrf-guard.ts
@@ -4,6 +4,8 @@
  * Adapted from backend/src/core/utils/ssrf-guard.ts
  */
 
+import { lookup } from 'node:dns/promises';
+
 const BLOCKED_IPV4_PATTERNS = [
   /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,
   /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,
@@ -62,6 +64,46 @@ export function validateUrl(urlString: string): URL {
 
   if (BLOCKED_SUFFIXES.some((s) => hostname.endsWith(s))) {
     throw new SsrfError('SSRF blocked: internal domain suffix');
+  }
+
+  return parsed;
+}
+
+/**
+ * DNS-resolving SSRF validation. Runs the sync `validateUrl()` checks first,
+ * then resolves the hostname (A + AAAA) and runs EVERY resolved address back
+ * through the private-IP blocklist. This closes the bypass where a publicly
+ * registered hostname resolves to an internal address (e.g. 169.254.169.254
+ * cloud metadata, 127.0.0.1, a Docker-internal service, or a DNS-rebinding
+ * domain) — the literal-string checks in validateUrl() never see that IP.
+ *
+ * NOTE: a TOCTOU gap remains between this lookup and the TCP connect; callers
+ * that follow redirects must re-validate each hop (fetch-url.ts uses
+ * redirect: 'manual' and rejects 3xx, so the connect target is fixed here).
+ *
+ * @throws SsrfError if the URL is malformed, non-HTTP(S), or any resolved
+ *   address is private/internal.
+ */
+export async function validateUrlWithDns(urlString: string): Promise<URL> {
+  // All sync syntax/protocol/literal-IP/hostname checks first.
+  const parsed = validateUrl(urlString);
+
+  // Resolve A + AAAA records and reject if ANY resolved address is private.
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await lookup(parsed.hostname, { all: true });
+  } catch {
+    // DNS failures (ENOTFOUND, etc.) are surfaced by the HTTP client later;
+    // a name that does not resolve cannot reach an internal address here.
+    return parsed;
+  }
+
+  for (const { address } of addresses) {
+    if (isBlockedIpv4(address) || isBlockedIpv6(address)) {
+      throw new SsrfError(
+        `SSRF blocked: '${parsed.hostname}' resolved to private IP ${address}`,
+      );
+    }
   }
 
   return parsed;

--- a/mcp-docs/src/tools/fetch-url.test.ts
+++ b/mcp-docs/src/tools/fetch-url.test.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ReadableStream } from 'node:stream/web';
+import { lookup } from 'node:dns/promises';
 import { fetchUrl } from './fetch-url.js';
 import { DocsCache, type CachedDoc } from '../cache/redis-cache.js';
 import * as auditLogger from '../security/audit-logger.js';
+
+// fetchUrl now runs validateUrlWithDns(), which resolves the hostname. Mock the
+// dns module (ESM named exports can't be spied) and point every lookup at a
+// public address so these tests stay hermetic and exercise the post-validation
+// paths rather than network resolution.
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async () => [{ address: '93.184.216.34', family: 4 }]),
+}));
 
 const TEST_URL = 'https://docs.example.com/api';
 
@@ -11,6 +20,7 @@ describe('fetchUrl — slice truncation (cached path)', () => {
   let auditSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    vi.mocked(lookup).mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
     auditSpy = vi.spyOn(auditLogger, 'logOutboundRequest').mockImplementation(() => {});
     getCachedDocSpy = vi.spyOn(DocsCache.prototype, 'getCachedDoc');
   });
@@ -84,6 +94,7 @@ describe('fetchUrl — response body size cap (uncached path)', () => {
   let getCachedDocSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    vi.mocked(lookup).mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
     fetchSpy = vi.spyOn(globalThis, 'fetch');
     auditSpy = vi.spyOn(auditLogger, 'logOutboundRequest').mockImplementation(() => {});
     // Force cache miss so the fetch path runs
@@ -175,6 +186,7 @@ describe('fetchUrl — streaming reader (chunked, no Content-Length)', () => {
   let getCachedDocSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    vi.mocked(lookup).mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
     fetchSpy = vi.spyOn(globalThis, 'fetch');
     auditSpy = vi.spyOn(auditLogger, 'logOutboundRequest').mockImplementation(() => {});
     getCachedDocSpy = vi.spyOn(DocsCache.prototype, 'getCachedDoc').mockResolvedValue(null);

--- a/mcp-docs/src/tools/fetch-url.ts
+++ b/mcp-docs/src/tools/fetch-url.ts
@@ -6,7 +6,7 @@
 import { JSDOM } from 'jsdom';
 import TurndownService from 'turndown';
 import type { RedisClientType } from 'redis';
-import { validateUrl } from '../security/ssrf-guard.js';
+import { validateUrlWithDns } from '../security/ssrf-guard.js';
 import { getDomainConfig, isDomainAllowed } from '../security/domain-filter.js';
 import { logOutboundRequest } from '../security/audit-logger.js';
 import { DocsCache, type CachedDoc } from '../cache/redis-cache.js';
@@ -45,8 +45,11 @@ export async function fetchUrl(
   const maxLength = Math.min(options.maxLength ?? DEFAULT_MAX_LENGTH, ABSOLUTE_MAX_LENGTH);
   const startIndex = options.startIndex ?? 0;
 
-  // 1. Validate URL (SSRF protection)
-  const parsed = validateUrl(url);
+  // 1. Validate URL (SSRF protection). DNS-resolving variant rejects a public
+  // hostname whose A/AAAA record points at an internal address — not just
+  // literal private-IP URLs. Redirects are blocked below (redirect: 'manual'),
+  // so the validated host is also the host actually connected to.
+  const parsed = await validateUrlWithDns(url);
 
   // 2. Check domain filter
   const domainConfig = await getDomainConfig(redis);

--- a/mcp-docs/src/tools/search-web.test.ts
+++ b/mcp-docs/src/tools/search-web.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { searchWeb } from './search-web.js';
+import { DocsCache } from '../cache/redis-cache.js';
+
+describe('searchWeb error signaling', () => {
+  let setCachedSearchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.spyOn(DocsCache.prototype, 'getCachedSearch').mockResolvedValue(null);
+    setCachedSearchSpy = vi
+      .spyOn(DocsCache.prototype, 'setCachedSearch')
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('throws on a network failure and does NOT cache it', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    await expect(searchWeb('hello world', null, {})).rejects.toThrow(/unavailable/);
+    expect(setCachedSearchSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws on a non-2xx response and does NOT cache it', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    await expect(searchWeb('hello world', null, {})).rejects.toThrow(/unavailable/);
+    expect(setCachedSearchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns [] and caches a genuinely-empty successful response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    }));
+    const out = await searchWeb('hello world', null, {});
+    expect(out).toEqual([]);
+    expect(setCachedSearchSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/mcp-docs/src/tools/search-web.ts
+++ b/mcp-docs/src/tools/search-web.ts
@@ -46,7 +46,7 @@ export async function searchWeb(
   searchUrl.searchParams.set('format', 'json');
   searchUrl.searchParams.set('categories', 'general');
 
-  let results: SearchResult[] = [];
+  let results: SearchResult[];
 
   try {
     const response = await fetch(searchUrl.toString(), {
@@ -69,12 +69,18 @@ export async function searchWeb(
       snippet: r.content ?? '',
     }));
   } catch (err) {
-    logger.warn({ err, query: sanitized }, 'SearXNG search failed');
-    // Return empty results rather than failing the tool call
-    results = [];
+    // Surface backend failures (timeout / non-2xx / DNS / parse) instead of
+    // masking them as an empty result set — and do NOT cache the failure, so a
+    // transient SearXNG outage isn't pinned for the cache TTL and a
+    // misconfigured SEARXNG_URL stays distinguishable from a genuine no-results
+    // (#798). The tool wrapper maps this to an isError MCP response.
+    logger.warn({ err, query: sanitized }, 'SearXNG search backend unavailable');
+    throw new Error(
+      `search backend unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
-  // 4. Cache results
+  // 4. Cache successful responses only — a genuinely-empty result set is cacheable.
   await cache.setCachedSearch(sanitized, {
     results, query: sanitized, fetchedAt: new Date().toISOString(),
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compendiq",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compendiq",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "workspaces": [
         "backend",
         "frontend",
@@ -29,7 +29,7 @@
       }
     },
     "backend": {
-      "version": "0.5.2",
+      "version": "0.6.0",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@fastify/compress": "^8.3.1",
@@ -104,7 +104,7 @@
       "license": "MIT"
     },
     "frontend": {
-      "version": "0.5.2",
+      "version": "0.6.0",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@dnd-kit/react": "^0.3.2",
@@ -1468,6 +1468,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1485,6 +1486,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1502,6 +1504,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1519,6 +1522,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1536,6 +1540,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1553,6 +1558,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1570,6 +1576,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1587,6 +1594,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1604,6 +1612,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1621,6 +1630,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1638,6 +1648,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1655,6 +1666,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1672,6 +1684,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1689,6 +1702,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1706,6 +1720,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1723,6 +1738,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1740,6 +1756,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1757,6 +1774,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1774,6 +1792,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1791,6 +1810,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1808,6 +1828,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1825,6 +1846,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1842,6 +1864,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1859,6 +1882,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1876,6 +1900,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1893,6 +1918,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6627,270 +6653,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
-    },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.4",
@@ -15553,6 +15315,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15574,6 +15337,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15595,6 +15359,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15616,6 +15381,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15637,6 +15403,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15658,6 +15425,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15679,6 +15447,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15700,6 +15469,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15721,6 +15491,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15742,6 +15513,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15763,6 +15535,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -19200,40 +18973,6 @@
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
-    "node_modules/rolldown": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.130.0",
-        "@rolldown/pluginutils": "^1.0.0"
-      },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.1",
-        "@rolldown/binding-darwin-arm64": "1.0.1",
-        "@rolldown/binding-darwin-x64": "1.0.1",
-        "@rolldown/binding-freebsd-x64": "1.0.1",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
-        "@rolldown/binding-linux-arm64-musl": "1.0.1",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-musl": "1.0.1",
-        "@rolldown/binding-openharmony-arm64": "1.0.1",
-        "@rolldown/binding-wasm32-wasi": "1.0.1",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
-        "@rolldown/binding-win32-x64-msvc": "1.0.1"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
@@ -20390,6 +20129,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -20875,17 +20615,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
-        "rolldown": "1.0.1",
-        "tinyglobby": "^0.2.16"
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -20901,10 +20642,9 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
-        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -20917,16 +20657,13 @@
         "@types/node": {
           "optional": true
         },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
         "jiti": {
           "optional": true
         },
         "less": {
+          "optional": true
+        },
+        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -20950,6 +20687,490 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/vite/node_modules/fsevents": {
@@ -21575,7 +21796,7 @@
     },
     "packages/contracts": {
       "name": "@compendiq/contracts",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "dependencies": {
         "zod": "^4.3.6"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compendiq",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compendiq",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "workspaces": [
         "backend",
         "frontend",
@@ -29,7 +29,7 @@
       }
     },
     "backend": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@fastify/compress": "^8.3.1",
@@ -104,7 +104,7 @@
       "license": "MIT"
     },
     "frontend": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@dnd-kit/react": "^0.3.2",
@@ -20189,7 +20189,7 @@
     },
     "packages/contracts": {
       "name": "@compendiq/contracts",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "zod": "^4.3.6"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,7 +162,7 @@
         "@testing-library/react": "^16.1.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.0.3",
-        "@vitejs/plugin-react": "^5.1.4",
+        "@vitejs/plugin-react": "^6.0.2",
         "@vitest/coverage-v8": "^4.1.4",
         "eslint": "^9.27.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -171,503 +171,8 @@
         "tailwindcss": "^4.2.1",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.56.1",
-        "vite": "^7.3.2",
+        "vite": "^8.0.16",
         "vitest": "^4.1.4"
-      }
-    },
-    "frontend/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "frontend/node_modules/esbuild": {
-      "version": "0.27.7",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
-    "frontend/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "frontend/node_modules/marked": {
@@ -678,79 +183,6 @@
       },
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "frontend/node_modules/vite": {
-      "version": "7.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
       }
     },
     "node_modules/@acemir/cssom": {
@@ -854,163 +286,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -1031,30 +306,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/parser": {
       "version": "7.29.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
@@ -1071,78 +322,12 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
-        "debug": "^4.3.1"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1456,9 +641,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1474,9 +659,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -1492,9 +677,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -1510,9 +695,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -1528,9 +713,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1546,9 +731,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -1564,9 +749,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -1582,9 +767,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -1600,9 +785,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -1618,9 +803,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -1636,9 +821,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -1654,9 +839,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -1672,9 +857,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -1690,9 +875,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1708,9 +893,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1726,9 +911,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -1744,9 +929,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -1762,9 +947,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -1780,9 +965,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -1798,9 +983,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1816,9 +1001,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -1834,9 +1019,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -1852,9 +1037,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -1870,9 +1055,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -1888,9 +1073,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1906,9 +1091,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -6654,24 +5839,10 @@
         "url": "https://opencollective.com/immer"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
-      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
-      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -6680,12 +5851,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
-      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -6694,12 +5868,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
-      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -6708,26 +5885,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
-      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
-      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -6736,12 +5902,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
-      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -6750,26 +5919,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
-      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
-      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -6778,12 +5936,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
-      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -6792,40 +5953,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
-      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
-      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
-      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -6834,54 +5970,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
-      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
-      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
-      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
-      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -6890,12 +5987,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -6904,12 +6004,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
-      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -6918,26 +6021,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
-      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
-      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -6946,12 +6038,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
-      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -6960,26 +6074,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
-      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -6988,21 +6091,17 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
-      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "license": "MIT"
     },
     "node_modules/@sentry-internal/tracing": {
       "version": "7.120.4",
@@ -8158,51 +7257,6 @@
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
       "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
       "license": "MIT"
-    },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
     },
     "node_modules/@types/bcrypt": {
       "version": "6.0.0",
@@ -9363,32 +8417,30 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
-      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
+      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.29.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-rc.3",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.18.0"
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/@vitejs/plugin-react/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
-      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.6",
@@ -9966,19 +9018,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.10.31",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
-      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/basic-ftp": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
@@ -10092,40 +9131,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/buffer": {
@@ -10254,27 +9259,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
     },
     "node_modules/canvas-color-tracker": {
       "version": "1.3.2",
@@ -11851,13 +10835,6 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.360",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
-      "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -11994,9 +10971,9 @@
       ]
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -12007,32 +10984,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -13319,16 +12296,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -14713,19 +13680,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -14796,19 +13750,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/kapsule": {
       "version": "1.16.3",
@@ -15315,7 +14256,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15337,7 +14277,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15359,7 +14298,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15381,7 +14319,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15403,7 +14340,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15425,7 +14361,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15447,7 +14382,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15469,7 +14403,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15491,7 +14424,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15513,7 +14445,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15535,7 +14466,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17074,13 +16004,6 @@
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
-    "node_modules/node-releases": {
-      "version": "2.0.44",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
-      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/nodemailer": {
       "version": "8.0.7",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
@@ -18498,16 +17421,6 @@
         }
       }
     },
-    "node_modules/react-refresh": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
-      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
@@ -18973,49 +17886,48 @@
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
-    "node_modules/rollup": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
-      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.4",
-        "@rollup/rollup-android-arm64": "4.60.4",
-        "@rollup/rollup-darwin-arm64": "4.60.4",
-        "@rollup/rollup-darwin-x64": "4.60.4",
-        "@rollup/rollup-freebsd-arm64": "4.60.4",
-        "@rollup/rollup-freebsd-x64": "4.60.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
-        "@rollup/rollup-linux-arm64-musl": "4.60.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
-        "@rollup/rollup-linux-loong64-musl": "4.60.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-musl": "4.60.4",
-        "@rollup/rollup-openbsd-x64": "4.60.4",
-        "@rollup/rollup-openharmony-arm64": "4.60.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
-        "@rollup/rollup-win32-x64-gnu": "4.60.4",
-        "@rollup/rollup-win32-x64-msvc": "4.60.4",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/rolldown/node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/rope-sequence": {
@@ -19920,9 +18832,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20434,37 +19346,6 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
-    "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -20615,18 +19496,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
-      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -20642,9 +19522,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -20657,13 +19538,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -20687,490 +19571,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/vite/node_modules/fsevents": {
@@ -21575,13 +19975,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "vitest": "^4.0.18"
   },
   "overrides": {
+    "vite": "^7.3.3",
     "protobufjs": "^7.5.5",
     "@fastify/static": "^9.1.1",
     "fast-uri": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "vitest": "^4.0.18"
   },
   "overrides": {
-    "vite": "^7.3.3",
+    "vite": "^8.0.16",
     "protobufjs": "^7.5.5",
     "@fastify/static": "^9.1.1",
     "fast-uri": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Compendiq - AI-powered knowledge base management with Confluence integration and Ollama LLM backend",
   "workspaces": [

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compendiq/contracts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -7,6 +7,7 @@ export * from './schemas/spaces.js';
 export * from './schemas/llm.js';
 export * from './schemas/admin.js';
 export * from './schemas/admin-users.js';
+export * from './schemas/notifications.js';
 export * from './schemas/templates.js';
 export * from './schemas/license.js';
 export * from './schemas/ip-allowlist.js';

--- a/packages/contracts/src/schemas/notifications.ts
+++ b/packages/contracts/src/schemas/notifications.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+/**
+ * Query schema for GET /api/notifications.
+ * Mirrors the admin pagination convention: limit is coerced and capped at 100,
+ * offset is coerced and non-negative, both with sane defaults.
+ */
+export const NotificationListQuerySchema = z.object({
+  unread: z.enum(['true', 'false']).optional(),
+  type: z.string().max(64).optional(),
+  limit: z.coerce.number().int().positive().max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export type NotificationListQuery = z.infer<typeof NotificationListQuerySchema>;
+
+/**
+ * Body schema for PUT /api/notification-preferences.
+ */
+export const NotificationPreferenceUpdateSchema = z.object({
+  type: z.string().min(1),
+  inApp: z.boolean().optional(),
+  email: z.boolean().optional(),
+});
+
+export type NotificationPreferenceUpdate = z.infer<typeof NotificationPreferenceUpdateSchema>;


### PR DESCRIPTION
Patch release of everything merged to `dev` since v0.6.0 (8 commits).

**Highlights** (full notes in `CHANGELOG.md`):
- Deep-review security & correctness fixes (#797)
- Search filters wired; mcp-docs `/mcp` shared-secret auth; `search_web` error signaling; correlation-id/circuit-breaker/ssrf/mcp-docs-settings hardening (#803)
- Vite 7→8 + plugin-react 6 (#801, #804)
- Flaky-test fixes: Radix focus-scope timer (#802), rag-service deadlock (#806)
- Defense-in-depth NaN guards + cache robustness (#807)

Versions bumped to 0.6.1 across root, backend, frontend, packages/contracts, mcp-docs.

On merge: tag `v0.6.1` (CI publishes `ghcr.io/compendiq/compendiq-ce-{backend,frontend,searxng,mcp-docs}:0.6.1`), create the GitHub release, then back-merge `main → dev`.