### PR TITLE
chore: back-merge main into dev (adopt 0.6.1 + CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-15
+
+> Patch release: deep-review follow-ups, the Vite 8 build upgrade, and test/flake hardening.
+
+### Added
+
+- Search results now apply the **Author / Date-range / Labels** filters — they were collected in the UI but never sent to the API. (#803)
+- Optional shared-secret auth (`MCP_DOCS_TOKEN`, constant-time compared) on the mcp-docs sidecar's `/mcp` endpoints, as defense-in-depth on top of Docker network isolation; `/health` stays open. (#803)
+
+### Changed
+
+- Frontend build upgraded to **Vite 8** (with `@vitejs/plugin-react` 6); `build.rollupOptions.output.manualChunks` migrated to Rolldown's function form. Lifts the temporary Vite 7 pin. (#801, #804)
+
+### Fixed
+
+- Deep-review security & correctness fixes across the backend. (#797)
+- `search_web` now surfaces a SearXNG backend failure (timeout / non-2xx / DNS / parse) instead of silently returning **and caching** empty results, so a misconfigured `SEARXNG_URL` is distinguishable from a genuine no-results. (#803)
+- Bounded the inbound `x-correlation-id` length; the LLM circuit breaker admits a single in-flight probe in `HALF_OPEN`; mcp-docs domain-list settings fall back per-field instead of disabling the feature on one corrupt value; SSRF guard validates all resolved IPs. (#803)
+- Stabilised two flaky tests: a Radix focus-scope timer firing after jsdom teardown (frontend), and a `rag-service` search-analytics write deadlocking the test DB reset (backend). (#802, #806)
+- Defense-in-depth: NaN-guarded integer parsing for the re-embed wait timeout (a garbage value previously caused a silent never-timeout) and chunk settings; mcp-docs cache listing skips a corrupted entry instead of truncating. (#807)
+
 ## [0.6.0] - 2026-06-13
 
 > Curated summary of the notable changes among ~159 PRs merged since 0.5.2.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "//hoisting-note": "`p-limit` and `ipaddr.js` are ALSO declared in the root package.json `dependencies` block to force npm to hoist them to root node_modules. The runtime Docker stage only copies the root tree, so any version pinned here that ends up nested under backend/node_modules disappears at runtime. If you change the ranges below, update the root mirror in lockstep — the docker-build smoke step is the safety net but local repros are faster.",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/mcp-docs/package-lock.json
+++ b/mcp-docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compendiq-mcp-docs",
-  "version": "0.5.2",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compendiq-mcp-docs",
-      "version": "0.5.2",
+      "version": "0.6.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "express": "^5.1.0",

--- a/mcp-docs/package.json
+++ b/mcp-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq-mcp-docs",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compendiq",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compendiq",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "workspaces": [
         "backend",
         "frontend",
@@ -29,7 +29,7 @@
       }
     },
     "backend": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@fastify/compress": "^8.3.1",
@@ -104,7 +104,7 @@
       "license": "MIT"
     },
     "frontend": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@dnd-kit/react": "^0.3.2",
@@ -20189,7 +20189,7 @@
     },
     "packages/contracts": {
       "name": "@compendiq/contracts",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "zod": "^4.3.6"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Compendiq - AI-powered knowledge base management with Confluence integration and Ollama LLM backend",
   "workspaces": [

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compendiq/contracts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Back-merges the v0.6.1 release commit (version bump + CHANGELOG) from main into dev, clearing the divergence banner. Mirrors #796 for 0.6.0.