### PR TITLE
ci(frontend): stamp build-info.json with the CE commit at image build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -113,6 +113,26 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Stamp the committed placeholder build-info.json (commit: "unknown")
+      # with the real CE commit. The frontend bundle bakes __APP_COMMIT__ at
+      # build time from this file (frontend/vite.config.ts), and the EE flow
+      # never rebuilds the frontend — both editions ship this same CE image —
+      # so "Frontend commit" in Settings → System can only be filled in here.
+      # Mirrors scripts/build-enterprise.sh (git rev-parse --short HEAD) and
+      # the placeholder's JSON shape so vite's `ceCommit ?? commit` resolves it.
+      - name: Stamp build-info.json with the CE commit
+        run: |
+          SHORT_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+          cat > build-info.json <<EOF
+          {
+            "edition": "community",
+            "commit": "${SHORT_SHA}",
+            "builtAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          echo "Stamped build-info.json:"
+          cat build-info.json
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## Why

The Settings → System page showed **Frontend commit: `unknown`**.

The frontend bundle bakes `__APP_COMMIT__` at build time from `build-info.json` (`frontend/vite.config.ts` → `buildInfo.ceCommit ?? buildInfo.commit`). The committed `build-info.json` is a placeholder (`commit: "unknown"`), and the CE frontend Docker build (`frontend/Dockerfile`) just `COPY`s it verbatim — it never runs `git rev-parse`. The only thing that stamps real hashes, `scripts/build-enterprise.sh`, runs for the **EE backend** image; the frontend is never rebuilt by the EE flow (both editions ship this same CE image), so it never got a real commit.

## What

Add a step to the `docker-frontend` job that writes the real CE short SHA into `build-info.json` before `docker build`:

- Mirrors `build-enterprise.sh` (`git rev-parse --short HEAD`) so the frontend `commit` equals the backend's **Backend CE commit** for the same CE checkout.
- Keeps the placeholder's exact JSON shape (`edition`/`commit`/`builtAt`), so vite's `ceCommit ?? commit` resolves it with no `vite.config.ts` change.
- `|| echo unknown` fallback preserves today's behavior if `.git` is ever unavailable.

## Tradeoff

The SHA changes every push, so the `COPY build-info.json` layer (and the `vite build` after it) cache-busts each commit. In practice `COPY frontend/src/` already busts that layer on most pushes; the only added cost is that pure backend/infra pushes now also rebuild the frontend image.

## Scope

Frontend image only, per the request. The CE **backend** image still ships the `unknown` placeholder (only the EE build stamps it) — could be fixed the same way for symmetry in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
