### PR TITLE
Register /knowledge-requests route so Search's Request-content CTA works (#836)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -156,6 +156,83 @@ describe('PageLoadingFallback', () => {
   });
 });
 
+describe('App – /knowledge-requests route (#836)', () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Setup complete + authenticated so ProtectedRoute renders the
+    // authed layout instead of bouncing to /setup or /login.
+    fetchSpy.mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : (input as Request).url;
+      if (url.includes('/health/setup-status')) {
+        return new Response(
+          JSON.stringify({
+            setupComplete: true,
+            steps: { admin: true, llm: true, confluence: true },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/knowledge-requests') || url.includes('/pages/tree')) {
+        return new Response(JSON.stringify({ items: [], total: 0 }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      // Sidebar space selectors expect arrays (/api/spaces, /api/spaces/local)
+      if (url.includes('/spaces')) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    useAuthStore.setState({
+      accessToken: 'test-token',
+      user: { id: '1', username: 'test', role: 'user' },
+      isAuthenticated: true,
+    });
+  });
+
+  afterEach(() => {
+    useAuthStore.getState().clearAuth();
+  });
+
+  function renderApp(initialPath: string) {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <App />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  }
+
+  it('renders KnowledgeRequestsPage instead of redirecting home', async () => {
+    renderApp('/knowledge-requests');
+
+    expect(
+      await screen.findByRole('heading', { name: 'Knowledge Requests' }),
+    ).toBeInTheDocument();
+  });
+
+  it('prefills the create modal title from the ?title= query param', async () => {
+    renderApp('/knowledge-requests?title=foo');
+
+    const titleInput = await screen.findByTestId('request-title-input');
+    expect(screen.getByTestId('create-request-modal')).toBeInTheDocument();
+    expect(titleInput).toHaveValue('foo');
+  });
+});
+
 describe('App – route-based code splitting (#186)', () => {
   const fetchSpy = vi.spyOn(globalThis, 'fetch');
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -60,6 +60,11 @@ const GraphPage = lazy(() =>
     default: m.GraphPage,
   })),
 );
+const KnowledgeRequestsPage = lazy(() =>
+  import('./features/knowledge-requests/KnowledgeRequestsPage').then((m) => ({
+    default: m.KnowledgeRequestsPage,
+  })),
+);
 const NewSpacePage = lazy(() =>
   import('./features/spaces/NewSpacePage').then((m) => ({
     default: m.NewSpacePage,
@@ -160,6 +165,10 @@ export function App() {
                           <Route path="/trash" element={<TrashPage />} />
                           <Route path="/ai" element={<AiAssistantPage />} />
                           <Route path="/graph" element={<GraphPage />} />
+                          <Route
+                            path="/knowledge-requests"
+                            element={<KnowledgeRequestsPage />}
+                          />
                           <Route path="/spaces/new" element={<NewSpacePage />} />
                           <Route path="/spaces/:key/settings" element={<SpaceSettingsPage />} />
                           <Route path="/admin/analytics" element={<AnalyticsPage />} />


### PR DESCRIPTION
Closes #836.

The knowledge-requests feature was fully built on both ends but the SPA never registered its route, so Search's **"Request content"** CTA (`SearchPage.tsx:497`, navigates to `/knowledge-requests?title=<query>`) fell through to the `path="*"` catch-all and silently redirected users to the homepage.

## Fix
Register the lazy `/knowledge-requests` route in `frontend/src/App.tsx`, inside the authed layout, after `/graph` and before the catch-all — following the exact existing lazy-import code-splitting pattern (a new `KnowledgeRequestsPage-*.js` chunk is emitted). No sidebar/nav entry added; per the issue that's a deferred product decision, and the search CTA is the entry point.

## Tests
Two new App-level tests (`App.test.tsx`, MemoryRouter + fetch mocked at the HTTP boundary): navigating to `/knowledge-requests?title=foo` now renders the page (not the home redirect) and the create-modal title prefills from `?title=`. Both fail on the pre-fix code (catch-all redirect) and pass after.

## Verification
Frontend suite **2285/2285 passing / 0 failures**, typecheck clean, lint clean (`--max-warnings=0`), production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
