### PR TITLE
Add a Space settings nav link (fix /spaces/:key/settings discoverability)

### DIFF
--- a/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
@@ -908,4 +908,34 @@ describe('SidebarTreeNode memoization', () => {
       expect(screen.getByText('4 pages in DEV')).toBeInTheDocument();
     });
   });
+
+  describe('space settings link', () => {
+    it('shows a Space settings action for a selected local space and navigates to its settings route', () => {
+      useUiStore.setState({ treeSidebarSpaceKey: 'NOTES' });
+      render(<SidebarTreeView />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByTestId('space-selector-toggle'));
+      const link = screen.getByTestId('space-settings-link');
+      expect(link).toBeInTheDocument();
+
+      fireEvent.click(link);
+      expect(mockNavigate).toHaveBeenCalledWith('/spaces/NOTES/settings');
+    });
+
+    it('does not show the Space settings action for a Confluence space (settings page is local-only)', () => {
+      useUiStore.setState({ treeSidebarSpaceKey: 'DEV' });
+      render(<SidebarTreeView />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByTestId('space-selector-toggle'));
+      expect(screen.queryByTestId('space-settings-link')).not.toBeInTheDocument();
+    });
+
+    it('does not show the Space settings action when All Spaces is selected', () => {
+      useUiStore.setState({ treeSidebarSpaceKey: undefined });
+      render(<SidebarTreeView />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByTestId('space-selector-toggle'));
+      expect(screen.queryByTestId('space-settings-link')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -11,6 +11,7 @@ import {
   Plus,
   Globe,
   HardDrive,
+  Settings,
 } from 'lucide-react';
 import { m, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { ShortcutHint } from '../ShortcutHint';
@@ -526,6 +527,7 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
         <div ref={spaceDropdownRef} className="relative">
           <button
             onClick={() => setSpaceDropdownOpen(!spaceDropdownOpen)}
+            data-testid="space-selector-toggle"
             className="flex w-full items-center justify-between rounded-lg bg-foreground/5 px-2.5 py-1.5 text-xs text-foreground hover:bg-foreground/8 transition-colors"
           >
             <span className="flex items-center gap-1.5 truncate">
@@ -614,6 +616,21 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
                     </button>
                   ))}
                 </>
+              )}
+
+              {/* Manage the selected local space (settings page is local-only) */}
+              {isLocalSpace && treeSidebarSpaceKey && (
+                <button
+                  onClick={() => {
+                    setSpaceDropdownOpen(false);
+                    navigate(`/spaces/${treeSidebarSpaceKey}/settings`);
+                  }}
+                  data-testid="space-settings-link"
+                  className="flex w-full items-center gap-1.5 border-t border-[var(--glass-sidebar-divider)] mt-1 pt-1 rounded-lg px-2.5 py-1.5 text-xs text-foreground hover:bg-[var(--glass-pill-hover)] transition-colors"
+                >
+                  <Settings size={10} />
+                  Space settings
+                </button>
               )}
 
               {/* Create new space link */}


### PR DESCRIPTION
Fixes the discoverability gap found in the unreachable-pages audit: `/spaces/:key/settings` (`SpaceSettingsPage`) was reachable **only by typing the URL** — nothing in the UI navigated to it.

## Change
Add a **"Space settings"** action to the sidebar space-selector dropdown (`SidebarTreeView`), placed just above the existing "New Space" footer link. It's shown **only when a local space is selected**, because `SpaceSettingsPage` manages local spaces only (it resolves the space via `useLocalSpaces()` by the `:key` param). It navigates to `/spaces/<key>/settings`.

## Tests
Three unit tests on `SidebarTreeView`: the link appears + navigates to the correct route for a selected local space; it's **absent** for a Confluence space (settings page is local-only) and for "All Spaces".

## Verification
- Unit: `SidebarTreeView` suite 73/73; frontend suite **2212 / 0**; typecheck + lint clean; build clean.
- **Live (container rebuild + browser):** created a local space, selected it in the sidebar dropdown, confirmed the "Space settings" link appears, clicked it, and confirmed it lands on `/spaces/ENG_DOCS/settings` with the page fully rendered (name/key/description populated, Save + Delete actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
