### PR TITLE
docs: sync live docs with the 0.6.2 codebase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,7 @@ BACKEND_PORT=3051
 # DEPRECATED: seed-only; consulted on first boot when llm_providers is empty. Configure providers in Settings → LLM.
 # OLLAMA_BASE_URL=http://localhost:11434
 
-# DEPRECATED: seed-only; consulted on first boot when llm_providers is empty. Configure providers in Settings → LLM.
+# DEPRECATED: no effect since migration 054 (a warning is logged if set). Configure per-use-case models in Settings → LLM.
 # EMBEDDING_MODEL=bge-m3
 
 # EMBEDDING_DIMENSIONS=1024            # Vector dimensions — must match the embedding model output (schema-level)
@@ -79,10 +79,10 @@ BACKEND_PORT=3051
 # REEMBED_WAIT_LOCKS_MS=600000         # Max time a re-embed job waits for per-user embedding locks to clear before aborting (default: 600000 = 10 min)
 # BGE-M3 via Ollama (1024 dims). Run: ollama pull bge-m3
 
-# DEPRECATED: seed-only; consulted on first boot when llm_providers is empty. Configure providers in Settings → LLM.
-# LLM_BEARER_TOKEN=           # Seeded as the default provider's api_key on first boot
+# DEPRECATED: no effect since migration 054 (a warning is logged if set). Set the provider's API key in Settings → LLM.
+# LLM_BEARER_TOKEN=
 
-# LLM_AUTH_TYPE=bearer         # Auth type for LLM connections: 'bearer' (default) or 'none' (seeded on first boot)
+# LLM_AUTH_TYPE=               # No effect since migration 054 — auth type is set per provider in Settings → LLM
 # LLM_VERIFY_SSL=true          # Set to 'false' to disable TLS certificate verification for LLM connections
 # LLM_STREAM_TIMEOUT_MS=300000 # Streaming request timeout in ms (default: 300000 = 5 min). Increase for very large articles.
 # LLM_CACHE_TTL=3600           # Redis TTL in seconds for LLM response cache (default: 3600 = 1 hour)
@@ -99,7 +99,7 @@ BACKEND_PORT=3051
 # --- Background Auto-Summarizer ---
 # SUMMARY_CHECK_INTERVAL_MINUTES=60  # How often the worker scans for pages needing summaries (default: 60)
 # SUMMARY_BATCH_SIZE=5               # Max pages to summarize per worker cycle (default: 5)
-# DEPRECATED: seed-only; consulted on first boot when llm_providers is empty. Configure providers in Settings → LLM.
+# DEPRECATED: no effect since migration 054 (a warning is logged if set). Configure per-use-case models in Settings → LLM.
 # SUMMARY_MODEL=
 
 # --- OpenAI-compatible seed values (DEPRECATED: seed-only; configure providers in Settings → LLM) ---
@@ -110,7 +110,7 @@ BACKEND_PORT=3051
 # --- Quality Analysis Worker ---
 # QUALITY_CHECK_INTERVAL_MINUTES=60  # How often the quality worker runs (default: 60 min)
 # QUALITY_BATCH_SIZE=5               # Pages analyzed per batch (default: 5)
-# DEPRECATED: seed-only; consulted on first boot when llm_providers is empty. Configure providers in Settings → LLM.
+# DEPRECATED: no effect since migration 054 (a warning is logged if set). Configure per-use-case models in Settings → LLM.
 # QUALITY_MODEL=
 
 # --- Sync Scheduler ---
@@ -118,8 +118,7 @@ BACKEND_PORT=3051
 # RESTRICTION_CONFIRM_WINDOW_HOURS=168  # (EE + RAG permission enforcement) Re-confirm each page's Confluence restrictions at least this often; the audit log is consulted to skip unchanged pages within the window. Fails safe to a full re-fetch. (default: 168 = 7 days)
 
 # --- Confluence API Rate Limiting ---
-# Configurable via admin_settings table (key: confluence_rate_limit_rpm). Env var is the startup default.
-# CONFLUENCE_RATE_LIMIT_RPM=60          # Max Confluence API requests per minute (default: 60)
+# Confluence API rate limit is configured via Admin Settings (key: confluence_rate_limit_rpm, default 60 rpm). There is no env var override.
 
 # --- MCP Documentation Sidecar (air-gapped LLM doc access) ---
 # MCP_DOCS_URL=http://mcp-docs:3100/mcp  # URL of the MCP docs sidecar (default in Docker)

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Bidirectional sync with XHTML storage format conversion. Round-trip support for 
 | **AI** | Multi-provider LLM (Ollama default, or any OpenAI-compatible API), real-time SSE streaming, conversation history, content summarization, knowledge gap detection, duplicate page detection, LLM request backpressure, audit hook extension point |
 | **Security** | AES-256-GCM PAT encryption, JWT with refresh token rotation, RBAC with custom roles, OIDC/SSO (Enterprise), rate limiting, SSRF protection, prompt injection guard |
 | **Analytics** | Page views, engagement metrics, search pattern tracking, knowledge graph visualization |
-| **Operations** | PDF import/export, page verification workflow, knowledge requests, audit logging, OpenTelemetry tracing, background job queue (BullMQ), email notifications (SMTP), Confluence API rate limiting |
+| **Operations** | PDF import/export, page verification workflow, audit logging, OpenTelemetry tracing, background job queue (BullMQ), email notifications (SMTP), Confluence API rate limiting |
 
 ---
 
@@ -159,7 +159,7 @@ Frontend (React 19 + Vite + TailwindCSS 4)
 | Layer | Technology |
 |-------|-----------|
 | **Backend** | Fastify 5, TypeScript, Node.js 22+, BullMQ |
-| **Frontend** | React 19, Vite 7, TailwindCSS 4, Radix UI, Zustand, TanStack Query, Framer Motion |
+| **Frontend** | React 19, Vite 8, TailwindCSS 4, Radix UI, Zustand, TanStack Query, Framer Motion |
 | **Editor** | TipTap v3 (ProseMirror) |
 | **Database** | PostgreSQL 17 + pgvector |
 | **Cache** | Redis 8 |

--- a/docs/ADMIN-GUIDE.md
+++ b/docs/ADMIN-GUIDE.md
@@ -193,19 +193,13 @@ Compendiq uses BullMQ (Redis-backed) for reliable background job processing. Six
 **Configuration:**
 - `USE_BULLMQ=true` (default) -- set to `false` to fall back to legacy `setInterval` workers
 - Redis `maxmemory-policy` must be `noeviction` (default in the provided Docker config)
-- Job history is stored in the `job_history` PostgreSQL table for observability
-- Queue metrics are exposed via `GET /api/health` under the `queues` key
+- Job history is stored in the `job_history` PostgreSQL table for observability; BullMQ queue metrics are not exposed via the API
 - `REEMBED_WAIT_LOCKS_MS=600000` (default 10 min): how long the `reembed-all`
   worker waits for in-flight per-user embedding runs to finish before
   aborting the job. Visible in the admin UI via `GET /api/admin/embedding/locks`.
 - `reembed_history_retention` (admin setting, default 150): how many
   completed/failed `reembed-all` job records BullMQ keeps in Redis before
   sweeping the oldest. Range [10, 10000]. Takes effect on the next run.
-
-**Monitoring:** The health endpoint returns per-queue counts (waiting, active, completed, failed):
-```bash
-curl http://localhost:8081/api/health | jq '.queues'
-```
 
 ### LLM Request Queue
 
@@ -217,7 +211,7 @@ LLM requests are managed through a concurrency-controlled queue with backpressur
 | `LLM_MAX_QUEUE_DEPTH` | `50` | Max queued requests before rejecting |
 | `LLM_STREAM_TIMEOUT_MS` | `300000` | Per-request timeout (5 min) |
 
-Queue metrics are exposed via `GET /api/health` under the `llmQueue` key. When the queue is full, new requests receive a `503` error with a message to retry later.
+When the queue is full, new requests receive a `503` error with a message to retry later.
 
 ### Per-User Concurrent SSE-Stream Cap (#268)
 
@@ -231,7 +225,7 @@ A Redis counter (`llm:streams:<userId>`) tracks currently-open SSE streams per u
 
 | Setting | Default | Range | Description |
 |---------|---------|-------|-------------|
-| **Settings → LLM → Runtime limits** (primary) | `3` | `1`–`20` | Admin-configurable. Changes apply within 60 s in every worker; the local worker sees them immediately. |
+| **Settings → AI → AI Models → LLM providers → Runtime limits** (primary) | `3` | `1`–`20` | Admin-configurable. Changes apply within 60 s in every worker; the local worker sees them immediately. |
 | `LLM_MAX_CONCURRENT_STREAMS_PER_USER` | `3` | `1`–`20` | **Deprecated bootstrap fallback** — consulted only when the `admin_settings` row is absent. |
 
 **Release semantics.** The counter decrements on all four exit paths: normal completion, error, upstream timeout, and client disconnect. A 1-hour TTL self-heals leaked counters from crashed processes.
@@ -268,7 +262,7 @@ A token bucket rate limiter protects your Confluence Data Center instance from b
 
 ### Email Notifications (SMTP)
 
-Compendiq can send email notifications for key events. Configure SMTP in **Settings > Email / SMTP**.
+Compendiq can send email notifications for key events. Configure SMTP in **Settings → System → Integrations → Email / SMTP**.
 
 **Configuration (env vars or admin UI):**
 
@@ -297,11 +291,11 @@ Settings configured via the admin UI are persisted in the `admin_settings` datab
 
 ### OIDC / SSO
 
-OIDC provider settings (issuer, client ID/secret, group mappings) are configured entirely via the Admin UI (Settings > OIDC/SSO) and stored in the database.
+OIDC provider settings (issuer, client ID/secret, group mappings) are configured entirely via the Admin UI (Settings → Governance → Access Control → SSO / OIDC) and stored in the database.
 
 **`FRONTEND_URL` must be your public origin behind a reverse proxy.** OIDC login uses a two-hop callback:
 
-1. The IdP redirects the browser back to the **Redirect URI** you configure in Settings > OIDC/SSO — e.g. `https://compendiq.example.com/api/auth/oidc/callback`. This hits the backend.
+1. The IdP redirects the browser back to the **Redirect URI** you configure in Settings → Governance → Access Control → SSO / OIDC — e.g. `https://compendiq.example.com/api/auth/oidc/callback`. This hits the backend.
 2. The backend exchanges the code and then redirects the browser to the SPA callback route (`/auth/oidc/callback?login_code=…`). It builds **that** redirect from the backend's `FRONTEND_URL` env var — **not** from the Redirect URI.
 
 These are two independent URLs. If `FRONTEND_URL` is left at its `http://localhost:8081` / `http://localhost:5273` default while the admin reaches the app through a public host, a correctly-configured Redirect URI still bounces the browser to `localhost` after the IdP round-trip, dead-ending login. Set:
@@ -310,11 +304,11 @@ These are two independent URLs. If `FRONTEND_URL` is left at its `http://localho
 FRONTEND_URL=https://compendiq.example.com
 ```
 
-(matching the origin of your Redirect URI) and restart the backend. `FRONTEND_URL` also accepts a comma-separated list, which doubles as the CORS allowlist — so if you already configured multiple origins, **append** the public origin (`…,https://compendiq.example.com`) rather than overwriting the existing list. The Settings > OIDC/SSO page warns inline when the Redirect URI origin diverges from the origin you loaded the app from, and surfaces the exact `FRONTEND_URL` value to set.
+(matching the origin of your Redirect URI) and restart the backend. `FRONTEND_URL` also accepts a comma-separated list, which doubles as the CORS allowlist — so if you already configured multiple origins, **append** the public origin (`…,https://compendiq.example.com`) rather than overwriting the existing list. The Settings → Governance → Access Control → SSO / OIDC page warns inline when the Redirect URI origin diverges from the origin you loaded the app from, and surfaces the exact `FRONTEND_URL` value to set.
 
 ### IP Allowlist (Enterprise, v0.4+)
 
-The IP allowlist is configured entirely via the Admin UI (Settings > IP allowlist) and persisted in the `admin_settings` table. It is an Enterprise-only feature — Community Edition builds ignore the configuration and register no routes. When enabled, a Fastify `onRequest` hook short-circuits requests from client IPs outside the configured CIDR ranges with a `403 ip_blocked` response, before any auth / business logic runs.
+The IP allowlist is configured entirely via the Admin UI (Settings → Governance → Access Control → IP allowlist) and persisted in the `admin_settings` table. It is an Enterprise-only feature — Community Edition builds ignore the configuration and register no routes. When enabled, a Fastify `onRequest` hook short-circuits requests from client IPs outside the configured CIDR ranges with a `403 ip_blocked` response, before any auth / business logic runs.
 
 **Config fields (admin UI)**
 
@@ -383,20 +377,20 @@ Tier-downgrade (license change to a non-enterprise tier) disables the flag. Exis
 
 Confluence is the system of record for synced pages, but Compendiq supports local edits — the in-app editor, AI improve / generate / apply-improvement write-backs, and draft publishing all stamp `pages.local_modified_at` to mark the row as having unpublished local changes (CE #305). The next inbound sync pulls a Confluence-side change for that same page, and the question becomes: which side wins? The sync conflict policy answers that question per-page.
 
-**Three policies (Settings → Content → Sync conflict policy)**
+**Three policies (Settings → Knowledge → Spaces & Sync → Conflict policy)**
 
 | Policy | Behaviour | When to use |
 |--------|-----------|-------------|
 | `Confluence wins` (default) | Apply the Confluence-side change; discard the local edit. Audit emits `SYNC_OVERWROTE_LOCAL_EDITS` whenever a local edit was actually present so you have a forensic record. No queue. | Compendiq is read-mostly — admins rarely edit pages locally, and Confluence remains the canonical source. The legacy v0.3 behaviour. |
 | `Compendiq wins` | Skip the inbound write; preserve the local edit. Audit emits `SYNC_CONFLICT_DETECTED` with `resolution: 'kept_local'`. The local edit must be pushed back to Confluence manually (the editor's "Publish to Confluence" button) — otherwise the two systems drift further apart on every sync cycle. | Short-window edits where you definitely want the local copy to take precedence (e.g. an AI-improvement run is mid-publish and you don't want a remote overwrite to land on top of it). Use sparingly: drift compounds. |
-| `Manual review` | Stash the inbound Confluence body in `pending_sync_versions`, flip `pages.conflict_pending = TRUE`, and surface the page in **Settings → Content → Sync conflicts** for admin review. The live row stays unchanged until the admin diff-reviews and picks. Audit emits `SYNC_CONFLICT_DETECTED` with `resolution: 'queued_for_review'`. | High-control workflows where every conflict needs explicit review (regulated documentation, contractual content). Trades sync latency for safety. |
+| `Manual review` | Stash the inbound Confluence body in `pending_sync_versions`, flip `pages.conflict_pending = TRUE`, and surface the page in **Settings → Knowledge → Spaces & Sync → Conflicts queue** for admin review. The live row stays unchanged until the admin diff-reviews and picks. Audit emits `SYNC_CONFLICT_DETECTED` with `resolution: 'queued_for_review'`. | High-control workflows where every conflict needs explicit review (regulated documentation, contractual content). Trades sync latency for safety. |
 
 **Important fall-through**: the policy only kicks in when there are *actual* local edits (`local_modified_at > last_synced`). If the page has no local edits, both `compendiq-wins` and `manual-review` transparently fall through to `confluence-wins` — there's nothing to preserve, so the queue isn't padded with non-conflicts and the routine sync rate isn't degraded.
 
 **Resolution flow (manual-review)**
 
 1. Sync detects a conflict; the page lands in the conflicts list.
-2. Admin opens **Settings → Content → Sync conflicts**, clicks **Review** on a row.
+2. Admin opens **Settings → Knowledge → Spaces & Sync → Conflicts queue**, clicks **Review** on a row.
 3. The dialog shows a side-by-side / unified diff of the local body against the queued Confluence body.
 4. Admin picks one of three actions:
    - **Keep local** — drop the queued Confluence version, keep the local row. Audit emits `SYNC_CONFLICT_RESOLVED_LOCAL`.
@@ -427,7 +421,7 @@ The conflict-detection branch in `sync-service.ts::syncPage` runs the inbound-up
 
 ### AI Review Policy (Enterprise, v0.4+)
 
-When the AI review workflow is enabled, AI-generated output is queued in `ai_output_reviews` rather than being written straight to the page draft. A reviewer must explicitly approve, reject, or edit-and-approve each row before the proposed content is applied. Configure the policy at **Settings → AI → AI review policy**.
+When the AI review workflow is enabled, AI-generated output is queued in `ai_output_reviews` rather than being written straight to the page draft. A reviewer must explicitly approve, reject, or edit-and-approve each row before the proposed content is applied. Configure the policy at **Settings → AI → AI Safety → Review policy**.
 
 **Three modes (per-action overridable)**
 
@@ -470,7 +464,7 @@ In CE-only deployments the routes 404 — the overlay isn't loaded, so there's n
 
 ### PII Detection (Enterprise, v0.4+)
 
-When the PII detector is licensed and enabled, every AI inference response is scanned for personally identifiable information before it reaches the end user. Three layers run on every inference: regex (German + generic checksum-validated rules — IBAN, credit card, DE Tax ID, DE Personalausweis, DE RVNR), Transformers.js NER (`Davlan/distilbert-base-multilingual-cased-ner-hrl`, q8 ONNX, CPU-only, multilingual — covers PERSON / LOCATION / ORGANIZATION), and an optional asynchronous LLM-as-judge for ambiguous spans. Configure the policy at **Settings → AI → PII detection**.
+When the PII detector is licensed and enabled, every AI inference response is scanned for personally identifiable information before it reaches the end user. Three layers run on every inference: regex (German + generic checksum-validated rules — IBAN, credit card, DE Tax ID, DE Personalausweis, DE RVNR), Transformers.js NER (`Davlan/distilbert-base-multilingual-cased-ner-hrl`, q8 ONNX, CPU-only, multilingual — covers PERSON / LOCATION / ORGANIZATION), and an optional asynchronous LLM-as-judge for ambiguous spans. Configure the policy at **Settings → AI → AI Safety → PII detection**.
 
 **Per-use-case actions**
 
@@ -513,7 +507,7 @@ In CE-only deployments the `GET`/`PUT /api/admin/pii-policy` routes 404 — the 
 
 ### Compliance Reports (Enterprise, v0.4+)
 
-When the `compliance_reports` feature is licensed and enabled, admins can self-serve evidence packets for SOC 2 Type II and ISO 27001:2022 audits at **Settings → Compliance Reports**. Each report produces a ZIP containing a PDF cover sheet (with a SHA-256 integrity hash of the CSV body) and the CSV evidence body. Generation is recorded in the audit log under `ADMIN_ACTION` with `action: 'generate_compliance_report'` for chain-of-custody.
+When the `compliance_reports` feature is licensed and enabled, admins can self-serve evidence packets for SOC 2 Type II and ISO 27001:2022 audits at **Settings → Governance → Data & Compliance → Reports**. Each report produces a ZIP containing a PDF cover sheet (with a SHA-256 integrity hash of the CSV body) and the CSV evidence body. Generation is recorded in the audit log under `ADMIN_ACTION` with `action: 'generate_compliance_report'` for chain-of-custody.
 
 **Customer model**
 
@@ -533,7 +527,7 @@ The buyer is the customer's IT or security manager — not the auditor. The repo
 
 **Generating a report**
 
-1. Open **Settings → Compliance Reports**. The tab is admin-only and gated on a valid Enterprise license with the `compliance_reports` feature.
+1. Open **Settings → Governance → Data & Compliance → Reports**. The tab is admin-only and gated on a valid Enterprise license with the `compliance_reports` feature.
 2. Pick a from / to window. The default is the last 30 days ending today (00:00 local). Inline validation rejects `from >= to`, `to` more than 24 hours in the future, and `from` more than 10 years in the past — the same bounds the backend orchestrator enforces.
 3. Click **Generate & download**. The browser downloads a ZIP named `compliance-<id>-YYYY-MM-DD.zip`. The success toast surfaces the first 12 characters of the cover sheet's SHA-256 hash for at-a-glance verification.
 
@@ -547,7 +541,7 @@ Report 5 reads from the `llm_audit_log` table but its SQL `SELECT` lists 14 expl
 2. The orchestrator's CSV writer enforces a `FORBIDDEN_CSV_COLUMNS` deny-list that includes `password_hash`, `pat_encrypted`, `oidc_secret`, `webhook_secret`, `signing_key`, `jwt_secret`, `input_text`, `output_text`, `input_messages`. Any column matching the list throws — and the thrown error message never echoes the offending cell value (no log leak).
 3. Every report module declares its column set up front (via the `ReportData.columns` array); the writer asserts that no row introduces a column outside the declared set.
 
-Auditors receive only the SHA-256 `prompt_hash`. To pivot from a hash back to the original call (e.g. during incident investigation), use the same hash on the LLM Audit page (**Settings → LLM Audit**) — that page is gated separately by the `llm_audit_trail` feature and may surface plaintext if `llm_audit_full_text` is on.
+Auditors receive only the SHA-256 `prompt_hash`. To pivot from a hash back to the original call (e.g. during incident investigation), use the same hash on the LLM Audit page (**Settings → AI → AI Safety → Audit log**) — that page is gated separately by the `llm_audit_trail` feature and may surface plaintext if `llm_audit_full_text` is on.
 
 **PDF cover sheet integrity**
 
@@ -579,7 +573,7 @@ Every generation emits `ADMIN_ACTION` with metadata `{ action: 'generate_complia
 
 **CE-only deployments**
 
-In CE-only deployments the `/api/admin/compliance-reports` and `/api/admin/compliance-reports/generate` routes 404 — the EE overlay isn't loaded. The Settings → Compliance Reports tab is hidden by the `requiresFeature: 'compliance_reports'` filter on the tab list; for a defence-in-depth direct URL navigation, the tab itself surfaces an "EE license required" panel.
+In CE-only deployments the `/api/admin/compliance-reports` and `/api/admin/compliance-reports/generate` routes 404 — the EE overlay isn't loaded. The Settings → Governance → Data & Compliance → Reports tab is hidden by the `requiresFeature: 'compliance_reports'` filter on the tab list; for a defence-in-depth direct URL navigation, the tab itself surfaces an "EE license required" panel.
 
 ### Monitoring (OpenTelemetry)
 
@@ -791,7 +785,7 @@ This exports traces to any OTLP-compatible collector (Jaeger, Grafana Tempo, Dat
 
 ### Audit Logging
 
-Compendiq logs user actions and system events. View audit logs in the Admin panel under **Admin > Audit Log**. Logs are stored in PostgreSQL and include:
+Compendiq logs user actions and system events. Query audit logs via the admin API: `GET /api/admin/audit-log` (admin-authenticated, supports pagination/filtering). Logs are stored in PostgreSQL and include:
 
 - User authentication events (login, logout, failed attempts)
 - Page operations (create, update, delete)
@@ -800,15 +794,15 @@ Compendiq logs user actions and system events. View audit logs in the Admin pane
 
 ## Managing Users
 
-Admins manage the full user lifecycle from **Settings → Users**. All mutations are audit-logged under `ADMIN_ACTION` events and rate-limited the same as other admin endpoints. Under the hood each action maps to one of the per-user admin endpoints (`POST|PUT|DELETE /api/admin/users/...`) so EE bulk tooling (#116) can compose the same primitives.
+Admins manage the full user lifecycle from **Settings → Governance → Access Control → Users**. All mutations are audit-logged under `ADMIN_ACTION` events and rate-limited the same as other admin endpoints. Under the hood each action maps to one of the per-user admin endpoints (`POST|PUT|DELETE /api/admin/users/...`) so EE bulk tooling (#116) can compose the same primitives.
 
 ### Creating a user
 
-1. Go to **Settings → Users** and click **Add user**.
+1. Go to **Settings → Governance → Access Control → Users** and click **Add user**.
 2. Fill in username (required), optional email, optional display name, and pick the role (`user` or `admin`).
 3. Choose one of two credential modes:
    - **Explicit password** — type it into the form. The user signs in with that password on first login.
-   - **Send invitation** — leave the password blank and tick *Send invitation email*. The backend generates a random temporary password and tries to email it to the new user via the configured SMTP server (see `SMTP_*` env vars and the Settings → Email admin tab). When SMTP is not configured the API returns the temporary password in the response so the admin can hand it over out-of-band.
+   - **Send invitation** — leave the password blank and tick *Send invitation email*. The backend generates a random temporary password and tries to email it to the new user via the configured SMTP server (see `SMTP_*` env vars and the Settings → System → Integrations → Email / SMTP admin tab). When SMTP is not configured the API returns the temporary password in the response so the admin can hand it over out-of-band.
 4. The new user is created immediately — there is no email-verification step in CE.
 
 ### Editing a user
@@ -841,13 +835,10 @@ From the user's row in the table:
 
 ### Resetting a password
 
-CE does not ship a self-serve "send password reset email" button. To reset a user's password as an admin:
+CE has no admin-side password reset — neither the Users admin UI nor the admin API can change an existing user's password. Users change their own password through the self-service flow on their profile page. If a user has lost their password, the recovery options are:
 
-1. From **Settings → Users**, open the user row and click **Edit → Reset password**.
-2. Pick either *Set temporary password* (displayed once, hand over out of band) or *Send invitation email* (requires SMTP configured). Behind the scenes this is the same flow as **Add user** in invitation mode — the user is expected to log in with the temporary password and then change it from their profile page.
-3. All refresh-tokens for the user are revoked as part of the reset, so existing sessions are terminated.
-
-If you need to reset a password without admin UI access (for example the last admin lost their password), set it directly in PostgreSQL with a known bcrypt hash — see **Troubleshooting → Recovering the last admin password** below.
+- **Set the password directly in PostgreSQL** with a known bcrypt hash — the same procedure used when the last admin loses their password.
+- **Delete and re-create the user** via **Settings → Governance → Access Control → Users** with a new explicit password or *Send invitation email* (mind the hard-delete caveats above — history pointers are nulled and owned content cascades).
 
 ### Self-service limits and the `__system__` user
 
@@ -856,9 +847,9 @@ If you need to reset a password without admin UI access (for example the last ad
 
 ### Bulk user operations (Enterprise, v0.4+)
 
-> Enterprise-only — this section applies only when the licence grants `bulk_user_operations`. The Settings → Users page degrades to the per-user CRUD described above when the feature is unlicensed.
+> Enterprise-only — this section applies only when the licence grants `bulk_user_operations`. The Settings → Governance → Access Control → Users page degrades to the per-user CRUD described above when the feature is unlicensed.
 
-The Settings → Users page surfaces two bulk affordances when the licence grants the feature:
+The Settings → Governance → Access Control → Users page surfaces two bulk affordances when the licence grants the feature:
 
 1. **Bulk import** — header button. Opens a three-step CSV import dialog: pick a `.csv` file → preview parsed rows with field-level errors and duplicate detection → confirm and apply with the chosen mode.
 2. **Multi-select bulk actions** — checkboxes on each row plus a select-all in the header. Once at least one row is checked the **Bulk actions** button appears, opening the action dialog (change role, deactivate with optional reason, reactivate, add to group, remove from group). The current admin's row never carries a checkbox so a single mistaken header click cannot bulk-deactivate the operator.
@@ -954,7 +945,7 @@ Compendiq supports zero-downtime rotation of the PAT encryption key:
 
 3. **Restart the backend.** New encryptions use the highest-version key. Decryption tries all keys, so existing PATs remain readable.
 
-4. **Re-encrypt existing PATs** via the Admin UI (Admin > Key Rotation).
+4. **Re-encrypt existing PATs** by calling the admin API: `curl -X POST -H "Authorization: Bearer <admin-token>" http://localhost:8081/api/admin/rotate-encryption-key`.
 
 5. **Remove the old key** once all PATs have been re-encrypted.
 
@@ -980,7 +971,7 @@ Check that the `POSTGRES_URL` and `REDIS_URL` in your `.env` match the container
 2. Check the `OLLAMA_BASE_URL` in `.env`. Inside Docker, use `http://host.docker.internal:11434`.
 3. If using a proxy, set `LLM_BEARER_TOKEN` and `LLM_AUTH_TYPE=bearer`.
 4. For timeout issues with large articles, increase `LLM_STREAM_TIMEOUT_MS`.
-5. Check circuit breaker status via `GET /api/health` (aggregated) or `GET /api/llm/circuit-breaker-status` (per-provider detail) -- if a provider shows `open`, the circuit breaker has tripped due to repeated failures. It will reset automatically.
+5. Check circuit breaker status via `GET /api/llm/circuit-breaker-status` (authenticated, per-provider detail) -- if a provider shows `open`, the circuit breaker has tripped due to repeated failures. It will reset automatically.
 
 ### TLS certificate errors
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,6 +12,8 @@ http://localhost:3051/api/docs
 
 This is the primary API reference. It is auto-generated from route schemas using `@fastify/swagger` and `@fastify/swagger-ui`, and is always up to date with the running server.
 
+> **Note:** Swagger UI is only served in non-production environments. It is disabled when `NODE_ENV=production` to avoid exposing the full API schema.
+
 ## Authentication
 
 All endpoints except `/api/health` and `/api/auth/*` require a valid JWT Bearer token.
@@ -62,7 +64,7 @@ Response:
     "llm": true
   },
   "llmProvider": "OpenAI Prod",
-  "version": "1.0.0",
+  "version": "0.6.2",
   "uptime": 3600.123
 }
 ```
@@ -156,7 +158,7 @@ Response:
     "postgres": true,
     "redis": true
   },
-  "version": "1.0.0",
+  "version": "0.6.2",
   "uptime": 3600.123
 }
 ```
@@ -165,7 +167,7 @@ Response:
 
 The API enforces rate limiting:
 
-- **Global:** 100 requests per minute per IP
+- **Global:** 300 requests per minute per IP (default; configurable by admins)
 - **Admin endpoints:** stricter limits
 - **LLM endpoints:** stricter limits (due to resource intensity)
 

--- a/docs/STEWARDSHIP.md
+++ b/docs/STEWARDSHIP.md
@@ -71,7 +71,7 @@ As of the [v0.3.0 release](./releases/v0.3.0.md), the following capabilities are
 **Knowledge base**
 - Pages CRUD (create, read, update, soft-delete, restore, trash, permanent delete)
 - Markdown/HTML/XHTML round-trip
-- Templates, comments, pinned pages, page versions, knowledge requests
+- Templates, comments, pinned pages, page versions (knowledge requests: removed in v0.6.2, see #841)
 - Full-text search (PostgreSQL, configurable language)
 - Tagging + duplicate detection + content analytics
 - Article feedback + page-view tracking + verification workflow

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -29,7 +29,7 @@ Your PAT is encrypted at rest with AES-256-GCM and is never sent back to the bro
 
 After configuring your Confluence connection:
 
-1. Go to **Spaces** in the sidebar.
+1. Go to **Settings → Knowledge → Spaces & Sync**.
 2. You will see all available Confluence spaces.
 3. Select the spaces you want to sync to Compendiq.
 4. Click **Sync** to start the initial synchronization.
@@ -54,7 +54,7 @@ The **Pages** view shows all synced pages from your selected Confluence spaces, 
 4. Use the formatting toolbar or keyboard shortcuts for rich text.
 5. Save with `Ctrl+S`.
 
-You can also generate pages from templates (runbook, how-to, architecture, troubleshooting) using the **Templates** feature.
+You can also start a page from a template (e.g. Meeting Notes, Incident Report, How-to Guide, ADR, Runbook) via the **Use Template** button on the New Page screen.
 
 ### Editing a Page
 
@@ -127,12 +127,11 @@ AI can analyze and improve existing articles:
 
 ### Generate an Article
 
-Create new articles from templates and prompts:
+Create new articles from prompts:
 
-1. Go to **Templates**.
-2. Choose a template type (runbook, how-to, architecture, troubleshooting).
-3. Provide a topic and any context.
-4. The AI generates a full article that you can edit and save.
+1. Open the **AI** panel and switch to **Generate** mode.
+2. Enter a topic or prompt (optionally attach a PDF or enable web search for extra context).
+3. The AI generates a full article that you can save as a new page.
 
 ### Summarize
 
@@ -171,7 +170,7 @@ For v0.4, any admin can act on the queue. (Per-space scoping based on editor-on-
 
 ### What the queue looks like
 
-Open **Settings → AI → AI review queue**. Each row shows:
+Open **Settings → AI → AI Safety → Review queue**. Each row shows:
 
 - The action type chip (Improve, Summary, Generate, Auto-tag, Apply improvement).
 - The page id the review targets, plus the page title once you click into the detail.
@@ -199,7 +198,7 @@ If the AI run flagged personally identifiable information, the header shows a **
 
 ### Handling rejected output
 
-A rejection is final for that particular review row, but the author is free to re-run the AI. The reviewer note is the right place to give the author a steer (e.g. "tone is too casual; prefer the existing prose style"). The author sees pending and rejected counts in the **AuthorPendingBanner** at the top of any page-edit view.
+A rejection is final for that particular review row, but the author is free to re-run the AI. The reviewer note is the right place to give the author a steer (e.g. "tone is too casual; prefer the existing prose style").
 
 ### Auto-expiry
 
@@ -229,9 +228,9 @@ Uses vector embeddings to find conceptually similar content. This finds results 
 
 ### Hybrid Search
 
-Combines keyword and semantic search with Reciprocal Rank Fusion (RRF) for the best results. This is the default search mode.
+Combines keyword and semantic search with Reciprocal Rank Fusion (RRF) for the best results. The default mode is keyword; pass `mode=hybrid` to the search API for RRF results.
 
-Access search via the **Search** page in the sidebar or the **Command Palette** (`Ctrl+K`).
+Access search via the search box in the top bar or the **Command Palette** (`Ctrl+K`).
 
 ## Knowledge Graph
 
@@ -311,7 +310,7 @@ Compendiq supports both dark and light themes:
 
 ## Webhook Integrations (Enterprise)
 
-Enterprise administrators can configure outbound webhooks so external systems receive a signed HTTP POST whenever specific events happen in Compendiq (page created / updated / deleted, sync completed, AI quality / summary complete). Configuration lives at **Settings → Webhooks**.
+Enterprise administrators can configure outbound webhooks so external systems receive a signed HTTP POST whenever specific events happen in Compendiq (page created / updated / deleted, sync completed, AI quality / summary complete). Configuration lives at **Settings → Governance → Data & Compliance → Webhooks**.
 
 ### Event catalogue (v0.4)
 
@@ -364,7 +363,7 @@ The receiver MUST:
 
 ### Secret rotation
 
-Under **Settings → Webhooks**, click **Rotate secret** to stage a new primary while keeping the old one as a secondary signer for a grace window. Receivers should accept *either* signature during the window. When all receivers are updated, click **Complete rotation** (or let the window expire) to drop the old secret.
+Under **Settings → Governance → Data & Compliance → Webhooks**, click **Rotate secret** to stage a new primary while keeping the old one as a secondary signer for a grace window. Receivers should accept *either* signature during the window. When all receivers are updated, click **Complete rotation** (or let the window expire) to drop the old secret.
 
 ## Tips
 

--- a/docs/architecture/01-system-context.md
+++ b/docs/architecture/01-system-context.md
@@ -35,8 +35,10 @@ C4Context
 
 - **Confluence PATs** are stored per-user, AES-256-GCM encrypted with
   `PAT_ENCRYPTION_KEY`. They never leave the backend to the browser.
-- **LLM provider** is resolved per-user (user setting) with server-wide
-  fallbacks set via `LLM_PROVIDER`, `OLLAMA_BASE_URL`, `OPENAI_BASE_URL`.
+- **LLM providers** are configured as rows in the `llm_providers` table
+  with per-use-case assignments (ADR-021). `OLLAMA_BASE_URL` /
+  `OPENAI_BASE_URL` survive only as deprecated fresh-install bootstrap
+  fallbacks.
 - **OIDC** is an Enterprise Edition feature gated by
   `ENTERPRISE_FEATURES.OIDC_SSO`. In CE the arrow does not exist.
 - **SMTP** is optional and used by `notification-service`.

--- a/docs/architecture/02-container.md
+++ b/docs/architecture/02-container.md
@@ -66,7 +66,7 @@ flowchart TB
 | mcp-docs  | MCP server (Node) | 3100 | `ghcr.io/compendiq/compendiq-ce-mcp-docs` |
 | searxng   | Python meta search | 8080 | `ghcr.io/compendiq/compendiq-ce-searxng` |
 
-Each Compendiq image carries three tag classes published by the GitHub Actions Docker workflow: `:latest` (refreshed on every push to `main` — recommended default for production), `:0.4.0` and `:0.4` (refreshed on every `v*` release tag — pin these for exact-version reproducibility), and `:dev` (refreshed on every push to `dev` — useful for staging / smoke environments). The shared `compendiq-ce-frontend` image is consumed by both Community and Enterprise editions; there is no separate `compendiq-ee-frontend` image.
+Each Compendiq image carries three tag classes published by the GitHub Actions Docker workflow: `:latest` (refreshed on every push to `main` — recommended default for production), `:X.Y.Z` and `:X.Y` (e.g. `:0.6.2` / `:0.6`; refreshed on every `v*` release tag — pin these for exact-version reproducibility), and `:dev` (refreshed on every push to `dev` — useful for staging / smoke environments). The shared `compendiq-ce-frontend` image is consumed by both Community and Enterprise editions; there is no separate `compendiq-ee-frontend` image.
 
 ## Background workers
 

--- a/docs/architecture/03-backend-domains.md
+++ b/docs/architecture/03-backend-domains.md
@@ -19,7 +19,7 @@ flowchart LR
     subgraph domains["domains/"]
         direction TB
         dC["<b>confluence</b><br/>confluence-client<br/>sync-service<br/>attachment-handler<br/>subpage-context<br/>sync-overview-service"]
-        dL["<b>llm</b><br/>openai-compatible-client<br/>llm-provider-service<br/>llm-provider-resolver<br/>llm-provider-bootstrap<br/>embedding-service<br/>rag-service<br/>llm-cache + llm-cache-bus"]
+        dL["<b>llm</b><br/>openai-compatible-client<br/>llm-provider-service<br/>llm-provider-resolver<br/>llm-provider-bootstrap<br/>embedding-service<br/>rag-service<br/>llm-cache + cache-bus"]
         dK["<b>knowledge</b><br/>auto-tagger<br/>quality-worker<br/>summary-worker<br/>version-tracker<br/>duplicate-detector"]
     end
 

--- a/docs/architecture/04-frontend-structure.md
+++ b/docs/architecture/04-frontend-structure.md
@@ -11,28 +11,23 @@ flowchart TB
 
     subgraph providers["Providers (wrap the app)"]
         direction TB
-        rp["RouterProvider"]
-        qp["QueryProvider (TanStack Query)"]
-        ap["AuthProvider<br/>(session + token refresh)"]
+        qp["QueryClientProvider (TanStack Query)"]
+        rp["BrowserRouter"]
         ep["EnterpriseProvider<br/>GET /api/admin/license → isEnterprise"]
-        tp["ThemeProvider"]
     end
 
     main --> providers
-    providers --> app["App.tsx<br/>(routes, SetupRoute gating)"]
+    providers --> app["App.tsx<br/>(routes, SetupRoute gating;<br/>session + token refresh + theme via<br/>useSessionInit · useTokenRefreshTimer · useThemeEffect)"]
 
     subgraph features["features/ (domain UI)"]
         direction LR
-        fAuth["auth/<br/>LoginPage<br/>OidcCallbackPage (EE route)"]
-        fDash["dashboard/"]
+        fAuth["auth/<br/>OidcCallbackPage (EE route)"]
         fPages["pages/<br/>list · view · new · trash · pinned"]
         fSpaces["spaces/<br/>settings · new"]
         fAI["ai/<br/>AiAssistantPage<br/>(ask / improve / generate / summarize)"]
-        fSearch["search/"]
-        fAnalytics["analytics/"]
         fGraph["graph/"]
-        fSettings["settings/<br/>user + admin"]
-        fAdmin["admin/<br/>LicenseStatusCard<br/>OidcSettingsPage (EE-gated)"]
+        fSettings["settings/<br/>LoginPage · user + admin"]
+        fAdmin["admin/<br/>LicenseStatusCard<br/>OidcSettingsPage (EE-gated)<br/>analytics/ (AnalyticsPage)"]
     end
 
     app --> features
@@ -62,8 +57,8 @@ flowchart TB
     classDef feat fill:#eefbe8,stroke:#4caf50
     classDef sh fill:#fff4e5,stroke:#e5a23c
     classDef st fill:#f5eafd,stroke:#9b59b6
-    class providers,rp,qp,ap,ep,tp prov
-    class features,fAuth,fDash,fPages,fSpaces,fAI,fSearch,fAnalytics,fGraph,fSettings,fAdmin feat
+    class providers,qp,rp,ep prov
+    class features,fAuth,fPages,fSpaces,fAI,fGraph,fSettings,fAdmin feat
     class shared,sEnt,sComp,sHooks,sLib sh
     class stores,zAuth,zTheme,zUI,zAV,zCmd,zKb st
 ```
@@ -97,10 +92,11 @@ the backend side.
   anchored on the brand palette (black `#0A0A0A` + honey `#F9C74F`); see
   ADR-010 v0.4 for the full rationale and the migration away from the
   v0.3-era glassmorphic surfaces.
-- **Neumorphic** surface system (ADR-010 v0.4): eleven `nm-*` `@utility`
+- **Neumorphic** surface system (ADR-010 v0.4): fifteen `nm-*` `@utility`
   classes (`nm-card`, `nm-card-elevated`, `nm-card-interactive`,
   `nm-toolbar`, `nm-sidebar`, `nm-header`, `nm-pill-active`,
-  `nm-button-primary`, `nm-button-ghost`, `nm-icon-button`, `nm-input`)
+  `nm-button-primary`, `nm-button-destructive`, `nm-button-ghost`,
+  `nm-icon-button`, `nm-composer`, `nm-input`, `nm-select`, `nm-select-md`)
   built on theme-tinted shadow recipes plus a mandatory 1px solid border
   for visibility under WCAG 1.4.11 and `forced-colors: active`.
 - **Framer Motion** for entrance animations, wrapped in `LazyMotion`;

--- a/docs/architecture/05-deployment.md
+++ b/docs/architecture/05-deployment.md
@@ -134,7 +134,7 @@ flowchart LR
 | Provider config invalidation | Pub/sub (advisory-only payloads) | `provider:cache:bump`, `provider:deleted` |
 | LLM admin settings (concurrency, queue depth) | Pub/sub + cached getters | `admin:llm:settings` |
 | IP allowlist hot-reload | Pub/sub | `ip_allowlist:changed` |
-| Confluence SSRF allowlist | Dedicated `ssrf-allowlist-bus` | `confluence:allowlist:changed` |
+| Confluence SSRF allowlist | Dedicated `ssrf-allowlist-bus` | `ssrf:allowlist:changed` |
 | Sync conflict / PII / license / per-page-restriction policy | Pub/sub | `sync:conflict:policy:changed`, `pii:policy:changed`, `license:changed` |
 | Recurring jobs (sync tick, retention prune, embedding tick, webhook outbox poll) | BullMQ `upsertJobScheduler` with stable IDs | Redis queue keys |
 | Sync worker leadership | Redis SET-NX lock | `sync:worker:lock` |
@@ -184,10 +184,9 @@ flowchart LR
    external mgmt poller — token-gated, returns richer diagnostics
    (version, edition, dirty pages, last-sync timestamp, error rate).
    The token lives in `admin_settings.health_api_token` (seeded by
-   migration 072). For v0.4 onward, rotate via
-   `POST /api/admin/health-api/rotate` (admin-only) — that route ships
-   in EE#113 sub-PR 1e (CE PR #613); until it merges, rotate manually
-   via `UPDATE admin_settings SET setting_value = ... WHERE setting_key = 'health_api_token'`.
+   migration 072). Admins rotate it via
+   `POST /api/admin/health-api/rotate` (admin-only, returns the new
+   token).
 
 ### Compose example (2 replicas)
 
@@ -196,7 +195,7 @@ flowchart LR
 services:
   backend:
     # `:latest` tracks the latest stable release on `main`; pin to a
-    # versioned tag like `:0.4.0` for reproducible production deploys,
+    # versioned tag like `:0.6.2` for reproducible production deploys,
     # or `:dev` for staging environments that want dev-branch nightlies.
     image: ghcr.io/compendiq/compendiq-ee-backend:latest
     stop_grace_period: 60s   # SIGTERM → drain → SIGKILL

--- a/docs/architecture/06-data-model.md
+++ b/docs/architecture/06-data-model.md
@@ -26,7 +26,8 @@ erDiagram
     roles ||--o{ group_memberships : "granted via"
     groups ||--o{ group_memberships : "has"
     users ||--o{ group_memberships : "member of"
-    groups ||--o{ space_role_assignments : "assigned in"
+    groups ||--o{ space_role_assignments : "assigned in (principal)"
+    users ||--o{ space_role_assignments : "assigned in (principal)"
     roles ||--o{ space_role_assignments : "used in"
 
     users {
@@ -190,7 +191,8 @@ erDiagram
         bigint id PK
         text space_key
         bigint role_id FK
-        bigint group_id FK
+        text principal_type "user | group"
+        text principal_id
     }
 
     local_attachments {

--- a/docs/architecture/09-flow-rag-chat.md
+++ b/docs/architecture/09-flow-rag-chat.md
@@ -25,71 +25,65 @@ sequenceDiagram
 
     FE->>BE: POST /api/llm/ask<br/>{ question, model, conversationId,<br/>  includeSubPages, externalUrls, searchWeb }
     BE->>SAN: sanitize(question)
-    alt prompt-injection detected
-        SAN-->>BE: flagged
-        BE->>PG: INSERT audit_log (llm_prompt_injection)
-        BE-->>FE: SSE error (blocked)
-    else clean
-        SAN-->>BE: ok
-        BE->>CACHE: getCachedResponse(key)
-        alt cache hit
-            CACHE-->>BE: answer
-            BE-->>FE: SSE { content, done:true, fromCache:true }
-        else miss (stampede lock)
-            CACHE-->>BE: lock acquired
-            BE->>EMB: POST /v1/embeddings (question)
-            EMB-->>BE: q_vector[N]
-            BE->>RBAC: getUserAccessibleSpacesMemoized(userId)
-            RBAC-->>BE: readableSpaceKeys[] (request-scoped)
-            par vector + keyword
-                BE->>RAG: vectorSearch(userId, q_vector)
-                RAG->>PG: WHERE cp.space_key = ANY(readableSpaceKeys) ...
-                PG-->>RAG: top-K chunks
-            and
-                BE->>RAG: keywordSearch(userId, question)
-                RAG->>PG: tsvector search WHERE same space filter
-                PG-->>RAG: matches
-            end
-            RAG-->>BE: merged + deduped + ranked
-            opt RAG_PERMISSION_ENFORCEMENT (EE)
-                BE->>RBAC: userCanAccessPage(userId, pageId) for each candidate
-                RBAC-->>BE: filter decision (per-page read ACE honoured)
-                note right of BE: candidates were overfetched 1.5x<br/>at vector/fts stage to compensate
-            end
-            opt includeSubPages
-                BE->>RBAC: userCanAccessPage(userId, parentPageId)
-                RBAC-->>BE: allow / deny (#814 — skip tree on deny)
-                BE->>SP: assembleSubPageContext(rootPageId)
-                SP->>RBAC: getUserAccessibleSpacesMemoized(userId)
-                SP->>CF: fetch child tree WHERE deleted_at IS NULL<br/>AND visible to user (space RBAC)
-                CF-->>SP: pages
-                SP-->>BE: tree context
-            end
-            opt externalUrls provided
-                BE->>MCP: fetch urls
-                MCP-->>BE: content
-            end
-            opt searchWeb
-                BE->>MCP: search(question)
-                MCP-->>BE: top results
-            end
-            BE->>BE: build system prompt + context<br/>(resolveSystemPrompt, guardrails)
-            BE->>BE: resolveChatAssignment(model)<br/>(getUsecaseLlmAssignment('chat') — #217)
-            alt admin set chat override (source.provider='usecase' or source.model='usecase')
-                BE->>PROV: providerStreamChatForUsecase(provider, model, prompt)
-            else no override
-                BE->>PROV: providerStreamChat(userId, model, prompt)
-            end
-            loop chunks
-                PROV-->>BE: delta
-                BE-->>FE: SSE { content: delta }
-            end
-            PROV-->>BE: done
-            BE->>CACHE: setCachedResponse(key, answer)
-            BE->>CONV: upsert message + answer + sources
-            BE->>PG: INSERT audit_log (tokens, latency, doc_ids)
-            BE-->>FE: SSE { done:true, conversationId, sources }
+    SAN-->>BE: sanitized question (+ warnings)
+    opt prompt-injection detected
+        BE->>PG: INSERT audit_log (PROMPT_INJECTION_DETECTED)
+        note right of BE: promptInjectionDetected / sanitized attestation<br/>flags set on the llm_audit_log row —<br/>request continues with the sanitized question
+    end
+    BE->>CACHE: getCachedResponse(key)
+    alt cache hit
+        CACHE-->>BE: answer
+        BE-->>FE: SSE { content, done:true, fromCache:true }
+    else miss (stampede lock)
+        CACHE-->>BE: lock acquired
+        BE->>EMB: POST /v1/embeddings (question)
+        EMB-->>BE: q_vector[N]
+        BE->>RBAC: getUserAccessibleSpacesMemoized(userId)
+        RBAC-->>BE: readableSpaceKeys[] (request-scoped)
+        par vector + keyword
+            BE->>RAG: vectorSearch(userId, q_vector)
+            RAG->>PG: WHERE cp.space_key = ANY(readableSpaceKeys) ...
+            PG-->>RAG: top-K chunks
+        and
+            BE->>RAG: keywordSearch(userId, question)
+            RAG->>PG: tsvector search WHERE same space filter
+            PG-->>RAG: matches
         end
+        RAG-->>BE: merged + deduped + ranked
+        opt RAG_PERMISSION_ENFORCEMENT (EE)
+            BE->>RBAC: userCanAccessPage(userId, pageId) for each candidate
+            RBAC-->>BE: filter decision (per-page read ACE honoured)
+            note right of BE: candidates were overfetched 1.5x<br/>at vector/fts stage to compensate
+        end
+        opt includeSubPages
+            BE->>RBAC: userCanAccessPage(userId, parentPageId)
+            RBAC-->>BE: allow / deny (#814 — skip tree on deny)
+            BE->>SP: assembleSubPageContext(rootPageId)
+            SP->>RBAC: getUserAccessibleSpacesMemoized(userId)
+            SP->>CF: fetch child tree WHERE deleted_at IS NULL<br/>AND visible to user (space RBAC)
+            CF-->>SP: pages
+            SP-->>BE: tree context
+        end
+        opt externalUrls provided
+            BE->>MCP: fetch urls
+            MCP-->>BE: content (sanitized; detections audited — same flags)
+        end
+        opt searchWeb
+            BE->>MCP: search(question)
+            MCP-->>BE: top results (sanitized; detections audited — #835)
+        end
+        BE->>BE: build system prompt + context<br/>(resolveSystemPrompt, guardrails)
+        BE->>BE: resolveUsecase('chat')<br/>→ { config, model }
+        BE->>PROV: streamChat(config, resolvedModel, messages)
+        loop chunks
+            PROV-->>BE: delta
+            BE-->>FE: SSE { content: delta }
+        end
+        PROV-->>BE: done
+        BE->>CACHE: setCachedResponse(key, answer)
+        BE->>CONV: upsert message + answer + sources
+        BE->>PG: INSERT audit_log (tokens, latency, doc_ids)
+        BE-->>FE: SSE { done:true, conversationId, sources }
     end
 ```
 
@@ -170,8 +164,8 @@ All of these go through the same provider resolver and sanitization layer:
 | `POST /api/llm/improve` | Improve an existing article |
 | `POST /api/llm/generate` | Generate a new article |
 | `POST /api/llm/summarize` | Summarize a page |
-| `POST /api/llm/diagram` | Generate a Mermaid diagram from prose |
-| `POST /api/llm/pdf/extract` | PDF → text → summary |
+| `POST /api/llm/generate-diagram` | Generate a Mermaid diagram from prose |
+| `POST /api/llm/extract-pdf` | PDF → text extraction (sanitized) |
 
 ## Key files
 

--- a/docs/architecture/10-flow-enterprise-license.md
+++ b/docs/architecture/10-flow-enterprise-license.md
@@ -114,7 +114,7 @@ build-time patch, no separate EE SPA. All gating happens at runtime via
 | `backend/src/core/enterprise/noop.ts` | Inert CE stub |
 | `backend/src/core/enterprise/loader.ts` | Dynamic import + fallback |
 | `backend/src/core/types/compendiq-enterprise.d.ts` | Type declaration for the optional EE package |
-| `backend/src/routes/foundation/admin.ts` | CE fallback `GET /api/admin/license` |
+| `backend/src/app.ts` | CE fallback `GET /api/admin/license` (community-mode inline route) |
 | `frontend/src/shared/enterprise/context.tsx` | `EnterpriseProvider` |
 | `frontend/src/shared/enterprise/use-enterprise.ts` | `useEnterprise()` hook |
 | `frontend/src/features/admin/LicenseStatusCard.tsx` | Admin UI for the license |

--- a/docs/architecture/11-content-pipeline.md
+++ b/docs/architecture/11-content-pipeline.md
@@ -346,9 +346,9 @@ server-side.
 ## Attachments
 
 Images, drawio diagrams, and PDFs are downloaded during sync to
-`ATTACHMENTS_DIR` (default `data/attachments`) and rewritten to
-Compendiq-local URLs in `body_html`. The original Confluence URLs are
-kept in a sidecar table (`image_references`) for reconciliation.
+`ATTACHMENTS_DIR` (default `data/attachments`) and rewritten in
+`body_html` to Compendiq-local `/api/attachments/{pageId}/{filename}`
+URLs; the on-disk cache is keyed by page and filename.
 
 See [`08-flow-sync.md`](./08-flow-sync.md) for where this hooks into the
 sync pipeline.


### PR DESCRIPTION
## What

Systematic audit of the **living** docs against the post-0.6.2 code (multi-agent: every flagged claim was verified against the current source before editing). Historical material (docs/plans, docs/issues, dated specs/audit reports) intentionally untouched.

15 files, ~55 verified fixes. Highlights:

- **README**: dropped removed Knowledge Requests from the feature table; Vite 7 → 8.
- **USER-GUIDE**: space-sync, search, review-queue, and webhook flows now match the restructured Settings navigation; template/AI-generation sections rewritten to the actual `Use Template` + AI Generate-mode flows; removed references to components that no longer exist (AuthorPendingBanner); corrected the default search mode (keyword, not hybrid).
- **ADMIN-GUIDE**: all Settings paths updated to the current nav tree (Governance/AI Safety/Knowledge groups); removed a nonexistent `/api/health .queues` claim; audit-log access documented via the API.
- **API.md**: Swagger-UI production note; realistic response examples; correct global rate limit.
- **architecture/**: 09-flow-rag-chat now shows the non-blocking prompt-injection attestation flow (#835/#839); structure diagrams (03/04) match the post-cleanup tree; deployment/data-model/content-pipeline touch-ups.
- **.env.example**: deprecated LLM env vars re-labeled accurately (no-ops since migration 054, not seed values).

## Verification

- `docker-compose-invariants.test.ts` (asserts `.env.example` contents): 25/25 pass.
- Spot-reviewed every file's diff; sampled claims re-checked against code (sanitizer non-blocking path, PROMPT_INJECTION_DETECTED audit event, settings-nav tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)