### PR TITLE
fix(sync): don't resurrect trashed pages in syncPage (#853)

### DIFF
--- a/backend/src/domains/confluence/services/sync-service-delete-reconcile.integration.test.ts
+++ b/backend/src/domains/confluence/services/sync-service-delete-reconcile.integration.test.ts
@@ -454,18 +454,14 @@ describe.skipIf(!dbAvailable)('purgeDeletedPages upstream gone-confirmation (#76
 // hit real Postgres and stub only `getPage`/`getPageAttachments`.
 
 /**
- * Minimal ConfluenceClient stub for driving `syncPage` directly. `getPage`
+ * Minimal ConfluenceClient stub for driving `syncPage` directly: `getPage`
  * returns whatever the test configures (a `status:'trashed'`/`'current'` body,
- * or throws a ConfluenceError); `getPageAttachments` is a no-op so the
- * current-page control test can reach the upsert without real attachments.
+ * or throws a ConfluenceError). The trashed/404 guards short-circuit before any
+ * attachment fetch, so only `getPage` is needed here; the one current-page test
+ * that reaches the upsert supplies its own `getPageAttachments`.
  */
 function makeSyncPageClient(getPageImpl: (id: string) => Promise<unknown>) {
-  return {
-    getPage: getPageImpl,
-    async getPageAttachments(): Promise<{ results: never[] }> {
-      return { results: [] };
-    },
-  };
+  return { getPage: getPageImpl };
 }
 
 function trashedBody(id: string, version = 2) {
@@ -536,6 +532,8 @@ describe.skipIf(!dbAvailable)('syncPage trashed/gone guard (#853)', () => {
     expect(await rowExists('trash-new')).toBe(false);
     expect(counts.pagesCreated).toBe(0);
     expect(counts.pagesUpdated).toBe(0);
+    // No live row existed, so the soft-delete affects nothing — counter stays put.
+    expect(counts.pagesDeleted).toBe(0);
   });
 
   it('soft-deletes (does not resurrect) a live local row whose page is trashed upstream', async () => {
@@ -576,9 +574,12 @@ describe.skipIf(!dbAvailable)('syncPage trashed/gone guard (#853)', () => {
       throw new ConfluenceError('Resource not found', 404);
     });
 
-    await expect(runSyncPage(client, 'race-404')).resolves.toBeDefined();
+    // Resolving (not rejecting) is the "does not abort the sync" contract.
+    const counts = await runSyncPage(client, 'race-404');
 
     expect(await rowExists('race-404')).toBe(false);
+    // No live row existed, so nothing transitioned.
+    expect(counts.pagesDeleted).toBe(0);
   });
 
   it('soft-deletes a live row when its page 404s mid-sync', async () => {
@@ -609,7 +610,13 @@ describe.skipIf(!dbAvailable)('syncPage trashed/gone guard (#853)', () => {
   it('still upserts a current page normally (guard does not over-correct)', async () => {
     // Regression pin: the trashed guard must not block the normal path, and a
     // genuine trash-restore (status back to current) must still re-materialise.
-    const client = makeSyncPageClient(async (id) => currentBody(id, 1));
+    // The only case that reaches the upsert, so it needs getPageAttachments.
+    const client = {
+      getPage: async (id: string) => currentBody(id, 1),
+      async getPageAttachments(): Promise<{ results: never[] }> {
+        return { results: [] };
+      },
+    };
 
     const counts = await runSyncPage(client, 'live-1');
 

--- a/backend/src/domains/confluence/services/sync-service-delete-reconcile.integration.test.ts
+++ b/backend/src/domains/confluence/services/sync-service-delete-reconcile.integration.test.ts
@@ -29,7 +29,7 @@ import { query } from '../../../core/db/postgres.js';
 import { ConfluenceError } from './confluence-client.js';
 
 const { __internal } = await import('./sync-service.js');
-const { detectDeletedPages, purgeDeletedPages } = __internal;
+const { detectDeletedPages, purgeDeletedPages, syncPage } = __internal;
 
 const dbAvailable = await isDbAvailable();
 
@@ -436,5 +436,185 @@ describe.skipIf(!dbAvailable)('purgeDeletedPages upstream gone-confirmation (#76
 
     expect(await rowExists('mix-gone')).toBe(false);
     expect(await rowExists('mix-live')).toBe(true);
+  });
+});
+
+// ── syncPage must never resurrect a trashed/gone page (#853) ────────────────
+//
+// Regression of #766: the single/bulk Delete routes are now atomic (they
+// trash upstream then hard-delete the local row), so after a delete the row
+// is gone. But `syncPage` fetches each listed page via `getPage()` and upserts
+// it with `deleted_at = NULL` — with NO status guard. Confluence DC's DELETE
+// TRASHES rather than purges; if a sync captured the page as `current` and it
+// is trashed before the walk reaches it, `getPage()` answers either 200
+// `status:'trashed'` (some DC versions serve trashed content on a direct GET)
+// or 404 (the default status=current filter no longer matches). Without a
+// guard, the 200-trashed case re-materialises the just-deleted article (the
+// #853 report) and the 404 case throws and aborts the whole sync. These tests
+// hit real Postgres and stub only `getPage`/`getPageAttachments`.
+
+/**
+ * Minimal ConfluenceClient stub for driving `syncPage` directly. `getPage`
+ * returns whatever the test configures (a `status:'trashed'`/`'current'` body,
+ * or throws a ConfluenceError); `getPageAttachments` is a no-op so the
+ * current-page control test can reach the upsert without real attachments.
+ */
+function makeSyncPageClient(getPageImpl: (id: string) => Promise<unknown>) {
+  return {
+    getPage: getPageImpl,
+    async getPageAttachments(): Promise<{ results: never[] }> {
+      return { results: [] };
+    },
+  };
+}
+
+function trashedBody(id: string, version = 2) {
+  return {
+    id,
+    title: `Page ${id}`,
+    status: 'trashed',
+    body: { storage: { value: '<p>trashed content</p>' } },
+    version: { number: version, when: '2026-01-01T00:00:00Z', by: { displayName: 'Author' } },
+    metadata: { labels: { results: [] } },
+    ancestors: [],
+  };
+}
+
+function currentBody(id: string, version = 1) {
+  return {
+    id,
+    title: `Page ${id}`,
+    status: 'current',
+    body: { storage: { value: '<p>live content</p>' } },
+    version: { number: version, when: '2026-01-01T00:00:00Z', by: { displayName: 'Author' } },
+    metadata: { labels: { results: [] } },
+    ancestors: [],
+  };
+}
+
+function freshCounts() {
+  return { pagesCreated: 0, pagesUpdated: 0, pagesDeleted: 0 };
+}
+
+async function runSyncPage(
+  client: unknown,
+  confluenceId: string,
+  counts = freshCounts(),
+): Promise<typeof counts> {
+  await syncPage(
+    client as never,
+    'sync-user',
+    'DEV',
+    { id: confluenceId } as never,
+    new Date(),
+    new Map(),
+    counts,
+    'run-1',
+  );
+  return counts;
+}
+
+describe.skipIf(!dbAvailable)('syncPage trashed/gone guard (#853)', () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+  beforeEach(async () => {
+    await truncateAllTables();
+  });
+
+  it('does not re-create a deleted page when getPage returns 200 trashed', async () => {
+    // The Delete button already hard-deleted the local row; a stale sync
+    // iteration reaches this id and getPage answers 200 {status:'trashed'}.
+    // The upsert must NOT fresh-INSERT it as a live, visible article.
+    const client = makeSyncPageClient(async (id) => trashedBody(id, 1));
+
+    const counts = await runSyncPage(client, 'trash-new');
+
+    expect(await rowExists('trash-new')).toBe(false);
+    expect(counts.pagesCreated).toBe(0);
+    expect(counts.pagesUpdated).toBe(0);
+  });
+
+  it('soft-deletes (does not resurrect) a live local row whose page is trashed upstream', async () => {
+    // A row still live locally (e.g. the delete intent has not hard-deleted it
+    // yet, or a previous soft-delete was cleared) whose page is now trashed
+    // upstream must be converged to hidden — never refreshed back to visible.
+    await insertPage('trash-live', 'DEV'); // deleted_at IS NULL
+    const client = makeSyncPageClient(async (id) => trashedBody(id, 2));
+
+    const counts = await runSyncPage(client, 'trash-live');
+
+    expect(await getDeletedAt('trash-live')).not.toBeNull();
+    expect(counts.pagesDeleted).toBe(1);
+    // Body must not have been overwritten with the trashed content.
+    const row = await query<{ body_html: string }>(
+      'SELECT body_html FROM pages WHERE confluence_id = $1',
+      ['trash-live'],
+    );
+    expect(row.rows[0]!.body_html).not.toContain('trashed content');
+  });
+
+  it('leaves an already soft-deleted row hidden when its page is trashed upstream', async () => {
+    await insertPage('trash-softdel', 'DEV');
+    await softDelete('trash-softdel', 60 * 60); // soft-deleted an hour ago
+    const client = makeSyncPageClient(async (id) => trashedBody(id, 2));
+
+    const counts = await runSyncPage(client, 'trash-softdel');
+
+    expect(await getDeletedAt('trash-softdel')).not.toBeNull();
+    // No live row transitioned, so the deletion counter does not move.
+    expect(counts.pagesDeleted).toBe(0);
+  });
+
+  it('tolerates a 404 on getPage (page trashed/purged mid-sync) without aborting or re-creating', async () => {
+    // On DC versions that answer 404 (not 200-trashed) for a trashed id, the
+    // per-page fetch must not abort the whole sync nor leave/insert a live row.
+    const client = makeSyncPageClient(async () => {
+      throw new ConfluenceError('Resource not found', 404);
+    });
+
+    await expect(runSyncPage(client, 'race-404')).resolves.toBeDefined();
+
+    expect(await rowExists('race-404')).toBe(false);
+  });
+
+  it('soft-deletes a live row when its page 404s mid-sync', async () => {
+    await insertPage('race-404-live', 'DEV');
+    const client = makeSyncPageClient(async () => {
+      throw new ConfluenceError('Resource not found', 404);
+    });
+
+    const counts = await runSyncPage(client, 'race-404-live');
+
+    expect(await getDeletedAt('race-404-live')).not.toBeNull();
+    expect(counts.pagesDeleted).toBe(1);
+  });
+
+  it('re-throws a non-404 getPage error and never soft-deletes on it (5xx/403)', async () => {
+    // A transient/permission failure must NOT be mistaken for a deletion — the
+    // row stays live and the error surfaces so the sync can be retried.
+    await insertPage('err-503', 'DEV');
+    const client = makeSyncPageClient(async () => {
+      throw new ConfluenceError('Service unavailable', 503);
+    });
+
+    await expect(runSyncPage(client, 'err-503')).rejects.toThrow();
+
+    expect(await getDeletedAt('err-503')).toBeNull();
+  });
+
+  it('still upserts a current page normally (guard does not over-correct)', async () => {
+    // Regression pin: the trashed guard must not block the normal path, and a
+    // genuine trash-restore (status back to current) must still re-materialise.
+    const client = makeSyncPageClient(async (id) => currentBody(id, 1));
+
+    const counts = await runSyncPage(client, 'live-1');
+
+    expect(await rowExists('live-1')).toBe(true);
+    expect(await getDeletedAt('live-1')).toBeNull();
+    expect(counts.pagesCreated).toBe(1);
   });
 });

--- a/backend/src/domains/confluence/services/sync-service.ts
+++ b/backend/src/domains/confluence/services/sync-service.ts
@@ -421,6 +421,46 @@ async function syncSpace(
   });
 }
 
+/**
+ * #853: converge the local row for a Confluence page that the per-page fetch
+ * reports as no longer live — trashed (200 `status: 'trashed'`) or gone (404).
+ * Confluence DC's DELETE trashes rather than purges, so a page can be trashed
+ * upstream between the moment a listing captured it as `current` and the moment
+ * `syncPage` fetches it (e.g. a user clicks Delete mid-sync). Letting `syncPage`
+ * fall through to its upsert would clear `deleted_at` and resurrect the just-
+ * deleted article (regression of #766). Instead we soft-delete the local row —
+ * the same terminal state `detectDeletedPages` produces — so every list/tree/
+ * search query (all filter `deleted_at IS NULL`) hides it and `purgeDeletedPages`
+ * converges it. Only a row we have not already soft-deleted is touched, so an
+ * in-flight delete-route intent is left exactly as it is.
+ */
+async function softDeleteVanishedPage(
+  userId: string,
+  confluenceId: string,
+  spaceKey: string,
+  counts: SyncSpaceCounts,
+  reason: string,
+): Promise<void> {
+  const res = await query(
+    'UPDATE pages SET deleted_at = NOW() WHERE confluence_id = $1 AND deleted_at IS NULL',
+    [confluenceId],
+  );
+  if ((res.rowCount ?? 0) > 0) {
+    counts.pagesDeleted++;
+    await cleanPageAttachments(userId, confluenceId);
+    await clearPageFailures(confluenceId);
+    logger.info(
+      { spaceKey, confluenceId, reason },
+      'Sync skipped upsert of a non-current Confluence page and soft-deleted the local row (#853)',
+    );
+  } else {
+    logger.debug(
+      { spaceKey, confluenceId, reason },
+      'Sync skipped upsert of a non-current Confluence page; no live local row to soft-delete (#853)',
+    );
+  }
+}
+
 async function syncPage(
   client: ConfluenceClient,
   userId: string,
@@ -432,8 +472,32 @@ async function syncPage(
   syncRunId: string,
   changeSet: RestrictionChangeSet = { mode: 'full' },
 ): Promise<void> {
-  // Fetch full page content
-  const page = await client.getPage(pageSummary.id);
+  // Fetch full page content. A page can be trashed upstream between the moment
+  // a listing captured it as `current` and this per-page fetch — e.g. a user
+  // clicks Delete in Compendiq while a sync is walking the space (#853,
+  // regression of #766). Confluence DC's DELETE trashes rather than purges;
+  // depending on the DC version the fetch then answers either 200 with
+  // `status: 'trashed'` (some versions still serve trashed content on a direct
+  // GET) or 404 (the default status=current filter no longer matches). In BOTH
+  // cases the page must NOT be re-materialised — the upsert below clears
+  // `deleted_at`, which would resurrect the article the user just deleted. So
+  // soft-delete the local row and skip the upsert. Only a definitive 404 is
+  // swallowed; any other fetch error (401/403/5xx/network) is a genuine failure
+  // and is re-thrown so a transient problem is never mistaken for a deletion.
+  let page: ConfluencePage;
+  try {
+    page = await client.getPage(pageSummary.id);
+  } catch (err) {
+    if (err instanceof ConfluenceError && err.statusCode === 404) {
+      await softDeleteVanishedPage(userId, pageSummary.id, spaceKey, counts, 'gone (404)');
+      return;
+    }
+    throw err;
+  }
+  if (page.status === 'trashed') {
+    await softDeleteVanishedPage(userId, page.id, spaceKey, counts, 'trashed (200)');
+    return;
+  }
   const bodyStorage = page.body?.storage?.value ?? '';
 
   // Convert to HTML
@@ -1841,4 +1905,9 @@ export const __internal = {
   // gone-confirmation) converges it fully without driving an entire
   // syncSpace run.
   purgeDeletedPages,
+  // Exposed for the #853 trashed-upsert integration tests: prove that a page
+  // Confluence reports as trashed (200 `status: 'trashed'`) or gone (404) on
+  // the per-page fetch is NOT re-materialised locally by the upsert path,
+  // without having to drive an entire syncSpace/syncUser walk.
+  syncPage,
 };

--- a/backend/src/domains/confluence/services/sync-service.ts
+++ b/backend/src/domains/confluence/services/sync-service.ts
@@ -435,7 +435,6 @@ async function syncSpace(
  * in-flight delete-route intent is left exactly as it is.
  */
 async function softDeleteVanishedPage(
-  userId: string,
   confluenceId: string,
   spaceKey: string,
   counts: SyncSpaceCounts,
@@ -447,7 +446,9 @@ async function softDeleteVanishedPage(
   );
   if ((res.rowCount ?? 0) > 0) {
     counts.pagesDeleted++;
-    await cleanPageAttachments(userId, confluenceId);
+    // Attachment dirs are keyed by confluence_id; cleanPageAttachments ignores
+    // its first arg (same call shape detectDeletedPages uses).
+    await cleanPageAttachments('', confluenceId);
     await clearPageFailures(confluenceId);
     logger.info(
       { spaceKey, confluenceId, reason },
@@ -489,13 +490,13 @@ async function syncPage(
     page = await client.getPage(pageSummary.id);
   } catch (err) {
     if (err instanceof ConfluenceError && err.statusCode === 404) {
-      await softDeleteVanishedPage(userId, pageSummary.id, spaceKey, counts, 'gone (404)');
+      await softDeleteVanishedPage(pageSummary.id, spaceKey, counts, 'gone (404)');
       return;
     }
     throw err;
   }
   if (page.status === 'trashed') {
-    await softDeleteVanishedPage(userId, page.id, spaceKey, counts, 'trashed (200)');
+    await softDeleteVanishedPage(page.id, spaceKey, counts, 'trashed (200)');
     return;
   }
   const bodyStorage = page.body?.storage?.value ?? '';


### PR DESCRIPTION
## Summary

Fixes #853 (regression of #766). Deleting a Confluence-backed page in Compendiq removed it in Confluence but the article stayed visible / reappeared in Compendiq.

The single/bulk **Delete routes are already atomic** (trash upstream → hard-delete the local row), so the row *is* removed on delete. The regression lived one layer down, in the **sync pipeline**: `syncPage()` fetched every listed page via `getPage()` and upserted it with `deleted_at = NULL` **without inspecting `page.status`**.

Confluence DC's `DELETE` **trashes** rather than purges a page. So in the **sync‑vs‑delete race** — a listing captures a page while `current`, the user clicks Delete mid‑walk — the per‑page fetch returns the page as trashed and the unconditional upsert **re‑materialises the article the user just deleted**.

Research against the Atlassian DC javadoc + CQL reference confirmed the steady‑state listings can't surface trashed content (content list and CQL both default to `status=current`), so the vector is specifically that race (plus any DC/gateway that serves trashed content on a direct GET).

## The fix

A guard in `syncPage` immediately after `getPage()`:

| Fetch result | Action |
|---|---|
| `200 status:'trashed'` | soft-delete the local row, skip the upsert |
| `404` (DC's default answer for a trashed id) | soft-delete, skip — also stops the race **aborting the whole space sync** |
| `401 / 403 / 5xx / network` | re-thrown — a transient failure is never mistaken for a deletion |

Design notes:
- The guard sits **before** the version/conflict logic, so it structurally covers **both** write sites that clear `deleted_at` (the main upsert *and* `applyConflictPolicyForExistingPage`) — one choke point, not two patches.
- Guard on `status === 'trashed'` (not `!== 'current'`) to match the `detectDeletedPages`/`purgeDeletedPages` vocabulary, stay backward-compatible with status-less test mocks, and avoid hiding **archived** (valid) pages.
- **No listing change** is needed. The content list and CQL search both default to `status=current`, and CQL has no `status` field — so `AND status = current` would have *broken* `getModifiedPages`. The single guard is sufficient.

## Tests

7 new real-Postgres integration tests in `sync-service-delete-reconcile.integration.test.ts` (written first, confirmed RED → GREEN):

- 200-trashed: does not re-create a deleted page; soft-deletes (doesn't resurrect) a live row; leaves an already soft-deleted row hidden (no `deleted_at` clear); doesn't overwrite body with trashed content
- 404: tolerated without abort and without re-insert; live row soft-deleted
- non-404 (503): re-thrown, row untouched
- current page: still upserts normally (regression pin)

`syncPage` is exposed via `__internal` for the tests.

## Verification

- ✅ 7 new tests RED → GREEN
- ✅ No regressions: 378 confluence-service tests, 66 delete/trash route tests, full backend suite green (3190 pass / 144 skip)
- ✅ `typecheck` clean, `eslint` clean

## Acceptance criteria (#853)

- [x] Deleting leaves the two stores consistent (already true; delete routes are atomic)
- [x] A page trashed/gone in Confluence stays removed locally and is **not** re-inserted by a subsequent sync
- [x] Reconciliation treats `status: trashed` (200) as gone, not only 404 (pre-existing; unchanged)
- [x] Regression tests cover: upstream delete succeeds but a later step leaves a trashed page reachable → no divergence/reappearance; trashed-but-not-404 page → not re-upserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)