### PR TITLE
fix(confluence): treat empty 204 as success so Confluence deletes remove the local page (#853)

### DIFF
--- a/backend/src/domains/confluence/services/confluence-client.test.ts
+++ b/backend/src/domains/confluence/services/confluence-client.test.ts
@@ -183,6 +183,36 @@ describe('ConfluenceClient', () => {
       // Not a transient error — withRetry must rethrow without retrying.
       expect(mockRequest).toHaveBeenCalledTimes(1);
     });
+
+    it('resolves (does not throw) on a 204 No Content with an empty body — #853', async () => {
+      const client = new ConfluenceClient(baseUrl, pat);
+      // Confluence DC's DELETE /content/{id} answers 204 with an EMPTY body. An
+      // empty 2xx is a legitimate success with no payload — it must NOT be
+      // treated as a non-JSON error (JSON.parse('') throwing). Before the fix,
+      // deletePage rejected with ConfluenceError(204), and the delete route
+      // mistook that for a failure and rolled back the local delete — leaving
+      // the page visible in Compendiq while it was trashed upstream (#853).
+      mockRequest.mockResolvedValue({
+        statusCode: 204,
+        headers: {},
+        body: { text: async () => '' },
+      } as never);
+
+      await expect(client.deletePage('688131')).resolves.toBeUndefined();
+      // Not a transient error path — no retries.
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves on an empty 200 body (empty success payload)', async () => {
+      const client = new ConfluenceClient(baseUrl, pat);
+      mockRequest.mockResolvedValue({
+        statusCode: 200,
+        headers: {},
+        body: { text: async () => '   ' },
+      } as never);
+
+      await expect(client.deletePage('42')).resolves.toBeUndefined();
+    });
   });
 
   describe('getSpaces homepage expansion', () => {

--- a/backend/src/domains/confluence/services/confluence-client.ts
+++ b/backend/src/domains/confluence/services/confluence-client.ts
@@ -193,13 +193,24 @@ export class ConfluenceClient {
       throw error;
     }
 
+    // An empty 2xx body is a legitimate success with no payload — most commonly
+    // Confluence DC's `DELETE /content/{id}`, which answers `204 No Content`.
+    // Treating it as a non-JSON error (JSON.parse('') throwing) made every page
+    // delete look like a failure: `deletePage` rejected with ConfluenceError(204)
+    // and the delete route rolled back the local removal, leaving the page
+    // visible in Compendiq while it was trashed upstream (#853). Return undefined
+    // for callers that don't expect a body (e.g. deletePage: Promise<void>).
+    if (text.trim() === '') {
+      return undefined as T;
+    }
+
     try {
       return JSON.parse(text) as T;
     } catch {
-      // A 2xx response whose body isn't JSON (e.g. a reverse proxy or SSO
-      // portal answering 200 with an HTML login page) must surface as a typed
-      // ConfluenceError with a body excerpt — not a raw SyntaxError whose
-      // opaque "Unexpected token" message aborts the whole sync (#746).
+      // A NON-empty 2xx response whose body isn't JSON (e.g. a reverse proxy or
+      // SSO portal answering 200 with an HTML login page) must surface as a typed
+      // ConfluenceError with a body excerpt — not a raw SyntaxError whose opaque
+      // "Unexpected token" message aborts the whole sync (#746).
       logger.error({ statusCode, url, body: text.slice(0, 500) }, 'Confluence API returned non-JSON response');
       throw new ConfluenceError(
         `Confluence API returned non-JSON response (HTTP ${statusCode}): ${text.slice(0, 200)}`,


### PR DESCRIPTION
## Summary

Found while testing #853 against a **real Confluence Data Center** (the mocked suite could not see it). Deleting a Confluence-backed page removed it in Confluence but left the article **visible in Compendiq** — the #853 symptom, on **every** Confluence page delete.

### Root cause

Confluence DC's `DELETE /rest/api/content/{id}` returns **`204 No Content`** with an empty body. `ConfluenceClient.fetchOnce` ran `JSON.parse(text)` on every 2xx response, so the empty body threw and was surfaced as a non-JSON error → `ConfluenceError(204)`.

```
deletePage() rejects on a SUCCESSFUL 204
        │
        ▼
DELETE /api/pages/:id  — only treats 404 as "already gone"
        │  204 ≠ 404  → looks like an upstream failure
        ▼
rolls back the local soft-delete  →  page trashed upstream, still visible locally
```

### Why the tests missed it

The delete-route tests mock `deletePage` with `mockResolvedValue(undefined)` — the mock's notion of "success" never reproduced the real *204-throws-on-success* behaviour of the actual client. The gap only appears against a real Confluence DC.

### Fix

In `fetchOnce`, an **empty 2xx body** is a legitimate success with no payload — return `undefined` instead of throwing. A **non-empty** 2xx body that isn't JSON (e.g. an SSO/HTML login page) still raises the typed `ConfluenceError` added in #746.

## Relationship to #854

- **#854** (merged) hardened the **sync side** — `syncPage` no longer re-materialises a trashed page.
- **This PR** fixes the **delete side** — the delete itself now actually removes the local row.

Both are required to fully close #853; this one is the more direct/primary production cause.

## Tests

`confluence-client.test.ts`:
- **new:** `204 No Content` empty body → `deletePage` resolves (no throw, no retry)
- **new:** empty `200` body → resolves
- **preserved:** non-empty non-JSON 2xx (HTML login page) still throws (#746)

✅ 107 client tests + 442 delete/sync route tests pass · typecheck + lint clean

## End-to-end verification (real Confluence DC)

1. Synced a `DEV` space (4 pages) into Compendiq.
2. **Pre-fix:** deleting a page → trashed in Confluence (404) but **still visible** in Compendiq (`deleted_at = NULL`) — #853 reproduced.
3. **Post-fix:** deleting a page → local row **hard-deleted** + trashed upstream, no error; **stays gone** after a subsequent sync; both stores consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)