### PR TITLE
fix(routes): exclude trashed pages from GET /api/spaces pageCount (#869)

### DIFF
--- a/backend/src/routes/confluence/spaces.test.ts
+++ b/backend/src/routes/confluence/spaces.test.ts
@@ -181,6 +181,36 @@ describe('Spaces routes', () => {
     expect(localSpace.pageCount).toBe(5);
   });
 
+  it('GET /spaces excludes soft-deleted (trashed) pages from pageCount (#869, #923)', async () => {
+    mockGetUserAccessibleSpaces.mockResolvedValueOnce(['DEV']);
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          space_key: 'DEV',
+          space_name: 'Development',
+          homepage_id: null,
+          homepage_numeric_id: null,
+          custom_home_page_id: null,
+          last_synced: '2026-03-18T10:00:00.000Z',
+          source: 'confluence',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ space_key: 'DEV', count: '1' }] });
+
+    const response = await app.inject({ method: 'GET', url: '/api/spaces' });
+    expect(response.statusCode).toBe(200);
+
+    // The per-space page-count query must filter soft-deleted rows so that
+    // sync-trashed and standalone-trashed pages do not inflate pageCount,
+    // matching the deleted_at IS NULL invariant used by every other count
+    // surface (#828).
+    const countCall = mockQuery.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('GROUP BY cp.space_key'),
+    );
+    expect(countCall).toBeDefined();
+    expect(countCall?.[0]).toMatch(/deleted_at IS NULL/);
+  });
+
   // ---------- #352: PUT /api/spaces/:key/home ----------
 
   it('GET /spaces surfaces customHomePageId when set, overriding the Confluence default (#352)', async () => {

--- a/backend/src/routes/confluence/spaces.ts
+++ b/backend/src/routes/confluence/spaces.ts
@@ -53,6 +53,7 @@ export async function spacesRoutes(fastify: FastifyInstance) {
       `SELECT cp.space_key, COUNT(*) as count
        FROM pages cp
        WHERE cp.space_key = ANY($1::text[])
+         AND cp.deleted_at IS NULL
        GROUP BY cp.space_key`,
       [userSpaces],
     );


### PR DESCRIPTION
## Summary
- The `GET /api/spaces` per-space page-count query counted soft-deleted (trashed) rows, inflating each space's `pageCount`.
- Added `AND cp.deleted_at IS NULL` so the badge count matches the page tree/list/search/overview surfaces (all of which already filter soft-deleted rows per #828).
- Fixes the "badge says 2, tree footer says 1, tree body says 0" divergence for spaces with trashed pages.

Closes #869. Closes #923.

## Root cause
The counts query in `spaces.ts` had a WHERE clause restricting only `space_key`, with no soft-delete filter, so sync-trashed and standalone-trashed pages (which are hidden everywhere else) still inflated `pageCount`.

## Fix
- Add `AND cp.deleted_at IS NULL` to the count query's WHERE clause in `backend/src/routes/confluence/spaces.ts`.
- No other change; the parameter list stays `[userSpaces]`.

## Testing
- TDD: added a regression test in `backend/src/routes/confluence/spaces.test.ts` that locates the count SQL (`GROUP BY cp.space_key`) and asserts it contains `deleted_at IS NULL`; **fails before** the fix (SQL lacked the filter), **passes after**.
- `cd backend && npx vitest run src/routes/confluence/spaces.test.ts` (13 passed) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code