### PR TITLE
fix(ui): keep homepage visible when it is a space's only page (#961)

### DIFF
--- a/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
@@ -453,6 +453,25 @@ describe('SidebarTreeView', () => {
     expect(screen.getByText('API Reference')).toBeInTheDocument();
   });
 
+  it('keeps the homepage visible when it is the only page in the space (#961)', () => {
+    mockTreeData = {
+      items: [
+        { id: 'root-1', spaceKey: 'DEV', title: 'Getting Started', pageType: 'page' as const, parentId: null, labels: [], lastModifiedAt: '2026-03-01T00:00:00Z', embeddingDirty: false },
+      ],
+      total: 1,
+    };
+    useUiStore.setState({
+      treeSidebarCollapsed: false,
+      treeSidebarSpaceKey: 'DEV',
+    });
+    render(<SidebarTreeView />, { wrapper: createWrapper() });
+    // Hiding the homepage would leave the tree empty, so it stays visible and
+    // navigable instead of rendering a false "empty space" state.
+    expect(screen.getByText('Getting Started')).toBeInTheDocument();
+    expect(screen.queryByText('No pages in this space')).not.toBeInTheDocument();
+    expect(screen.queryByText('This space has no content.')).not.toBeInTheDocument();
+  });
+
   it('has a New Space button in sidebar header', () => {
     render(<SidebarTreeView />, { wrapper: createWrapper() });
     expect(screen.getByLabelText('New Space')).toBeInTheDocument();

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -63,9 +63,16 @@ function buildTree(pages: PageTreeItem[], homepageId?: string | null): TreeNode[
     if (homepageNode) {
       const promoted = homepageNode.children;
       const withoutHomepage = roots.filter((r) => r.page.id !== homepageId);
-      return [...promoted, ...withoutHomepage].sort((a, b) =>
-        a.page.title.localeCompare(b.page.title),
-      );
+      const withoutHome = [...promoted, ...withoutHomepage];
+      // #961: hiding the homepage must not leave the sidebar empty. When the
+      // space contains only its homepage (no children, no sibling roots),
+      // keep the homepage visible so the tree doesn't render a false
+      // "empty space" state above a "1 page in <SPACE>" footer.
+      if (withoutHome.length > 0) {
+        return withoutHome.sort((a, b) =>
+          a.page.title.localeCompare(b.page.title),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- A space that contains only its homepage rendered a false "No pages in this space" / "This space has no content." empty state in the sidebar tree — while the footer still read "1 page in <SPACE>".
- `buildTree()`'s #352 homepage-hiding rule now only applies when it leaves something to show; otherwise the homepage stays visible and navigable.

Closes #961.

## Root cause
For a homepage-only space, the #352 rule promoted the homepage's (empty) children and dropped the homepage, returning `[]`. `tree.length === 0` then triggered the empty-state copy, contradicting the footer's page count.

## Fix
- Compute `withoutHome = [...promoted, ...withoutHomepage]` and only return it (sorted) when non-empty.
- Otherwise fall through to the existing `return roots` (just the homepage node), so the single page renders in the tree.
- Multi-page #352 behavior is unchanged (any child or sibling keeps `withoutHome` non-empty).

## Testing
- TDD: added a SidebarTreeView test ("keeps the homepage visible when it is the only page in the space (#961)"); **fails before** the fix (tree is empty so "Getting Started" is absent and the empty-state copy renders), **passes after**.
- `cd frontend && npx vitest run src/shared/components/layout/SidebarTreeView.test.tsx` (74 pass, incl. the #352 regression test) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code