### PR TITLE
fix(confluence): widen incremental-sync CQL window to a tz-safe datetime bound (#858)

### DIFF
--- a/backend/src/domains/confluence/services/confluence-client.test.ts
+++ b/backend/src/domains/confluence/services/confluence-client.test.ts
@@ -284,6 +284,24 @@ describe('ConfluenceClient', () => {
       expect(decodedCql).toContain('space="OPS\\" OR space=\\"SECRET" AND type=page');
       expect(decodedCql).not.toContain('space="OPS" OR space="SECRET"');
     });
+
+    it('uses a minute-granular datetime lower bound widened by a 24h overlap margin (#858)', async () => {
+      const client = new ConfluenceClient(baseUrl, pat);
+      mockRequest.mockResolvedValue({
+        statusCode: 200,
+        body: { text: async () => JSON.stringify({ results: [], start: 0, limit: 50, size: 0 }) },
+      } as never);
+
+      await client.getModifiedPages(new Date('2026-07-10T02:00:00Z'), 'OPS');
+
+      const callUrl = mockRequest.mock.calls[0][0] as string;
+      const decodedCql = decodeURIComponent(callUrl.split('cql=')[1].split('&')[0]);
+      // A minute-granular datetime literal, not a bare calendar date.
+      expect(decodedCql).toMatch(/lastmodified>="\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}"/);
+      // Lower bound widened ~24h below `since` to absorb the instance timezone offset.
+      expect(decodedCql).toContain('lastmodified>="2026/07/09 02:00"');
+      expect(decodedCql).not.toContain('lastmodified>="2026-07-10"');
+    });
   });
 
   describe('label management', () => {

--- a/backend/src/domains/confluence/services/confluence-client.ts
+++ b/backend/src/domains/confluence/services/confluence-client.ts
@@ -628,8 +628,16 @@ export class ConfluenceClient {
   }
 
   async getModifiedPages(since: Date, spaceKey: string): Promise<ConfluencePage[]> {
-    const dateStr = since.toISOString().split('T')[0];
-    const cql = `space="${this.escapeCqlValue(spaceKey)}" AND type=page AND lastmodified>="${dateStr}" ORDER BY lastmodified DESC`;
+    // CQL date/datetime literals are evaluated in the Confluence instance's
+    // configured timezone, not UTC. We don't know that timezone, so we widen the
+    // lower bound by a generous overlap margin (covering the full -12h..+14h
+    // offset range) and use minute-granular datetime format, so edits made near
+    // a UTC-day boundary on a west-of-UTC instance are not silently missed (#858).
+    // Over-fetching is harmless: syncPage's version guard skips unchanged pages.
+    const OVERLAP_MS = 24 * 60 * 60 * 1000;
+    const from = new Date(since.getTime() - OVERLAP_MS);
+    const cqlDate = formatCqlDateTime(from);
+    const cql = `space="${this.escapeCqlValue(spaceKey)}" AND type=page AND lastmodified>="${cqlDate}" ORDER BY lastmodified DESC`;
     const pages: ConfluencePage[] = [];
     let start = 0;
     const limit = 50;
@@ -975,6 +983,20 @@ export class ConfluenceClient {
     );
     return res.body?.storage?.value ?? '';
   }
+}
+
+/**
+ * Formats an instant as a Confluence CQL minute-granular datetime literal
+ * (`yyyy/MM/dd HH:mm`), built from its UTC wall-clock. Used by
+ * `getModifiedPages` for the incremental-sync lower bound (#858).
+ */
+export function formatCqlDateTime(d: Date): string {
+  const y = d.getUTCFullYear();
+  const mo = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const da = String(d.getUTCDate()).padStart(2, '0');
+  const h = String(d.getUTCHours()).padStart(2, '0');
+  const mi = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${y}/${mo}/${da} ${h}:${mi}`;
 }
 
 /**

--- a/docs/architecture/08-flow-sync.md
+++ b/docs/architecture/08-flow-sync.md
@@ -110,6 +110,16 @@ sequenceDiagram
   `NODE_EXTRA_CA_CERTS` for self-signed internal CAs.
 - **Idempotency** — upsert by `(user_id, confluence_id)`. `version` column
   is written from Confluence's own version counter; no double-writes.
+- **Timezone-safe incremental window (#858)** — `getModifiedPages` builds the
+  `lastmodified >=` lower bound as a **minute-granular CQL datetime literal**
+  (`yyyy/MM/dd HH:mm`, from the UTC wall-clock) widened by a **24h overlap
+  margin**. CQL date/time literals are resolved in the Confluence instance's
+  configured timezone (not UTC, and not exposed to us); the old bare-UTC-date
+  bound silently dropped edits made near a UTC-day boundary on west-of-UTC
+  instances, and the miss was permanent because the bound only advances forward.
+  The 24h margin provably covers the full real-world offset range (−12h…+14h);
+  over-fetching is a no-op because the `version` idempotency guard above skips
+  any re-fetched page whose stored version is already current.
 - **Circuit breaker** — `core/services/circuit-breaker.ts` protects against
   runaway failure against a broken Confluence instance.
 - **Per-page failure isolation (#822)** — the per-page loop in `syncSpace`


### PR DESCRIPTION
## Summary
- `getModifiedPages` now builds the incremental-sync `lastmodified >=` lower bound as a minute-granular CQL datetime literal (`yyyy/MM/dd HH:mm`, UTC wall-clock) widened by a 24h overlap margin, replacing the bare-UTC-date bound.
- Adds a small module-scope `formatCqlDateTime` helper alongside the other exported client helpers.
- Documents the timezone-safe window in `docs/architecture/08-flow-sync.md`.

Closes #858.

## Root cause
CQL date/datetime literals are resolved in the Confluence instance's configured timezone, not UTC. The old bare-UTC-date bound (`lastmodified>="yyyy-MM-dd"`) was interpreted as a later absolute instant on west-of-UTC instances, so edits made between 00:00 UTC and local midnight were excluded — and the miss was permanent because the bound only advances forward and the >=24h full-sync backstop did not re-cover it.

## Fix
- Subtract a 24h overlap margin from `since` (provably covers the full −12h…+14h offset range).
- Format the bound as a minute-granular `yyyy/MM/dd HH:mm` datetime literal instead of a bare date.
- Over-fetching is harmless: `syncPage`'s version guard skips any re-fetched page whose stored version is already current.

## Testing
- TDD: extended `backend/src/domains/confluence/services/confluence-client.test.ts`; **fails before** the fix (current code emits `lastmodified>="2026-07-10"`, matching neither the minute-granular regex nor the widened literal), **passes after**.
- `cd backend && npx vitest run src/domains/confluence/services/confluence-client.test.ts` (106 passed) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code