### PR TITLE
fix(sync): scope stale-ACE sweep to the run's spaces and preserve ACEs on fetch failure (#859)

### DIFF
--- a/backend/src/domains/confluence/services/sync-service.integration.test.ts
+++ b/backend/src/domains/confluence/services/sync-service.integration.test.ts
@@ -424,8 +424,8 @@ describe.skipIf(!dbAvailable)('sync-service per-page restriction branch (EE #112
     expect(await getInheritPerms(pageDbId)).toBe(true);
     // ACE for alice is still there (sweep hasn't run yet inside syncUser).
 
-    // Now simulate the end-of-run sweep.
-    await __internal.sweepStaleConfluenceAces(secondStartedAt);
+    // Now simulate the end-of-run sweep (scoped to this run's space).
+    await __internal.sweepStaleConfluenceAces(secondStartedAt, ['DOCS']);
 
     // The confluence-sourced ACE for alice is gone.
     const pageAces = await getAces(pageDbId);
@@ -435,6 +435,84 @@ describe.skipIf(!dbAvailable)('sync-service per-page restriction branch (EE #112
     const otherAces = await getAces(otherPageDbId);
     expect(otherAces).toHaveLength(2);
     expect(otherAces.map((a) => a.source).sort()).toEqual(['confluence', 'local']);
+  });
+
+  it('stale-ACE sweep is scoped to the run\'s spaces — ACEs in spaces this run did not visit survive', async () => {
+    // Regression for #859 (Fix 1): the end-of-run sweep must only age out
+    // ACEs for pages in the spaces this run actually synced. A run over
+    // SPACEX must not wipe ACEs another user's run wrote for SPACEY.
+    const userA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    await insertUser(userA, 'alice');
+    await ensureSpace('SPACEX');
+    await ensureSpace('SPACEY');
+    const pageX = await insertPage('c-x', 'SPACEX');
+    const pageY = await insertPage('c-y', 'SPACEY');
+
+    // Both pages have a stale Confluence ACE (synced in a prior run).
+    const oldSyncedAt = new Date('2026-01-01T10:00:00Z');
+    for (const pid of [pageX, pageY]) {
+      await query(
+        `INSERT INTO access_control_entries
+           (resource_type, resource_id, principal_type, principal_id,
+            permission, source, synced_at)
+         VALUES ('page', $1, 'user', $2, 'read', 'confluence', $3)`,
+        [pid, userA, oldSyncedAt],
+      );
+    }
+
+    // This run only visited SPACEX.
+    await __internal.sweepStaleConfluenceAces(
+      new Date('2026-01-02T10:00:00Z'),
+      ['SPACEX'],
+    );
+
+    // pageX's stale ACE is gone (its space was in the run).
+    expect(await getAces(pageX)).toHaveLength(0);
+    // pageY's ACE survives (SPACEY was not part of this run).
+    expect(await getAces(pageY)).toHaveLength(1);
+  });
+
+  it('failed restriction fetch bumps synced_at so the scoped sweep keeps pre-existing ACEs', async () => {
+    // Regression for #859 (Fix 2): when computeEffectivePageReadRestrictions
+    // throws a ConfluenceError, syncPageRestrictions must bump the page's
+    // existing Confluence ACEs to the current run so the end-of-run sweep —
+    // which covers this page's own space — leaves them alone.
+    const userA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    await insertUser(userA, 'alice');
+    await ensureSpace('DOCS');
+    const pageDbId = await insertPage('c-500', 'DOCS');
+
+    // Pre-existing Confluence ACE from a prior run.
+    await query(
+      `INSERT INTO access_control_entries
+         (resource_type, resource_id, principal_type, principal_id,
+          permission, source, synced_at)
+       VALUES ('page', $1, 'user', $2, 'read', 'confluence', $3)`,
+      [pageDbId, userA, new Date('2026-01-01T10:00:00Z')],
+    );
+
+    // Restriction fetch fails this round.
+    const client = makeMockClient();
+    client.getPageRestrictions = async () => {
+      throw new ConfluenceError('boom', 503);
+    };
+
+    const runStartedAt = new Date('2026-01-02T10:00:00Z');
+    await __internal.syncPageRestrictions(
+      client as never,
+      fakePage('c-500'),
+      runStartedAt,
+      new Map(),
+    );
+
+    // The existing ACE is preserved and its synced_at bumped to this run.
+    const aces = await getAces(pageDbId);
+    expect(aces).toHaveLength(1);
+    expect(aces[0]!.synced_at?.getTime()).toBe(runStartedAt.getTime());
+
+    // The scoped end-of-run sweep therefore leaves it in place.
+    await __internal.sweepStaleConfluenceAces(runStartedAt, ['DOCS']);
+    expect(await getAces(pageDbId)).toHaveLength(1);
   });
 
   it('emits ACE_SYNC_SKIPPED_UNMAPPED_USER audit and persists no ACE for an unknown userKey', async () => {

--- a/backend/src/domains/confluence/services/sync-service.ts
+++ b/backend/src/domains/confluence/services/sync-service.ts
@@ -272,7 +272,7 @@ export async function syncUser(userId: string): Promise<void> {
     // authoritative and must be removed. Admin-authored rows have
     // `source='local'` and never appear in this sweep.
     if (isFeatureEnabled(ENTERPRISE_FEATURES.RAG_PERMISSION_ENFORCEMENT)) {
-      await sweepStaleConfluenceAces(syncRunStartedAt);
+      await sweepStaleConfluenceAces(syncRunStartedAt, spaces);
     }
 
     // Set status to 'embedding' while processing dirty pages
@@ -1158,6 +1158,16 @@ async function syncPageRestrictions(
         },
         'Failed to fetch Confluence restrictions for page — skipping this round; pre-existing ACEs untouched',
       );
+      // Bump this page's existing Confluence ACEs to the current run so the
+      // end-of-run sweep leaves them alone (#859) — matches the documented
+      // contract that they stay authoritative until a later successful sync
+      // rewrites them. Same UPDATE as the incremental-skip fast path above.
+      await query(
+        `UPDATE access_control_entries
+            SET synced_at = $1
+          WHERE resource_type = 'page' AND resource_id = $2 AND source = 'confluence'`,
+        [syncRunStartedAt, pageDbId],
+      );
       return;
     }
     throw err;
@@ -1306,14 +1316,24 @@ async function resolveConfluenceGroup(name: string): Promise<number | null> {
  * exist. Runs once at the end of `syncUser`, outside any per-page
  * transaction, so a partial sync doesn't wipe ACEs for pages we never got
  * to.
+ *
+ * Scoped to `spaceKeys` — the spaces this run actually visited (#859). Without
+ * the scope, one user's end-of-run sweep would age out the ACEs another user's
+ * earlier run wrote for a different space (their `synced_at` predates this run),
+ * silently wiping restrictions across every space but the last one synced.
  */
-async function sweepStaleConfluenceAces(syncRunStartedAt: Date): Promise<void> {
+async function sweepStaleConfluenceAces(
+  syncRunStartedAt: Date,
+  spaceKeys: string[],
+): Promise<void> {
+  if (spaceKeys.length === 0) return;
   const res = await query(
     `DELETE FROM access_control_entries
      WHERE resource_type = 'page'
        AND source = 'confluence'
-       AND (synced_at IS NULL OR synced_at < $1)`,
-    [syncRunStartedAt],
+       AND (synced_at IS NULL OR synced_at < $1)
+       AND resource_id IN (SELECT id FROM pages WHERE space_key = ANY($2))`,
+    [syncRunStartedAt, spaceKeys],
   );
   if (res.rowCount && res.rowCount > 0) {
     logger.info(


### PR DESCRIPTION
## Summary
- Scope `sweepStaleConfluenceAces` to the spaces the run actually visited so one user's sync no longer deletes the Confluence restriction ACEs another user's earlier run wrote for a different space.
- When a page's restriction fetch throws a `ConfluenceError`, bump its existing Confluence ACEs' `synced_at` to the current run so the scoped sweep leaves them alone (restoring the documented "pre-existing ACEs untouched" contract).
- Add two real-Postgres integration tests covering both failure modes; update the existing sweep test to pass the space list.

Closes #859.

## Root cause
`sweepStaleConfluenceAces(syncRunStartedAt)` ran an unscoped `DELETE` of every `source='confluence'` page ACE whose `synced_at` predated this run's start. It wasn't restricted to the run's spaces (cross-user/cross-space wipe), and the `ConfluenceError` catch in `syncPageRestrictions` returned without bumping `synced_at`, so failed-fetch pages in the run's own spaces were swept too. A restricted page then has `inherit_perms=FALSE` and no ACE, denying every non-admin reader.

## Fix
- `sweepStaleConfluenceAces(syncRunStartedAt, spaceKeys)`: early-return on empty list; add `AND resource_id IN (SELECT id FROM pages WHERE space_key = ANY($2))`. Caller passes the run's `spaces`.
- In the `ConfluenceError` branch, run the same `synced_at` UPDATE used by the incremental-skip fast path before returning.

## Testing
- TDD: extended `backend/src/domains/confluence/services/sync-service.integration.test.ts` with cross-space-scoping and failed-fetch-preservation tests; both **fail before** the fix (unscoped DELETE wipes the other space's ACE / `synced_at` stays stale) and **pass after**.
- `cd backend && npx vitest run src/domains/confluence/services/sync-service.integration.test.ts` (16 passed) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code