### PR TITLE
fix(routes): enforce owner-only rule on bulk standalone page delete (#861)

### DIFF
--- a/backend/src/core/services/bulk-page-selection.ts
+++ b/backend/src/core/services/bulk-page-selection.ts
@@ -89,6 +89,12 @@ interface ResolvedBulkRow {
    * are their current tags" needs of the tag/replace-tag routes.
    */
   labels: string[];
+  /**
+   * Owner of the page (`created_by_user_id`). Delete routes use this to
+   * enforce the standalone owner-only rule (#861); other bulk callers ignore
+   * it. NULL for legacy rows with no recorded owner.
+   */
+  createdByUserId: string | null;
 }
 
 interface BulkSelectionResolutionError {
@@ -245,11 +251,12 @@ export async function resolveBulkSelection(
       space_key: string | null;
       source: string;
       labels: string[] | null;
+      created_by_user_id: string | null;
     }>(
       // Deliberately NOT visiblePagesPredicate(): ids-mode grants owners access
       // to their private pages regardless of visibility, and the space branch
       // is not gated on source = 'confluence'.
-      `SELECT cp.id, cp.confluence_id, cp.space_key, cp.source, cp.labels FROM pages cp
+      `SELECT cp.id, cp.confluence_id, cp.space_key, cp.source, cp.labels, cp.created_by_user_id FROM pages cp
        WHERE (cp.id = ANY($1::int[]) OR cp.confluence_id = ANY($2::text[]))
          AND cp.deleted_at IS NULL
          AND ((cp.source = 'standalone' AND (cp.visibility = 'shared' OR cp.created_by_user_id = $3))
@@ -263,6 +270,7 @@ export async function resolveBulkSelection(
       spaceKey: r.space_key,
       source: r.source as 'confluence' | 'standalone',
       labels: r.labels ?? [],
+      createdByUserId: r.created_by_user_id,
     }));
 
     // Map each returned row back to the *original* id the caller supplied so
@@ -340,8 +348,9 @@ export async function resolveBulkSelection(
     space_key: string | null;
     source: string;
     labels: string[] | null;
+    created_by_user_id: string | null;
   }>(
-    `SELECT cp.id, cp.confluence_id, cp.space_key, cp.source, cp.labels FROM pages cp ${where}
+    `SELECT cp.id, cp.confluence_id, cp.space_key, cp.source, cp.labels, cp.created_by_user_id FROM pages cp ${where}
      ORDER BY cp.id ASC
      LIMIT ${HARD_CAP}`,
     allValues,
@@ -353,6 +362,7 @@ export async function resolveBulkSelection(
     spaceKey: r.space_key,
     source: r.source as 'confluence' | 'standalone',
     labels: r.labels ?? [],
+    createdByUserId: r.created_by_user_id,
   }));
 
   return { rows, notFoundIds: [] };

--- a/backend/src/routes/knowledge/bulk-pages.test.ts
+++ b/backend/src/routes/knowledge/bulk-pages.test.ts
@@ -233,7 +233,7 @@ describe('Bulk Pages Routes (Parallelized)', () => {
 
     it('should delete standalone pages without Confluence configured', async () => {
       mockQueryFn.mockResolvedValueOnce({
-        rows: [{ id: 42, confluence_id: null, source: 'standalone', space_key: null }],
+        rows: [{ id: 42, confluence_id: null, source: 'standalone', space_key: null, created_by_user_id: 'test-user-id' }],
         rowCount: 1,
       });
 
@@ -305,7 +305,7 @@ describe('Bulk Pages Routes (Parallelized)', () => {
     it('should delete mixed standalone and Confluence pages in one request', async () => {
       mockQueryFn.mockResolvedValueOnce({
         rows: [
-          { id: 42, confluence_id: null, source: 'standalone', space_key: null },
+          { id: 42, confluence_id: null, source: 'standalone', space_key: null, created_by_user_id: 'test-user-id' },
           { id: 1, confluence_id: 'page-1', source: 'confluence', space_key: 'OPS' },
         ],
         rowCount: 2,
@@ -427,7 +427,7 @@ describe('Bulk Pages Routes (Parallelized)', () => {
       // COUNT → 1; SELECT resolved → 1 row; UPDATE deleted_at + DELETE pinned (parallel)
       mockQueryFn.mockResolvedValueOnce({ rows: [{ count: '1' }], rowCount: 1 });
       mockQueryFn.mockResolvedValueOnce({
-        rows: [{ id: 50, confluence_id: null, space_key: null, source: 'standalone', labels: [] }],
+        rows: [{ id: 50, confluence_id: null, space_key: null, source: 'standalone', labels: [], created_by_user_id: 'test-user-id' }],
         rowCount: 1,
       });
       mockQueryFn.mockResolvedValue({ rows: [], rowCount: 1 });

--- a/backend/src/routes/knowledge/pages-crud-delete-atomicity.integration.test.ts
+++ b/backend/src/routes/knowledge/pages-crud-delete-atomicity.integration.test.ts
@@ -112,6 +112,31 @@ async function insertPin(pageId: number): Promise<void> {
   await query('INSERT INTO pinned_pages (user_id, page_id) VALUES ($1, $2)', [userId, pageId]);
 }
 
+/** Insert a standalone (non-Confluence) page owned by `ownerId`. */
+async function insertStandalone(
+  title: string,
+  ownerId: string,
+  visibility: 'private' | 'shared',
+): Promise<number> {
+  const res = await query<{ id: number }>(
+    `INSERT INTO pages (source, title, body_text, body_storage, body_html,
+                        created_by_user_id, visibility, version, page_type,
+                        embedding_dirty, embedding_status, last_synced)
+     VALUES ('standalone', $1, 'text', NULL, '<p>x</p>', $2, $3, 1, 'page', TRUE, 'not_embedded', NOW())
+     RETURNING id`,
+    [title, ownerId, visibility],
+  );
+  return res.rows[0]!.id;
+}
+
+async function getRowById(id: number): Promise<{ id: number; deleted_at: Date | null } | null> {
+  const res = await query<{ id: number; deleted_at: Date | null }>(
+    'SELECT id, deleted_at FROM pages WHERE id = $1',
+    [id],
+  );
+  return res.rows[0] ?? null;
+}
+
 async function getRow(confluenceId: string): Promise<{ id: number; deleted_at: Date | null } | null> {
   const res = await query<{ id: number; deleted_at: Date | null }>(
     'SELECT id, deleted_at FROM pages WHERE confluence_id = $1',
@@ -337,5 +362,57 @@ describe.skipIf(!dbAvailable)('delete atomicity — no local/Confluence divergen
     } finally {
       await unblockPageDeletes();
     }
+  });
+
+  // ── bulk delete ownership (#861) ────────────────────────────────────────────
+
+  it('bulk: a non-owner cannot trash another user\'s shared standalone page (#861)', async () => {
+    // A second user A owns a SHARED standalone page. The request user (B) can
+    // SEE it (shared standalone is visible to everyone) but must not be able to
+    // delete it — mirroring the single-delete owner-only 403.
+    const ownerA = (await query<{ id: string }>(
+      "INSERT INTO users (username, email, password_hash, role) VALUES ('owner_a', 'a@test', 'x', 'user') RETURNING id",
+    )).rows[0]!.id;
+    const pageId = await insertStandalone('A shared page', ownerA, 'shared');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/bulk/delete',
+      payload: { ids: [String(pageId)] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.succeeded).toBe(0);
+    expect(body.failed).toBe(1);
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0]).toContain('not the owner');
+
+    // The page is untouched — still live.
+    const row = await getRowById(pageId);
+    expect(row).not.toBeNull();
+    expect(row!.deleted_at).toBeNull();
+  });
+
+  it('bulk: an owner can still trash their own shared standalone page (#861)', async () => {
+    // Positive companion: user B owns a SHARED standalone page and bulk-deletes
+    // it — the owner check must not regress the normal path.
+    const pageId = await insertStandalone('B shared page', userId, 'shared');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/pages/bulk/delete',
+      payload: { ids: [String(pageId)] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.succeeded).toBe(1);
+    expect(body.failed).toBe(0);
+
+    // Standalone bulk-delete is a soft-delete (move to trash).
+    const row = await getRowById(pageId);
+    expect(row).not.toBeNull();
+    expect(row!.deleted_at).not.toBeNull();
   });
 });

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -1821,7 +1821,18 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     let failed = resolved.notFoundIds.length;
 
     // --- Partition by source ---
-    const standalonePages = resolved.rows.filter((r) => r.source === 'standalone')
+    // #861: standalone delete is owner-only, mirroring DELETE /pages/:id.
+    // Shared standalone pages resolve for every viewer (read/edit is allowed),
+    // but only the owner may trash them. Non-owned standalone rows are reported
+    // as failures exactly like the single-delete 403 ('not the owner').
+    for (const r of resolved.rows) {
+      if (r.source === 'standalone' && r.createdByUserId !== userId) {
+        failed++;
+        errors.push(`Page ${r.id}: not the owner`);
+      }
+    }
+    const standalonePages = resolved.rows
+      .filter((r) => r.source === 'standalone' && r.createdByUserId === userId)
       .map((r) => ({ id: r.id, source: 'standalone', confluence_id: r.confluenceId, space_key: r.spaceKey }));
     const confluencePages = resolved.rows.filter((r) => r.source !== 'standalone')
       .map((r) => ({ id: r.id, source: r.source, confluence_id: r.confluenceId, space_key: r.spaceKey }));


### PR DESCRIPTION
## Summary
- Bulk delete (`POST /api/pages/bulk/delete`) let any user trash another user's shared standalone article, because the selection resolver returns shared standalone pages for every viewer (read/edit is intentionally allowed) and the route partitioned standalone rows with **no ownership filter**.
- The resolver now returns `createdByUserId`; the bulk-delete route only soft-deletes standalone rows the caller owns and reports non-owned rows as `not the owner` failures, mirroring the single-delete 403.
- Resolver change is additive and backwards-compatible for sync/embed/quality/tag callers, which ignore the new field.

Closes #861.

## Root cause
`DELETE /pages/:id` enforces `created_by_user_id === userId`, but the bulk-delete route soft-deleted every resolved standalone row regardless of owner, and trash/restore are owner-only — so a non-owner could hide someone else's page with no way to undo it.

## Fix
- Add `createdByUserId` to `ResolvedBulkRow` + both SQL SELECTs and row maps in `bulk-page-selection.ts`.
- In `pages-crud.ts` bulk-delete: only `r.createdByUserId === userId` standalone rows are trashed; each non-owned standalone row increments `failed` and pushes `Page <id>: not the owner`.
- Confluence-page handling and the resolver's visibility contract are unchanged.

## Testing
- TDD: extended `backend/src/routes/knowledge/pages-crud-delete-atomicity.integration.test.ts` (real Postgres). Non-owner test **fails before** the fix (page gets trashed, `succeeded===1`), **passes after** (`succeeded===0`, `failed===1`, `not the owner`, `deleted_at` stays NULL). Positive companion proves an owner can still bulk-trash their own shared page.
- Updated mocked standalone-delete rows in `bulk-pages.test.ts` to include `created_by_user_id` (risk_notes item 1).
- `cd backend && npx vitest run src/routes/knowledge/pages-crud-delete-atomicity.integration.test.ts` (8 pass) - `bulk-pages.test.ts` + `bulk-page-selection.test.ts` (63 pass) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code