### PR TITLE
fix(routes): compute LIMIT/OFFSET bind index from value count in GET /pages search (#862)

### DIFF
--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -470,7 +470,7 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       visibility: string;
     };
 
-    async function executeSearchQuery(wc: string, vals: unknown[], ob: string, pi: number, obVals: unknown[] = []) {
+    async function executeSearchQuery(wc: string, vals: unknown[], ob: string, obVals: unknown[] = []) {
       // Count query uses only WHERE params (no ORDER BY params)
       const countSql = `SELECT COUNT(*) as count FROM pages cp ${wc}`;
       const countResult = await query<{ count: string }>(countSql, [...vals]);
@@ -483,6 +483,10 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       }
 
       const offset = (page - 1) * limit;
+      // Derive the LIMIT/OFFSET placeholder index from the actual bound-value
+      // count (WHERE params + ORDER BY params) so it never goes stale when the
+      // relevance ORDER BY param is dropped in the ILIKE fallback (#862).
+      const pi = vals.length + obVals.length + 1;
       const dataSql = `
         SELECT cp.id, cp.confluence_id, cp.space_key, cp.title, cp.version,
                cp.parent_id, cp.labels, cp.author, cp.last_modified_at, cp.last_synced,
@@ -503,7 +507,7 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     }
 
     // First attempt: FTS query
-    let { total, rows } = await executeSearchQuery(whereClause, values, orderBy, paramIdx, orderByValues);
+    let { total, rows } = await executeSearchQuery(whereClause, values, orderBy, orderByValues);
 
     // ILIKE fallback: when FTS returns 0 results and search term >= 3 chars,
     // retry with a broader ILIKE match on title + body_text.
@@ -521,7 +525,7 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
         ilikeOrderBy = 'cp.last_modified_at DESC NULLS LAST';
         ilikeObVals = [];
       }
-      const fallbackResult = await executeSearchQuery(ilikeWhereClause, ilikeValues, ilikeOrderBy, paramIdx, ilikeObVals);
+      const fallbackResult = await executeSearchQuery(ilikeWhereClause, ilikeValues, ilikeOrderBy, ilikeObVals);
       total = fallbackResult.total;
       rows = fallbackResult.rows;
       usedIlikeFallback = true;

--- a/backend/src/routes/knowledge/pages-search-relevance-fallback.integration.test.ts
+++ b/backend/src/routes/knowledge/pages-search-relevance-fallback.integration.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Integration test for the ILIKE fallback under `sort=relevance` (#862) —
+ * `GET /api/pages?search=...&sort=relevance` against a REAL PostgreSQL.
+ *
+ * #862 production bug: when FTS (`ts_rank` + `plainto_tsquery`) returns zero
+ * rows but the ILIKE fallback matches, the data query 500s with a bind
+ * mismatch. Under `sort=relevance` the ORDER BY consumes an extra bind slot
+ * (the ts_rank search term), but the fallback drops that ORDER BY param while
+ * still passing the stale `paramIdx`, so LIMIT/OFFSET render one slot too high
+ * relative to the (now shorter) value array. Postgres rejects the bind.
+ *
+ * A real DB is mandatory here: the sibling `page-filters.test.ts` mocks
+ * `core/db/postgres.query`, and a mock silently accepts a mismatched
+ * placeholder/value count, so it cannot reproduce the bind failure. The seed
+ * page's tsvector lexeme is `confluence`, so `plainto_tsquery('confl')` does
+ * NOT match (FTS total 0) but `%confl%` ILIKE matches the title — the exact
+ * shape that triggered the 500.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+import { ZodError } from 'zod';
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../test-db-helper.js';
+import { query } from '../../core/db/postgres.js';
+
+// --- Boundary mocks (everything else is real) ---
+
+vi.mock('../../core/services/redis-cache.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../core/services/redis-cache.js')>()),
+  RedisCache: class MockRedisCache {
+    get = vi.fn().mockResolvedValue(null);
+    set = vi.fn().mockResolvedValue(undefined);
+    invalidate = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('../../core/services/audit-service.js', () => ({
+  logAuditEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../core/services/webhook-emit-hook.js', () => ({
+  emitWebhookEvent: vi.fn(),
+}));
+
+vi.mock('../../domains/confluence/services/attachment-handler.js', () => ({
+  cleanPageAttachments: vi.fn().mockResolvedValue(undefined),
+  syncDrawioAttachments: vi.fn().mockResolvedValue(undefined),
+  syncImageAttachments: vi.fn().mockResolvedValue(undefined),
+  getMissingAttachments: vi.fn().mockResolvedValue([]),
+  writeAttachmentCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../domains/llm/services/embedding-service.js', () => ({
+  processDirtyPages: vi.fn().mockResolvedValue(undefined),
+  isProcessingUser: vi.fn().mockReturnValue(false),
+  computePageRelationships: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('../../domains/knowledge/services/quality-worker.js', () => ({
+  triggerQualityBatch: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetUserAccessibleSpaces = vi.fn();
+vi.mock('../../core/services/rbac-service.js', () => ({
+  getUserAccessibleSpaces: (...args: unknown[]) => mockGetUserAccessibleSpaces(...args),
+  invalidateRbacCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetClientForUser = vi.fn();
+vi.mock('../../domains/confluence/services/sync-service.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../domains/confluence/services/sync-service.js')>();
+  return {
+    ...actual,
+    getClientForUser: (...args: unknown[]) => mockGetClientForUser(...args),
+  };
+});
+
+const dbAvailable = await isDbAvailable();
+
+let userId: string;
+
+describe.skipIf(!dbAvailable)('GET /pages relevance ILIKE fallback bind mismatch (#862)', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    await setupTestDb();
+
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+    app.setErrorHandler((error: Error & { statusCode?: number }, _request, reply) => {
+      if (error instanceof ZodError) {
+        return reply.status(400).send({ error: 'Validation failed' });
+      }
+      return reply.status(error.statusCode ?? 500).send({ error: error.message });
+    });
+    app.decorate('authenticate', async (request: { userId: string }) => {
+      request.userId = userId;
+    });
+    app.decorate('requireAdmin', async (request: { userId: string }) => {
+      request.userId = userId;
+    });
+    app.decorate('redis', {});
+    const { pagesCrudRoutes } = await import('./pages-crud.js');
+    await app.register(pagesCrudRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await truncateAllTables();
+    const res = await query<{ id: string }>(
+      "INSERT INTO users (username, email, password_hash, role) VALUES ('rel_user', 'rel@test', 'x', 'user') RETURNING id",
+    );
+    userId = res.rows[0]!.id;
+    mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
+
+    // Seed a page whose stored tsvector lexeme is `confluence` (via the
+    // trg_pages_tsv trigger + to_tsvector), so plainto_tsquery('confl') does
+    // NOT match, but title/body ILIKE '%confl%' does.
+    await query(
+      `INSERT INTO pages (confluence_id, source, space_key, title, body_text,
+                          body_storage, body_html, inherit_perms)
+       VALUES ('rel-1', 'confluence', 'DEV', 'Confluence Guide', 'confluence guide',
+               '', '', TRUE)`,
+    );
+  });
+
+  it('returns the fuzzy match instead of 500 when FTS misses but ILIKE hits (#862)', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages?search=confl&sort=relevance',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.fuzzyMatch).toBe(true);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].title).toBe('Confluence Guide');
+  });
+
+  it('regression: the non-relevance fallback path keeps working (sort=title)', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/pages?search=confl&sort=title',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.fuzzyMatch).toBe(true);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].title).toBe('Confluence Guide');
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /pages` returned 500 on `sort=relevance` whenever FTS found nothing but the ILIKE fallback matched (the default flow, since the frontend auto-switches to relevance on search).
- `executeSearchQuery` now derives the LIMIT/OFFSET placeholder index from the real bound-value count instead of a caller-passed `paramIdx` that goes stale in the fallback.

Closes #862.

## Root cause
Under `sort=relevance` the ORDER BY consumes one extra bind slot (the `ts_rank` search term). The ILIKE fallback replaces that ORDER BY with `last_modified_at` and drops the term from the value array, but still passed the un-adjusted `paramIdx`, so `LIMIT`/`OFFSET` rendered one placeholder higher than the shorter `dataVals` — Postgres rejected the bind and the request 500'd.

## Fix
- Remove the `pi` parameter from `executeSearchQuery`; signature is now `executeSearchQuery(wc, vals, ob, obVals = [])`.
- Compute `const pi = vals.length + obVals.length + 1` internally, the provably-correct LIMIT slot (`dataVals` is `vals` then `obVals` then limit then offset).
- Update both call sites to stop passing `paramIdx`. This eliminates the whole off-by-one class.

## Testing
- TDD: added `backend/src/routes/knowledge/pages-search-relevance-fallback.integration.test.ts` (real Postgres, seeds a page whose lexeme is `confluence` so `plainto_tsquery('confl')` misses but `%confl%` ILIKE hits). **Fails before** the fix (relevance query 500s on the bind mismatch), **passes after** (returns the fuzzy match). A second test guards the already-working `sort=title` fallback.
- `cd backend && npx vitest run src/routes/knowledge/pages-search-relevance-fallback.integration.test.ts` (pass) - sibling `page-filters.test.ts` (pass) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code