### PR TITLE
fix(routes): send correct version on draft publish push (#863)

### DIFF
--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -1719,12 +1719,29 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     }
 
     // For Confluence articles, push updated content upstream (best-effort)
+    let publishedVersion = page.version + 1;
     if (page.source === 'confluence' && page.confluence_id) {
       try {
         const client = await getClientForUser(userId);
         if (client) {
           const storageBody = htmlToConfluence(page.draft_body_html!);
-          await client.updatePage(page.confluence_id, page.title, storageBody, page.version + 1);
+          // updatePage() increments internally, so pass the *previous* live
+          // version (page.version) — the version Confluence currently holds
+          // pre-publish. The local row is already at page.version + 1 from the
+          // transaction above.
+          const confPage = await client.updatePage(page.confluence_id, page.title, storageBody, page.version);
+          // Trust the API-returned version over our locally-computed bump so
+          // local `version` can't drift and mis-trigger the next sync's
+          // conflict guard (mirrors the restore route). Persist the storage
+          // Confluence accepted and clear local-edit markers — local state now
+          // matches the remote.
+          publishedVersion = confPage.version?.number ?? publishedVersion;
+          await query(
+            `UPDATE pages SET body_storage = $2, version = $3, last_synced = NOW(),
+               local_modified_at = NULL, local_modified_by = NULL
+             WHERE id = $1`,
+            [page.id, storageBody, publishedVersion],
+          );
         }
       } catch (err) {
         // Log but don't fail — local publish succeeded
@@ -1734,7 +1751,7 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
 
     await cache.invalidate(userId, 'pages');
     await logAuditEvent(userId, 'DRAFT_PUBLISHED', 'page', String(page.id),
-      { version: page.version + 1 }, request);
+      { version: publishedVersion }, request);
 
     emitWebhookEvent({
       eventType: 'page.updated',
@@ -1746,7 +1763,7 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       },
     });
 
-    return { id: page.id, version: page.version + 1, published: true };
+    return { id: page.id, version: publishedVersion, published: true };
   });
 
   // DELETE /api/pages/:id/draft — discard draft

--- a/backend/src/routes/knowledge/pages-draft.test.ts
+++ b/backend/src/routes/knowledge/pages-draft.test.ts
@@ -444,7 +444,18 @@ describe('Draft-while-published routes', () => {
 
       expect(response.statusCode).toBe(200);
       expect(mockHtmlToConfluence).toHaveBeenCalledWith('<p>draft</p>');
-      expect(mockUpdatePage).toHaveBeenCalledWith('conf-123', 'Confluence Article', '<p>storage</p>', 4);
+      // updatePage() increments internally, so it must receive the *previous*
+      // live version (page.version = 3), not page.version + 1 (4). Passing 4
+      // makes Confluence receive version 5 while it holds 3 → silent 409 (#863).
+      expect(mockUpdatePage).toHaveBeenCalledWith('conf-123', 'Confluence Article', '<p>storage</p>', 3);
+      // Trust the API-returned version (5) over the local bump (4)
+      expect(response.json().version).toBe(5);
+      // The API version is persisted back so local `version` can't drift
+      const persistCall = mockQuery.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0].includes('version = $3') && c[0].includes('last_synced'),
+      );
+      expect(persistCall).toBeDefined();
+      expect(persistCall![1]).toEqual([10, '<p>storage</p>', 5]);
     });
   });
 


### PR DESCRIPTION
## Summary
- Draft publish for Confluence-sourced pages pushed an off-by-one version upstream, so every push silently 409'd while the route still reported `published: true`.
- Pass the pre-publish live version to `updatePage()` (which increments internally) instead of `page.version + 1`.
- Persist the API-returned version back to the local row so `version` can't drift and mis-trigger the next sync's conflict guard, mirroring the restore route.

Closes #863.

## Root cause
`ConfluenceClient.updatePage()` sends `version: { number: version + 1 }` internally, so callers must pass the *current* remote version. The publish route passed `page.version + 1`, making Confluence receive `page.version + 2` while it held `page.version` — a 409 that the surrounding try/catch swallowed.

## Fix
- `pages-crud.ts`: pass `page.version` to `updatePage()`; capture `confPage.version.number` and `UPDATE pages` with the accepted storage + returned version (clearing local-edit markers).
- Use the reconciled `publishedVersion` in the audit event and JSON response.

## Testing
- TDD: extended `backend/src/routes/knowledge/pages-draft.test.ts` best-effort push test; **fails before** the fix (updatePage called with 4, expected 3), **passes after**, and now asserts the returned version (5) is trusted and persisted.
- `cd backend && npx vitest run src/routes/knowledge/pages-draft.test.ts` (27 pass) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code