### PR TITLE
fix(infra): stop GNU wget COPY from clobbering /bin/busybox in runtime images (#864)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -47,7 +47,6 @@ FROM node:24-alpine AS runtime
 
 # Copy runtime utilities from tools stage
 COPY --from=tools /usr/bin/dumb-init /usr/bin/dumb-init
-COPY --from=tools /usr/bin/wget /usr/bin/wget
 # Copy pre-created data directory with correct ownership
 COPY --from=tools --chown=node:node /opt/app/data /app/data
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -54,7 +54,7 @@ RUN apk add --no-cache wget
 FROM nginx:alpine AS runtime
 
 # Copy wget + shared libraries needed on the minimal runtime image
-COPY --from=tools /usr/bin/wget /usr/bin/wget
+COPY --from=tools /usr/bin/wget /usr/local/bin/wget
 COPY --from=tools /usr/lib/libidn2* /usr/lib/
 COPY --from=tools /usr/lib/libunistring* /usr/lib/
 
@@ -69,7 +69,7 @@ COPY frontend/nginx-cache-drawio.conf /etc/nginx/cache-drawio.conf
 EXPOSE 8081
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD ["/usr/bin/wget", "--spider", "--quiet", "http://127.0.0.1:8081/"]
+  CMD ["/usr/local/bin/wget", "--spider", "--quiet", "http://127.0.0.1:8081/"]
 
 USER nginx
 # Override the docker-entrypoint.sh from nginx:alpine so CMD ["-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- In alpine base images (`node:24-alpine`, `nginx:alpine`) `/usr/bin/wget` is a symlink to `/bin/busybox`. `COPY --from=tools /usr/bin/wget /usr/bin/wget` follows that destination symlink and overwrites `/bin/busybox` with the GNU wget binary, so `/bin/sh` and every busybox applet (`ls`, `cat`, etc.) break — killing `docker exec ... sh` and any shell-based healthcheck.
- **Backend:** delete the wget COPY entirely — the backend HEALTHCHECK uses `node -e fetch(...)`, so the copied GNU wget was never used (and was non-functional anyway, its libs are never copied). The base image's busybox wget symlink stays intact.
- **Frontend:** retarget the COPY to a non-symlink path `/usr/local/bin/wget` and point the HEALTHCHECK at it, preserving the exact GNU-wget behavior while leaving `/bin/busybox` intact.
- `docker/Dockerfile.enterprise` is left untouched — it installs wget via `apk add`, which manages the symlink/deps correctly and does not clobber busybox.

Closes #864.

## Root cause
Docker `COPY` follows a symlink at the destination path; copying GNU wget onto the base image's `/usr/bin/wget -> /bin/busybox` symlink overwrites `/bin/busybox`, replacing the whole busybox shell environment.

## Fix
- `backend/Dockerfile`: remove `COPY --from=tools /usr/bin/wget /usr/bin/wget`.
- `frontend/Dockerfile`: `COPY --from=tools /usr/bin/wget /usr/local/bin/wget` and update HEALTHCHECK to `["/usr/local/bin/wget", "--spider", "--quiet", "http://127.0.0.1:8081/"]`.

## Testing
- Pure Dockerfile/infra change — no Vitest test applies. Verified by real image builds.
- **RED** (minimal repro on the same bases): `COPY .../wget /usr/bin/wget` then `sh -c 'echo shell-ok'` fails with `libpcre2-8.so.0 / libidn2.so.0 not found` (GNU wget clobbered `/bin/sh`); `shell-ok` never prints — matching the issue.
- **GREEN backend:** `docker build -f backend/Dockerfile -t compendiq-backend:864 .` → `sh -c 'echo shell-ok && /bin/busybox | head -1'` prints `shell-ok` + `BusyBox v1.37.0 ... multi-call binary`; `/usr/bin/wget` resolves to the busybox banner.
- **GREEN frontend:** build succeeds, `sh -c 'echo shell-ok'` prints `shell-ok` (busybox intact), `/usr/local/bin/wget --version` → `GNU Wget 1.25.0`, and the running container's healthcheck reaches `healthy`.

Generated with Claude Code