### PR TITLE
fix(ui): flush pending draft on editor unmount so nav-away preserves the last edit (#877)

### DIFF
--- a/frontend/src/shared/components/article/Editor.test.tsx
+++ b/frontend/src/shared/components/article/Editor.test.tsx
@@ -27,7 +27,7 @@ vi.mock('sonner', () => ({
   },
 }));
 
-import { Editor, EditorToolbar } from './Editor';
+import { Editor, EditorToolbar, clearDraft } from './Editor';
 import type { Editor as EditorType } from '@tiptap/react';
 
 // Minimal mock of a TipTap Editor instance for toolbar-level tests
@@ -726,6 +726,73 @@ describe('Editor', () => {
         }
       });
     });
+  });
+});
+
+describe('draft auto-save flush on unmount (#877)', () => {
+  // Real timers + async TipTap init (immediatelyRender:false). Fake timers
+  // conflict with the editor's async setup, so we lean on the fact that the
+  // AUTO_SAVE_DELAY (2000ms) never elapses within a synchronous test body —
+  // the debounced write is still pending when we unmount.
+  beforeEach(() => {
+    // Wipe drafts AND the module-level suppressedFlushKeys' observable effect
+    // between tests so unique keys can't bleed across cases.
+    localStorage.clear();
+    mockFetchAuthenticatedBlob.mockResolvedValue(null);
+  });
+
+  it('flushes a pending debounced draft to localStorage when the editor unmounts', async () => {
+    let editor: EditorType | null = null;
+    const { unmount } = render(
+      <Editor
+        content="<p>seed</p>"
+        editable={true}
+        draftKey="page-877-flush"
+        onEditorReady={(e) => { editor = e; }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(editor).not.toBeNull();
+    });
+
+    // A real doc change fires onUpdate -> saveDraft, scheduling the 2000ms
+    // debounce. The write has NOT happened yet (test runs in ms).
+    editor!.commands.insertContent(' typed');
+    expect(localStorage.getItem('draft:page-877-flush')).toBeNull();
+
+    // Navigating away unmounts the Editor within the debounce window. Pre-fix
+    // this cleared the timer without writing, silently losing the edit.
+    unmount();
+
+    const draft = localStorage.getItem('draft:page-877-flush');
+    expect(draft).not.toBeNull();
+    expect(draft).toContain('typed');
+  });
+
+  it('does not resurrect a draft the parent explicitly cleared before unmount', async () => {
+    let editor: EditorType | null = null;
+    const { unmount } = render(
+      <Editor
+        content="<p>seed</p>"
+        editable={true}
+        draftKey="page-877-suppress"
+        onEditorReady={(e) => { editor = e; }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(editor).not.toBeNull();
+    });
+
+    // Schedule a pending debounced save…
+    editor!.commands.insertContent(' typed');
+    // …then the parent saves/cancels, which clears the draft and unmounts.
+    clearDraft('page-877-suppress');
+    unmount();
+
+    // The unmount flush must skip the suppressed key — no resurrection.
+    expect(localStorage.getItem('draft:page-877-suppress')).toBeNull();
   });
 });
 

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -1226,11 +1226,17 @@ export function getDraft(key: string): string | null {
   }
 }
 
+// Keys whose pending unmount-flush must be suppressed because the parent
+// explicitly cleared the draft (page saved or edit cancelled). Prevents the
+// #877 flush-on-unmount from resurrecting a draft the user just discarded.
+const suppressedFlushKeys = new Set<string>();
+
 // eslint-disable-next-line react-refresh/only-export-components
 export function clearDraft(key: string): void {
   try {
     localStorage.removeItem(`draft:${key}`);
   } catch { /* ignore */ }
+  suppressedFlushKeys.add(key);
 }
 
 const VIM_STORAGE_KEY = 'compendiq-vim-mode';
@@ -1242,6 +1248,8 @@ function defaultVimDisplayState(): VimState {
 export function Editor({ content, onChange, editable = true, placeholder, draftKey, naked = false, onEditorReady, hideToolbar = false, pageId, onSave, vimEnabled: vimEnabledProp }: EditorProps) {
   const isLight = useIsLightTheme();
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // Latest debounced draft awaiting write, so unmount can flush it (#877)
+  const pendingDraftRef = useRef<{ key: string; html: string } | null>(null);
   // Ref for the editor instance so async paste/drop handlers can insert images
   const editorRef = useRef<EditorType | null>(null);
   // Keep pageId in a ref so editorProps closures see the latest value
@@ -1280,17 +1288,32 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
 
   const saveDraft = useCallback((html: string) => {
     if (!draftKey) return;
+    // Fresh edits mean there IS unsaved work again — allow it to be flushed.
+    suppressedFlushKeys.delete(draftKey);
+    pendingDraftRef.current = { key: draftKey, html };
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
       try {
         localStorage.setItem(`draft:${draftKey}`, html);
       } catch { /* quota exceeded — ignore */ }
+      pendingDraftRef.current = null;
+      timerRef.current = undefined;
     }, AUTO_SAVE_DELAY);
   }, [draftKey]);
 
-  // Cleanup timer on unmount
+  // Flush any pending debounced draft on unmount so navigating away within
+  // the AUTO_SAVE_DELAY window still persists the last edit (#877). Skip keys
+  // the parent explicitly cleared (save/cancel) to avoid resurrecting a
+  // discarded draft. Uses refs only, so [] deps are correct.
   useEffect(() => () => {
     if (timerRef.current) clearTimeout(timerRef.current);
+    const pending = pendingDraftRef.current;
+    if (pending && !suppressedFlushKeys.has(pending.key)) {
+      try {
+        localStorage.setItem(`draft:${pending.key}`, pending.html);
+      } catch { /* quota exceeded — ignore */ }
+    }
+    pendingDraftRef.current = null;
   }, []);
 
   /**


### PR DESCRIPTION
## Summary
- The TipTap `Editor` debounces its `localStorage` draft-save by 2000ms; the unmount cleanup cancelled the pending timer without ever running the write.
- Typing and then navigating away (which unmounts `PageViewPage` -> `Editor`) within that 2s window silently discarded the last edit, so no restore dialog ever fired on return.
- The unmount cleanup now flushes the pending draft synchronously.
- A module-level suppression set prevents resurrecting a draft the user just saved or cancelled.

Closes #877.

## Root cause
`saveDraft` scheduled a 2000ms `setTimeout` write, but the unmount effect called `clearTimeout` without flushing the pending value — a nav-away inside the debounce window lost the last keystrokes.

## Fix
- Track the latest scheduled draft in a `pendingDraftRef` (cleared when the timer fires).
- On unmount, synchronously write that pending draft to `localStorage`, skipping keys the parent explicitly cleared.
- `clearDraft` (called on save/cancel) registers the key in a `suppressedFlushKeys` set; `saveDraft` un-suppresses on fresh edits so genuine later work still flushes.

## Testing
- TDD: added `describe('draft auto-save flush on unmount (#877)')` in `Editor.test.tsx` with two real-timer tests; test 1 **fails before** the fix (`expected null not to be null` — draft never persisted), **passes after**. Test 2 guards against draft resurrection after `clearDraft`.
- `cd frontend && npx vitest run src/shared/components/article/Editor.test.tsx` (40 passed) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code