### PR TITLE
fix(sync): descend standalone sub-page trees keyed by DB id (#886)

### DIFF
--- a/backend/src/domains/confluence/services/subpage-context.standalone.test.ts
+++ b/backend/src/domains/confluence/services/subpage-context.standalone.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Sub-page context standalone/local-space descent against a REAL PostgreSQL.
+ *
+ * Regression (#886): `fetchSubPages` queued the child's `confluence_id` for the
+ * next BFS level. Standalone (local-space) pages have `confluence_id = NULL` and
+ * are keyed on `parent_id = <parent DB id as text>` (see pages-crud.ts:1090 /
+ * :952 `COALESCE(confluence_id, id::text)`). Queuing NULL made the next
+ * iteration run `WHERE parent_id = NULL` (matches nothing), so any standalone
+ * descendant below depth 1 was silently dropped from the LLM context. The fix
+ * queues `row.confluence_id ?? String(row.id)`, mirroring the recursive-CTE
+ * keying used by the page-tree endpoint.
+ *
+ * The resolver (`getUserAccessibleSpacesMemoized`) is mocked at the boundary;
+ * standalone+shared pages are visible regardless of accessible spaces, so it
+ * can return [].
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../../test-db-helper.js';
+import { query } from '../../../core/db/postgres.js';
+
+// --- Boundary mock: the accessible-space resolver (tested elsewhere) ---
+const mockGetSpaces = vi.fn();
+vi.mock('../../../core/services/rbac-service.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../core/services/rbac-service.js')>()),
+  getUserAccessibleSpacesMemoized: (...args: unknown[]) => mockGetSpaces(...args),
+}));
+
+import { fetchSubPages } from './subpage-context.js';
+
+async function insertUser(username: string): Promise<string> {
+  const res = await query<{ id: string }>(
+    "INSERT INTO users (username, email, password_hash, role) VALUES ($1, $2, 'x', 'user') RETURNING id",
+    [username, `${username}@test`],
+  );
+  return res.rows[0]!.id;
+}
+
+async function insertStandalone(
+  title: string,
+  parentId: string | null,
+  createdBy: string,
+): Promise<number> {
+  const res = await query<{ id: number }>(
+    `INSERT INTO pages (title, source, visibility, space_key, confluence_id, parent_id,
+                        body_text, body_storage, body_html, embedding_dirty, created_by_user_id)
+     VALUES ($1, 'standalone', 'shared', NULL, NULL, $2, 'text', '', '<p>x</p>', FALSE, $3)
+     RETURNING id`,
+    [title, parentId, createdBy],
+  );
+  return res.rows[0]!.id;
+}
+
+const dbAvailable = await isDbAvailable();
+
+describe.skipIf(!dbAvailable)('fetchSubPages — standalone/local-space descent (DB)', () => {
+  let caller: string;
+
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await truncateAllTables();
+    caller = await insertUser('subpage_standalone_caller');
+    // Accessible spaces are irrelevant: standalone+shared pages are always visible.
+    mockGetSpaces.mockResolvedValue([]);
+  });
+
+  it('descends a standalone tree keyed by DB id past depth 1', async () => {
+    // handbook -> policies -> vacation, all local-space (confluence_id NULL).
+    const handbook = await insertStandalone('Handbook', null, caller);
+    const policies = await insertStandalone('Policies', String(handbook), caller);
+    await insertStandalone('Vacation Policy', String(policies), caller);
+
+    const result = await fetchSubPages(caller, String(handbook));
+
+    expect(result.map((p) => p.title)).toEqual(['Policies', 'Vacation Policy']);
+  });
+});

--- a/backend/src/domains/confluence/services/subpage-context.ts
+++ b/backend/src/domains/confluence/services/subpage-context.ts
@@ -64,11 +64,12 @@ export async function fetchSubPages(
     visited.add(current.id);
 
     const result = await query<{
+      id: number;
       confluence_id: string;
       title: string;
       body_html: string;
     }>(
-      `SELECT confluence_id, title, body_html
+      `SELECT id, confluence_id, title, body_html
        FROM pages
        WHERE parent_id = $1
          AND deleted_at IS NULL
@@ -86,8 +87,12 @@ export async function fetchSubPages(
         depth: current.depth,
       });
 
-      // Queue children for next depth level
-      queue.push({ id: row.confluence_id, depth: current.depth + 1 });
+      // Queue children for next depth level. Standalone (local-space) pages have
+      // a NULL confluence_id and are keyed on `parent_id = <parent DB id as text>`,
+      // so fall back to the DB id — mirroring COALESCE(confluence_id, id::text)
+      // in pages-crud.ts (#886). Without this, standalone descendants below depth
+      // 1 are dropped (WHERE parent_id = NULL matches nothing).
+      queue.push({ id: row.confluence_id ?? String(row.id), depth: current.depth + 1 });
     }
   }
 


### PR DESCRIPTION
## Summary
- `fetchSubPages` (LLM sub-page context assembly) now descends standalone/local-space page trees correctly at every depth.
- BFS previously queued each child's `confluence_id`; standalone pages store `confluence_id = NULL` and are keyed on `parent_id = <parent DB id as text>`, so the queue received NULL and grandchildren+ were silently dropped from the LLM prompt.
- Selects `pages.id` and queues `row.confluence_id ?? String(row.id)`, mirroring the `COALESCE(confluence_id, id::text)` keying already used by the page-tree endpoint (pages-crud.ts:952).
- Confluence-source pages are unaffected (non-null `confluence_id` makes the coalesce a no-op); the #814 RBAC/visibility gate is preserved.

Closes #886.

## Root cause
The BFS in `subpage-context.ts` keyed the next traversal level on the child's `confluence_id`, but standalone pages have `confluence_id = NULL` and are keyed on the parent's DB id cast to text. Queuing NULL ran `WHERE parent_id = NULL` (matches nothing), so standalone descendants below depth 1 never surfaced.

## Fix
- Add `id: number` to the query row type and `SELECT id, confluence_id, ...`.
- Queue the next level with the dual-key coalesce: `row.confluence_id ?? String(row.id)`.

## Testing
- TDD: added `backend/src/domains/confluence/services/subpage-context.standalone.test.ts` (real Postgres); **fails before** the fix (a 3-level standalone tree yields only `['Policies']`, dropping `Vacation Policy`), **passes after** (`['Policies', 'Vacation Policy']`).
- `cd backend && npx vitest run src/domains/confluence/services/subpage-context.standalone.test.ts` (pass) - sibling `subpage-context.rbac.test.ts` + `subpage-context.test.ts` still green - eslint (pass) - `tsc --noEmit` (pass)

Generated with Claude Code