### PR TITLE
perf(sync): persist expected sync-overview asset filenames per page (#887)

### DIFF
--- a/backend/src/core/db/migrations/081_pages_expected_assets.sql
+++ b/backend/src/core/db/migrations/081_pages_expected_assets.sql
@@ -1,0 +1,39 @@
+-- Migration 081: persist expected asset filenames per page (#887)
+--
+-- getSyncOverview previously re-derived each page's expected image/draw.io
+-- filenames from raw XHTML on every dashboard request: the overview query
+-- materialised the whole corpus's body_storage in one result set and then
+-- JSDOM-parsed every body twice per request. Those derived filename sets are a
+-- pure function of body_storage + space_key and only change when body_storage
+-- changes, so we persist them here and recompute only on churn.
+--
+-- Columns are nullable on purpose:
+--   NULL -> not yet computed (lazy-backfilled on the next overview read)
+--   '{}' -> computed, page has no assets
+ALTER TABLE pages ADD COLUMN IF NOT EXISTS expected_image_files TEXT[];
+ALTER TABLE pages ADD COLUMN IF NOT EXISTS expected_drawio_files TEXT[];
+
+-- ────────────────────────────────────────────────────────────────────────
+-- BEFORE UPDATE trigger — invalidate the cached filename sets whenever
+-- body_storage changes, so every body_storage writer (sync upsert, editor,
+-- AI edits, import, restore, attachments) gets the cache reset with zero
+-- changes to those call sites. Resetting to NULL forces a lazy recompute on
+-- the next overview read.
+--
+-- This trigger and migration 060's pages_local_modified_trigger are
+-- independent (disjoint columns), so their fire-order does not matter.
+-- ────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION invalidate_pages_expected_assets() RETURNS trigger AS $$
+BEGIN
+  IF NEW.body_storage IS DISTINCT FROM OLD.body_storage THEN
+    NEW.expected_image_files := NULL;
+    NEW.expected_drawio_files := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS pages_expected_assets_invalidate ON pages;
+CREATE TRIGGER pages_expected_assets_invalidate
+  BEFORE UPDATE ON pages
+  FOR EACH ROW EXECUTE FUNCTION invalidate_pages_expected_assets();

--- a/backend/src/domains/confluence/services/sync-overview-persist.db.test.ts
+++ b/backend/src/domains/confluence/services/sync-overview-persist.db.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Real-Postgres test for migration 081's invalidation trigger (#887).
+ *
+ * The persisted `expected_image_files` / `expected_drawio_files` columns must be
+ * reset to NULL whenever a page's `body_storage` changes, so getSyncOverview's
+ * lazy backfill recomputes them. Anything else (e.g. a title-only edit, or the
+ * overview's own persist UPDATE that writes the array columns) must leave the
+ * cached sets untouched. This exercises the trigger against the actual `pages`
+ * table via `test-db-helper.ts`; it `describe.skipIf(!dbAvailable)` so
+ * contributors without a running test Postgres can still run the rest of the
+ * suite.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../../test-db-helper.js';
+import { query } from '../../../core/db/postgres.js';
+
+const dbAvailable = await isDbAvailable();
+
+async function insertPage(confluenceId: string, bodyStorage: string): Promise<void> {
+  await query(
+    `INSERT INTO pages (confluence_id, source, space_key, title, body_text,
+                        body_storage, body_html, inherit_perms)
+     VALUES ($1, 'confluence', 'OPS', $2, 'text', $3, '', TRUE)`,
+    [confluenceId, `Page ${confluenceId}`, bodyStorage],
+  );
+}
+
+async function getExpected(confluenceId: string): Promise<{
+  image: string[] | null;
+  drawio: string[] | null;
+}> {
+  const res = await query<{ expected_image_files: string[] | null; expected_drawio_files: string[] | null }>(
+    'SELECT expected_image_files, expected_drawio_files FROM pages WHERE confluence_id = $1',
+    [confluenceId],
+  );
+  return {
+    image: res.rows[0]?.expected_image_files ?? null,
+    drawio: res.rows[0]?.expected_drawio_files ?? null,
+  };
+}
+
+describe.skipIf(!dbAvailable)('pages expected-asset invalidation trigger (#887)', () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  it('resets both expected-asset columns to NULL when body_storage changes', async () => {
+    await insertPage('page-1', '<p>original</p>');
+    await query(
+      `UPDATE pages SET expected_image_files = '{x.png}', expected_drawio_files = '{y.png}' WHERE confluence_id = $1`,
+      ['page-1'],
+    );
+
+    // Precondition: the cache is populated.
+    const before = await getExpected('page-1');
+    expect(before.image).toEqual(['x.png']);
+    expect(before.drawio).toEqual(['y.png']);
+
+    // Change body_storage -> trigger must invalidate the cache.
+    await query('UPDATE pages SET body_storage = $2 WHERE confluence_id = $1', ['page-1', '<p>edited</p>']);
+
+    const after = await getExpected('page-1');
+    expect(after.image).toBeNull();
+    expect(after.drawio).toBeNull();
+  });
+
+  it('leaves the cached sets untouched when body_storage is unchanged', async () => {
+    await insertPage('page-2', '<p>stable</p>');
+    await query(
+      `UPDATE pages SET expected_image_files = '{a.png}', expected_drawio_files = '{}' WHERE confluence_id = $1`,
+      ['page-2'],
+    );
+
+    // A title-only edit does not touch body_storage -> cache survives.
+    await query('UPDATE pages SET title = $2 WHERE confluence_id = $1', ['page-2', 'Renamed']);
+
+    const after = await getExpected('page-2');
+    expect(after.image).toEqual(['a.png']);
+    expect(after.drawio).toEqual([]);
+  });
+});

--- a/backend/src/domains/confluence/services/sync-overview-service.test.ts
+++ b/backend/src/domains/confluence/services/sync-overview-service.test.ts
@@ -40,10 +40,8 @@ describe('getSyncOverview', () => {
           space_last_synced: new Date('2026-03-11T09:00:00.000Z'),
           page_id: 'page-1',
           page_title: 'Runbook',
-          body_storage: `
-            <ac:image><ri:attachment ri:filename="diagram.png" /></ac:image>
-            <ac:structured-macro ac:name="drawio"><ac:parameter ac:name="diagramName">topology</ac:parameter></ac:structured-macro>
-          `,
+          expected_image_files: ['diagram.png'],
+          expected_drawio_files: ['topology.png'],
         },
         {
           space_key: 'OPS',
@@ -51,7 +49,8 @@ describe('getSyncOverview', () => {
           space_last_synced: new Date('2026-03-11T09:00:00.000Z'),
           page_id: 'page-2',
           page_title: 'Overview',
-          body_storage: '<p>No binary assets</p>',
+          expected_image_files: [],
+          expected_drawio_files: [],
         },
       ],
     });
@@ -95,7 +94,8 @@ describe('getSyncOverview', () => {
         space_last_synced: null,
         page_id: null,
         page_title: null,
-        body_storage: null,
+        expected_image_files: null,
+        expected_drawio_files: null,
       }],
     });
 
@@ -138,7 +138,8 @@ describe('getSyncOverview', () => {
         space_last_synced: new Date('2026-03-11T09:00:00.000Z'),
         page_id: 'page-7',
         page_title: 'Architecture',
-        body_storage: '<p>Text only</p>',
+        expected_image_files: [],
+        expected_drawio_files: [],
       }],
     });
     mockGetSyncStatus.mockReturnValue({
@@ -151,5 +152,65 @@ describe('getSyncOverview', () => {
 
     expect(overview.sync.status).toBe('syncing');
     expect(overview.spaces[0]?.status).toBe('syncing');
+  });
+
+  it('reads persisted expected asset filenames without loading body_storage', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        space_key: 'OPS',
+        space_name: 'Operations',
+        space_last_synced: new Date('2026-03-11T09:00:00.000Z'),
+        page_id: 'page-1',
+        page_title: 'Runbook',
+        expected_image_files: ['diagram.png'],
+        expected_drawio_files: ['topology.png'],
+      }],
+    });
+
+    mockAttachmentExists.mockImplementation(async (_userId: string, pageId: string, filename: string) => {
+      return pageId === 'page-1' && filename === 'topology.png';
+    });
+
+    const overview = await getSyncOverview('user-1');
+
+    expect(overview.totals.images).toEqual({ expected: 1, cached: 0, missing: 1 });
+    expect(overview.totals.drawio).toEqual({ expected: 1, cached: 1, missing: 0 });
+
+    const sql = mockQuery.mock.calls[0]![0] as string;
+    expect(sql).toMatch(/expected_image_files/);
+    expect(sql).not.toMatch(/body_storage/);
+    // No NULL columns -> no lazy backfill query is issued.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('lazily backfills and persists pages whose expected asset columns are NULL', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          space_key: 'OPS',
+          space_name: 'Operations',
+          space_last_synced: new Date('2026-03-11T09:00:00.000Z'),
+          page_id: 'page-9',
+          page_title: 'Fresh',
+          expected_image_files: null,
+          expected_drawio_files: null,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          confluence_id: 'page-9',
+          space_key: 'OPS',
+          body_storage: '<ac:image><ri:attachment ri:filename="a.png" /></ac:image>',
+        }],
+      });
+
+    const overview = await getSyncOverview('user-1');
+
+    // A persist UPDATE writing the recomputed arrays must have been issued.
+    const updateCall = mockQuery.mock.calls.find(
+      (call) => typeof call[0] === 'string' && /UPDATE pages[\s\S]*expected_image_files = \$2/.test(call[0] as string),
+    );
+    expect(updateCall).toBeDefined();
+    expect(overview.totals.images.expected).toBe(1);
   });
 });

--- a/backend/src/domains/confluence/services/sync-overview-service.ts
+++ b/backend/src/domains/confluence/services/sync-overview-service.ts
@@ -11,7 +11,11 @@ interface OverviewRow {
   space_last_synced: Date | null;
   page_id: string | null;
   page_title: string | null;
-  body_storage: string | null;
+  // Persisted per-page asset expectations (#887). pg maps TEXT[] -> string[]
+  // and SQL NULL -> null. NULL means "not yet computed" (lazy-backfilled on
+  // this read); an empty array means "computed, page has no assets".
+  expected_image_files: string[] | null;
+  expected_drawio_files: string[] | null;
 }
 
 function emptyCounts(): AssetSyncCounts {
@@ -61,7 +65,8 @@ export async function getSyncOverview(userId: string): Promise<SyncOverviewRespo
        cs.last_synced AS space_last_synced,
        cp.confluence_id AS page_id,
        cp.title AS page_title,
-       cp.body_storage
+       cp.expected_image_files,
+       cp.expected_drawio_files
      FROM unnest($1::text[]) AS s(space_key)
      LEFT JOIN spaces cs ON cs.space_key = s.space_key
      -- #828: keep the soft-delete filter in the JOIN (not WHERE) so a space
@@ -73,6 +78,38 @@ export async function getSyncOverview(userId: string): Promise<SyncOverviewRespo
      ORDER BY s.space_key, cp.title NULLS LAST`,
     [overviewSpaces],
   );
+
+  // Lazy backfill (#887): rows whose persisted asset columns are still NULL
+  // (legacy pages from before migration 081, or pages the invalidation trigger
+  // just reset after a body_storage change) are recomputed once from raw XHTML
+  // and persisted. Bounded batches keep peak heap small on first-load-after-
+  // upgrade; steady-state reads hit zero NULL rows and do zero JSDOM work.
+  const backfillIds = rowsResult.rows
+    .filter((r) => r.page_id && r.expected_image_files === null)
+    .map((r) => r.page_id!);
+  const computed = new Map<string, { imageFiles: string[]; drawioFiles: string[] }>();
+  const BATCH = 200;
+  for (let i = 0; i < backfillIds.length; i += BATCH) {
+    const chunk = backfillIds.slice(i, i + BATCH);
+    const bodies = await query<{ confluence_id: string; space_key: string; body_storage: string | null }>(
+      `SELECT confluence_id, space_key, body_storage FROM pages
+       WHERE confluence_id = ANY($1) AND deleted_at IS NULL`,
+      [chunk],
+    );
+    for (const b of bodies.rows) {
+      const body = b.body_storage ?? '';
+      const imageFiles = extractImageReferences(body, b.space_key).map((ref) => ref.localFilename);
+      const drawioFiles = extractDrawioDiagramNames(body).map((name) => `${name}.png`);
+      computed.set(b.confluence_id, { imageFiles, drawioFiles });
+      // This UPDATE does not touch body_storage, so both BEFORE UPDATE triggers
+      // on pages (invalidate_pages_expected_assets, set_pages_local_modified)
+      // are no-ops on it.
+      await query(
+        `UPDATE pages SET expected_image_files = $2, expected_drawio_files = $3 WHERE confluence_id = $1`,
+        [b.confluence_id, imageFiles, drawioFiles],
+      );
+    }
+  }
 
   const sync = await getSyncStatus(userId);
   const spaces = new Map<string, SyncOverviewSpace>();
@@ -102,9 +139,9 @@ export async function getSyncOverview(userId: string): Promise<SyncOverviewRespo
 
     space.pageCount += 1;
 
-    const bodyStorage = row.body_storage ?? '';
-    const imageFiles = extractImageReferences(bodyStorage, row.space_key).map((ref) => ref.localFilename);
-    const drawioFiles = extractDrawioDiagramNames(bodyStorage).map((name) => `${name}.png`);
+    const persisted = computed.get(row.page_id);
+    const imageFiles = persisted?.imageFiles ?? row.expected_image_files ?? [];
+    const drawioFiles = persisted?.drawioFiles ?? row.expected_drawio_files ?? [];
 
     if (imageFiles.length > 0 || drawioFiles.length > 0) {
       space.pagesWithAssets += 1;

--- a/docs/architecture/06-data-model.md
+++ b/docs/architecture/06-data-model.md
@@ -74,6 +74,8 @@ erDiagram
         bool embedding_dirty
         timestamptz local_modified_at "non-null => local edit since last_synced (#305)"
         uuid local_modified_by FK "who last edited locally (#305)"
+        text_array expected_image_files "cached asset filenames; NULL => recompute (#887)"
+        text_array expected_drawio_files "cached draw.io filenames; NULL => recompute (#887)"
         timestamptz deleted_at
     }
 
@@ -315,3 +317,14 @@ erDiagram
   Confluence version so the next sync doesn't clobber the revert. Retention
   keeps the last `RETENTION_VERSIONS_MAX` (default 50) snapshots per page
   (`data-retention-service.ts`).
+- **Cached asset expectations** (`pages.expected_image_files` /
+  `expected_drawio_files`, migration 081, #887). The sync-overview dashboard
+  needs each page's expected image/draw.io filenames; deriving them from raw
+  XHTML on every request materialised the whole corpus's `body_storage` and
+  double-JSDOM-parsed each body. They are now persisted as `TEXT[]` and reset to
+  NULL by the `pages_expected_assets_invalidate` BEFORE UPDATE trigger whenever
+  `body_storage` changes (covering every writer without touching their call
+  sites). `getSyncOverview` lazily recomputes the NULL rows in bounded batches
+  and persists them, so steady-state reads do zero XHTML parsing. NULL means
+  "recompute"; an empty array means "computed, no assets". This trigger is
+  independent of the migration 060 `local_modified` trigger (disjoint columns).

--- a/docs/architecture/08-flow-sync.md
+++ b/docs/architecture/08-flow-sync.md
@@ -349,6 +349,25 @@ readable spaces solely from those rows. Deselection (an empty set, handled by th
 DELETE path) is always safe and skips the PAT lookup. Cross-user space grants remain
 the exclusive domain of the admin-managed RBAC routes.
 
+## Sync-overview read path (#887)
+
+`GET /api/settings/sync-overview` (`getSyncOverview`) reports, per accessible
+space, how many expected image / draw.io assets are cached on disk. It once
+re-derived each page's expected filenames from raw XHTML on every request — the
+overview query materialised the whole corpus's `body_storage` and then JSDOM-
+parsed each body twice (`extractImageReferences` + `extractDrawioDiagramNames`),
+so an admin on a large instance blocked the event loop for tens of seconds per
+poll. Those filename sets are a pure function of `body_storage` + `space_key`, so
+they are now persisted on `pages.expected_image_files` / `expected_drawio_files`
+(migration 081) and reset to NULL by the `pages_expected_assets_invalidate`
+BEFORE UPDATE trigger whenever `body_storage` changes. The overview query selects
+the cached arrays instead of `body_storage`; a bounded (200/batch) lazy backfill
+recomputes and persists only the still-NULL rows (legacy pages, or pages just
+invalidated by a sync/edit) using the same extractors in that rare path. The
+per-page `fs.access` cache checks stay at read time (attachment downloads change
+cache state independently of page sync). The `SyncOverviewResponse` contract is
+unchanged, so the frontend needs no change.
+
 ## Content pipeline hand-off
 
 The `confluenceToHtml()` call produces `body_html` and `body_text`. The


### PR DESCRIPTION
## Summary
- The sync-overview dashboard (`GET /api/settings/sync-overview`) re-derived every page's expected image/draw.io filenames from raw XHTML on **every** request, loading the whole corpus's `body_storage` in one query and JSDOM-parsing each body twice.
- Persist those filename sets on the `pages` row so the overview reads cheap `TEXT[]` arrays; heap is bounded and steady-state requests do zero JSDOM parsing.
- Migration 081 adds a BEFORE UPDATE trigger that invalidates the cache whenever `body_storage` changes, so every writer (sync, editor, AI, import, restore) is covered without touching their call sites.
- `SyncOverviewResponse` contract is unchanged — no frontend change.

Closes #887.

## Root cause
`getSyncOverview` selected `cp.body_storage` for every live page across all accessible spaces and called `extractImageReferences` + `extractDrawioDiagramNames` (each an independent `new JSDOM(...)`) per row on every read, blocking the event loop for tens of seconds on large instances.

## Fix
- Migration 081: `pages.expected_image_files` / `expected_drawio_files` (`TEXT[]`, nullable; NULL = recompute, `{}` = computed-no-assets) + `pages_expected_assets_invalidate` BEFORE UPDATE trigger (independent of the migration 060 local-modified trigger — disjoint columns).
- Overview query selects the cached arrays instead of `body_storage`; a bounded (200/batch) lazy backfill recomputes+persists only still-NULL rows, then the loop uses the arrays.

## Testing
- TDD: extended `sync-overview-service.test.ts` (reads persisted arrays without loading `body_storage`; lazily backfills+persists NULL rows) and added `sync-overview-persist.db.test.ts` (real-Postgres trigger test). The unit cases **fail before** the fix (asset counts come out empty because current code reads absent `body_storage`), **pass after**.
- `cd backend && npx vitest run src/domains/confluence/services/sync-overview-service.test.ts` (pass) - db trigger test (pass) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code