### PR TITLE
perf(sync): pre-filter pages before missing-attachment retry pass (#888)

### DIFF
--- a/backend/src/domains/confluence/services/sync-embedding.test.ts
+++ b/backend/src/domains/confluence/services/sync-embedding.test.ts
@@ -431,6 +431,17 @@ describe('incremental sync with missing attachments', () => {
     expect(syncImageAttachments).not.toHaveBeenCalled();
   });
 
+  it('pre-filters pages by attachment markers in the SQL query (#888)', async () => {
+    setupIncrementalSync({ cachedPages: [] });
+    await syncUser('user-prefilter');
+    const selectCall = mocks.query.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('FROM pages') && sql.includes('space_key'),
+    );
+    expect(selectCall).toBeDefined();
+    expect(selectCall![0]).toContain("LIKE '%<ac:image%'");
+    expect(selectCall![0]).toContain("LIKE '%drawio%'");
+  });
+
   it('does not run syncMissingAttachments during full sync', async () => {
     mocks.query
       // 1. getClientForUser

--- a/backend/src/domains/confluence/services/sync-service.ts
+++ b/backend/src/domains/confluence/services/sync-service.ts
@@ -147,6 +147,9 @@ async function releaseSyncLock(lockId: string): Promise<void> {
 
 const MAX_ATTACHMENT_FAILURES = REDIS_MAX_ATTACHMENT_FAILURES;
 
+/** Page batch size for the missing-attachment retry pass — bounds peak heap (#888). */
+const MISSING_ATTACHMENT_BATCH_SIZE = 500;
+
 /** Clear all attachment failure counters for a page (delegates to Redis). */
 async function clearPageFailures(pageId: string): Promise<void> {
   const redis = getRedisClient();
@@ -1339,63 +1342,79 @@ async function syncMissingAttachments(
 ): Promise<void> {
   const redis = getRedisClient();
 
-  // Query pages in this space that have XHTML content (body_storage)
-  const pagesResult = await query<{ confluence_id: string; body_storage: string }>(
-    'SELECT confluence_id, body_storage FROM pages WHERE space_key = $1 AND body_storage IS NOT NULL',
-    [spaceKey],
-  );
-
   let retried = 0;
-  for (const row of pagesResult.rows) {
-    const allMissing = await getMissingAttachments(userId, row.confluence_id, row.body_storage, spaceKey);
-    if (allMissing.length === 0) continue;
-
-    // Filter out attachments that have exceeded the failure threshold
-    const retriableChecks = await Promise.all(
-      allMissing.map(async (f) => ({
-        filename: f,
-        count: await getAttachmentFailureCount(redis, row.confluence_id, f),
-      })),
-    );
-    const retriable = retriableChecks
-      .filter((c) => c.count < MAX_ATTACHMENT_FAILURES)
-      .map((c) => c.filename);
-
-    if (retriable.length === 0) continue;
-
-    logger.info(
-      { pageId: row.confluence_id, missing: retriable.length },
-      'Retrying missing attachments for unchanged page',
+  let offset = 0;
+  for (;;) {
+    // Only load pages whose XHTML actually references an attachment. `<ac:image`
+    // covers both `<ri:attachment>` and external `<ri:url>` image forms; `drawio`
+    // covers the drawio structured-macro. This cheap string pre-filter avoids
+    // pulling every body into heap and JSDOM-parsing pages with no attachments
+    // (#888). Batched LIMIT/OFFSET bounds peak memory on large spaces.
+    const pagesResult = await query<{ confluence_id: string; body_storage: string }>(
+      `SELECT confluence_id, body_storage FROM pages
+       WHERE space_key = $1 AND body_storage IS NOT NULL
+         AND (body_storage LIKE '%<ac:image%' OR body_storage LIKE '%drawio%')
+       ORDER BY confluence_id
+       LIMIT $2 OFFSET $3`,
+      [spaceKey, MISSING_ATTACHMENT_BATCH_SIZE, offset],
     );
 
-    try {
-      const { results: attachments } = await client.getPageAttachments(row.confluence_id);
-      await syncDrawioAttachments(client, userId, row.confluence_id, row.body_storage, attachments);
-      await syncImageAttachments(client, userId, row.confluence_id, row.body_storage, attachments, spaceKey);
+    if (pagesResult.rows.length === 0) break;
 
-      // Check which are still missing and update failure counts
-      const stillMissing = new Set(
-        await getMissingAttachments(userId, row.confluence_id, row.body_storage, spaceKey),
+    for (const row of pagesResult.rows) {
+      const allMissing = await getMissingAttachments(userId, row.confluence_id, row.body_storage, spaceKey);
+      if (allMissing.length === 0) continue;
+
+      // Filter out attachments that have exceeded the failure threshold
+      const retriableChecks = await Promise.all(
+        allMissing.map(async (f) => ({
+          filename: f,
+          count: await getAttachmentFailureCount(redis, row.confluence_id, f),
+        })),
+      );
+      const retriable = retriableChecks
+        .filter((c) => c.count < MAX_ATTACHMENT_FAILURES)
+        .map((c) => c.filename);
+
+      if (retriable.length === 0) continue;
+
+      logger.info(
+        { pageId: row.confluence_id, missing: retriable.length },
+        'Retrying missing attachments for unchanged page',
       );
 
-      for (const f of retriable) {
-        if (stillMissing.has(f)) {
-          await recordAttachmentFailure(redis, row.confluence_id, f);
-          const count = await getAttachmentFailureCount(redis, row.confluence_id, f);
-          if (count >= MAX_ATTACHMENT_FAILURES) {
-            logger.warn(
-              { pageId: row.confluence_id, filename: f, failures: count },
-              'Attachment permanently failed — skipping until TTL expiry',
-            );
-          }
-        }
-        // No explicit delete needed: Redis keys expire via TTL
-      }
+      try {
+        const { results: attachments } = await client.getPageAttachments(row.confluence_id);
+        await syncDrawioAttachments(client, userId, row.confluence_id, row.body_storage, attachments);
+        await syncImageAttachments(client, userId, row.confluence_id, row.body_storage, attachments, spaceKey);
 
-      retried++;
-    } catch (err) {
-      logger.error({ err, pageId: row.confluence_id }, 'Failed to retry missing attachments');
+        // Check which are still missing and update failure counts
+        const stillMissing = new Set(
+          await getMissingAttachments(userId, row.confluence_id, row.body_storage, spaceKey),
+        );
+
+        for (const f of retriable) {
+          if (stillMissing.has(f)) {
+            await recordAttachmentFailure(redis, row.confluence_id, f);
+            const count = await getAttachmentFailureCount(redis, row.confluence_id, f);
+            if (count >= MAX_ATTACHMENT_FAILURES) {
+              logger.warn(
+                { pageId: row.confluence_id, filename: f, failures: count },
+                'Attachment permanently failed — skipping until TTL expiry',
+              );
+            }
+          }
+          // No explicit delete needed: Redis keys expire via TTL
+        }
+
+        retried++;
+      } catch (err) {
+        logger.error({ err, pageId: row.confluence_id }, 'Failed to retry missing attachments');
+      }
     }
+
+    if (pagesResult.rows.length < MISSING_ATTACHMENT_BATCH_SIZE) break;
+    offset += MISSING_ATTACHMENT_BATCH_SIZE;
   }
 
   if (retried > 0) {


### PR DESCRIPTION
## Summary
- `syncMissingAttachments` no longer materialises and JSDOM-parses every page body of a space on every incremental sync (~every 15 min).
- The SELECT now pre-filters to pages whose `body_storage` actually contains an image (`<ac:image`) or drawio marker, and iterates in bounded `LIMIT/OFFSET` batches of 500.
- On a 10k-page space this replaces ~1 GB of result heap and ~20k DOM parses per cycle with a cheap string scan over the handful of pages that can have missing attachments.

Closes #888.

## Root cause
The unbounded `SELECT confluence_id, body_storage FROM pages WHERE space_key = $1 AND body_storage IS NOT NULL` loaded the full XHTML of every page, then the loop double-JSDOM-parsed each one via `getMissingAttachments`, even though almost no page has an `<ac:image>` or drawio macro.

## Fix
- Add `AND (body_storage LIKE '%<ac:image%' OR body_storage LIKE '%drawio%')` — a superset guard matching every real image/drawio ref the extractors detect.
- Wrap the pass in a `LIMIT/OFFSET` batch loop (`MISSING_ATTACHMENT_BATCH_SIZE = 500`) to bound peak heap.
- Inner loop body (failure-count bookkeeping, retry logic) is unchanged.

## Testing
- TDD: extended `backend/src/domains/confluence/services/sync-embedding.test.ts` with a test asserting the LIKE pre-filter is present in the SELECT; **fails before** the fix (query had no LIKE clause), **passes after**. Existing incremental-sync tests still pass (a sub-batch consumes one mocked query then breaks, preserving mock order).
- `cd backend && npx vitest run src/domains/confluence/services/sync-embedding.test.ts` (13 passed) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code