### PR TITLE
fix(routes): guard PAT re-encryption against concurrent update during key rotation (#889)

### DIFF
--- a/backend/src/routes/foundation/admin-rotate-encryption-key.integration.test.ts
+++ b/backend/src/routes/foundation/admin-rotate-encryption-key.integration.test.ts
@@ -15,6 +15,7 @@ import {
   teardownTestDb,
   isDbAvailable,
 } from '../../test-db-helper.js';
+import * as pg from '../../core/db/postgres.js';
 import { query } from '../../core/db/postgres.js';
 import { encryptPat, decryptPat } from '../../core/utils/crypto.js';
 import { adminRoutes } from './admin.js';
@@ -140,6 +141,62 @@ describe.skipIf(!dbAvailable)(
       expect(res.statusCode).toBe(200);
       expect(res.json()).toMatchObject({ rotated: 0, skipped: 1, errors: 0, total: 1 });
       expect(await readSmtpPass()).toBe(current);
+    });
+
+    it('does not clobber a PAT that was concurrently replaced mid-rotation (lost-update guard, #889)', async () => {
+      // Seed the user's PAT under key version 0 (the "old" ciphertext the
+      // rotation loop snapshots).
+      await query(`INSERT INTO user_settings (user_id, confluence_pat) VALUES ($1, $2)`, [
+        adminId,
+        encryptPat('old-pat'),
+      ]);
+
+      // Operator rotates: introduce key version 1 so reEncryptPat re-encrypts
+      // the snapshotted old ciphertext (rotation actually happens for this row).
+      process.env.PAT_ENCRYPTION_KEY_V1 = 'versioned-key-one-at-least-32-chars!!';
+
+      // A concurrent PUT /settings saves a brand-new PAT under the latest key.
+      const newCipher = encryptPat('new-pat');
+
+      // Simulate the race: land the concurrent write AFTER the rotation's
+      // snapshot SELECT but BEFORE the per-row UPDATE. Capture the real query
+      // fn first so the injected write and passthrough bypass the spy.
+      const realQuery = pg.query;
+      let injected = false;
+      const spy = vi
+        .spyOn(pg, 'query')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockImplementation(async (sql: any, params?: any) => {
+          const res = await realQuery(sql, params);
+          if (!injected && /SELECT user_id, confluence_pat FROM user_settings/i.test(String(sql))) {
+            injected = true;
+            await realQuery(
+              'UPDATE user_settings SET confluence_pat = $1 WHERE user_id = $2',
+              [newCipher, adminId],
+            );
+          }
+          return res;
+        });
+
+      try {
+        const res = await app.inject({ method: 'POST', url: '/api/admin/rotate-encryption-key' });
+        expect(res.statusCode).toBe(200);
+        // The raced row must not be counted as rotated; it is a no-op skip.
+        expect(res.json()).toMatchObject({ rotated: 0, skipped: 1, errors: 0, total: 1 });
+      } finally {
+        spy.mockRestore();
+      }
+
+      // The concurrently-saved new PAT survived — it was NOT reverted to a
+      // re-encryption of the stale snapshot value.
+      const pat = (
+        await query<{ confluence_pat: string }>(
+          `SELECT confluence_pat FROM user_settings WHERE user_id = $1`,
+          [adminId],
+        )
+      ).rows[0]!.confluence_pat;
+      expect(pat).toBe(newCipher);
+      expect(decryptPat(pat)).toBe('new-pat');
     });
 
     it('ignores an empty smtp_pass row (cleared password is not a secret)', async () => {

--- a/backend/src/routes/foundation/admin.ts
+++ b/backend/src/routes/foundation/admin.ts
@@ -78,11 +78,20 @@ export async function adminRoutes(fastify: FastifyInstance) {
       try {
         const reEncrypted = reEncryptPat(row.confluence_pat);
         if (reEncrypted) {
-          await query(
-            'UPDATE user_settings SET confluence_pat = $1 WHERE user_id = $2',
-            [reEncrypted, row.user_id],
+          // Conditional on the exact ciphertext read at snapshot time so a
+          // concurrent PUT /settings that saved a NEW PAT is never clobbered
+          // with a re-encryption of the OLD value (lost-update guard, #889).
+          const updated = await query(
+            'UPDATE user_settings SET confluence_pat = $1 WHERE user_id = $2 AND confluence_pat = $3',
+            [reEncrypted, row.user_id, row.confluence_pat],
           );
-          rotated++;
+          if ((updated.rowCount ?? 0) > 0) {
+            rotated++;
+          } else {
+            // Concurrently replaced by PUT /settings — the new PAT is already
+            // encrypted under the latest key, so it must not be reverted.
+            skipped++;
+          }
         } else {
           skipped++; // Already using latest key
         }


### PR DESCRIPTION
## Summary
- `POST /api/admin/rotate-encryption-key` snapshotted every user's encrypted PAT, then rewrote each row with an **unconditional** `UPDATE ... WHERE user_id = $2`.
- If a user saved a new PAT via `PUT /settings` during the rotation loop, the sweep later reverted it to a re-encryption of the stale snapshot ciphertext — a silent lost update.
- Add a ciphertext compare-and-swap guard so a concurrently-replaced row is left untouched and correctly counted as `skipped`, mirroring the existing `smtp_pass` guard right below it.

Closes #889.

## Root cause
The per-user PAT re-encryption UPDATE had no value-guard, so it clobbered any credential written between the snapshot `SELECT` and the row's UPDATE. The sibling `smtp_pass` branch was already hardened with an `AND setting_value = $2` guard; the user-PAT branch was never given the equivalent.

## Fix
- Change `UPDATE user_settings SET confluence_pat = $1 WHERE user_id = $2` to `... AND confluence_pat = $3` passing the snapshot ciphertext.
- Branch on `rowCount`: `> 0 → rotated++`, else `skipped++` (row was concurrently replaced and is already under the latest key). Response shape `{ rotated, skipped, errors, total }` is unchanged.

## Testing
- TDD: extended `backend/src/routes/foundation/admin-rotate-encryption-key.integration.test.ts` with a real-DB test that injects a concurrent PUT /settings write right after the snapshot SELECT; **fails before** the fix (raced PAT reverted, `rotated:1/skipped:0`), **passes after** (new PAT survives, `rotated:0/skipped:1`).
- `cd backend && npx vitest run src/routes/foundation/admin-rotate-encryption-key.integration.test.ts` (5 passed) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code