### PR TITLE
fix(routes): gate content-analytics view/feedback writes by page access (#890)

### DIFF
--- a/backend/src/routes/knowledge/content-analytics-routes.test.ts
+++ b/backend/src/routes/knowledge/content-analytics-routes.test.ts
@@ -8,6 +8,12 @@ vi.mock('../../core/db/postgres.js', () => ({
   query: (...args: unknown[]) => mockQuery(...args),
 }));
 
+// --- Mock: page-access gate (boundary) ---
+const mockUserCanAccessPage = vi.fn();
+vi.mock('../../core/services/rbac-service.js', () => ({
+  userCanAccessPage: (...args: unknown[]) => mockUserCanAccessPage(...args),
+}));
+
 import { contentAnalyticsRoutes } from './content-analytics.js';
 
 const TEST_USER_ID = 'user-abc';
@@ -87,9 +93,38 @@ describe('Content analytics routes - authenticated', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default-allow so happy-path tests keep passing; individual tests
+    // override with mockResolvedValueOnce(false) to exercise the gate.
+    mockUserCanAccessPage.mockResolvedValue(true);
   });
 
   // ── POST /api/pages/:id/feedback ──────────────────────────────────
+
+  it('returns 404 and does not insert feedback when the user cannot access the page (#890)', async () => {
+    mockUserCanAccessPage.mockResolvedValueOnce(false);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/pages/999999/feedback',
+      payload: { isHelpful: true },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 and does not record a view when the user cannot access the page (#890)', async () => {
+    mockUserCanAccessPage.mockResolvedValueOnce(false);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/pages/999999/view',
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
 
   it('should submit feedback', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
@@ -355,6 +390,7 @@ describe('Content analytics routes - admin required for aggregates', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUserCanAccessPage.mockResolvedValue(true);
   });
 
   it('should return 403 for GET /api/analytics/trending without admin', async () => {

--- a/backend/src/routes/knowledge/content-analytics-routes.test.ts
+++ b/backend/src/routes/knowledge/content-analytics-routes.test.ts
@@ -179,6 +179,16 @@ describe('Content analytics routes - authenticated', () => {
 
   // ── GET /api/pages/:id/feedback ───────────────────────────────────
 
+  it('returns 404 and does not query feedback when the user cannot access the page (#890)', async () => {
+    mockUserCanAccessPage.mockResolvedValueOnce(false);
+
+    const res = await app.inject({ method: 'GET', url: '/api/pages/999999/feedback' });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().message).toBe('Page not found');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
   it('should get feedback summary for a page', async () => {
     // Summary query
     mockQuery.mockResolvedValueOnce({
@@ -197,6 +207,7 @@ describe('Content analytics routes - authenticated', () => {
     expect(body.notHelpful).toBe(2);
     expect(body.total).toBe(7);
     expect(body.userVote).toEqual({ isHelpful: true, comment: 'Nice' });
+    expect(mockUserCanAccessPage).toHaveBeenCalledWith(TEST_USER_ID, 42);
   });
 
   it('should return null userVote when user has not voted', async () => {

--- a/backend/src/routes/knowledge/content-analytics.ts
+++ b/backend/src/routes/knowledge/content-analytics.ts
@@ -63,9 +63,14 @@ export async function contentAnalyticsRoutes(fastify: FastifyInstance) {
 
   // ── GET /api/pages/:id/feedback ──────────────────────────────────────────
   // Feedback summary for a specific page + current user's vote
-  fastify.get('/pages/:id/feedback', async (request) => {
+  fastify.get('/pages/:id/feedback', async (request, reply) => {
     const { id: pageId } = IdParamSchema.parse(request.params);
     const userId = request.userId;
+
+    // #890: gate by page access so missing/restricted pages return 404 (not a 500 FK oracle)
+    if (!(await userCanAccessPage(userId, pageId))) {
+      return reply.notFound('Page not found');
+    }
 
     const [summary, userVote] = await Promise.all([
       query<{

--- a/backend/src/routes/knowledge/content-analytics.ts
+++ b/backend/src/routes/knowledge/content-analytics.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { query } from '../../core/db/postgres.js';
+import { userCanAccessPage } from '../../core/services/rbac-service.js';
 
 // ── Request schemas ────────────────────────────────────────────────────────────
 
@@ -40,6 +41,11 @@ export async function contentAnalyticsRoutes(fastify: FastifyInstance) {
     const { id: pageId } = IdParamSchema.parse(request.params);
     const { isHelpful, comment } = FeedbackBodySchema.parse(request.body);
     const userId = request.userId;
+
+    // #890: gate by page access so missing/restricted pages return 404 (not a 500 FK oracle)
+    if (!(await userCanAccessPage(userId, pageId))) {
+      return reply.notFound('Page not found');
+    }
 
     const result = await query<{ id: number }>(
       `INSERT INTO article_feedback (page_id, user_id, is_helpful, comment)
@@ -101,6 +107,11 @@ export async function contentAnalyticsRoutes(fastify: FastifyInstance) {
     const { id: pageId } = IdParamSchema.parse(request.params);
     const { sessionId } = ViewBodySchema.parse(request.body ?? {});
     const userId = request.userId;
+
+    // #890: gate by page access so missing/restricted pages return 404 (not a 500 FK oracle)
+    if (!(await userCanAccessPage(userId, pageId))) {
+      return reply.notFound('Page not found');
+    }
 
     // Deduplicate: skip if same user+page+session viewed within last 30 min
     if (sessionId) {


### PR DESCRIPTION
## Summary
- `POST /pages/:id/feedback` and `POST /pages/:id/view` in `content-analytics.ts` wrote directly into `article_feedback` / `page_views` with no page lookup or access check.
- A nonexistent page id triggered a Postgres FK violation (23503) surfaced as HTTP 500 — a 201-vs-500 existence oracle distinguishing restricted pages from missing ones — and any authenticated user could pump views/feedback into pages they cannot read, polluting admin-only analytics.
- Both handlers now gate on `userCanAccessPage` before touching the tables, mirroring the #733 hardening already applied to `comments.ts`.

Closes #890.

## Root cause
The two POST write handlers never resolved the page or called `userCanAccessPage`, so the `page_id NOT NULL REFERENCES pages(id)` FK was the only (and wrong) line of defense — raising an unhandled 500 for missing ids and leaving restricted pages writable.

## Fix
- Import `userCanAccessPage` from `rbac-service`.
- Add `if (!(await userCanAccessPage(userId, pageId))) return reply.notFound('Page not found');` to the feedback handler (before the upsert) and the view handler (before the dedup SELECT).
- `userCanAccessPage` returns false for missing, soft-deleted, and restricted pages alike, collapsing them into a uniform 404 that closes the FK-500 path and the oracle at once.

## Testing
- TDD: extended `content-analytics-routes.test.ts` with two boundary-mocked gating tests (rbac-service mocked); **fails before** the fix (feedback 500, view 201, query invoked), **passes after** (404, no query call).
- `cd backend && npx vitest run src/routes/knowledge/content-analytics-routes.test.ts` (23 pass) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code