### PR TITLE
fix(routes): invalidate cache across users on shared/Confluence page mutations (#893)

### DIFF
--- a/backend/src/routes/knowledge/bulk-pages.test.ts
+++ b/backend/src/routes/knowledge/bulk-pages.test.ts
@@ -7,14 +7,17 @@ import { pagesCrudRoutes } from './pages-crud.js';
 const mockConfluenceToHtml = vi.fn().mockReturnValue('<p>content</p>');
 
 // Mock external dependencies
+// Shared spies so tests can assert which invalidation path a route took (#893).
+const mockCacheInvalidate = vi.fn();
+const mockCacheInvalidateAcrossUsers = vi.fn();
 vi.mock('../../core/services/redis-cache.js', () => {
   return {
     RedisCache: class MockRedisCache {
       get = vi.fn().mockResolvedValue(null);
       set = vi.fn().mockResolvedValue(undefined);
-      invalidate = vi.fn().mockResolvedValue(undefined);
+      invalidate = (...args: unknown[]) => mockCacheInvalidate(...args);
       // Bulk deletes clear every user's cache (#893).
-      invalidateAcrossUsers = vi.fn().mockResolvedValue(undefined);
+      invalidateAcrossUsers = (...args: unknown[]) => mockCacheInvalidateAcrossUsers(...args);
     },
   };
 });
@@ -181,6 +184,13 @@ describe('Bulk Pages Routes (Parallelized)', () => {
       expect(body.succeeded).toBe(2);
       expect(body.failed).toBe(0);
       expect(body.errors).toEqual([]);
+
+      // #893: a bulk delete may remove Confluence/shared pages from every
+      // user's view — both the pages and spaces caches (the latter carries
+      // per-space pageCount) must be cleared across all users.
+      expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('pages');
+      expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('spaces');
+      expect(mockCacheInvalidate).not.toHaveBeenCalled();
     });
 
     it('should return 400 for empty ids', async () => {

--- a/backend/src/routes/knowledge/bulk-pages.test.ts
+++ b/backend/src/routes/knowledge/bulk-pages.test.ts
@@ -13,6 +13,8 @@ vi.mock('../../core/services/redis-cache.js', () => {
       get = vi.fn().mockResolvedValue(null);
       set = vi.fn().mockResolvedValue(undefined);
       invalidate = vi.fn().mockResolvedValue(undefined);
+      // Bulk deletes clear every user's cache (#893).
+      invalidateAcrossUsers = vi.fn().mockResolvedValue(undefined);
     },
   };
 });

--- a/backend/src/routes/knowledge/folder-pages.test.ts
+++ b/backend/src/routes/knowledge/folder-pages.test.ts
@@ -9,6 +9,8 @@ vi.mock('../../core/services/redis-cache.js', () => ({
     get = vi.fn().mockResolvedValue(null);
     set = vi.fn().mockResolvedValue(undefined);
     invalidate = vi.fn().mockResolvedValue(undefined);
+    // Shared/Confluence mutations clear every user's cache (#893).
+    invalidateAcrossUsers = vi.fn().mockResolvedValue(undefined);
   },
 }));
 

--- a/backend/src/routes/knowledge/page-update.test.ts
+++ b/backend/src/routes/knowledge/page-update.test.ts
@@ -263,7 +263,10 @@ describe('PUT /api/pages/:id', () => {
       expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('pages');
     });
 
-    it('keeps per-user invalidation when the payload sends the same visibility', async () => {
+    it('invalidates across users when a shared page is edited with the same visibility (#893)', async () => {
+      // A shared page's list rows (title/snippet) are visible to every user, so
+      // an edit that keeps visibility='shared' must still clear every user's
+      // cache — not just the editor's — or others see the stale title for 15 min.
       mockStandalonePage('shared');
 
       const response = await app.inject({
@@ -273,8 +276,20 @@ describe('PUT /api/pages/:id', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(mockCacheInvalidateAcrossUsers).not.toHaveBeenCalled();
-      expect(mockCacheInvalidate).toHaveBeenCalledWith('user-1', 'pages');
+      expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('pages');
+    });
+
+    it('invalidates across users when a shared page is edited and the payload omits visibility (#893)', async () => {
+      mockStandalonePage('shared');
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/7',
+        payload: { title: 'Note', bodyHtml: '<p>note</p>', version: 3 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('pages');
     });
 
     it('keeps per-user invalidation when the payload omits visibility', async () => {
@@ -289,6 +304,23 @@ describe('PUT /api/pages/:id', () => {
       expect(response.statusCode).toBe(200);
       expect(mockCacheInvalidateAcrossUsers).not.toHaveBeenCalled();
       expect(mockCacheInvalidate).toHaveBeenCalledWith('user-1', 'pages');
+    });
+  });
+
+  describe('Confluence-push edit — cache invalidation (#893)', () => {
+    it('invalidates the pages cache across all users after a Confluence-push edit', async () => {
+      // Default beforeEach mock resolves a Confluence-backed page (id 42),
+      // which every user with space access can see — so its cached list rows
+      // must be cleared for all users, not just the editor's.
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/page-1',
+        payload: { title: 'Updated title', bodyHtml: '<p>updated body</p>', version: 7 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('pages');
+      expect(mockCacheInvalidate).not.toHaveBeenCalledWith('user-1', 'pages');
     });
   });
 });

--- a/backend/src/routes/knowledge/pages-crud-create.test.ts
+++ b/backend/src/routes/knowledge/pages-crud-create.test.ts
@@ -4,11 +4,16 @@ import sensible from '@fastify/sensible';
 import { ZodError } from 'zod';
 import { pagesCrudRoutes } from './pages-crud.js';
 
+const mockCacheInvalidate = vi.fn();
+const mockCacheInvalidateAcrossUsers = vi.fn();
+
 vi.mock('../../core/services/redis-cache.js', () => ({
   RedisCache: class MockRedisCache {
     get = vi.fn().mockResolvedValue(null);
     set = vi.fn().mockResolvedValue(undefined);
-    invalidate = vi.fn().mockResolvedValue(undefined);
+    invalidate = (...args: unknown[]) => mockCacheInvalidate(...args);
+    // Creating a shared/Confluence page clears every user's cache (#893).
+    invalidateAcrossUsers = (...args: unknown[]) => mockCacheInvalidateAcrossUsers(...args);
   },
 }));
 
@@ -398,5 +403,90 @@ describe('POST /api/pages - parentId validation', () => {
     expect(response.statusCode).toBe(400);
     const body = JSON.parse(response.payload);
     expect(body.error).toContain('Confluence not configured');
+  });
+
+  // #893 review follow-up: a newly created shared/Confluence page appears in
+  // every user's lists/trees, so only invalidating the creator's cache leaves
+  // the page missing for other users for up to the cache TTL (15 min).
+  describe('cache invalidation (#893)', () => {
+    it('invalidates the pages cache across all users when creating a standalone page with default (shared) visibility', async () => {
+      // INSERT returns new page
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{ id: 80, title: 'Shared note', version: 1 }],
+      });
+      // UPDATE path
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages',
+        payload: {
+          title: 'Shared note',
+          bodyHtml: '<p>Hello</p>',
+          source: 'standalone',
+          // visibility omitted — CreatePageSchema defaults to 'shared'
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('pages');
+      expect(mockCacheInvalidate).not.toHaveBeenCalledWith('test-user-id', 'pages');
+    });
+
+    it('keeps per-user invalidation when creating a private standalone page', async () => {
+      mockQueryFn.mockResolvedValueOnce({
+        rows: [{ id: 81, title: 'Private note', version: 1 }],
+      });
+      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages',
+        payload: {
+          title: 'Private note',
+          bodyHtml: '<p>Hello</p>',
+          source: 'standalone',
+          visibility: 'private',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockCacheInvalidateAcrossUsers).not.toHaveBeenCalled();
+      expect(mockCacheInvalidate).toHaveBeenCalledWith('test-user-id', 'pages');
+    });
+
+    it('invalidates pages AND spaces caches across all users when creating a Confluence page', async () => {
+      // Space lookup: CONFSPACE is a Confluence space
+      mockQueryFn.mockResolvedValueOnce({ rows: [{ source: 'confluence' }] });
+      // Local cache INSERT + anything after
+      mockQueryFn.mockResolvedValue({ rows: [] });
+
+      const { getClientForUser } = await import('../../domains/confluence/services/sync-service.js');
+      vi.mocked(getClientForUser).mockResolvedValueOnce({
+        createPage: vi.fn().mockResolvedValue({
+          id: 'conf-100',
+          title: 'New Conf Page',
+          version: { number: 1 },
+          body: { storage: { value: '<p>Hello</p>' } },
+        }),
+      } as never);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/pages',
+        payload: {
+          title: 'New Conf Page',
+          bodyHtml: '<p>Hello</p>',
+          spaceKey: 'CONFSPACE',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('pages');
+      // The cached GET /api/spaces payload carries per-space pageCount, which
+      // this create just changed for every user with access to the space.
+      expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('spaces');
+      expect(mockCacheInvalidate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/src/routes/knowledge/pages-crud-delete-atomicity.integration.test.ts
+++ b/backend/src/routes/knowledge/pages-crud-delete-atomicity.integration.test.ts
@@ -41,6 +41,8 @@ vi.mock('../../core/services/redis-cache.js', async (importOriginal) => ({
     get = vi.fn().mockResolvedValue(null);
     set = vi.fn().mockResolvedValue(undefined);
     invalidate = vi.fn().mockResolvedValue(undefined);
+    // Shared/Confluence mutations clear every user's cache (#893).
+    invalidateAcrossUsers = vi.fn().mockResolvedValue(undefined);
   },
 }));
 

--- a/backend/src/routes/knowledge/pages-crud-delete-rbac.test.ts
+++ b/backend/src/routes/knowledge/pages-crud-delete-rbac.test.ts
@@ -8,13 +8,16 @@ import { cleanPageAttachments } from '../../domains/confluence/services/attachme
 
 // --- Mocks ---
 
+// Shared spies so tests can assert which invalidation path a delete took (#893).
+const mockCacheInvalidate = vi.fn();
+const mockCacheInvalidateAcrossUsers = vi.fn();
 vi.mock('../../core/services/redis-cache.js', () => ({
   RedisCache: class MockRedisCache {
     get = vi.fn().mockResolvedValue(null);
     set = vi.fn().mockResolvedValue(undefined);
-    invalidate = vi.fn().mockResolvedValue(undefined);
+    invalidate = (...args: unknown[]) => mockCacheInvalidate(...args);
     // Confluence deletes clear every user's cache (#893).
-    invalidateAcrossUsers = vi.fn().mockResolvedValue(undefined);
+    invalidateAcrossUsers = (...args: unknown[]) => mockCacheInvalidateAcrossUsers(...args);
   },
 }));
 
@@ -250,6 +253,100 @@ describe('DELETE /api/pages/:id RBAC space access checks', () => {
 
     expect(response.statusCode).toBe(200);
     expect(mockDeletePage).toHaveBeenCalledWith('page-42');
+  });
+
+  // ── #893: cross-user cache invalidation on delete ──────────────────────────
+  // A Confluence or shared standalone page is visible to other users, so its
+  // deletion must clear every user's cached lists/trees — not just the deleter's.
+
+  describe('cache invalidation (#893)', () => {
+    it('invalidates pages AND spaces caches across all users on a Confluence delete', async () => {
+      const mockDeletePage = vi.fn().mockResolvedValue(undefined);
+      mockGetClientForUser.mockResolvedValue({ deletePage: mockDeletePage });
+
+      mockQueryFn.mockImplementation((sql: string) => {
+        if (typeof sql === 'string' && sql.includes('id, source, created_by_user_id')) {
+          return Promise.resolve({
+            rows: [{
+              id: 10,
+              source: 'confluence',
+              created_by_user_id: null,
+              confluence_id: 'page-100',
+              space_key: 'DEV',
+              visibility: 'shared',
+            }],
+          });
+        }
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      });
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/pages/page-100',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('pages');
+      // Deleting a Confluence page may drop its space, and the cached spaces
+      // payload carries per-space pageCount — clear it for everyone too.
+      expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('spaces');
+      expect(mockCacheInvalidate).not.toHaveBeenCalled();
+    });
+
+    it('invalidates the pages cache across all users when deleting a shared standalone page', async () => {
+      mockQueryFn.mockImplementation((sql: string) => {
+        if (typeof sql === 'string' && sql.includes('id, source, created_by_user_id')) {
+          return Promise.resolve({
+            rows: [{
+              id: 10,
+              source: 'standalone',
+              created_by_user_id: TEST_USER,
+              confluence_id: null,
+              space_key: null,
+              visibility: 'shared',
+            }],
+          });
+        }
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      });
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/pages/10',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('pages');
+      // Standalone pages never drop a Confluence space — the spaces cache stays.
+      expect(mockCacheInvalidateAcrossUsers).not.toHaveBeenCalledWith('spaces');
+    });
+
+    it('keeps per-user invalidation when deleting a private standalone page', async () => {
+      mockQueryFn.mockImplementation((sql: string) => {
+        if (typeof sql === 'string' && sql.includes('id, source, created_by_user_id')) {
+          return Promise.resolve({
+            rows: [{
+              id: 10,
+              source: 'standalone',
+              created_by_user_id: TEST_USER,
+              confluence_id: null,
+              space_key: null,
+              visibility: 'private',
+            }],
+          });
+        }
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      });
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/pages/10',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockCacheInvalidateAcrossUsers).not.toHaveBeenCalled();
+      expect(mockCacheInvalidate).toHaveBeenCalledWith(TEST_USER, 'pages');
+    });
   });
 
   // ── #706: tolerate a Confluence page already deleted remotely ──────────────

--- a/backend/src/routes/knowledge/pages-crud-delete-rbac.test.ts
+++ b/backend/src/routes/knowledge/pages-crud-delete-rbac.test.ts
@@ -13,6 +13,8 @@ vi.mock('../../core/services/redis-cache.js', () => ({
     get = vi.fn().mockResolvedValue(null);
     set = vi.fn().mockResolvedValue(undefined);
     invalidate = vi.fn().mockResolvedValue(undefined);
+    // Confluence deletes clear every user's cache (#893).
+    invalidateAcrossUsers = vi.fn().mockResolvedValue(undefined);
   },
 }));
 

--- a/backend/src/routes/knowledge/pages-crud-webhooks.test.ts
+++ b/backend/src/routes/knowledge/pages-crud-webhooks.test.ts
@@ -19,6 +19,8 @@ vi.mock('../../core/services/redis-cache.js', () => ({
     get = vi.fn().mockResolvedValue(null);
     set = vi.fn().mockResolvedValue(undefined);
     invalidate = vi.fn().mockResolvedValue(undefined);
+    // Shared/Confluence mutations clear every user's cache (#893).
+    invalidateAcrossUsers = vi.fn().mockResolvedValue(undefined);
   },
 }));
 

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -993,9 +993,9 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
 
     const existing = await query<{
       id: number; title: string; source: string;
-      created_by_user_id: string | null; deleted_at: Date | null;
+      created_by_user_id: string | null; deleted_at: Date | null; visibility: string;
     }>(
-      'SELECT id, title, source, created_by_user_id, deleted_at FROM pages WHERE id = $1',
+      'SELECT id, title, source, created_by_user_id, deleted_at, visibility FROM pages WHERE id = $1',
       [id],
     );
     if (existing.rows.length === 0) {
@@ -1015,7 +1015,13 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
 
     await query('UPDATE pages SET deleted_at = NULL WHERE id = $1', [page.id]);
 
-    await cache.invalidate(userId, 'pages');
+    // A restored shared page reappears in every user's lists/trees (#893) —
+    // mirror the delete path: clear all users' caches. Private stays per-user.
+    if (page.visibility === 'shared') {
+      await cache.invalidateAcrossUsers('pages');
+    } else {
+      await cache.invalidate(userId, 'pages');
+    }
     await logAuditEvent(userId, 'PAGE_RESTORED', 'page', String(id),
       { source: 'standalone', title: page.title }, request);
 
@@ -1057,6 +1063,7 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
 
     if (isStandalone) {
       // --- Standalone article: no Confluence call, store locally ---
+      const visibility = body.visibility ?? 'shared';
       const isFolder = pageType === 'folder';
       const effectiveBodyHtml = isFolder ? '' : body.bodyHtml;
       const { htmlToText } = await import('../../core/services/content-converter.js');
@@ -1091,7 +1098,7 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
                  $8, $9, 'not_embedded', NOW())
          RETURNING id, title, version`,
         [body.title, effectiveBodyHtml, bodyText, userId,
-         body.visibility ?? 'shared', spaceKey, body.parentId ?? null,
+         visibility, spaceKey, body.parentId ?? null,
          pageType, !isFolder],
       );
 
@@ -1103,9 +1110,16 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       await query('UPDATE pages SET path = $1, depth = $2 WHERE id = $3',
         [newPath, depth, newPage.id]);
 
-      await cache.invalidate(userId, 'pages');
+      // A new shared page appears in every user's lists/trees (#893) — clear
+      // all users' caches so it isn't missing for them until the TTL expires.
+      // Private pages only concern the creator.
+      if (visibility === 'shared') {
+        await cache.invalidateAcrossUsers('pages');
+      } else {
+        await cache.invalidate(userId, 'pages');
+      }
       await logAuditEvent(userId, 'PAGE_CREATED', 'page', String(newPage.id),
-        { source: 'standalone', title: body.title, visibility: body.visibility ?? 'shared', spaceKey, pageType }, request);
+        { source: 'standalone', title: body.title, visibility, spaceKey, pageType }, request);
 
       emitWebhookEvent({
         eventType: 'page.created',
@@ -1162,9 +1176,11 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
        bodyHtml, bodyText, page.version.number, body.parentId ?? null],
     );
 
-    // Invalidate cache
-    await cache.invalidate(userId, 'pages');
-    await cache.invalidate(userId, 'spaces');
+    // A new Confluence page is visible to every user with space access (#893),
+    // and the cached spaces payload carries per-space pageCount which this
+    // create just changed — clear both caches for every user.
+    await cache.invalidateAcrossUsers('pages');
+    await cache.invalidateAcrossUsers('spaces');
 
     await logAuditEvent(userId, 'PAGE_CREATED', 'page', page.id, { spaceKey: body.spaceKey, title: body.title }, request);
 
@@ -1742,7 +1758,14 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       }
     }
 
-    await cache.invalidate(userId, 'pages');
+    // Publishing a draft rewrites the live content — the same mutation class
+    // as PUT /pages/:id (#893): Confluence/shared pages are visible to other
+    // users, so their cached lists/trees must be cleared for everyone.
+    if (page.source === 'confluence' || page.visibility === 'shared') {
+      await cache.invalidateAcrossUsers('pages');
+    } else {
+      await cache.invalidate(userId, 'pages');
+    }
     await logAuditEvent(userId, 'DRAFT_PUBLISHED', 'page', String(page.id),
       { version: page.version + 1 }, request);
 

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -1264,10 +1264,12 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
           : [id, body.title, body.bodyHtml, bodyText, newVersion, userId],
       );
 
-      // A visibility change alters what OTHER users can see — their cached
-      // trees/lists would serve stale data for up to the cache TTL (15 min)
-      // if we only invalidated the editor's own cache.
-      if (body.visibility && body.visibility !== existingPage.visibility) {
+      // A shared page's list rows (title/snippet) and a visibility flip both
+      // change what OTHER users see (#893) — their cached trees/lists would
+      // serve stale data for up to the cache TTL (15 min) if we only
+      // invalidated the editor's own cache. Private edits stay per-user.
+      const visibilityChanged = body.visibility && body.visibility !== existingPage.visibility;
+      if (visibilityChanged || existingPage.visibility === 'shared') {
         await cache.invalidateAcrossUsers('pages');
       } else {
         await cache.invalidate(userId, 'pages');
@@ -1352,8 +1354,9 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
        bodyHtml, bodyText, confPage.version.number],
     );
 
-    // Invalidate cache
-    await cache.invalidate(userId, 'pages');
+    // Confluence pages are visible to every user with space access (#893), so
+    // clear every user's cached lists/trees, not just the editor's.
+    await cache.invalidateAcrossUsers('pages');
 
     await logAuditEvent(userId, 'PAGE_UPDATED', 'page', String(id), { title: body.title }, request);
 
@@ -1383,9 +1386,9 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     // Load the page to determine source
     const existing = await query<{
       id: number; source: string; created_by_user_id: string | null;
-      confluence_id: string | null; space_key: string | null;
+      confluence_id: string | null; space_key: string | null; visibility: string;
     }>(
-      `SELECT id, source, created_by_user_id, confluence_id, space_key FROM pages WHERE ${isNumericId ? 'id = $1' : 'confluence_id = $1'}`,
+      `SELECT id, source, created_by_user_id, confluence_id, space_key, visibility FROM pages WHERE ${isNumericId ? 'id = $1' : 'confluence_id = $1'}`,
       [isNumericId ? parseInt(id, 10) : id],
     );
     if (existing.rows.length === 0) {
@@ -1409,7 +1412,13 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
         await query('UPDATE pages SET deleted_at = NOW() WHERE id = $1', [existingPage.id]);
       }
 
-      await cache.invalidate(userId, 'pages');
+      // A shared standalone page is visible to every user (#893), so its
+      // removal must clear all users' cached lists/trees. Private stays per-user.
+      if (existingPage.visibility === 'shared') {
+        await cache.invalidateAcrossUsers('pages');
+      } else {
+        await cache.invalidate(userId, 'pages');
+      }
       await logAuditEvent(userId, 'PAGE_DELETED', 'page', String(id),
         { source: 'standalone', permanent: queryParams.permanent === 'true' }, request);
 
@@ -1538,9 +1547,10 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       }
     }
 
-    // Invalidate cache
-    await cache.invalidate(userId, 'pages');
-    await cache.invalidate(userId, 'spaces');
+    // Confluence pages are visible to every user with space access (#893), and
+    // deleting one may also drop its space — clear every user's cache.
+    await cache.invalidateAcrossUsers('pages');
+    await cache.invalidateAcrossUsers('spaces');
 
     await logAuditEvent(userId, 'PAGE_DELETED', 'page', String(id), { alreadyGoneRemotely: alreadyGone }, request);
 
@@ -1954,8 +1964,10 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
     }
 
     const succeeded = standaloneSucceeded + confluenceSucceeded;
-    await cache.invalidate(userId, 'pages');
-    await cache.invalidate(userId, 'spaces');
+    // A bulk delete may include Confluence/shared pages visible to every user
+    // (#893), so clear all users' cached lists/trees/spaces unconditionally.
+    await cache.invalidateAcrossUsers('pages');
+    await cache.invalidateAcrossUsers('spaces');
     await logAuditEvent(
       userId,
       'PAGE_DELETED',

--- a/backend/src/routes/knowledge/pages-draft.test.ts
+++ b/backend/src/routes/knowledge/pages-draft.test.ts
@@ -33,11 +33,16 @@ vi.mock('../../core/services/content-converter.js', () => ({
   htmlToText: (...args: unknown[]) => mockHtmlToText(...args),
 }));
 
+const mockCacheInvalidate = vi.fn();
+const mockCacheInvalidateAcrossUsers = vi.fn();
+
 vi.mock('../../core/services/redis-cache.js', () => ({
   RedisCache: class MockRedisCache {
     get = vi.fn().mockResolvedValue(null);
     set = vi.fn().mockResolvedValue(undefined);
-    invalidate = vi.fn().mockResolvedValue(undefined);
+    invalidate = (...args: unknown[]) => mockCacheInvalidate(...args);
+    // Publishing a draft to a shared/Confluence page clears every user's cache (#893).
+    invalidateAcrossUsers = (...args: unknown[]) => mockCacheInvalidateAcrossUsers(...args);
   },
 }));
 
@@ -445,6 +450,73 @@ describe('Draft-while-published routes', () => {
       expect(response.statusCode).toBe(200);
       expect(mockHtmlToConfluence).toHaveBeenCalledWith('<p>draft</p>');
       expect(mockUpdatePage).toHaveBeenCalledWith('conf-123', 'Confluence Article', '<p>storage</p>', 4);
+    });
+
+    // #893 review follow-up: publishing a draft writes new live content — the
+    // same mutation class as PUT /pages/:id — so shared/Confluence pages must
+    // clear every user's cached lists/trees, not just the publisher's.
+    describe('cache invalidation (#893)', () => {
+      function mockPublishablePage(overrides: Record<string, unknown> = {}) {
+        mockQuery.mockImplementation((sql: string) => {
+          if (sql.includes('SELECT id, version, title')) {
+            return Promise.resolve({
+              rows: [{
+                id: 10, version: 3, title: 'My Article',
+                body_html: '<p>live</p>', body_text: 'live',
+                body_storage: null, source: 'standalone',
+                created_by_user_id: TEST_USER, visibility: 'private',
+                confluence_id: null, space_key: null,
+                draft_body_html: '<p>draft</p>', draft_body_storage: null,
+                ...overrides,
+              }],
+            });
+          }
+          return Promise.resolve({ rows: [], rowCount: 1 });
+        });
+        mockTxQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+      }
+
+      it('invalidates the pages cache across all users when publishing on a Confluence page', async () => {
+        mockGetClientForUser.mockResolvedValue({ updatePage: vi.fn().mockResolvedValue({}) });
+        mockPublishablePage({
+          source: 'confluence', created_by_user_id: null, visibility: 'shared',
+          confluence_id: 'conf-123', space_key: 'DEV', body_storage: '<p>storage</p>',
+        });
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/pages/10/draft/publish',
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('pages');
+        expect(mockCacheInvalidate).not.toHaveBeenCalledWith(TEST_USER, 'pages');
+      });
+
+      it('invalidates across users when publishing on a shared standalone page', async () => {
+        mockPublishablePage({ visibility: 'shared' });
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/pages/10/draft/publish',
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('pages');
+      });
+
+      it('keeps per-user invalidation when publishing on a private standalone page', async () => {
+        mockPublishablePage();
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/pages/10/draft/publish',
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(mockCacheInvalidateAcrossUsers).not.toHaveBeenCalled();
+        expect(mockCacheInvalidate).toHaveBeenCalledWith(TEST_USER, 'pages');
+      });
     });
   });
 

--- a/backend/src/routes/knowledge/pages-trash.test.ts
+++ b/backend/src/routes/knowledge/pages-trash.test.ts
@@ -32,14 +32,17 @@ import {
 // --- Boundary mocks (everything else is real) ---
 
 // No Redis in tests — no-op cache so every request hits the real DB.
+// Shared spies so tests can assert which invalidation path a route took (#893).
+const mockCacheInvalidate = vi.fn();
+const mockCacheInvalidateAcrossUsers = vi.fn();
 vi.mock('../../core/services/redis-cache.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../core/services/redis-cache.js')>()),
   RedisCache: class MockRedisCache {
     get = vi.fn().mockResolvedValue(null);
     set = vi.fn().mockResolvedValue(undefined);
-    invalidate = vi.fn().mockResolvedValue(undefined);
-    // Shared/Confluence deletes clear every user's cache (#893).
-    invalidateAcrossUsers = vi.fn().mockResolvedValue(undefined);
+    invalidate = (...args: unknown[]) => mockCacheInvalidate(...args);
+    // Shared/Confluence mutations clear every user's cache (#893).
+    invalidateAcrossUsers = (...args: unknown[]) => mockCacheInvalidateAcrossUsers(...args);
   },
 }));
 
@@ -148,6 +151,39 @@ describe.skipIf(!dbAvailable)('GET /api/pages/trash + standalone auto-purge (DB)
 
     // Second run finds nothing — count is per-run, not cumulative.
     expect(await purgeExpiredStandalonePages()).toBe(0);
+  });
+
+  // #893 review follow-up: a restored shared standalone page reappears in
+  // every user's lists/trees, so restore must clear all users' caches — not
+  // just the owner's — or the page stays missing for others up to the TTL.
+  describe('POST /api/pages/:id/restore — cache invalidation (#893)', () => {
+    it('invalidates the pages cache across all users when restoring a shared page', async () => {
+      const pageId = await insertStandalonePage('Shared trashed note', 'shared', userA, 'NOTES', {
+        deletedAt: new Date(),
+      });
+
+      currentUserId = userA;
+      const response = await app.inject({ method: 'POST', url: `/api/pages/${pageId}/restore` });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().restored).toBe(true);
+      expect(mockCacheInvalidateAcrossUsers).toHaveBeenCalledWith('pages');
+      expect(mockCacheInvalidate).not.toHaveBeenCalledWith(userA, 'pages');
+    });
+
+    it('keeps per-user invalidation when restoring a private page', async () => {
+      const pageId = await insertStandalonePage('Private trashed note', 'private', userA, 'NOTES', {
+        deletedAt: new Date(),
+      });
+
+      currentUserId = userA;
+      const response = await app.inject({ method: 'POST', url: `/api/pages/${pageId}/restore` });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().restored).toBe(true);
+      expect(mockCacheInvalidateAcrossUsers).not.toHaveBeenCalled();
+      expect(mockCacheInvalidate).toHaveBeenCalledWith(userA, 'pages');
+    });
   });
 
   // Nested here to reuse the real-DB app bootstrap + seeders (this file is

--- a/backend/src/routes/knowledge/pages-trash.test.ts
+++ b/backend/src/routes/knowledge/pages-trash.test.ts
@@ -38,6 +38,8 @@ vi.mock('../../core/services/redis-cache.js', async (importOriginal) => ({
     get = vi.fn().mockResolvedValue(null);
     set = vi.fn().mockResolvedValue(undefined);
     invalidate = vi.fn().mockResolvedValue(undefined);
+    // Shared/Confluence deletes clear every user's cache (#893).
+    invalidateAcrossUsers = vi.fn().mockResolvedValue(undefined);
   },
 }));
 

--- a/backend/src/routes/knowledge/pinned-pages.test.ts
+++ b/backend/src/routes/knowledge/pinned-pages.test.ts
@@ -12,6 +12,8 @@ vi.mock('../../core/services/redis-cache.js', () => {
       get = vi.fn().mockResolvedValue(null);
       set = vi.fn().mockResolvedValue(undefined);
       invalidate = vi.fn().mockResolvedValue(undefined);
+      // Shared/Confluence mutations clear every user's cache (#893).
+      invalidateAcrossUsers = vi.fn().mockResolvedValue(undefined);
     },
   };
 });


### PR DESCRIPTION
## Summary
- Deletes/edits of Confluence and shared standalone pages only cleared the acting user's per-user Redis cache namespace, so other users kept seeing stale/deleted rows for up to the 15-min TTL.
- Switch the standalone/Confluence UPDATE, single DELETE, and bulk DELETE handlers to `cache.invalidateAcrossUsers` when the mutated page is visible to other users, mirroring the existing visibility-flip branch.
- Private standalone edits/deletes keep the cheap per-user invalidation.
- The delete-path test mocks gain `invalidateAcrossUsers` so the new cross-user calls don't throw.

Closes #893.

## Root cause
Mutation handlers invalidated only `kb:{userId}:pages:*`, but Confluence pages (RBAC-visible to every user in the space) and shared standalone pages appear in other users' cached lists/trees, whose namespaces were never touched on delete/edit.

## Fix
- Standalone UPDATE: cross-user invalidate when the page is already `shared` or its visibility changes; else per-user.
- Confluence UPDATE: always cross-user invalidate `pages`.
- Standalone single DELETE: fetch `visibility`, cross-user invalidate when `shared`, else per-user.
- Confluence single DELETE and bulk DELETE: cross-user invalidate `pages` and `spaces`.

## Testing
- TDD: extended `backend/src/routes/knowledge/page-update.test.ts`; the shared-edit and Confluence-edit assertions **fail before** the fix (`invalidateAcrossUsers` never called), **pass after**. The existing shared-page test that encoded the bug was flipped to assert cross-user; the private-page test is unchanged.
- `cd backend && npx vitest run src/routes/knowledge/page-update.test.ts src/routes/knowledge/pages-crud-delete-rbac.test.ts src/routes/knowledge/bulk-pages.test.ts src/routes/knowledge/pages-trash.test.ts` (69 passed) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code