### PR TITLE
fix(routes): scope search suggestions to the requesting user (#895)

### DIFF
--- a/backend/src/routes/knowledge/search.test.ts
+++ b/backend/src/routes/knowledge/search.test.ts
@@ -721,5 +721,19 @@ describe('Search Routes', () => {
 
       expect(response.statusCode).toBe(400);
     });
+
+    it('should scope suggestions to the requesting user (#895)', async () => {
+      mockQueryFn.mockResolvedValue({ rows: [] });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/search/suggestions?q=redis',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const [sql, params] = mockQueryFn.mock.calls[0];
+      expect(sql).toMatch(/user_id\s*=\s*\$2/);
+      expect(params).toEqual(['redis', 'test-user-id']);
+    });
   });
 });

--- a/backend/src/routes/knowledge/search.ts
+++ b/backend/src/routes/knowledge/search.ts
@@ -461,11 +461,12 @@ export async function searchRoutes(fastify: FastifyInstance) {
     }>(
       `SELECT LOWER(TRIM(query)) AS query_text, COUNT(*) AS frequency
        FROM search_analytics
-       WHERE LOWER(TRIM(query)) LIKE LOWER($1) || '%' ESCAPE '\\'
+       WHERE user_id = $2
+         AND LOWER(TRIM(query)) LIKE LOWER($1) || '%' ESCAPE '\\'
        GROUP BY LOWER(TRIM(query))
        ORDER BY COUNT(*) DESC
        LIMIT 10`,
-      [escapedQ],
+      [escapedQ, request.userId],
     );
 
     return {


### PR DESCRIPTION
## Summary
- `GET /api/search/suggestions` aggregated the `search_analytics` table with no `user_id` filter, so autocomplete surfaced query strings recorded by every user.
- Any authenticated user could prefix-walk (`a`, `ab`, `abc`...) to enumerate colleagues' searches (names, project codenames, HR topics) — re-exposing the raw-search-term data that #818 deliberately admin-gated elsewhere.
- Scope the aggregation to `request.userId` so suggestions only include the caller's own past queries.
- Bonus: the scoped query can use the existing `idx_search_analytics_user` index (migration 013) instead of a full-table GROUP BY on every keystroke.

Closes #895.

## Root cause
The suggestions handler's SQL had no `user_id` predicate; `request.userId` (populated by the `fastify.authenticate` onRequest hook) was in scope but unused, letting one user's prefix match every user's stored queries.

## Fix
- Add `WHERE user_id = $2 AND ...` to the suggestions query in `backend/src/routes/knowledge/search.ts`.
- Bind `request.userId` as the second parameter (`[escapedQ, request.userId]`).

## Testing
- TDD: extended `backend/src/routes/knowledge/search.test.ts` with a test asserting the SQL is user-scoped and receives the userId param; **fails before** the fix (no `user_id = $2`, params length 1), **passes after**.
- `cd backend && npx vitest run src/routes/knowledge/search.test.ts` (pass, 24/24) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code