### PR TITLE
fix(llm): gate analyze-quality and generate-diagram streams with RBAC (#896)

### DIFF
--- a/backend/src/routes/llm/analyze-quality.test.ts
+++ b/backend/src/routes/llm/analyze-quality.test.ts
@@ -107,6 +107,8 @@ describe('POST /api/llm/analyze-quality', () => {
     app.decorateRequest('userId', '');
     app.addHook('onRequest', async (request) => {
       request.userId = 'test-user-123';
+      // Grant all permissions; individual tests here don't exercise RBAC.
+      request.userCan = async () => true;
     });
 
     await app.register(llmQualityRoutes, { prefix: '/api' });
@@ -239,5 +241,46 @@ describe('POST /api/llm/analyze-quality', () => {
     });
 
     expect(response.statusCode).toBe(200);
+  });
+});
+
+// =============================================================================
+// RBAC: a principal lacking the `llm:query` grant must be 403-blocked (#896)
+// =============================================================================
+
+describe('POST /api/llm/analyze-quality - RBAC', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.decorate('authenticate', async () => {});
+    app.decorate('requireAdmin', async () => {});
+    app.decorate('redis', {});
+    app.decorateRequest('userId', '');
+    app.addHook('onRequest', async (request) => {
+      request.userId = 'no-perm-user';
+      // Simulate a custom role holding none of the llm:* grants.
+      request.userCan = async () => false;
+    });
+
+    await app.register(llmQualityRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should return 403 when the principal lacks llm:query', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/analyze-quality',
+      payload: { content: '<p>x</p>', model: 'llama3' },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(JSON.parse(response.body).message).toContain('Permission "llm:query" required');
   });
 });

--- a/backend/src/routes/llm/generate-diagram.test.ts
+++ b/backend/src/routes/llm/generate-diagram.test.ts
@@ -255,3 +255,44 @@ describe('POST /api/llm/generate-diagram', () => {
     expect(mockGetSystemPrompt).toHaveBeenCalledWith('generate_diagram_sequence');
   });
 });
+
+// =============================================================================
+// RBAC: a principal lacking the `llm:generate` grant must be 403-blocked (#896)
+// =============================================================================
+
+describe('POST /api/llm/generate-diagram - RBAC', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+
+    app.decorate('authenticate', async () => {});
+    app.decorate('requireAdmin', async () => {});
+    app.decorate('redis', {});
+    app.decorateRequest('userId', '');
+    app.addHook('onRequest', async (request) => {
+      request.userId = 'no-perm-user';
+      // Simulate a custom role holding none of the llm:* grants.
+      request.userCan = async () => false;
+    });
+
+    await app.register(llmDiagramRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should return 403 when the principal lacks llm:generate', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/llm/generate-diagram',
+      payload: { content: '<p>x</p>', model: 'llama3' },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(JSON.parse(response.body).message).toContain('Permission "llm:generate" required');
+  });
+});

--- a/backend/src/routes/llm/llm-diagram.ts
+++ b/backend/src/routes/llm/llm-diagram.ts
@@ -16,6 +16,7 @@ import {
   MAX_INPUT_LENGTH,
 } from './_helpers.js';
 import { acquireStreamSlot } from '../../core/services/sse-stream-limiter.js';
+import { requireGlobalPermission } from '../../core/utils/rbac-guards.js';
 
 export async function llmDiagramRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -23,7 +24,7 @@ export async function llmDiagramRoutes(fastify: FastifyInstance) {
   const llmCache = new LlmCache(fastify.redis);
 
   // POST /api/llm/generate-diagram - stream Mermaid diagram from article content
-  fastify.post('/llm/generate-diagram', LLM_STREAM_RATE_LIMIT, async (request, reply) => {
+  fastify.post('/llm/generate-diagram', { ...LLM_STREAM_RATE_LIMIT, preHandler: requireGlobalPermission('llm:generate') }, async (request, reply) => {
     // Per-user concurrent SSE-stream cap (#268). Must fire BEFORE reply.hijack()
     // so rejections can be returned as a normal JSON 429.
     const slot = await acquireStreamSlot(request.userId);

--- a/backend/src/routes/llm/llm-quality.ts
+++ b/backend/src/routes/llm/llm-quality.ts
@@ -16,6 +16,7 @@ import {
   MAX_INPUT_LENGTH,
 } from './_helpers.js';
 import { acquireStreamSlot } from '../../core/services/sse-stream-limiter.js';
+import { requireGlobalPermission } from '../../core/utils/rbac-guards.js';
 
 export async function llmQualityRoutes(fastify: FastifyInstance) {
   fastify.addHook('onRequest', fastify.authenticate);
@@ -23,7 +24,7 @@ export async function llmQualityRoutes(fastify: FastifyInstance) {
   const llmCache = new LlmCache(fastify.redis);
 
   // POST /api/llm/analyze-quality - stream article quality analysis
-  fastify.post('/llm/analyze-quality', LLM_STREAM_RATE_LIMIT, async (request, reply) => {
+  fastify.post('/llm/analyze-quality', { ...LLM_STREAM_RATE_LIMIT, preHandler: requireGlobalPermission('llm:query') }, async (request, reply) => {
     // Per-user concurrent SSE-stream cap (#268). Must fire BEFORE reply.hijack()
     // so rejections can be returned as a normal JSON 429.
     const slot = await acquireStreamSlot(request.userId);


### PR DESCRIPTION
## Summary
- Attach the missing `preHandler: requireGlobalPermission(...)` to the two LLM streaming routes that lacked it, closing an authorization gap.
- `POST /api/llm/analyze-quality` now requires `llm:query`; `POST /api/llm/generate-diagram` now requires `llm:generate` — mirroring their four already-gated siblings.
- Both permissions are already seeded to viewer/commenter/editor/space_admin by migration 052, so there is **no new migration** and **no default-role access loss**; only custom roles holding none of the `llm:*` grants are now correctly 403-blocked.

Closes #896.

## Root cause
`llm-quality.ts` and `llm-diagram.ts` registered with only the rate-limit config object and relied solely on the module-level `authenticate` hook, so any authenticated principal could invoke LLM inference on these endpoints while being 403-blocked on `/llm/ask`, `/llm/generate`, `/llm/improve`, and `/llm/summarize`.

## Fix
- Add `import { requireGlobalPermission } from '../../core/utils/rbac-guards.js';` to both route files.
- Spread `LLM_STREAM_RATE_LIMIT` and add `preHandler: requireGlobalPermission('llm:query')` (quality) / `('llm:generate')` (diagram) — the semantically closest sibling permission for each route.

## Testing
- TDD: added a `- RBAC` describe block to `analyze-quality.test.ts` and `generate-diagram.test.ts` asserting a permission-less principal (`userCan → false`) gets **403** with `Permission "..." required`; **fails before** the fix (route returned 200 SSE), **passes after**. Also decorated the existing quality happy-path hook with `userCan → true` so its tests stay green once the gate is live.
- `cd backend && npx vitest run src/routes/llm/analyze-quality.test.ts src/routes/llm/generate-diagram.test.ts` -> 17 passed - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code