### PR TITLE
fix(content): strip model preamble/meta-chatter from AI summaries (#912)

### DIFF
--- a/backend/src/domains/knowledge/services/summary-worker.test.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.test.ts
@@ -9,10 +9,40 @@ import {
   runSummaryBatch,
   startSummaryWorker,
   stopSummaryWorker,
+  stripSummaryPreamble,
 } from './summary-worker.js';
 import { setPiiScanHook, _resetPiiScanHookForTests } from '../../../core/services/pii-scan-hook.js';
 
 const dbAvailable = await isDbAvailable();
+
+// Pure-function tests: run without Postgres so the strip logic is always covered.
+describe('stripSummaryPreamble', () => {
+  it('strips a leading framing line', () => {
+    expect(
+      stripSummaryPreamble(
+        "Here's a summary of the article in Markdown format:\n\n- Point one\n- Point two",
+      ),
+    ).toBe('- Point one\n- Point two');
+  });
+
+  it('strips a trailing meta/offer line', () => {
+    expect(
+      stripSummaryPreamble(
+        'The system deploys nightly.\n\nIf the text was in German, please provide it so I can respond in German.',
+      ),
+    ).toBe('The system deploys nightly.');
+  });
+
+  it('does not strip a real sentence that merely starts with a conditional', () => {
+    expect(
+      stripSummaryPreamble('If the deployment fails, roll back to the prior release.'),
+    ).toBe('If the deployment fails, roll back to the prior release.');
+  });
+
+  it('is a no-op on clean input', () => {
+    expect(stripSummaryPreamble('- A\n- B')).toBe('- A\n- B');
+  });
+});
 
 // Mock the LLM streaming helper to avoid real LLM calls in tests.
 // The worker streams via `streamChat` from openai-compatible-client using
@@ -236,6 +266,37 @@ describe.skipIf(!dbAvailable)('Summary Worker', () => {
       expect(result.rows[0].summary_html).toContain('test');
       expect(result.rows[0].summary_model).toBe('test-model');
       expect(result.rows[0].summary_content_hash).toHaveLength(64);
+    });
+
+    it('strips model preamble/meta framing before persisting the summary (#912)', async () => {
+      const { streamChat } = await import('../../llm/services/openai-compatible-client.js');
+      vi.mocked(streamChat).mockImplementationOnce(() => {
+        async function* g() {
+          yield {
+            content:
+              "Here's a summary of the article in Markdown format:\n\n- Deploys nightly.\n\nIf the text was in German, please provide it so I can respond in German.",
+            done: false,
+          };
+          yield { content: '', done: true };
+        }
+        return g();
+      });
+
+      await query(
+        `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status)
+         VALUES ('preamble1', $1, 'Preamble Page', $2, 'pending')`,
+        [testSpaceKey, 'A'.repeat(200)],
+      );
+
+      await runSummaryBatch('test-model');
+
+      const row = await query<{ summary_status: string; summary_text: string }>(
+        "SELECT summary_status, summary_text FROM pages WHERE confluence_id = 'preamble1'",
+      );
+      expect(row.rows[0].summary_status).toBe('summarized');
+      expect(row.rows[0].summary_text).toContain('Deploys nightly');
+      expect(row.rows[0].summary_text).not.toContain('Here');
+      expect(row.rows[0].summary_text).not.toContain('please provide');
     });
 
     describe('PII guard (EE #119)', () => {

--- a/backend/src/domains/knowledge/services/summary-worker.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.ts
@@ -180,6 +180,46 @@ function stripHtml(html: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Strip model preamble / trailing meta-chatter from generated summaries (#912)
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove framing text some models wrap around the actual summary — a leading
+ * "Here's a summary…" line and trailing offer/meta lines (e.g. "…please provide
+ * it so I can respond in German."). Deliberately conservative so a genuine
+ * summary is never eaten: the leading strip requires an explicit framing opener
+ * plus the word "summary" plus a following newline, and the trailing strip only
+ * peels a final line that carries an explicit offer/meta phrase.
+ */
+export function stripSummaryPreamble(markdown: string): string {
+  let text = markdown.trim();
+
+  // Leading framing line, e.g. "Here's a concise summary of the article in
+  // Markdown format:" / "Below is a summary:". Requires a following newline so
+  // the real summary (on later lines) is never eaten.
+  text = text.replace(
+    /^\s*(?:sure[,.!]?\s*)?(?:here(?:'s|\s+is|\s+are)|below\s+is|the\s+following\s+is)\b[^\n]*?\bsummary\b[^\n]*?\n+/i,
+    '',
+  );
+
+  // Bare heading-style preamble line: "Summary:" / "**Summary:**".
+  text = text.replace(/^\s*\**\s*summary\s*\**\s*:?\s*\n+/i, '');
+
+  // Trailing meta/offer lines (optionally bold). Match only lines carrying an
+  // explicit offer/meta phrase so real summary sentences beginning with "If"
+  // survive. Loop to peel multiple trailing meta lines.
+  const TRAILING_META =
+    /\n+\s*\**[^\n]*\b(?:please\s+(?:provide|let\s+me\s+know|note)|let\s+me\s+know|feel\s+free|would\s+you\s+like|i\s+can\s+(?:help|provide|assist)|if\s+you(?:'d| would)\s+like|i\s+hope\s+this\s+helps|respond\s+in\s+(?:german|english))\b[^\n]*\**\s*$/i;
+  let prev: string;
+  do {
+    prev = text;
+    text = text.replace(TRAILING_META, '');
+  } while (text !== prev);
+
+  return text.trim();
+}
+
+// ---------------------------------------------------------------------------
 // Core batch processing
 // ---------------------------------------------------------------------------
 
@@ -258,7 +298,10 @@ async function summarizePage(
       },
       { role: 'user', content: sanitized },
     ]);
-    const markdownSummary = await collectStream(generator);
+    const rawSummary = await collectStream(generator);
+    // Strip model framing/meta-chatter before the empty-check, PII scan, and
+    // HTML conversion so both summary_text and summary_html are stored clean (#912).
+    const markdownSummary = stripSummaryPreamble(rawSummary);
 
     if (!markdownSummary.trim()) {
       throw new Error('LLM returned empty summary');

--- a/backend/src/domains/llm/services/prompts.ts
+++ b/backend/src/domains/llm/services/prompts.ts
@@ -67,7 +67,7 @@ const SYSTEM_PROMPTS = {
 
   generate_from_pdf: `You are a technical documentation writer. You are given the extracted text of a PDF document as source material. Using this source content and the user's instructions, generate a well-structured knowledge base article. Reorganize, clarify, and improve the content as needed. Use clear headings, code examples where appropriate, and follow best practices for technical documentation. Return the article in Markdown format.`,
 
-  summarize: `You are a technical writing assistant. Provide a concise summary of the following article. Focus on the key points, decisions, and actionable items. Return the summary in Markdown format. ${LANGUAGE_PRESERVATION_INSTRUCTION}`,
+  summarize: `You are a technical writing assistant. Provide a concise summary of the following article. Focus on the key points, decisions, and actionable items. Return ONLY the summary itself in Markdown format — no preamble, no meta-commentary, and no closing questions or offers. Do not begin with phrases like "Here is a summary". ${LANGUAGE_PRESERVATION_INSTRUCTION}`,
 
   ask: `You are a knowledgeable assistant that answers questions based on the provided knowledge base context. Answer accurately based on the context. If the context doesn't contain enough information, say so. Always cite which articles your answer is based on. Respond in the same language as the user's question.`,
 


### PR DESCRIPTION
## Summary
- AI summaries were persisting the model's raw output verbatim, so framing preambles ("Here's a summary of the article in Markdown format:") and trailing meta/offer lines ("…please provide it so I can respond in German.") got stored and rendered.
- Adds an exported, conservative `stripSummaryPreamble()` in the summary worker, applied right after the stream is collected and **before** the empty-check, PII scan, and Markdown→HTML conversion, so both `summary_text` and `summary_html` are stored clean.
- Hardens the `summarize` system prompt to tell the model to output only the summary (defense-in-depth; the strip pass is the guarantee).
- Backend-only: no schema, contract, or frontend change.

Closes #912.

## Root cause
`summarizePage()` stored the collected LLM stream directly, and the `summarize` prompt — unlike the `improve_*` prompts — never told the model to omit preamble/closing remarks, so framing and meta-chatter leaked into the stored/rendered summary.

## Fix
- New pure helper `stripSummaryPreamble(markdown)`: strips a leading framing line (requires an explicit "here's/below is/the following is … summary …" opener plus a following newline) and any bare "Summary:" heading, then peels trailing lines carrying an explicit offer/meta phrase (e.g. "please provide", "let me know", "respond in German/English").
- Wired in before the empty-check/PII-scan/HTML step; the existing empty-summary guard now also covers a model that returned only preamble.
- Tightened the `summarize` prompt.

## Testing
- TDD: extended `backend/src/domains/knowledge/services/summary-worker.test.ts` — pure unit tests of the helper (strip leading/trailing, no false-positive on a real "If…" sentence, no-op on clean input) plus a DB-backed wiring test asserting the stored `summary_text` drops the framing and keeps the real content. **Fails before** the fix (`stripSummaryPreamble is not a function`; wiring test stored the framing text), **passes after**.
- `cd backend && npx vitest run src/domains/knowledge/services/summary-worker.test.ts` (24 pass) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code