### PR TITLE
fix(ui): surface zero-embeddings cause in AI chat and semantic search (#938)

### DIFF
--- a/frontend/src/features/ai/AiAssistantPage.test.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.test.tsx
@@ -24,9 +24,16 @@ vi.mock('../../shared/lib/sse', () => ({
 
 // Default: no page selected
 let mockPageData: { data: unknown; isLoading?: boolean } = { data: undefined };
-vi.mock('../../shared/hooks/use-pages', () => ({
+// Controllable embedding-status feed for the #938 zero-embeddings notice.
+// importActual keeps the real `isZeroEmbeddings` helper exported — the
+// component imports it from this same module, so the mock must not drop it.
+let mockEmbeddingStatus: { data: unknown } = { data: undefined };
+vi.mock('../../shared/hooks/use-pages', async () => ({
+  ...(await vi.importActual<typeof import('../../shared/hooks/use-pages')>(
+    '../../shared/hooks/use-pages',
+  )),
   usePage: () => mockPageData,
-  useEmbeddingStatus: () => ({ data: undefined }),
+  useEmbeddingStatus: () => mockEmbeddingStatus,
 }));
 
 // Mock sonner toast so we can verify error messages
@@ -82,6 +89,7 @@ describe('AiAssistantPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPageData = { data: undefined };
+    mockEmbeddingStatus = { data: undefined };
     useAuthStore.getState().setAuth('test-token', {
       id: '1',
       username: 'testuser',
@@ -1316,6 +1324,32 @@ describe('AiAssistantPage', () => {
       expect(screen.getByText('Your questions will be answered using RAG over your Confluence pages')).toBeInTheDocument();
       // Should NOT show other mode messages
       expect(screen.queryByText('Select a page and improvement type')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('zero-embeddings notice (#938)', () => {
+    it('warns that pages are not embedded yet in Q&A mode when embeddedPages is 0', () => {
+      // Pages exist but none are embedded — RAG has no context to draw on, so
+      // the user must be told the real cause instead of a misleading answer.
+      mockEmbeddingStatus = {
+        data: { totalPages: 10, embeddedPages: 0, dirtyPages: 10, totalEmbeddings: 0, isProcessing: false },
+      };
+
+      render(<AiAssistantPage />, { wrapper: createWrapper() });
+
+      const notice = screen.getByTestId('ai-no-embeddings-notice');
+      expect(notice).toBeInTheDocument();
+      expect(notice.textContent).toMatch(/not embedded/i);
+    });
+
+    it('does not show the notice when pages are embedded', () => {
+      mockEmbeddingStatus = {
+        data: { totalPages: 10, embeddedPages: 10, dirtyPages: 0, totalEmbeddings: 10, isProcessing: false },
+      };
+
+      render(<AiAssistantPage />, { wrapper: createWrapper() });
+
+      expect(screen.queryByTestId('ai-no-embeddings-notice')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/features/ai/AiAssistantPage.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.tsx
@@ -21,6 +21,7 @@ import {
   DiagramTypeSelector, DiagramPreview, DiagramModeInput, DIAGRAM_EMPTY_TITLE, diagramEmptySubtitle,
   QualityModeInput, QUALITY_EMPTY_TITLE, qualityEmptySubtitle,
 } from './modes';
+import { isZeroEmbeddings } from '../../shared/hooks/use-pages';
 
 // ---------------------------------------------------------------------------
 // Typing indicator: 3 dots with staggered bounce
@@ -218,6 +219,7 @@ function AiAssistantInner() {
     model, models, setModel, modelsError, refetchModels, isLight,
     includeSubPages, setIncludeSubPages,
     thinkingMode, setThinkingMode,
+    embeddingStatus,
   } = ctx;
 
   const shouldReduceMotion = useReducedMotion();
@@ -423,6 +425,26 @@ function AiAssistantInner() {
           the sticky input bar to the bottom of the page. */}
       <div className="flex-1 overflow-hidden rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm">
         <div className="min-h-[360px] space-y-4 p-5">
+          {/* Zero-embeddings notice (#938). Q&A answers via RAG over embedded
+              pages; with none embedded, buildRagContext returns "No relevant
+              context found", so the LLM answers as if the query matched
+              nothing. Surface the real cause here — scoped to ask mode (other
+              modes operate on the current page's text, not RAG) and shown in
+              both the empty and answered states so it never gets hidden behind
+              a misleading answer. */}
+          {mode === 'ask' && isZeroEmbeddings(embeddingStatus) && (
+            <div
+              data-testid="ai-no-embeddings-notice"
+              className="flex items-start gap-3 rounded-lg border border-warning/30 bg-warning/10 p-3 text-sm text-warning"
+            >
+              <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+              <span>
+                Pages not embedded yet — configure an embedding provider in
+                Settings → LLM and run an embedding pass. Until then, Q&amp;A has
+                no knowledge-base context to draw on.
+              </span>
+            </div>
+          )}
           {messages.length === 0 && (
             <div className="flex min-h-[300px] flex-col items-center justify-center text-center">
               {/* Robot wrapped in a honey-tinted aura so the empty state reads

--- a/frontend/src/features/pages/PagesPage.test.tsx
+++ b/frontend/src/features/pages/PagesPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { PagesPage } from './PagesPage';
@@ -581,6 +581,91 @@ describe('PagesPage', () => {
       // Wait for re-render
       await screen.findByText('Try a different search term');
       expect(screen.queryByText('Go to Settings')).not.toBeInTheDocument();
+    });
+  });
+
+  // --- Semantic search empty state (#938, review follow-up on #993) ---
+
+  describe('semantic search empty state (#938)', () => {
+    /** Mock fetch where /search returns zero results for every mode, with the
+     *  given hasEmbeddings flag. All other endpoints return their normal mocks. */
+    function mockFetchWithEmptySearch(hasEmbeddings: boolean) {
+      return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        if (url.includes('/search?')) {
+          const mode = new URL(url, 'http://localhost').searchParams.get('mode') ?? 'keyword';
+          return new Response(
+            JSON.stringify({ items: [], total: 0, page: 1, limit: 10, totalPages: 0, mode, hasEmbeddings }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        if (url.includes('/embeddings/status')) {
+          return new Response(JSON.stringify(mockEmbeddingStatusIdle), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/pages/filters')) {
+          return new Response(JSON.stringify(mockFilterOptions), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/spaces')) {
+          return new Response(JSON.stringify(mockSpaces), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/sync/status')) {
+          return new Response(JSON.stringify({ status: 'idle' }), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/pages/pinned')) {
+          return new Response(JSON.stringify({ items: [], total: 0 }), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/settings')) {
+          return new Response(JSON.stringify({}), { headers: { 'Content-Type': 'application/json' } });
+        }
+        return new Response(JSON.stringify(mockPagesResponse), { headers: { 'Content-Type': 'application/json' } });
+      });
+    }
+
+    /** Render, switch to semantic mode, and type a query that matches nothing.
+     *  useSearch debounces 300ms before firing, so assertions must findBy/waitFor. */
+    function renderSemanticSearchWithNoResults(hasEmbeddings: boolean) {
+      vi.restoreAllMocks();
+      const fetchSpy = mockFetchWithEmptySearch(hasEmbeddings);
+      render(<PagesPage />, { wrapper: createWrapper() });
+      fireEvent.click(screen.getByTestId('search-mode-semantic'));
+      fireEvent.change(screen.getByPlaceholderText('Search pages...'), {
+        target: { value: 'nonexistent topic' },
+      });
+      return fetchSpy;
+    }
+
+    it('zero embeddings + zero results: empty state acknowledges the keyword fallback and the missing embeddings', async () => {
+      renderSemanticSearchWithNoResults(false);
+
+      // The fallback banner and the empty state show together, so their copy
+      // must not contradict: the banner already says keyword search ran, so
+      // the empty state must not imply embedding alone would find a match.
+      expect(await screen.findByText('No matching pages', undefined, { timeout: 2000 })).toBeInTheDocument();
+      expect(
+        screen.getByText('Keyword search found no matches. Semantic search is unavailable until pages are embedded — configure an embedding provider in Settings → LLM and run an embedding pass.'),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('no-embeddings-warning')).toBeInTheDocument();
+    });
+
+    it('embeddings exist + zero results: empty state blames the query, not embeddings', async () => {
+      const fetchSpy = renderSemanticSearchWithNoResults(true);
+
+      // Wait for the debounced search queries to actually fire and settle so
+      // the assertion pins the resolved state, not the optimistic first render.
+      await waitFor(
+        () => {
+          const urls = fetchSpy.mock.calls.map(([input]) =>
+            typeof input === 'string' ? input : (input as Request).url,
+          );
+          expect(urls.some((u) => u.includes('/search?') && u.includes('mode=semantic'))).toBe(true);
+        },
+        { timeout: 2000 },
+      );
+
+      expect(await screen.findByTestId('empty-state-title')).toHaveTextContent('No pages found');
+      expect(screen.getByText('Try a different search term or switch to keyword mode')).toBeInTheDocument();
+      expect(screen.queryByTestId('no-embeddings-warning')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Semantic search is unavailable until pages are embedded/)).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -735,8 +735,12 @@ export function PagesPage() {
             return displayItems.length === 0 ? (
               <EmptyState
                 icon={FolderOpen}
-                title="No pages found"
-                description="Try a different search term or switch to keyword mode"
+                title={searchResults.hasEmbeddings ? 'No pages found' : 'Pages not embedded yet'}
+                description={
+                  searchResults.hasEmbeddings
+                    ? 'Try a different search term or switch to keyword mode'
+                    : 'Configure an embedding provider in Settings → LLM and run an embedding pass to enable semantic search.'
+                }
               />
             ) : (
               <>

--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -735,11 +735,15 @@ export function PagesPage() {
             return displayItems.length === 0 ? (
               <EmptyState
                 icon={FolderOpen}
-                title={searchResults.hasEmbeddings ? 'No pages found' : 'Pages not embedded yet'}
+                title={searchResults.hasEmbeddings ? 'No pages found' : 'No matching pages'}
                 description={
                   searchResults.hasEmbeddings
                     ? 'Try a different search term or switch to keyword mode'
-                    : 'Configure an embedding provider in Settings → LLM and run an embedding pass to enable semantic search.'
+                    // Zero embeddings: the banner above already says keyword
+                    // fallback ran, so acknowledge both facts — the query
+                    // matched nothing AND semantic search is unavailable
+                    // (#938; copy reconciled in the #993 review).
+                    : 'Keyword search found no matches. Semantic search is unavailable until pages are embedded — configure an embedding provider in Settings → LLM and run an embedding pass.'
                 }
               />
             ) : (

--- a/frontend/src/shared/hooks/use-pages.ts
+++ b/frontend/src/shared/hooks/use-pages.ts
@@ -284,6 +284,18 @@ export interface EmbeddingStatusData {
   isProcessing: boolean;
 }
 
+/**
+ * Shared zero-embeddings detection (#938), reused by the AI chat and the
+ * semantic-search empty state so both surface the real cause instead of
+ * blaming the query. True only when pages exist but none are embedded — the
+ * exact semantics of GraphPage's `meta.pagesEmbedded === 0` branch. The
+ * `totalPages > 0` guard keeps a brand-new install with nothing synced
+ * (totalPages === 0) out of the "not embedded yet" state.
+ */
+export function isZeroEmbeddings(status: EmbeddingStatusData | undefined): boolean {
+  return !!status && status.totalPages > 0 && status.embeddedPages === 0;
+}
+
 export function useEmbeddingStatus() {
   return useQuery<EmbeddingStatusData>({
     queryKey: ['embeddings', 'status'],


### PR DESCRIPTION
## Summary
- AI chat (Q&A mode) now shows a "Pages not embedded yet" warning when pages exist but none are embedded, instead of letting the LLM answer as if the query matched nothing.
- The semantic-search empty state on the Pages page now says to configure an embedding provider instead of blaming the query ("Try a different search term").
- Both surfaces reuse a new shared `isZeroEmbeddings()` helper that mirrors the Graph page's existing `pagesEmbedded === 0` semantics.

Closes #938.

## Root cause
With zero embeddings, `buildRagContext([])` returns "No relevant context found in the knowledge base", which is injected into the prompt so the assistant answers as if nothing matched — never telling the user the real cause. The AI page already received an `embeddingStatus` signal but nothing in the UI consumed it, and the semantic-search empty state rendered "No pages found / Try a different search term" regardless of `hasEmbeddings`.

## Fix
- Add exported pure helper `isZeroEmbeddings(status)` in `use-pages.ts` (true when `totalPages > 0 && embeddedPages === 0`; the `totalPages > 0` guard keeps a nothing-synced install out of this state).
- `AiAssistantPage.tsx`: consume the already-exposed `ctx.embeddingStatus` and render a warning notice at the top of the messages card when `mode === 'ask'` and embeddings are zero (shown in both empty and answered states).
- `PagesPage.tsx`: branch the semantic-search empty state on `searchResults.hasEmbeddings`. No backend changes.

## Testing
- TDD: extended `frontend/src/features/ai/AiAssistantPage.test.tsx` (controllable `mockEmbeddingStatus` via `importActual` so the real helper stays exported); the notice-present assertion **fails before** the fix (element not rendered), **passes after**. A regression test asserts the notice is absent when pages are embedded.
- `cd frontend && npx vitest run src/features/ai/AiAssistantPage.test.tsx` (56 pass) - full `src/features/pages/` suite (190 pass) - eslint (pass) - `tsc --noEmit` (pass)

Generated with Claude Code