### PR TITLE
fix(ui): confirm before discarding unsaved editor changes on Cancel (#944)

### DIFF
--- a/frontend/src/features/pages/PageViewPage.test.tsx
+++ b/frontend/src/features/pages/PageViewPage.test.tsx
@@ -828,5 +828,83 @@ describe('PageViewPage', () => {
     });
   });
 
+  // #944 — Cancel in the editor must not silently discard unsaved work. When
+  // the working title/body diverges from the persisted page, Cancel opens a
+  // destructive discard confirmation instead of dropping out of edit mode.
+  // A pristine editor (no edits) still exits immediately.
+  describe('cancel discard confirmation', () => {
+    it('prompts before discarding when the editor has unsaved changes', async () => {
+      render(<PageViewPage />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByText('Edit'));
+      fireEvent.change(screen.getByLabelText('Article editor'), {
+        target: { value: '<p>rewritten</p>' },
+      });
+      fireEvent.click(screen.getByText('Cancel'));
+
+      // The discard confirmation appears and the editor stays mounted — the
+      // work is NOT thrown away until the user confirms.
+      expect(await screen.findByText('Discard changes?')).toBeInTheDocument();
+      expect(screen.getByLabelText('Article editor')).toBeInTheDocument();
+
+      // Close the portal dialog before teardown (afterEach wipes document.body).
+      fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      });
+    });
+
+    it('confirming the discard exits edit mode', async () => {
+      render(<PageViewPage />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByText('Edit'));
+      fireEvent.change(screen.getByLabelText('Article editor'), {
+        target: { value: '<p>rewritten</p>' },
+      });
+      fireEvent.click(screen.getByText('Cancel'));
+
+      await screen.findByText('Discard changes?');
+      fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+
+      await waitFor(() => {
+        expect(screen.queryByLabelText('Article editor')).not.toBeInTheDocument();
+      });
+      expect(screen.getByText('Edit')).toBeInTheDocument();
+    });
+
+    it('keeps editing when the discard dialog is dismissed', async () => {
+      render(<PageViewPage />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByText('Edit'));
+      fireEvent.change(screen.getByLabelText('Article editor'), {
+        target: { value: '<p>rewritten</p>' },
+      });
+      fireEvent.click(screen.getByText('Cancel'));
+
+      await screen.findByText('Discard changes?');
+      fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      });
+      // Still editing — the work is preserved.
+      expect(screen.getByLabelText('Article editor')).toBeInTheDocument();
+    });
+
+    it('exits immediately without a prompt when the editor is pristine', async () => {
+      render(<PageViewPage />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByText('Edit'));
+      // No edits made — Cancel should exit straight to view mode.
+      fireEvent.click(screen.getByText('Cancel'));
+
+      await waitFor(() => {
+        expect(screen.queryByLabelText('Article editor')).not.toBeInTheDocument();
+      });
+      expect(screen.queryByText('Discard changes?')).not.toBeInTheDocument();
+      expect(screen.getByText('Edit')).toBeInTheDocument();
+    });
+  });
+
 });
 

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -157,6 +157,9 @@ export function PageViewPage() {
   const [drawioEditingDiagram, setDrawioEditingDiagram] = useState<string | null>(null);
   const [drawioXml, setDrawioXml] = useState<string>('');
   const [confirmTrashOpen, setConfirmTrashOpen] = useState(false);
+  // Discard-changes guard (#944): while true, the Cancel flow shows a
+  // confirmation instead of dropping the in-progress edit.
+  const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
   // Draft awaiting a restore decision (ConfirmDialog replaces native confirm()).
   // While non-null, edit mode is deferred until the user picks a side.
   const [pendingDraft, setPendingDraft] = useState<string | null>(null);
@@ -244,10 +247,35 @@ export function PageViewPage() {
     setEditing(true);
   }, [page]);
 
-  const handleCancelEditing = useCallback(() => {
+  // The editor is dirty when the working title/body diverges from the
+  // persisted page. editHtml starts equal to page.bodyHtml (or the restored
+  // draft) and only changes on a genuine Editor onChange, so a pristine
+  // editor produces no false positive (#944).
+  const isEditorDirty = useCallback(() => {
+    if (!page) return false;
+    return editTitle !== page.title || editHtml !== page.bodyHtml;
+  }, [page, editTitle, editHtml]);
+
+  const discardAndExit = useCallback(() => {
     if (draftKey) clearDraft(draftKey);
     setEditing(false);
   }, [draftKey]);
+
+  // Cancel guards against silently throwing away unsaved work: when dirty it
+  // opens the discard confirmation, otherwise it exits immediately. Backs the
+  // Cancel button plus the Ctrl+E / Escape shortcuts (#944).
+  const handleCancelEditing = useCallback(() => {
+    if (isEditorDirty()) {
+      setConfirmDiscardOpen(true);
+      return;
+    }
+    discardAndExit();
+  }, [isEditorDirty, discardAndExit]);
+
+  const handleConfirmDiscard = useCallback(() => {
+    setConfirmDiscardOpen(false);
+    discardAndExit();
+  }, [discardAndExit]);
 
   const handleSave = useCallback(async () => {
     if (!id || !page) return;
@@ -803,6 +831,22 @@ export function PageViewPage() {
         destructive
         onConfirm={handleConfirmMoveToTrash}
         onCancel={() => setConfirmTrashOpen(false)}
+      />
+
+      {/* Discard changes — guards the Cancel path when the editor is dirty
+          (#944). Confirming runs the original clearDraft + exit; Cancel /
+          Escape / overlay just close the dialog and stay in edit mode so the
+          in-progress work (e.g. a full AI rewrite) is not lost. */}
+      <ConfirmDialog
+        open={confirmDiscardOpen}
+        title="Discard changes?"
+        description="This page has unsaved changes. Discarding them cannot be undone."
+        confirmLabel="Discard changes"
+        cancelLabel="Keep editing"
+        destructive
+        onConfirm={handleConfirmDiscard}
+        onCancel={() => setConfirmDiscardOpen(false)}
+        onDismiss={() => setConfirmDiscardOpen(false)}
       />
 
       {/* Draft restore — drafts are autosaved to localStorage on this device


### PR DESCRIPTION
## Summary
- Cancel in the page editor no longer silently throws away unsaved work.
- When the working title or body diverges from the persisted page, Cancel now opens a destructive "Discard changes?" confirmation instead of dropping out of edit mode.
- A pristine editor (no edits) still exits immediately with no prompt.
- The guard covers every exit-from-edit path (Cancel button, Ctrl+E toggle, Escape shortcut) since they all funnel through `handleCancelEditing`.

Closes #944.

## Root cause
`handleCancelEditing` cleared the local-storage draft and called `setEditing(false)` unconditionally — it never checked for unsaved changes or surfaced a confirmation, so a full rewrite or a restored AI draft was lost with zero prompt.

## Fix
- Added an `isEditorDirty()` predicate (`editTitle !== page.title || editHtml !== page.bodyHtml`) and a `discardAndExit()` helper wrapping the original clearDraft + exit.
- `handleCancelEditing` now opens a new `confirmDiscardOpen` ConfirmDialog when dirty; confirming runs `discardAndExit()`, cancel/Escape/overlay just close the dialog and stay in edit mode.
- Reuses the existing `ConfirmDialog` primitive already used for trash and draft-restore (ADR-010 neumorphic pattern).

## Testing
- TDD: extended `frontend/src/features/pages/PageViewPage.test.tsx` with a `cancel discard confirmation` block; the three dirty-state tests **fail before** the fix (no "Discard changes?" dialog exists, Cancel exits synchronously), **pass after**. Pristine-exit test is a regression guard.
- `cd frontend && npx vitest run src/features/pages/PageViewPage.test.tsx` (43 passed) - eslint (pass) - tsc --noEmit (pass)

Generated with Claude Code