### PR TITLE
fix(llm): sanitize embedding provider errors before exposing them to users (#964)

### DIFF
--- a/backend/src/domains/llm/services/embedding-error-message.test.ts
+++ b/backend/src/domains/llm/services/embedding-error-message.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { toUserFacingEmbeddingError } from './embedding-error-message.js';
+
+describe('toUserFacingEmbeddingError', () => {
+  it('maps an LM Studio "no models loaded" leak to the model-unavailable message and hides the raw text', () => {
+    const result = toUserFacingEmbeddingError(
+      new Error(
+        'generateEmbedding HTTP 400: {"error":"No models loaded. Load one with the lms load command"}',
+      ),
+    );
+    expect(result).toBe(
+      'The embedding model is not available. Check the model configuration and try again.',
+    );
+    expect(result).not.toMatch(/lms load|No models loaded/i);
+  });
+
+  it('maps a connection-refused error to the connectivity message', () => {
+    const result = toUserFacingEmbeddingError(new Error('connect ECONNREFUSED 127.0.0.1:1234'));
+    expect(result).toBe(
+      'Could not reach the embedding service. Check the provider connection and try again.',
+    );
+    expect(result).not.toMatch(/ECONNREFUSED|127\.0\.0\.1/);
+  });
+
+  it('maps a rate-limit error to the rate-limit message', () => {
+    const result = toUserFacingEmbeddingError(
+      new Error('generateEmbedding HTTP 429: rate limit exceeded'),
+    );
+    expect(result).toBe('The embedding service is busy (rate limited). Try again shortly.');
+  });
+
+  it('maps an auth error to the auth message', () => {
+    const result = toUserFacingEmbeddingError(new Error('generateEmbedding HTTP 401 Unauthorized'));
+    expect(result).toBe(
+      'The embedding service rejected the request. Check the provider credentials.',
+    );
+  });
+
+  it('maps an opaque error to the generic fallback and does not leak the raw text', () => {
+    const raw = 'kaboom-internal-stacktrace-42';
+    const result = toUserFacingEmbeddingError(new Error(raw));
+    expect(result).toBe('Embedding failed due to a provider error. See server logs for details.');
+    expect(result).not.toContain(raw);
+  });
+
+  it('handles non-Error (string) input without throwing', () => {
+    const result = toUserFacingEmbeddingError('some raw string failure');
+    expect(result).toBe('Embedding failed due to a provider error. See server logs for details.');
+    expect(result).not.toContain('some raw string failure');
+  });
+});

--- a/backend/src/domains/llm/services/embedding-error-message.ts
+++ b/backend/src/domains/llm/services/embedding-error-message.ts
@@ -1,0 +1,58 @@
+/**
+ * Maps raw embedding/provider errors to short, category-based, user-safe messages.
+ *
+ * Raw upstream provider strings (e.g. LM Studio's "No models loaded ... use the
+ * lms load command", stack traces, host:port details) must NEVER reach end
+ * users: they leak infrastructure internals and are meaningless to non-operators.
+ * Those raw strings stay in the server logs only (callers keep their existing
+ * `logger.error({ err })` calls). This helper is the single place that decides
+ * what a user is allowed to see for a failed embedding.
+ */
+
+/**
+ * Convert any thrown embedding error into a short, safe, user-facing message.
+ * Never returns the raw upstream text — every branch, including the fallback,
+ * yields a fixed constant string.
+ */
+export function toUserFacingEmbeddingError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const m = raw.toLowerCase();
+
+  // Connectivity / circuit-breaker: the provider is unreachable.
+  if (
+    ['econnrefused', 'enotfound', 'econnreset', 'etimedout', 'fetch failed', 'network', 'timeout', 'timed out', 'circuit breaker', 'socket'].some(
+      (needle) => m.includes(needle),
+    )
+  ) {
+    return 'Could not reach the embedding service. Check the provider connection and try again.';
+  }
+
+  // Auth: credentials rejected.
+  if (['http 401', 'http 403', 'unauthorized', 'forbidden'].some((needle) => m.includes(needle))) {
+    return 'The embedding service rejected the request. Check the provider credentials.';
+  }
+
+  // Rate limit: provider is busy.
+  if (['http 429', 'rate limit', 'too many requests'].some((needle) => m.includes(needle))) {
+    return 'The embedding service is busy (rate limited). Try again shortly.';
+  }
+
+  // Model unavailable: model not loaded / not found.
+  if (
+    ['http 404', 'not found', 'no models loaded', 'model not loaded', 'lms load'].some((needle) =>
+      m.includes(needle),
+    )
+  ) {
+    return 'The embedding model is not available. Check the model configuration and try again.';
+  }
+
+  // Content too long: input exceeds the model's context window.
+  if (
+    ['context length', 'input length', 'too long', 'maximum context'].some((needle) => m.includes(needle))
+  ) {
+    return 'Content was too long to index. It will be retried automatically.';
+  }
+
+  // Generic fallback: something else went wrong on the provider side.
+  return 'Embedding failed due to a provider error. See server logs for details.';
+}

--- a/backend/src/domains/llm/services/embedding-service.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.test.ts
@@ -711,7 +711,7 @@ describe('embedding-service', () => {
       expect(result.alreadyProcessing).toBeUndefined();
     });
 
-    it('should store error message when embedding fails', async () => {
+    it('should store a sanitized, user-safe error message when embedding fails', async () => {
       const embeddingError = new Error('Model bge-m3 not found');
 
       mockChunkSettings();
@@ -746,10 +746,15 @@ describe('embedding-service', () => {
       );
       expect(failedUpdateCall).toBeDefined();
       expect(failedUpdateCall![0]).toContain('embedding_error');
-      expect(failedUpdateCall![1]).toContain('Model bge-m3 not found');
+      // The raw provider text ('Model bge-m3 not found' -> "not found") is mapped
+      // to a safe, category-based message and never persisted verbatim.
+      expect(failedUpdateCall![1][1]).toBe(
+        'The embedding model is not available. Check the model configuration and try again.',
+      );
+      expect(failedUpdateCall![1][1]).not.toContain('Model bge-m3');
     });
 
-    it('should truncate long error messages to 1000 characters', async () => {
+    it('should not persist raw provider text in the embedding error column', async () => {
       const longMessage = 'x'.repeat(2000);
       const longError = new Error(longMessage);
 
@@ -781,10 +786,14 @@ describe('embedding-service', () => {
         (call) => typeof call[0] === 'string' && (call[0] as string).includes("embedding_status = 'failed'"),
       );
       expect(failedUpdateCall).toBeDefined();
-      // The error message in params should be truncated to 1000 chars
+      // The mapper returns a fixed generic fallback for opaque errors; the raw
+      // provider payload (the 'x'.repeat(2000) string) is never persisted.
       // Error message is at [1][1]: params are [confluenceId, errorMessage]
       const storedError = failedUpdateCall![1][1] as string;
-      expect(storedError).toHaveLength(1000);
+      expect(storedError).toBe(
+        'Embedding failed due to a provider error. See server logs for details.',
+      );
+      expect(storedError).not.toContain('xxxx');
     });
 
     it('should clear error when embedding succeeds after previous failure', async () => {
@@ -951,7 +960,12 @@ describe('embedding-service', () => {
       expect(completeEvent!.errors).toBeDefined();
       expect(completeEvent!.errors!.length).toBe(1);
       expect(completeEvent!.errors![0]).toContain('Failing');
-      expect(completeEvent!.errors![0]).toContain('Network timeout');
+      // The SSE error list carries the sanitized message, not the raw provider
+      // text ('Network timeout' is mapped to the connectivity message).
+      expect(completeEvent!.errors![0]).toContain(
+        'Could not reach the embedding service. Check the provider connection and try again.',
+      );
+      expect(completeEvent!.errors![0]).not.toContain('Network timeout');
     });
 
     it('should wait and retry on CircuitBreakerOpenError instead of marking page as failed', async () => {

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -12,6 +12,7 @@ import { CircuitBreakerOpenError, getProviderBreaker } from '../../../core/servi
 import { getReembedHistoryRetention } from '../../../core/services/admin-settings-service.js';
 import { enqueueJob } from '../../../core/services/queue-service.js';
 import { listRelationshipProducers } from './embedding-relationship-hooks.js';
+import { toUserFacingEmbeddingError } from './embedding-error-message.js';
 import pgvector from 'pgvector';
 
 const CHUNK_SIZE = 500;          // ~500 tokens target
@@ -740,17 +741,18 @@ export async function processDirtyPages(
                 break; // Success, move to next page
               } catch (retryErr) {
                 if (!isCircuitBreakerError(retryErr)) {
-                  // Different error, mark as failed and move on
-                  const errorMessage = retryErr instanceof Error ? retryErr.message : String(retryErr);
+                  // Different error, mark as failed and move on. The raw provider
+                  // text stays in the server log below; the user-facing column and
+                  // SSE progress get a sanitized, category-based message only.
                   logger.error({ err: retryErr, pageId: page.id }, 'Failed to embed page after circuit breaker recovery');
                   await query(
                     `UPDATE pages SET embedding_status = 'failed', embedding_error = $2 WHERE id = $1`,
-                    [page.id, errorMessage.slice(0, 1000)],
+                    [page.id, toUserFacingEmbeddingError(retryErr)],
                   ).catch((updateErr) => logger.error({ err: updateErr }, 'Failed to update embedding_status to failed'));
                   totalErrors++;
                   batchRemainingDirty++;
                   consecutiveFailures++;
-                  errorList.push(`${page.title}: ${errorMessage.slice(0, 200)}`);
+                  errorList.push(`${page.title}: ${toUserFacingEmbeddingError(retryErr)}`);
                   cbSuccess = true; // Mark as handled (failed, but handled)
                   break;
                 }
@@ -771,18 +773,19 @@ export async function processDirtyPages(
             continue; // handled by circuit breaker path
           }
 
-          // Non-circuit-breaker error: mark page as failed
+          // Non-circuit-breaker error: mark page as failed. The raw provider text
+          // stays in the server log above; the user-facing column and SSE progress
+          // get a sanitized, category-based message only.
           logger.error({ err, pageId: page.id }, 'Failed to embed page');
-          const errorMessage = err instanceof Error ? err.message : String(err);
           await query(
             `UPDATE pages SET embedding_status = 'failed', embedding_error = $2 WHERE id = $1`,
-            [page.id, errorMessage.slice(0, 1000)],
+            [page.id, toUserFacingEmbeddingError(err)],
           ).catch((updateErr) => logger.error({ err: updateErr }, 'Failed to update embedding_status to failed'));
           totalErrors++;
           batchRemainingDirty++;
           pagesProcessedSinceGuardCheck++;
           consecutiveFailures++;
-          errorList.push(`${page.title}: ${errorMessage.slice(0, 200)}`);
+          errorList.push(`${page.title}: ${toUserFacingEmbeddingError(err)}`);
 
           // Pause after too many consecutive failures to let the server recover
           if (consecutiveFailures >= CONSECUTIVE_FAILURE_PAUSE_THRESHOLD) {


### PR DESCRIPTION
## Summary
- Raw upstream LLM/embedding provider error strings were leaking to end users through `pages.embedding_error` (rendered in the badge tooltip) and the SSE embedding-progress `errors` array (shown in the progress toast).
- Add a small pure helper `toUserFacingEmbeddingError(err)` that maps errors to short, category-based, user-safe messages (connectivity, auth, rate-limit, model-unavailable, content-too-long, generic fallback) and never returns the raw text.
- Apply it at the four leak sites in `embedding-service.ts` (two `embedding_error` UPDATE writes + two `errorList.push` calls that feed the SSE `complete` event).
- `logger.error({ err })` calls are left intact so operators still get the full raw diagnostic in server logs only.

Closes #964.

## Root cause
On embedding failure the verbatim provider response body (e.g. LM Studio's "No models loaded ... use the lms load command") propagated as `err.message` and was written unmodified to the frontend-exposed `embedding_error` column and pushed into the SSE progress `errors` array, then rendered directly in the UI.

## Fix
- New `backend/src/domains/llm/services/embedding-error-message.ts` — pure, category-based sanitizer.
- `embedding-service.ts` writes/streams the sanitized message; raw text stays in logs.
- No frontend change needed — the badge tooltip and progress toast display the mapped message automatically.

## Testing
- TDD: added `backend/src/domains/llm/services/embedding-error-message.test.ts` (6 cases incl. the LM Studio leak, connectivity, auth, rate-limit, opaque fallback, non-Error input); **fails before** the fix (module does not exist), **passes after**.
- Updated three existing `embedding-service.test.ts` assertions that asserted the old raw-persist / raw-SSE behavior; they **fail before** the service change and **pass after**, proving the raw string is no longer persisted or streamed.
- `cd backend && npx vitest run src/domains/llm/services/embedding-error-message.test.ts` (pass, 6/6) - `npx vitest run src/domains/llm/services/embedding-service.test.ts` (pass, 91/91) - eslint (pass, 0 warnings) - `tsc --noEmit` (pass).

Generated with Claude Code