### PR TITLE
fix(auth): proactively refresh expired token in apiFetch to stop 401 storm (#965)

### DIFF
--- a/docs/architecture/07-flow-auth.md
+++ b/docs/architecture/07-flow-auth.md
@@ -45,6 +45,21 @@ sequenceDiagram
     BE-->>FE: 200 { accessToken (new) }
 ```
 
+### Client-side token refresh
+
+The SPA keeps the access token in memory (rehydrated from `localStorage` on
+reload) and refreshes it three ways, all funneling through the single-flight
+`refreshAccessTokenOnce()` so concurrent requests trigger exactly one
+`POST /api/auth/refresh`:
+
+- **Scheduled** — `useTokenRefreshTimer` refreshes shortly before expiry.
+- **Proactive (#965)** — `apiFetch` decodes the token's `exp` and, if it is
+  already expired (or within a 5s skew), refreshes **before** sending. This
+  stops a burst of concurrent queries on session resume from each round-tripping
+  to a guaranteed 401 (the "401 storm").
+- **Reactive** — a `401` response still triggers a refresh + retry as the
+  fallback for server-side revocation / clock skew.
+
 ### Registration quirks
 
 - `POST /api/auth/register` is rate-limited (5/min).
@@ -166,5 +181,6 @@ posts to a JSON endpoint and only then receives the real JWT.
 | OIDC routes (EE only) | `@compendiq/enterprise` (loaded via `core/enterprise/loader.ts`) |
 | Frontend session init | `frontend/src/shared/hooks/useSessionInit.ts` |
 | Refresh timer | `frontend/src/shared/hooks/useTokenRefreshTimer.ts` |
+| API client (single-flight + proactive/reactive refresh) | `frontend/src/shared/lib/api.ts` |
 | OIDC callback UI | `frontend/src/features/auth/OidcCallbackPage.tsx` |
 | OIDC admin config UI | `frontend/src/features/admin/OidcSettingsPage.tsx` |

--- a/frontend/src/shared/lib/api.test.ts
+++ b/frontend/src/shared/lib/api.test.ts
@@ -16,6 +16,13 @@ vi.mock('../../stores/auth-store', () => ({
 // Import after mocks are set up
 const { apiFetch, logoutApi } = await import('./api');
 
+/** Build a JWT whose payload carries the given `exp` (seconds since epoch). */
+function makeJwt(exp: number): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = btoa(JSON.stringify({ exp }));
+  return `${header}.${payload}.sig`;
+}
+
 describe('apiFetch', () => {
   beforeEach(() => {
     storeState = {
@@ -144,6 +151,41 @@ describe('apiFetch', () => {
 
     // Only ONE refresh call should have been made (deduplication)
     expect(refreshCallCount).toBe(1);
+  });
+
+  it('proactively refreshes an already-expired JWT before firing the request', async () => {
+    // Token expired 60s ago — the "401 storm" scenario on session resume.
+    storeState.accessToken = makeJwt(Math.floor(Date.now() / 1000) - 60);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async (input: string | URL | Request) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url === '/api/auth/refresh') {
+          return new Response(
+            JSON.stringify({
+              accessToken: 'fresh-token',
+              user: { id: '1', username: 'test', role: 'user' },
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response(JSON.stringify({ ok: true }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    );
+
+    const result = await apiFetch('/data');
+
+    expect(result).toEqual({ ok: true });
+    // The FIRST network call must be the proactive refresh, not /api/data.
+    expect(fetchSpy.mock.calls[0][0]).toBe('/api/auth/refresh');
+    // /api/data must be fetched exactly once, carrying the refreshed token.
+    const dataCalls = fetchSpy.mock.calls.filter((c) => c[0] === '/api/data');
+    expect(dataCalls).toHaveLength(1);
+    expect((dataCalls[0][1]?.headers as Headers).get('Authorization')).toBe('Bearer fresh-token');
+    // Auth store received the fresh token.
+    expect(mockSetAuth).toHaveBeenCalledWith('fresh-token', { id: '1', username: 'test', role: 'user' });
   });
 
   it('attempts refresh on 401 when accessToken exists but expired', async () => {

--- a/frontend/src/shared/lib/api.ts
+++ b/frontend/src/shared/lib/api.ts
@@ -45,11 +45,45 @@ export function refreshAccessTokenOnce(): Promise<string | null> {
   return pendingRefresh;
 }
 
+/**
+ * Decode a JWT's `exp` claim (client-readable; signature not verified — the
+ * backend validates tokens) and report whether it is expired or within a small
+ * skew window of expiring. Returns false for non-JWT / malformed tokens so the
+ * caller falls back to the reactive 401 path.
+ */
+function isTokenExpired(token: string): boolean {
+  try {
+    const payload = token.split('.')[1];
+    if (!payload) return false;
+    const { exp } = JSON.parse(
+      atob(payload.replace(/-/g, '+').replace(/_/g, '/')),
+    ) as { exp?: number };
+    if (typeof exp !== 'number') return false;
+    // Refresh 5s early so a request doesn't expire in flight.
+    return Date.now() >= exp * 1000 - 5000;
+  } catch {
+    return false;
+  }
+}
+
 export async function apiFetch<T = unknown>(
   path: string,
   options: RequestInit = {},
 ): Promise<T> {
-  const { accessToken } = useAuthStore.getState();
+  let { accessToken } = useAuthStore.getState();
+
+  // Proactive refresh: if the in-memory token is already expired, refresh once
+  // (deduped via refreshAccessTokenOnce) BEFORE firing so a burst of concurrent
+  // queries on session resume doesn't each round-trip to a guaranteed 401 (the
+  // "401 storm"). The reactive 401 handler below stays as a fallback for
+  // server-side revocation / clock skew.
+  if (accessToken && isTokenExpired(accessToken)) {
+    accessToken = await refreshAccessTokenOnce();
+    if (!accessToken) {
+      useAuthStore.getState().clearAuth();
+      throw new ApiError(401, 'Session expired');
+    }
+  }
 
   const headers = new Headers(options.headers);
   if (accessToken) {


### PR DESCRIPTION
## Summary
- On session resume the access token is rehydrated from `localStorage`; when it is already expired, `apiFetch` fired every concurrent TanStack Query with the stale token and only refreshed **reactively** after each request 401'd — an "N wasted round-trips + N red console errors" storm on every app open.
- Add a proactive expiry guard: `apiFetch` now decodes the JWT `exp` and, if expired (5s skew), refreshes once via the existing single-flight `refreshAccessTokenOnce()` **before** sending.
- The reactive `401` handler is untouched and stays as a fallback for server-side revocation / clock skew.

Closes #965.

## Root cause
Refresh was reactive-only: `useSessionInit` refreshes only on a falsy token and `useTokenRefreshTimer` bails on an already-expired token, so `apiFetch` sent the stale token and each concurrent query 401'd before the (correctly deduped) refresh ran.

## Fix
- New private `isTokenExpired(token)` helper (base64url-decodes the `exp` claim; returns `false` for non-JWT/malformed tokens so behavior is unchanged there).
- `apiFetch` proactively `await refreshAccessTokenOnce()` on an expired token; on null it `clearAuth()`s and throws `ApiError(401, 'Session expired')`.
- Single-flight preserved, so concurrent expired-token requests collapse onto exactly one `/api/auth/refresh` and none fires with the stale token.

## Testing
- TDD: extended `frontend/src/shared/lib/api.test.ts` with `makeJwt(exp)` and a case asserting the **first** fetch is `/api/auth/refresh`, `/api/data` fires exactly once with `Bearer fresh-token`, and `setAuth` got the fresh token. **Fails before** the fix (first call is `/api/data`), **passes after**. All 8 existing cases stay green (non-JWT tokens decode-fail → guard is inert).
- `cd frontend && npx vitest run src/shared/lib/api.test.ts` (9 passed) - `eslint` (pass) - `tsc --noEmit` (pass)

Generated with Claude Code