### PR TITLE
fix(setup): send confluenceUrl so wizard persists the Confluence URL (#875)

### DIFF
--- a/frontend/src/features/setup/steps/ConfluenceStep.test.tsx
+++ b/frontend/src/features/setup/steps/ConfluenceStep.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { LazyMotion, domMax } from 'framer-motion';
+import { UpdateSettingsSchema } from '@compendiq/contracts';
 import { ConfluenceStep } from './ConfluenceStep';
 
 vi.mock('sonner', () => ({
@@ -68,6 +69,40 @@ describe('ConfluenceStep', () => {
 
     expect(screen.getByTestId('confluence-next-btn')).toBeDisabled();
     expect(screen.queryByTestId('confluence-test-result')).not.toBeInTheDocument();
+  });
+
+  it('persists the URL under the confluenceUrl key the backend expects (#875)', async () => {
+    const fetchSpy = mockOkFetch();
+    renderStep();
+
+    fireEvent.change(screen.getByTestId('confluence-url'), {
+      target: { value: 'https://confluence.example.com' },
+    });
+    fireEvent.change(screen.getByTestId('confluence-pat'), {
+      target: { value: 'secret-pat' },
+    });
+
+    fireEvent.click(screen.getByTestId('test-confluence-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('confluence-next-btn')).not.toBeDisabled();
+    });
+
+    // Find the PUT /settings call and inspect its payload.
+    const putCall = fetchSpy.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'PUT',
+    );
+    expect(putCall).toBeDefined();
+    const body = JSON.parse((putCall![1] as RequestInit).body as string);
+
+    // The URL must go under `confluenceUrl` (a non-strict UpdateSettingsSchema
+    // silently strips the old `confluenceBaseUrl` key, leaving confluence_url NULL).
+    expect(body.confluenceBaseUrl).toBeUndefined();
+    expect(body.confluenceUrl).toBe('https://confluence.example.com');
+
+    // The whole payload must validate against the contract the backend parses with.
+    const parsed = UpdateSettingsSchema.parse(body);
+    expect(parsed.confluenceUrl).toBe('https://confluence.example.com');
   });
 
   it('re-requires a test after the PAT is edited following a passing test', async () => {

--- a/frontend/src/features/setup/steps/ConfluenceStep.tsx
+++ b/frontend/src/features/setup/steps/ConfluenceStep.tsx
@@ -24,7 +24,7 @@ export function ConfluenceStep({ onNext, onBack }: ConfluenceStepProps) {
       await apiFetch('/settings', {
         method: 'PUT',
         body: JSON.stringify({
-          confluenceBaseUrl: confluenceUrl,
+          confluenceUrl,
           confluencePat: pat,
         }),
       });


### PR DESCRIPTION
Fixes #875.

Confirmed the diagnosis and applied the frontend-only fix. ConfluenceStep.tsx PUT /settings sent the URL under confluenceBaseUrl, a key UpdateSettingsSchema (non-strict) silently strips, leaving confluence_url NULL. Renamed the payload key to confluenceUrl (the field contracts already defines). Added a regression test that drives the wizard, inspects the PUT payload, asserts confluenceBaseUrl is absent and confluenceUrl carries the value, and validates the whole body against UpdateSettingsSchema. Test fails on old code (confluenceBaseUrl present) and passes after the fix; all 4 tests in the file green.

**Test:** `frontend/src/features/setup/steps/ConfluenceStep.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)