### PR TITLE
fix(enterprise): re-fetch license on auth change so post-mount login enables EE (#881)

### DIFF
--- a/docs/architecture/10-flow-enterprise-license.md
+++ b/docs/architecture/10-flow-enterprise-license.md
@@ -95,11 +95,20 @@ ATM-{tier}-{seats}-{expiryYYYYMMDD}-{licenseId}.{ed25519SignatureBase64url}
 
 ```mermaid
 flowchart LR
-    boot(["App mount"]) --> fetch[["GET /api/admin/license"]]
+    boot(["App mount +<br/>every auth change<br/>(login / logout / token refresh)"]) --> fetch[["GET /api/admin/license"]]
     fetch --> decide{edition !== 'community'<br/>AND valid}
     decide -- yes --> ee["isEnterprise = true<br/>→ show OIDC tab,<br/>license form, EE features"]
     decide -- no  --> ce["isEnterprise = false<br/>→ CE UI only"]
+    fetch -- 401 / 403 --> clear["license cleared<br/>(logout / not admin)"]
+    fetch -- network / 5xx --> keep["transient — previously<br/>loaded license preserved"]
 ```
+
+The fetch runs on mount **and whenever the access token changes** (a
+post-mount SPA login must flip EE surfaces on without a reload; logout
+clears the previous session's license/ui from memory). Only a genuine
+auth signal (401/403) clears the license — transient failures (network
+error, 5xx) leave the previously loaded license untouched, and the
+loading skeleton shows on the initial load only.
 
 CE and EE ship the **same frontend image**. There is no IIFE bundle, no
 build-time patch, no separate EE SPA. All gating happens at runtime via

--- a/frontend/src/shared/enterprise/context.auth-relogin.test.tsx
+++ b/frontend/src/shared/enterprise/context.auth-relogin.test.tsx
@@ -148,4 +148,71 @@ describe('EnterpriseProvider re-fetches license on auth change (#881)', () => {
     });
     expect(screen.getByTestId('license').textContent).toBe('null');
   });
+
+  it('preserves an already-loaded EE license when a refetch fails transiently (5xx)', async () => {
+    let failLicense = false;
+    let licenseCalls = 0;
+    _setScriptLoaderForTesting(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__COMPENDIQ_UI__ = { LicenseStatusCard: () => null, version: '1.0.0' };
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = urlOf(input as RequestInfo | URL);
+      if (url.includes('/auth/refresh')) {
+        return new Response(null, { status: 401 });
+      }
+      if (url.includes('/admin/license')) {
+        licenseCalls += 1;
+        if (failLicense) return new Response(null, { status: 500 });
+        return new Response(
+          JSON.stringify({
+            edition: 'enterprise',
+            tier: 'enterprise',
+            features: ['oidc_sso'],
+            valid: true,
+            canUpdate: true,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response(null, { status: 404 });
+    });
+
+    act(() => {
+      useAuthStore
+        .getState()
+        .setAuth('ee-admin-token', { id: '1', username: 'admin', role: 'admin' });
+    });
+
+    render(
+      <EnterpriseProvider>
+        <TestConsumer />
+      </EnterpriseProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('enterprise').textContent).toBe('true');
+    });
+
+    // Token rotates mid-session (routine refresh) but the refetch hits a 500.
+    const callsBefore = licenseCalls;
+    failLicense = true;
+    act(() => {
+      useAuthStore
+        .getState()
+        .setAuth('ee-admin-token-rotated', { id: '1', username: 'admin', role: 'admin' });
+    });
+
+    await waitFor(() => {
+      expect(licenseCalls).toBeGreaterThan(callsBefore);
+    });
+
+    // Transient failure must NOT flip an EE admin to community.
+    expect(screen.getByTestId('enterprise').textContent).toBe('true');
+    expect(screen.getByTestId('license').textContent).toBe('enterprise');
+    expect(screen.getByTestId('ui').textContent).toBe('loaded');
+    // And no loading flicker on a refetch.
+    expect(screen.getByTestId('loading').textContent).toBe('false');
+  });
 });

--- a/frontend/src/shared/enterprise/context.auth-relogin.test.tsx
+++ b/frontend/src/shared/enterprise/context.auth-relogin.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { EnterpriseProvider } from './context';
+import { useEnterprise } from './use-enterprise';
+import { _resetForTesting, _setScriptLoaderForTesting } from './loader';
+// Deliberately NOT mocking the auth store here: the fix relies on the
+// provider subscribing to real (reactive) auth state, so this test drives the
+// real zustand store to reproduce a post-mount login.
+import { useAuthStore } from '../../stores/auth-store';
+
+function TestConsumer() {
+  const { isEnterprise, license, ui, isLoading } = useEnterprise();
+  return (
+    <div>
+      <span data-testid="loading">{String(isLoading)}</span>
+      <span data-testid="enterprise">{String(isEnterprise)}</span>
+      <span data-testid="ui">{ui === null ? 'null' : 'loaded'}</span>
+      <span data-testid="license">{license === null ? 'null' : license.tier}</span>
+    </div>
+  );
+}
+
+function urlOf(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof Request) return input.url;
+  return String(input);
+}
+
+describe('EnterpriseProvider re-fetches license on auth change (#881)', () => {
+  beforeEach(() => {
+    _resetForTesting();
+    useAuthStore.getState().clearAuth();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useAuthStore.getState().clearAuth();
+  });
+
+  it('flips EE surfaces on when an admin logs in after mount (SPA navigate, no reload)', async () => {
+    let loggedIn = false;
+    _setScriptLoaderForTesting(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__COMPENDIQ_UI__ = { LicenseStatusCard: () => null, version: '1.0.0' };
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = urlOf(input as RequestInfo | URL);
+      if (url.includes('/auth/refresh')) {
+        // No refresh cookie in a fresh tab → refresh fails.
+        return new Response(null, { status: 401 });
+      }
+      if (url.includes('/admin/license')) {
+        if (!loggedIn) return new Response(null, { status: 401 });
+        return new Response(
+          JSON.stringify({
+            edition: 'enterprise',
+            tier: 'enterprise',
+            features: ['oidc_sso'],
+            valid: true,
+            canUpdate: true,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response(null, { status: 404 });
+    });
+
+    render(
+      <EnterpriseProvider>
+        <TestConsumer />
+      </EnterpriseProvider>,
+    );
+
+    // Mounted unauthenticated → /admin/license 401 → community fallback.
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+    expect(screen.getByTestId('enterprise').textContent).toBe('false');
+    expect(screen.getByTestId('license').textContent).toBe('null');
+
+    // Admin logs in after mount (LoginPage does setAuth + navigate, no reload).
+    loggedIn = true;
+    act(() => {
+      useAuthStore
+        .getState()
+        .setAuth('ee-admin-token', { id: '1', username: 'admin', role: 'admin' });
+    });
+
+    // The license must be re-fetched so EE surfaces switch on without a reload.
+    await waitFor(() => {
+      expect(screen.getByTestId('enterprise').textContent).toBe('true');
+    });
+    expect(screen.getByTestId('license').textContent).toBe('enterprise');
+    expect(screen.getByTestId('ui').textContent).toBe('loaded');
+  });
+
+  it("clears the previous admin's license and ui from memory on logout", async () => {
+    _setScriptLoaderForTesting(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__COMPENDIQ_UI__ = { LicenseStatusCard: () => null, version: '1.0.0' };
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = urlOf(input as RequestInfo | URL);
+      const { accessToken } = useAuthStore.getState();
+      if (url.includes('/auth/refresh')) {
+        return new Response(null, { status: 401 });
+      }
+      if (url.includes('/admin/license')) {
+        if (!accessToken) return new Response(null, { status: 401 });
+        return new Response(
+          JSON.stringify({
+            edition: 'enterprise',
+            tier: 'enterprise',
+            features: ['oidc_sso'],
+            valid: true,
+            canUpdate: true,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response(null, { status: 404 });
+    });
+
+    act(() => {
+      useAuthStore
+        .getState()
+        .setAuth('ee-admin-token', { id: '1', username: 'admin', role: 'admin' });
+    });
+
+    render(
+      <EnterpriseProvider>
+        <TestConsumer />
+      </EnterpriseProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('enterprise').textContent).toBe('true');
+    });
+
+    act(() => {
+      useAuthStore.getState().clearAuth();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('enterprise').textContent).toBe('false');
+    });
+    expect(screen.getByTestId('license').textContent).toBe('null');
+  });
+});

--- a/frontend/src/shared/enterprise/context.tsx
+++ b/frontend/src/shared/enterprise/context.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, type ReactNode } from 'react';
 import type { EnterpriseUI, LicenseInfo } from './types';
 import { EnterpriseContext } from './enterprise-context';
 import { loadEnterpriseUI } from './loader';
-import { apiFetch } from '../lib/api';
+import { apiFetch, ApiError } from '../lib/api';
 import { useAuthStore } from '../../stores/auth-store';
 
 /**
@@ -33,18 +33,31 @@ export function EnterpriseProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let cancelled = false;
-    setIsLoading(true);
+    // isLoading starts true and is only ever set back to false, so skeletons
+    // show on the initial load only — a token-change refetch (routine refresh)
+    // keeps the current UI up while the license is re-checked, no flicker.
 
     async function init() {
       // License first — CE returns edition:'community', EE returns actual
       // tier. The response tells us whether the backend is EE at all.
       let info: LicenseInfo | null = null;
+      let transientFailure = false;
       try {
         info = await apiFetch<LicenseInfo>('/admin/license');
-      } catch {
-        // Not admin, unauthenticated, or endpoint unavailable — license clears
+      } catch (err) {
+        // Only a genuine auth signal (401 logged out / 403 not admin) clears
+        // the license. Anything else — network error, 5xx — is transient and
+        // must NOT flip an EE admin to community mid-session.
+        const isAuthError =
+          err instanceof ApiError && (err.statusCode === 401 || err.statusCode === 403);
+        transientFailure = !isAuthError;
       }
       if (cancelled) return;
+      if (transientFailure) {
+        // Preserve the previously loaded license/ui; just settle loading.
+        setIsLoading(false);
+        return;
+      }
       // Set unconditionally so a logout (fetch now 401s → info null) drops the
       // previous session's license instead of leaving it stale in memory.
       setLicense(info);

--- a/frontend/src/shared/enterprise/context.tsx
+++ b/frontend/src/shared/enterprise/context.tsx
@@ -3,6 +3,7 @@ import type { EnterpriseUI, LicenseInfo } from './types';
 import { EnterpriseContext } from './enterprise-context';
 import { loadEnterpriseUI } from './loader';
 import { apiFetch } from '../lib/api';
+import { useAuthStore } from '../../stores/auth-store';
 
 /**
  * Provider that fetches license info and, only on EE backends, loads the
@@ -23,9 +24,16 @@ export function EnterpriseProvider({ children }: { children: ReactNode }) {
   const [ui, setUi] = useState<EnterpriseUI | null>(null);
   const [license, setLicense] = useState<LicenseInfo | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  // Re-fetch whenever the access token changes. A login performed after mount
+  // is a pure SPA transition (LoginPage/OidcCallbackPage do setAuth + navigate,
+  // no reload), so without this dependency an EE admin who logs in from a fresh
+  // tab would stay in the community fallback all session. The same dependency
+  // clears the previous admin's license/ui from memory on logout.
+  const accessToken = useAuthStore((s) => s.accessToken);
 
   useEffect(() => {
     let cancelled = false;
+    setIsLoading(true);
 
     async function init() {
       // License first — CE returns edition:'community', EE returns actual
@@ -34,10 +42,12 @@ export function EnterpriseProvider({ children }: { children: ReactNode }) {
       try {
         info = await apiFetch<LicenseInfo>('/admin/license');
       } catch {
-        // Not admin, or endpoint unavailable — license stays null
+        // Not admin, unauthenticated, or endpoint unavailable — license clears
       }
       if (cancelled) return;
-      if (info) setLicense(info);
+      // Set unconditionally so a logout (fetch now 401s → info null) drops the
+      // previous session's license instead of leaving it stale in memory.
+      setLicense(info);
 
       // Only an EE backend (which marks itself with canUpdate: true) can
       // serve the overlay bundle, so don't even attempt the load otherwise.
@@ -51,6 +61,9 @@ export function EnterpriseProvider({ children }: { children: ReactNode }) {
         const enterpriseUi = await loadEnterpriseUI();
         if (cancelled) return;
         setUi(enterpriseUi);
+      } else {
+        // Not EE (or logged out) — drop any bundle loaded for a prior session.
+        setUi(null);
       }
 
       setIsLoading(false);
@@ -60,7 +73,7 @@ export function EnterpriseProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [accessToken]);
 
   const hasFeature = (feature: string): boolean => {
     if (!license || !license.valid) return false;


### PR DESCRIPTION
Fixes #881.

EnterpriseProvider fetched /admin/license once in a useEffect([]) and never re-ran after a post-mount SPA login, so an EE admin logging in from a fresh tab stayed in the community fallback all session (and logout left stale license/ui). Fix: subscribe to the auth store's accessToken via `useAuthStore((s) => s.accessToken)` and use it as the effect dependency, so the license is re-fetched on login/logout/token-refresh. License is now set unconditionally (a logged-out 401 clears it) and ui resets when the backend is not EE. Added a focused jsdom test (context.auth-relogin.test.tsx) that drives the real zustand store: one case verifies EE surfaces flip on after a post-mount login, another verifies license/ui clear on logout. Both failed on the old code and pass on the fix; all 18 enterprise tests pass; typecheck and eslint clean.

**Test:** `frontend/src/shared/enterprise/context.auth-relogin.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)