### PR TITLE
fix(frontend): don't dump authenticated users into setup wizard on failed setup-status fetch (#932)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useAuthStore } from './stores/auth-store';
@@ -192,6 +192,129 @@ describe('App – ProtectedRoute setup-status fail-safe (#932)', () => {
       { timeout: 8000 },
     );
     expect(screen.queryByText('Welcome to Compendiq')).not.toBeInTheDocument();
+  }, 15000);
+});
+
+describe('App – SetupRoute setup-status error handling (#932)', () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    useAuthStore.getState().clearAuth();
+  });
+
+  function renderApp(
+    initialPath: string,
+    seedStaleSetupStatus?: { setupComplete: boolean },
+  ) {
+    const queryClient = new QueryClient({
+      // useSetupStatus pins retry: 2; a zero retryDelay lets those retries
+      // exhaust instantly so the query settles into its error state quickly.
+      defaultOptions: { queries: { retryDelay: () => 0 } },
+    });
+    if (seedStaleSetupStatus) {
+      // Backdate the entry past the hook's 30s staleTime so mounting
+      // triggers a background refetch while the cached answer survives.
+      queryClient.setQueryData(
+        ['setup-status'],
+        {
+          setupComplete: seedStaleSetupStatus.setupComplete,
+          steps: { admin: true, llm: true, confluence: true },
+        },
+        { updatedAt: Date.now() - 60_000 },
+      );
+    }
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <App />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  }
+
+  function failSetupStatusFetches() {
+    fetchSpy.mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : (input as Request).url;
+      if (url.includes('/api/health/setup-status')) {
+        return new Response('Internal Server Error', { status: 500 });
+      }
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+  }
+
+  it('shows a retry affordance (not an infinite spinner) when the fetch fails with no cached data, and recovers on retry', async () => {
+    failSetupStatusFetches();
+
+    renderApp('/setup');
+
+    // Once retries are exhausted the route must settle into a terminal
+    // error state with an explicit retry — not the wizard, not a spinner.
+    await waitFor(
+      () => {
+        expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
+      },
+      { timeout: 8000 },
+    );
+    expect(screen.queryByText('Welcome to Compendiq')).not.toBeInTheDocument();
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+
+    // Backend comes back reporting setup incomplete: retrying must recover
+    // into the wizard.
+    fetchSpy.mockImplementation(async () =>
+      new Response(
+        JSON.stringify({
+          setupComplete: false,
+          steps: { admin: false, llm: false, confluence: false },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Compendiq')).toBeInTheDocument();
+    });
+  }, 15000);
+
+  it('keeps routing on stale cached data when only a background refetch fails', async () => {
+    useAuthStore.setState({
+      accessToken: 'persisted-token',
+      user: { id: '1', username: 'admin', role: 'admin' },
+      isAuthenticated: true,
+    });
+    failSetupStatusFetches();
+
+    // Rerun flow with a stale "setup complete" answer in the cache: the
+    // failed background refetch must not blank the wizard into a spinner
+    // or the error card — the cached data is still authoritative enough.
+    // (On rerun the wizard starts at the LLM step, hence llm-next-btn.)
+    renderApp('/setup?rerun=true', { setupComplete: true });
+
+    expect(screen.getByTestId('llm-next-btn')).toBeInTheDocument();
+
+    // Wait for the background refetch (initial attempt + 2 retries) to fail.
+    await waitFor(
+      () => {
+        const setupStatusCalls = fetchSpy.mock.calls.filter(([input]) => {
+          const url = typeof input === 'string' ? input : (input as Request).url;
+          return url.includes('/api/health/setup-status');
+        });
+        expect(setupStatusCalls.length).toBeGreaterThanOrEqual(3);
+      },
+      { timeout: 8000 },
+    );
+
+    // Still on the wizard — no spinner, no error card.
+    expect(screen.getByTestId('llm-next-btn')).toBeInTheDocument();
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Try Again' })).not.toBeInTheDocument();
   }, 15000);
 });
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -132,6 +132,69 @@ describe('App – ProtectedRoute token restoration', () => {
   });
 });
 
+describe('App – ProtectedRoute setup-status fail-safe (#932)', () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    useAuthStore.getState().clearAuth();
+  });
+
+  function renderApp(initialPath = '/') {
+    const queryClient = new QueryClient({
+      // useSetupStatus pins retry: 2; a zero retryDelay lets those retries
+      // exhaust instantly so the query settles into its error state quickly.
+      defaultOptions: { queries: { retryDelay: () => 0 } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <App />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  }
+
+  it('does not dump an authenticated user into the setup wizard when the setup-status fetch fails', async () => {
+    useAuthStore.setState({
+      accessToken: 'persisted-token',
+      user: { id: '1', username: 'test', role: 'user' },
+      isAuthenticated: true,
+    });
+
+    // Simulate the backend restarting: /api/health/setup-status returns a
+    // transient 5xx while every other call succeeds.
+    fetchSpy.mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : (input as Request).url;
+      if (url.includes('/api/health/setup-status')) {
+        return new Response('Internal Server Error', { status: 500 });
+      }
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    renderApp('/');
+
+    // The authenticated user must stay in the app shell (AppLayout's header
+    // renders a "Toggle sidebar" button) rather than being redirected into
+    // the first-run wizard on a transient setup-status error. The generous
+    // timeout lets useSetupStatus exhaust its pinned retries and settle into
+    // the error state (mirrors useSetupStatus.test.ts).
+    await waitFor(
+      () => {
+        expect(screen.getByLabelText('Toggle sidebar')).toBeInTheDocument();
+      },
+      { timeout: 8000 },
+    );
+    expect(screen.queryByText('Welcome to Compendiq')).not.toBeInTheDocument();
+  }, 15000);
+});
+
 describe('PageLoadingFallback', () => {
   it('renders a glassmorphic loading indicator', () => {
     render(<PageLoadingFallback />);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -94,18 +94,41 @@ export function PageLoadingFallback() {
 }
 
 /**
+ * Terminal error state for SetupRoute: the setup-status fetch failed and we
+ * have no cached data to route on. Offers an explicit retry instead of an
+ * infinite spinner (useSetupStatus disables refetchOnWindowFocus, so once
+ * retries are exhausted nothing would ever recover on its own).
+ */
+function SetupStatusUnavailable({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex items-center justify-center h-64">
+      <div className="nm-card p-8 text-center">
+        <p className="mb-6 text-sm text-muted-foreground">
+          Could not check the setup status. The server may be restarting.
+        </p>
+        <button onClick={onRetry} className="nm-button-primary">
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
  * SetupRoute — only accessible when setup is NOT complete.
  * Redirects to "/" once setup has been finished.
  */
 function SetupRoute({ children }: { children: React.ReactNode }) {
-  const { setupComplete, isLoading, error } = useSetupStatus();
+  const { setupComplete, hasData, isLoading, error, refetch } = useSetupStatus();
   const [searchParams] = useSearchParams();
   const isRerun = searchParams.get('rerun') === 'true';
   if (isLoading) return <PageLoadingFallback />;
-  // A failed setup-status fetch leaves setupComplete defaulting to false.
-  // Don't render the first-run wizard on that ambiguity — an already
-  // configured instance would otherwise show setup to a real user (#932).
-  if (error) return <PageLoadingFallback />;
+  // A failed setup-status fetch with no cached data leaves setup state truly
+  // unknown. Don't render the first-run wizard on that ambiguity — an already
+  // configured instance would otherwise show setup to a real user (#932) —
+  // but do offer a retry rather than spinning forever. When React Query still
+  // holds stale successful data, fall through and route on that instead.
+  if (error && !hasData) return <SetupStatusUnavailable onRetry={() => void refetch()} />;
   if (setupComplete && !isRerun) return <Navigate to="/" replace />;
   return <>{children}</>;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,23 +98,31 @@ export function PageLoadingFallback() {
  * Redirects to "/" once setup has been finished.
  */
 function SetupRoute({ children }: { children: React.ReactNode }) {
-  const { setupComplete, isLoading } = useSetupStatus();
+  const { setupComplete, isLoading, error } = useSetupStatus();
   const [searchParams] = useSearchParams();
   const isRerun = searchParams.get('rerun') === 'true';
   if (isLoading) return <PageLoadingFallback />;
+  // A failed setup-status fetch leaves setupComplete defaulting to false.
+  // Don't render the first-run wizard on that ambiguity — an already
+  // configured instance would otherwise show setup to a real user (#932).
+  if (error) return <PageLoadingFallback />;
   if (setupComplete && !isRerun) return <Navigate to="/" replace />;
   return <>{children}</>;
 }
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
-  const { setupComplete, isLoading } = useSetupStatus();
+  const { setupComplete, isLoading, error } = useSetupStatus();
 
   // While checking setup status, show loading
   if (isLoading) return <PageLoadingFallback />;
 
-  // Redirect to setup wizard if setup is not complete
-  if (!setupComplete) return <Navigate to="/setup" replace />;
+  // Redirect to the setup wizard only when we positively know setup is
+  // incomplete. A failed/undefined setup-status fetch (backend restart,
+  // transient 5xx, network blip) must NOT be treated as "setup incomplete":
+  // doing so would dump an authenticated user into the first-run wizard and
+  // destroy their deep link (#932). Fail safe and fall through instead.
+  if (!error && !setupComplete) return <Navigate to="/setup" replace />;
 
   // accessToken is now persisted in localStorage, so new tabs have it
   // immediately. If the token expired, apiFetch's 401 interceptor or

--- a/frontend/src/shared/hooks/useSetupStatus.ts
+++ b/frontend/src/shared/hooks/useSetupStatus.ts
@@ -32,6 +32,10 @@ export function useSetupStatus() {
   return {
     setupComplete: data?.setupComplete ?? false,
     steps: data?.steps ?? { admin: false, llm: false, confluence: false },
+    // True when React Query holds a (possibly stale) successful response.
+    // Lets callers distinguish "errored with no data at all" from "background
+    // refetch failed but the cached answer is still routable" (#932).
+    hasData: data !== undefined,
     isLoading,
     error,
     refetch,


### PR DESCRIPTION
Fixes #932.

Confirmed and fixed #932. ProtectedRoute treated any errored/undefined setup-status fetch as "setup incomplete" (useSetupStatus returns setupComplete = data?.setupComplete ?? false), redirecting authenticated users into the first-run wizard with replace-navigation and destroying their deep link on a transient backend blip. Fix: consult the query error and fail safe. In ProtectedRoute the redirect guard is now `if (!error && !setupComplete) return <Navigate to="/setup">`, so on error we fall through — authenticated users render their route, unauthenticated ones still go to /login. SetupRoute now renders the loading fallback on error instead of showing the wizard on an already-configured instance. Added a focused App.test.tsx test (jsdom + @testing-library/react) that mocks /api/health/setup-status returning 500 for an authenticated user and asserts the app shell (AppLayout's "Toggle sidebar" button) renders and the wizard's "Welcome to Compendiq" does not. Test failed on the original code (red) and passes after the fix (green). Full App/useSetupStatus/SetupWizard suites (35 tests) pass; tsc and eslint on changed files are clean. Committed and pushed; no PR opened per instructions.

**Test:** `frontend/src/App.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)