### PR TITLE
fix(ai): share one useExtractPdf instance so PDF extraction spinner shows (#940)

### DIFF
--- a/frontend/src/features/ai/modes/GenerateMode.pdf-extracting.test.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.pdf-extracting.test.tsx
@@ -113,4 +113,28 @@ describe('GenerateMode PDF extraction busy state (#940)', () => {
     });
     expect(screen.getByTestId('pdf-upload-zone')).toBeDisabled();
   });
+
+  it('disables the Generate (send) button while extraction is in progress', async () => {
+    render(<GenerateModeInput />, { wrapper: createWrapper() });
+
+    // Type a prompt and wait until the send button is enabled (model loaded),
+    // so the later assertion can only fail on the extraction state.
+    const promptInput = screen.getByPlaceholderText('Describe the page to generate...');
+    fireEvent.change(promptInput, { target: { value: 'Summarize the attached PDF' } });
+    const sendButton = screen.getByRole('button', { name: 'Send message' });
+    await waitFor(() => {
+      expect(sendButton).not.toBeDisabled();
+    });
+
+    // Kick off an extraction that stays pending.
+    const fileInput = screen.getByTestId('pdf-file-input');
+    const pdfFile = new File(['%PDF-1.4 dummy content'], 'report.pdf', { type: 'application/pdf' });
+    fireEvent.change(fileInput, { target: { files: [pdfFile] } });
+
+    // Clicking Generate mid-extraction would send the prompt without pdfText,
+    // so the button must be disabled until extraction settles (#940).
+    await waitFor(() => {
+      expect(sendButton).toBeDisabled();
+    });
+  });
 });

--- a/frontend/src/features/ai/modes/GenerateMode.pdf-extracting.test.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.pdf-extracting.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { LazyMotion, domAnimation } from 'framer-motion';
+import { GenerateModeInput } from './GenerateMode';
+import { AiProvider } from '../AiContext';
+import { useAuthStore } from '../../../stores/auth-store';
+
+Element.prototype.scrollIntoView = vi.fn();
+
+const apiFetchMock = vi.fn();
+vi.mock('../../../shared/lib/api', async () =>
+  (await import('../../../test-utils')).apiModuleMock(() => apiFetchMock));
+
+vi.mock('../../../shared/lib/sse', () => ({
+  streamSSE: vi.fn(),
+}));
+
+// Per-instance mock of useExtractPdf that mirrors the REAL hook's behaviour:
+// each call to useExtractPdf() owns its own `isExtracting` state (the real
+// hook keeps it in per-instance useState). `extractPdf` flips that instance's
+// state to true and never resolves, so we can observe the busy state.
+//
+// This is the crux of #940: GenerateModeInput and PdfUploadZone must share a
+// single instance. A shared-singleton mock (as in GenerateMode.test.tsx) would
+// hide the bug because both instances would read the same value.
+vi.mock('../../../shared/hooks/use-extract-pdf', async () => {
+  const React = await import('react');
+  return {
+    useExtractPdf: () => {
+      const [isExtracting, setIsExtracting] = React.useState(false);
+      const extractPdf = React.useCallback(() => {
+        setIsExtracting(true);
+        return new Promise(() => { /* stays pending: keeps this instance busy */ });
+      }, []);
+      return { extractPdf, isExtracting, error: null };
+    },
+  };
+});
+
+vi.mock('../../../shared/hooks/use-pages', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../shared/hooks/use-pages')>();
+  return { ...actual, usePage: () => ({ data: undefined }), useEmbeddingStatus: () => ({ data: undefined }) };
+});
+
+vi.mock('../../../shared/hooks/use-spaces', () => ({
+  useSpaces: () => ({ data: [] }),
+}));
+
+vi.mock('../../../shared/hooks/use-standalone', () => ({
+  useLocalSpaces: () => ({ data: [] }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/ai?mode=generate']}>
+          <LazyMotion features={domAnimation}>
+            <AiProvider>{children}</AiProvider>
+          </LazyMotion>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('GenerateMode PDF extraction busy state (#940)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.getState().setAuth('test-token', { id: '1', username: 'testuser', role: 'user' });
+    apiFetchMock.mockImplementation((path: string) => {
+      if (path === '/settings') {
+        return Promise.resolve({ llmProvider: 'ollama', ollamaModel: 'llama3', openaiModel: null });
+      }
+      if (path.startsWith('/ollama/models')) {
+        return Promise.resolve([{ name: 'llama3' }]);
+      }
+      if (path === '/llm/conversations') {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve([]);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useAuthStore.getState().clearAuth();
+  });
+
+  it('shows the "Extracting text..." spinner and disables the upload zone while extraction is in progress', async () => {
+    render(<GenerateModeInput />, { wrapper: createWrapper() });
+
+    const uploadZone = screen.getByTestId('pdf-upload-zone');
+    expect(uploadZone).not.toBeDisabled();
+
+    // Kick off an extraction that stays pending.
+    const fileInput = screen.getByTestId('pdf-file-input');
+    const pdfFile = new File(['%PDF-1.4 dummy content'], 'report.pdf', { type: 'application/pdf' });
+    fireEvent.change(fileInput, { target: { files: [pdfFile] } });
+
+    // The busy state must surface: spinner text visible and the zone disabled.
+    // With two separate useExtractPdf instances (the #940 bug) the parent's
+    // isExtracting never flips, so neither of these ever becomes true.
+    await waitFor(() => {
+      expect(screen.getByText('Extracting text...')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('pdf-upload-zone')).toBeDisabled();
+  });
+});

--- a/frontend/src/features/ai/modes/GenerateMode.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.tsx
@@ -512,7 +512,9 @@ export function GenerateModeInput() {
   }, []);
 
   const handleGenerate = useCallback(async () => {
-    if (!input.trim() || isStreaming) return;
+    // Block generation while a PDF extraction is in flight — otherwise the
+    // prompt would be sent without the pdfText that is still being extracted (#940).
+    if (!input.trim() || isStreaming || isExtracting) return;
     if (!model) {
       toast.error('No model available. Check your LLM provider settings.');
       return;
@@ -547,7 +549,7 @@ export function GenerateModeInput() {
         }
       },
     });
-  }, [input, model, isStreaming, pdfData, pdfFilename, searchWeb, thinkingMode, setInput, setMessages, runStream]);
+  }, [input, model, isStreaming, isExtracting, pdfData, pdfFilename, searchWeb, thinkingMode, setInput, setMessages, runStream]);
 
   const handleSubmit = () => handleGenerate();
 
@@ -603,7 +605,7 @@ export function GenerateModeInput() {
           />
           <button
             onClick={handleSubmit}
-            disabled={isStreaming || !input.trim() || !model}
+            disabled={isStreaming || isExtracting || !input.trim() || !model}
             aria-label={isStreaming ? 'Sending...' : 'Send message'}
             className="shrink-0 flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
           >

--- a/frontend/src/features/ai/modes/GenerateMode.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.tsx
@@ -167,6 +167,7 @@ function ParentPagePicker({
 // ---------------------------------------------------------------------------
 
 function PdfUploadZone({
+  extractPdf,
   onExtracted,
   pdfData,
   pdfFilename,
@@ -174,6 +175,7 @@ function PdfUploadZone({
   isExtracting,
   disabled,
 }: {
+  extractPdf: (file: File) => Promise<ExtractPdfResult>;
   onExtracted: (result: ExtractPdfResult, filename: string) => void;
   pdfData: ExtractPdfResult | null;
   pdfFilename: string | null;
@@ -181,7 +183,6 @@ function PdfUploadZone({
   isExtracting: boolean;
   disabled: boolean;
 }) {
-  const { extractPdf } = useExtractPdf();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isDragOver, setIsDragOver] = useState(false);
 
@@ -493,8 +494,10 @@ export function GenerateModeInput() {
   });
   const mcpEnabled = mcpSettings?.enabled ?? false;
 
-  // PDF upload state
-  const { isExtracting } = useExtractPdf();
+  // PDF upload state — a single useExtractPdf instance shared with PdfUploadZone
+  // so that `isExtracting` reflects the same extraction that PdfUploadZone runs
+  // (#940). Two separate instances left the spinner/disabled state stuck.
+  const { extractPdf, isExtracting } = useExtractPdf();
   const [pdfData, setPdfData] = useState<ExtractPdfResult | null>(null);
   const [pdfFilename, setPdfFilename] = useState<string | null>(null);
 
@@ -566,6 +569,7 @@ export function GenerateModeInput() {
 
       <div className="mt-3 space-y-3 border-t border-border/40 pt-3">
         <PdfUploadZone
+          extractPdf={extractPdf}
           onExtracted={handlePdfExtracted}
           pdfData={pdfData}
           pdfFilename={pdfFilename}


### PR DESCRIPTION
Fixes #940.

Confirmed and fixed #940: GenerateModeInput and PdfUploadZone each created their own useExtractPdf instance, so the parent's isExtracting (which drove the spinner and disabled prop) never flipped true while the child's instance did the actual extraction. Fix lifts extraction to the parent's single useExtractPdf instance and passes extractPdf down to PdfUploadZone, so isExtracting now reflects the extraction that actually runs — the "Extracting text..." spinner shows and the upload zone is disabled during extraction. Added a focused jsdom/RTL test (GenerateMode.pdf-extracting.test.tsx) using a per-instance mock of useExtractPdf that faithfully reproduces the two-separate-instances behavior (the existing GenerateMode.test.tsx mocked the hook as a shared singleton, which masked this exact bug). The test failed on the original code and passes after the fix.

**Test:** `frontend/src/features/ai/modes/GenerateMode.pdf-extracting.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)