### PR TITLE
fix(banner): attach auth token to license fetch so TrialBanner renders (#956)

### DIFF
--- a/frontend/src/shared/components/banners/TrialBanner.test.tsx
+++ b/frontend/src/shared/components/banners/TrialBanner.test.tsx
@@ -154,6 +154,28 @@ describe('TrialBanner', () => {
     expect(banner).not.toHaveTextContent('days');
   });
 
+  it('attaches the Authorization Bearer token to the license request (#956)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          tier: 'business',
+          type: 'trial',
+          expiresAt: '2026-06-04T23:59:59Z',
+          daysRemaining: 28,
+          isValid: true,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    render(<TrialBanner />);
+    // The banner only renders once the auth-protected endpoint answers, which
+    // requires the Bearer token to be attached to the request.
+    await screen.findByTestId('trial-banner');
+    const [, init] = fetchSpy.mock.calls[0];
+    const headers = new Headers(init?.headers);
+    expect(headers.get('Authorization')).toBe('Bearer test-token');
+  });
+
   it('renders nothing when fetch rejects (network error)', async () => {
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'));
     render(<TrialBanner />);

--- a/frontend/src/shared/components/banners/TrialBanner.test.tsx
+++ b/frontend/src/shared/components/banners/TrialBanner.test.tsx
@@ -171,7 +171,9 @@ describe('TrialBanner', () => {
     // The banner only renders once the auth-protected endpoint answers, which
     // requires the Bearer token to be attached to the request.
     await screen.findByTestId('trial-banner');
-    const [, init] = fetchSpy.mock.calls[0];
+    const licenseCall = fetchSpy.mock.calls.find(([url]) => url === '/api/license/info');
+    expect(licenseCall).toBeDefined();
+    const [, init] = licenseCall!;
     const headers = new Headers(init?.headers);
     expect(headers.get('Authorization')).toBe('Bearer test-token');
   });

--- a/frontend/src/shared/components/banners/TrialBanner.tsx
+++ b/frontend/src/shared/components/banners/TrialBanner.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Clock, AlertTriangle } from 'lucide-react';
 import { cn } from '../../lib/cn';
+import { apiFetch } from '../../lib/api';
 import { useAuthStore } from '../../../stores/auth-store';
 
 /**
@@ -40,13 +41,15 @@ export function TrialBanner() {
   useEffect(() => {
     if (!isAdmin) return;
     let cancelled = false;
-    fetch('/api/license/info')
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data: LicenseInfoResponse | null) => {
+    // apiFetch attaches the in-memory Bearer token; the /license/info route is
+    // auth-protected, so a raw fetch would 401 and the banner never renders.
+    apiFetch<LicenseInfoResponse>('/license/info')
+      .then((data) => {
         if (!cancelled) setInfo(data);
       })
       .catch(() => {
-        // Network error or CE deployment without EE — banner stays hidden.
+        // ApiError (e.g. 404 in a CE deployment without EE) or network error —
+        // banner stays hidden.
       });
     return () => {
       cancelled = true;


### PR DESCRIPTION
Fixes #956.

Confirmed the diagnosis and fixed it: TrialBanner.tsx used a raw fetch('/api/license/info') with no Authorization header, so the auth-protected route always 401'd and the banner never rendered. Replaced it with the shared apiFetch<LicenseInfoResponse>('/license/info'), which attaches the in-memory Bearer token (plus 401->refresh retry); ApiError (e.g. 404 in CE-without-EE) and network errors are still caught silently so the banner stays hidden. Added a TDD test 'attaches the Authorization Bearer token to the license request (#956)' that asserts the outbound request carries 'Bearer test-token'; it failed on the old code (got null) and passes after the fix. Full file suite: 13/13 pass. tsc --noEmit and eslint on the changed files are clean. Committed with the #956 subject and Co-Authored-By trailer, node_modules symlinks stripped from the commit, and pushed to origin. No PR opened, per instructions.

**Test:** `frontend/src/shared/components/banners/TrialBanner.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)