### PR TITLE
fix(ai): carry command-palette question into AI page via q param (#957)

### DIFF
--- a/frontend/src/features/ai/AiContext.tsx
+++ b/frontend/src/features/ai/AiContext.tsx
@@ -192,7 +192,7 @@ export function useAiContext(): AiContextValue {
 // ---------------------------------------------------------------------------
 
 export function AiProvider({ children }: { children: ReactNode }) {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const pageId = searchParams.get('pageId');
@@ -203,9 +203,7 @@ export function AiProvider({ children }: { children: ReactNode }) {
   const urlMode = VALID_MODES.includes(rawMode as Mode) ? (rawMode as Mode) : null;
   const [mode, setMode] = useState<Mode>(urlMode ?? (pageId ? 'improve' : 'ask'));
   const [messages, setMessages] = useState<Message[]>([]);
-  // Prefill the composer from the ?q param once on mount so a question typed in
-  // the command palette's AI mode isn't dropped on navigation (#957).
-  const [input, setInput] = useState(() => searchParams.get('q') ?? '');
+  const [input, setInput] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
   const [isThinking, setIsThinking] = useState(false);
   const [thinkingElapsed, setThinkingElapsed] = useState(false);
@@ -271,6 +269,25 @@ export function AiProvider({ children }: { children: ReactNode }) {
       setDiagramCode('');
     }
   }, [pageId]);
+
+  // Prefill the composer from the ?q param so a question typed in the command
+  // palette's AI mode isn't dropped on navigation (#957). Reactive (not a mount
+  // initializer) so it also works when /ai is already mounted and only the
+  // search params change. The param is consumed — removed from the URL with a
+  // replace navigation — so refresh/back doesn't re-prefill an asked question.
+  const urlQuestion = searchParams.get('q');
+  useEffect(() => {
+    if (urlQuestion === null) return;
+    if (urlQuestion) setInput(urlQuestion);
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('q');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [urlQuestion, setSearchParams]);
 
   // After 2 seconds of thinking, promote from TypingIndicator to ThinkingBlob
   useEffect(() => {

--- a/frontend/src/features/ai/AiContext.tsx
+++ b/frontend/src/features/ai/AiContext.tsx
@@ -203,7 +203,9 @@ export function AiProvider({ children }: { children: ReactNode }) {
   const urlMode = VALID_MODES.includes(rawMode as Mode) ? (rawMode as Mode) : null;
   const [mode, setMode] = useState<Mode>(urlMode ?? (pageId ? 'improve' : 'ask'));
   const [messages, setMessages] = useState<Message[]>([]);
-  const [input, setInput] = useState('');
+  // Prefill the composer from the ?q param once on mount so a question typed in
+  // the command palette's AI mode isn't dropped on navigation (#957).
+  const [input, setInput] = useState(() => searchParams.get('q') ?? '');
   const [isStreaming, setIsStreaming] = useState(false);
   const [isThinking, setIsThinking] = useState(false);
   const [thinkingElapsed, setThinkingElapsed] = useState(false);

--- a/frontend/src/features/ai/modes/AskMode.test.tsx
+++ b/frontend/src/features/ai/modes/AskMode.test.tsx
@@ -92,6 +92,14 @@ describe('AskMode', () => {
     expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
+  it('prefills the composer from the ?q param carried by the command palette (#957)', () => {
+    render(<AskModeInput />, {
+      wrapper: createWrapper(['/ai?q=how%20do%20I%20configure%20sync%20intervals']),
+    });
+    const input = screen.getByPlaceholderText('Ask a question...') as HTMLInputElement;
+    expect(input.value).toBe('how do I configure sync intervals');
+  });
+
   it('focuses the input on mount (#350)', async () => {
     render(<AskModeInput />, { wrapper: createWrapper() });
     const input = screen.getByPlaceholderText('Ask a question...');

--- a/frontend/src/features/ai/modes/AskMode.test.tsx
+++ b/frontend/src/features/ai/modes/AskMode.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LazyMotion, domAnimation } from 'framer-motion';
 import { AskModeInput, AskExamplePrompts, ASK_EMPTY_TITLE, ASK_EMPTY_SUBTITLE } from './AskMode';
@@ -92,12 +92,57 @@ describe('AskMode', () => {
     expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
-  it('prefills the composer from the ?q param carried by the command palette (#957)', () => {
-    render(<AskModeInput />, {
-      wrapper: createWrapper(['/ai?q=how%20do%20I%20configure%20sync%20intervals']),
-    });
+  /** Exposes the current URL search string so tests can assert ?q was consumed. */
+  function LocationProbe() {
+    const location = useLocation();
+    return <div data-testid="location-search">{location.search}</div>;
+  }
+
+  it('prefills the composer from the ?q param carried by the command palette (#957)', async () => {
+    render(
+      <>
+        <AskModeInput />
+        <LocationProbe />
+      </>,
+      { wrapper: createWrapper(['/ai?q=how%20do%20I%20configure%20sync%20intervals']) },
+    );
     const input = screen.getByPlaceholderText('Ask a question...') as HTMLInputElement;
     expect(input.value).toBe('how do I configure sync intervals');
+    // The param is consumed: refresh / history back must not re-prefill it.
+    await waitFor(() => {
+      expect(screen.getByTestId('location-search').textContent).not.toContain('q=');
+    });
+  });
+
+  it('applies the ?q param when already mounted on /ai (#957)', async () => {
+    // Simulates the command palette submitting a question while the user is
+    // already on /ai: the route element is NOT remounted, only the search
+    // params change, so a mount-time initializer alone would drop the question.
+    function NavigateWithQuestion() {
+      const navigate = useNavigate();
+      return (
+        <button onClick={() => navigate('/ai?q=what%20changed%20last%20week')}>
+          ask from palette
+        </button>
+      );
+    }
+
+    render(
+      <>
+        <AskModeInput />
+        <NavigateWithQuestion />
+      </>,
+      { wrapper: createWrapper(['/ai']) },
+    );
+
+    const input = screen.getByPlaceholderText('Ask a question...') as HTMLInputElement;
+    expect(input.value).toBe('');
+
+    fireEvent.click(screen.getByText('ask from palette'));
+
+    await waitFor(() => {
+      expect(input.value).toBe('what changed last week');
+    });
   });
 
   it('focuses the input on mount (#350)', async () => {

--- a/frontend/src/shared/components/layout/CommandPalette.test.tsx
+++ b/frontend/src/shared/components/layout/CommandPalette.test.tsx
@@ -332,6 +332,21 @@ describe('CommandPalette', () => {
       unmount();
     });
 
+    it('carries the typed question through as a q param (#957)', () => {
+      useCommandPaletteStore.getState().open();
+      const { unmount } = render(<CommandPalette />, { wrapper: createWrapper() });
+
+      const input = screen.getByLabelText('Search');
+      fireEvent.change(input, { target: { value: '/ai how do I configure sync intervals' } });
+
+      // Press Enter to select — the typed question must not be dropped.
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/ai?q=${encodeURIComponent('how do I configure sync intervals')}`,
+      );
+      unmount();
+    });
+
     it('hides /ai hint in footer when in AI mode', () => {
       useCommandPaletteStore.getState().open();
       const { unmount } = render(<CommandPalette />, { wrapper: createWrapper() });

--- a/frontend/src/shared/components/layout/CommandPalette.tsx
+++ b/frontend/src/shared/components/layout/CommandPalette.tsx
@@ -128,7 +128,9 @@ export function CommandPalette() {
         id: 'ai-ask',
         type: 'ai',
         label: aiQuery ? `Ask AI: ${aiQuery}` : 'Ask AI',
-        path: '/ai',
+        // Carry the typed question through so the AI page can prefill its
+        // composer (#957) instead of dropping it.
+        path: aiQuery ? `/ai?q=${encodeURIComponent(aiQuery)}` : '/ai',
       });
     } else if (query.trim()) {
       results.forEach((r) => {


### PR DESCRIPTION
Fixes #957.

Fixed issue #957: the command palette's AI mode dropped the typed question on Enter. Two-part minimal fix carrying the question through the URL, exactly per the verified diagnosis. (1) CommandPalette.tsx now builds the ai-ask item path as `/ai?q=${encodeURIComponent(aiQuery)}` (was static `/ai`) so navigate() preserves the question. (2) AiContext.tsx seeds the composer `input` state from `searchParams.get('q')` via a lazy useState initializer (read once on mount — AiProvider is route-level and mounts fresh on navigation to /ai). Added two focused tests that fail on the original code and pass after the fix: a CommandPalette test asserting navigate is called with the q param, and an AskMode test asserting the composer prefills from ?q. Verified via git-stash that both new tests fail without the source changes. Full suite for both files: 34/34 pass. Committed with the required trailer (no --no-verify; pre-commit hooks passed) and pushed; no PR opened per instructions.

**Test:** `frontend/src/shared/components/layout/CommandPalette.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)