### PR TITLE
fix(pages): correct Markdown import endpoint and result handling (#883)

### DIFF
--- a/frontend/src/features/pages/NewPagePage.test.tsx
+++ b/frontend/src/features/pages/NewPagePage.test.tsx
@@ -40,12 +40,13 @@ vi.mock('../../shared/hooks/use-spaces', () => ({
   }),
 }));
 
-const { mockSetContent, mockEditorInstance, mockUseTemplateMutateAsync, templatesState } = vi.hoisted(() => {
+const { mockSetContent, mockEditorInstance, mockUseTemplateMutateAsync, mockImportMutateAsync, templatesState } = vi.hoisted(() => {
   const setContent = vi.fn();
   return {
     mockSetContent: setContent,
     mockEditorInstance: { commands: { setContent } },
     mockUseTemplateMutateAsync: vi.fn(),
+    mockImportMutateAsync: vi.fn(),
     templatesState: { items: [] as { id: number; title: string; category: string | null }[] },
   };
 });
@@ -54,7 +55,7 @@ vi.mock('../../shared/hooks/use-standalone', () => ({
   // GET /api/templates returns a bare array — mirror the real wire shape.
   useTemplates: () => ({ data: templatesState.items, isLoading: false }),
   useUseTemplate: () => ({ mutateAsync: mockUseTemplateMutateAsync, isPending: false }),
-  useImportMarkdown: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useImportMarkdown: () => ({ mutateAsync: mockImportMutateAsync, isPending: false }),
   useLocalSpaces: () => ({
     data: [
       { key: '__local__', name: 'Default Local Space', source: 'local', description: null, icon: null, pageCount: 0, createdBy: null, createdAt: '2026-01-01T00:00:00Z' },
@@ -114,7 +115,22 @@ describe('NewPagePage', () => {
     mockCreateMutateAsync.mockClear();
     mockSetContent.mockClear();
     mockUseTemplateMutateAsync.mockReset();
+    mockImportMutateAsync.mockReset();
     templatesState.items.length = 0;
+  });
+
+  it('navigates to the imported page using articles[0].id from the import envelope', async () => {
+    mockImportMutateAsync.mockResolvedValue({
+      imported: 1,
+      total: 1,
+      articles: [{ id: 'standalone-xyz', title: 'note', success: true }],
+    });
+    render(<NewPagePage />, { wrapper: createWrapper() });
+    const input = screen.getByTestId('import-markdown-input');
+    const file = new File(['# hi'], 'note.md', { type: 'text/markdown' });
+    fireEvent.change(input, { target: { files: [file] } });
+    // Real bug: the old code read result.id (undefined) → navigated to /pages/undefined.
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/pages/standalone-xyz'));
   });
 
   it('renders the New Page title and form fields', () => {

--- a/frontend/src/features/pages/NewPagePage.tsx
+++ b/frontend/src/features/pages/NewPagePage.tsx
@@ -101,16 +101,22 @@ export function NewPagePage() {
       const result = await importMarkdownMutation.mutateAsync({
         markdown,
         title: fileTitle,
-        spaceKey: spaceKey || undefined,
       });
-      navigate(`/pages/${result.id}`);
-      toast.success('Markdown imported successfully');
+      // The backend returns a batch envelope; the created page's id is the
+      // synthetic standalone-<uuid> confluence id in articles[0].
+      const newId = result.articles[0]?.id;
+      if (newId) {
+        navigate(`/pages/${newId}`);
+        toast.success('Markdown imported successfully');
+      } else {
+        toast.error('Import did not return a page');
+      }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to import markdown');
     }
     // Reset file input so the same file can be re-selected
     if (fileInputRef.current) fileInputRef.current.value = '';
-  }, [spaceKey, importMarkdownMutation, navigate]);
+  }, [importMarkdownMutation, navigate]);
 
   const isCreateDisabled = createMutation.isPending
     || !title.trim()

--- a/frontend/src/shared/hooks/use-standalone.test.ts
+++ b/frontend/src/shared/hooks/use-standalone.test.ts
@@ -234,13 +234,26 @@ describe('use-standalone hooks', () => {
   // ---- Import/Export ----
 
   describe('useImportMarkdown', () => {
-    it('sends import request', async () => {
-      const mock = mockFetch({ id: 99, title: 'Imported' });
+    it('posts to /pages/import and returns the batch envelope (id from articles[0])', async () => {
+      // The backend registers POST /api/pages/import (not /pages/import/markdown)
+      // and returns { imported, total, articles:[{ id: 'standalone-<uuid>', ... }] }.
+      const mock = mockFetch({
+        imported: 1,
+        total: 1,
+        articles: [{ id: 'standalone-abc', title: 'Hello', success: true }],
+      });
       const { result } = renderHook(() => useImportMarkdown(), { wrapper: createWrapper() });
-      await result.current.mutateAsync({ markdown: '# Hello', title: 'Hello' });
+      const data = await result.current.mutateAsync({ markdown: '# Hello', title: 'Hello' });
       const [url, opts] = mock.mock.calls[0] as [string, RequestInit];
-      expect(url).toContain('/pages/import/markdown');
+      expect(url).toContain('/pages/import');
+      expect(url).not.toContain('/pages/import/markdown');
       expect(opts.method).toBe('POST');
+      // spaceKey is ignored by the backend (standalone always lands in _standalone),
+      // so it must not be sent.
+      const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+      expect(body.spaceKey).toBeUndefined();
+      // The created page id is the synthetic confluence id from articles[0].
+      expect(data.articles[0]!.id).toBe('standalone-abc');
     });
   });
 

--- a/frontend/src/shared/hooks/use-standalone.ts
+++ b/frontend/src/shared/hooks/use-standalone.ts
@@ -203,9 +203,16 @@ export function useExportPdf() {
 
 export function useImportMarkdown() {
   const queryClient = useQueryClient();
+  // Backend route is POST /api/pages/import (see backend pages-import.ts); it
+  // returns a batch envelope and always files standalone imports under the
+  // '_standalone' space, so spaceKey is not accepted.
   return useMutation({
-    mutationFn: (data: { markdown: string; title: string; spaceKey?: string }) =>
-      apiFetch<{ id: number; title: string }>('/pages/import/markdown', {
+    mutationFn: (data: { markdown: string; title: string }) =>
+      apiFetch<{
+        imported: number;
+        total: number;
+        articles: { id: string; title: string; success: boolean }[];
+      }>('/pages/import', {
         method: 'POST',
         body: JSON.stringify(data),
       }),


### PR DESCRIPTION
## Summary

Fixes #883. The **Import Markdown** feature 404'd on every use.

- `useImportMarkdown` POSTed to `/pages/import/markdown`, but the backend only registers `POST /pages/import` (`backend/src/routes/knowledge/pages-import.ts`). Repointed the hook at the real route.
- The hook typed the response as `{ id, title }`, but the route returns a batch envelope `{ imported, total, articles: [{ id, title, success }] }`. Retyped it accordingly.
- `NewPagePage` navigated to `/pages/${result.id}` — `undefined` on the real contract, so `/pages/undefined`. Now reads `result.articles[0]?.id` (the synthetic `standalone-<uuid>` confluence id) with a guard.
- Dropped `spaceKey` from the request: the backend ignores it and always files standalone imports under `_standalone`.

No backend/contract/DB change — the client is brought in line with the existing, working route.

## Tests

Both suites previously **encoded the buggy contract** (mocked the wrong URL / a fake `{ id }` shape). Updated them to assert the real route and envelope:

- `use-standalone.test.ts` — asserts the POST hits `/pages/import` (not `/pages/import/markdown`), sends no `spaceKey`, and surfaces `articles[0].id`.
- `NewPagePage.test.tsx` — imports a file and asserts navigation to `/pages/standalone-xyz` from `articles[0].id`.

Both fail before the fix, pass after. Full `use-standalone` + `NewPagePage` suites green (43/43); frontend `typecheck` and `eslint` clean.

## Docs / ADR impact

None — client-only UX plumbing; no auth/sync/RAG/license/content-pipeline flow touched (CLAUDE.md rule 6 not triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)