### PR TITLE
fix(llm): cancel upstream body when streamChat terminates early (#868)

### DIFF
--- a/backend/src/domains/llm/services/openai-compatible-client.test.ts
+++ b/backend/src/domains/llm/services/openai-compatible-client.test.ts
@@ -89,6 +89,70 @@ describe('openai-compatible-client — chat', () => {
   });
 });
 
+// ─── #868: early termination must cancel the upstream body ──────────────────
+// When a consumer stops iterating streamChat() early (e.g. streamSSE breaks its
+// loop on client disconnect), the JS runtime calls generator.return(). Without
+// a try/finally around the read loop, reader.cancel() is never called, so the
+// undici response body / TCP socket stays open and the OpenAI-compatible /
+// Ollama backend keeps generating the full response — holding a GPU slot and
+// billing output tokens. This fake server writes ONE frame and then holds the
+// connection open forever (never [DONE], never res.end()), so the only way it
+// can observe a 'close' event is the client tearing down the socket.
+describe('openai-compatible-client — streamChat cancels upstream on early termination (#868)', () => {
+  let leakSrv: Server;
+  let leakBase: string;
+  let serverSawClose = false;
+  let resolveClose!: () => void;
+
+  beforeAll(async () => {
+    leakSrv = createServer((req, res) => {
+      if (req.url === '/v1/chat/completions') {
+        let body = '';
+        req.on('data', (c) => (body += c));
+        req.on('end', () => {
+          res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+          // One frame, then hold the connection open forever: no [DONE], no end().
+          res.write('data: ' + JSON.stringify({ choices: [{ delta: { content: 'hi' } }] }) + '\n\n');
+          // Never completes on its own, so 'close' can only mean the client aborted.
+          res.on('close', () => { serverSawClose = true; resolveClose(); });
+        });
+        return;
+      }
+      res.writeHead(404); res.end();
+    });
+    await new Promise<void>((r) => leakSrv.listen(0, r));
+    const { port } = leakSrv.address() as AddressInfo;
+    leakBase = `http://127.0.0.1:${port}/v1`;
+  });
+  afterAll(() => new Promise<void>((r) => leakSrv.close(() => r())));
+
+  it('breaking out of the for-await loop tears down the upstream connection', async () => {
+    serverSawClose = false;
+    const closePromise = new Promise<void>((r) => { resolveClose = r; });
+
+    let received = '';
+    for await (const c of streamChat(
+      { ...cfg, baseUrl: leakBase, providerId: 'leak-test' },
+      'm',
+      [{ role: 'user', content: 'hi' }],
+    )) {
+      received += c.content;
+      break; // early termination → generator.return() → finally → reader.cancel()
+    }
+    // Confirm we actually consumed a chunk before bailing (the leak scenario).
+    expect(received).toBe('hi');
+
+    // Give the socket teardown up to 1s to reach the server. Pre-fix the reader
+    // is never cancelled, the connection stays open, and this race times out
+    // (serverSawClose stays false). Post-fix reader.cancel() closes the socket.
+    await Promise.race([
+      closePromise,
+      new Promise<void>((r) => setTimeout(r, 1000)),
+    ]);
+    expect(serverSawClose).toBe(true);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Thinking-mode pure function — branches on (provider strictness, model)
 //

--- a/backend/src/domains/llm/services/openai-compatible-client.ts
+++ b/backend/src/domains/llm/services/openai-compatible-client.ts
@@ -236,23 +236,33 @@ export async function* streamChat(
   const reader = res.body!.getReader();
   const dec = new TextDecoder();
   let buf = '';
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buf += dec.decode(value, { stream: true });
-    let idx;
-    while ((idx = buf.indexOf('\n\n')) !== -1) {
-      const frame = buf.slice(0, idx).trim();
-      buf = buf.slice(idx + 2);
-      if (!frame.startsWith('data:')) continue;
-      const data = frame.slice(5).trim();
-      if (data === '[DONE]') { yield { content: '', done: true }; return; }
-      try {
-        const parsed = JSON.parse(data) as { choices?: Array<{ delta?: { content?: string } }> };
-        const content = parsed.choices?.[0]?.delta?.content ?? '';
-        if (content) yield { content, done: false };
-      } catch { /* ignore parse errors on malformed frames */ }
+  // The try/finally guarantees teardown on ANY exit — including the early
+  // generator.return() the runtime triggers when a consumer stops iterating
+  // (e.g. streamSSE breaks its loop on client disconnect). reader.cancel()
+  // aborts the undici body and destroys the socket, so an abandoned stream no
+  // longer leaves the upstream backend generating (GPU slot / billed tokens).
+  // On normal completion the stream is already drained, so cancel() is a no-op.
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+      let idx;
+      while ((idx = buf.indexOf('\n\n')) !== -1) {
+        const frame = buf.slice(0, idx).trim();
+        buf = buf.slice(idx + 2);
+        if (!frame.startsWith('data:')) continue;
+        const data = frame.slice(5).trim();
+        if (data === '[DONE]') { yield { content: '', done: true }; return; }
+        try {
+          const parsed = JSON.parse(data) as { choices?: Array<{ delta?: { content?: string } }> };
+          const content = parsed.choices?.[0]?.delta?.content ?? '';
+          if (content) yield { content, done: false };
+        } catch { /* ignore parse errors on malformed frames */ }
+      }
     }
+  } finally {
+    await reader.cancel().catch(() => { /* already closed / benign cancel race */ });
   }
   yield { content: '', done: true };
 }


### PR DESCRIPTION
Fixes #868

## Summary
`streamChat()` in `openai-compatible-client.ts` now tears down the upstream response body when a consumer stops iterating early. The read loop is wrapped in `try/finally` with `await reader.cancel().catch(() => {})`, so any early `generator.return()`/`throw()` cancels the WHATWG reader, which propagates to undici's body and destroys the socket.

## Root cause
The generator obtained the reader and drove a bare `for(;;)` read loop with **no** `try/finally`. When a consumer stops iterating early, the runtime calls `generator.return()`, which resumes at the suspended `yield` and returns without reaching any teardown, so `reader.cancel()` was never called and the undici body / TCP connection stayed open. The shared SSE consumer `streamSSE` breaks its `for-await` loop on client disconnect, and five routes (`llm-improve`, `llm-generate`, `llm-summarize`, `llm-quality`, `llm-diagram`) call `streamChat(..., undefined, ...)` with no abort signal — only `llm-ask` wired a real signal. As a result, on every client disconnect the OpenAI-compatible / Ollama backend kept generating the full response, holding a GPU slot and billing output tokens. Because streaming intentionally bypasses the `enqueue()` concurrency queue, these orphaned generations were unbounded and stacked on page reloads/impatient retries.

The single `finally` fix covers all five undefined-signal routes at once because they all funnel through `streamSSE`, whose `break` triggers `generator.return()`. `cancel()` on an already-drained stream (normal `[DONE]`/`done` completion) is a harmless no-op, so the happy path and the summary/quality workers are unaffected.

## Tests
Added a backend-unit test in `openai-compatible-client.test.ts`: an http server writes one SSE frame then holds the connection open forever (never `[DONE]`, never `res.end()`) and records `res.on('close')`. The consumer breaks after the first chunk to trigger `generator.return()`.
- **Before the fix:** the reader is never cancelled, the socket stays open, `serverSawClose` stays `false` (the assertion fails, and the `afterAll` server-close also hangs) — confirmed RED.
- **After the fix:** `reader.cancel()` closes the socket, the server observes `close`, and the assertion passes — confirmed GREEN (65/65 in the file).
- The existing `streamChat yields chunks then done` happy-path test still passes, proving the `finally` cancel does not break normal completion.

Gates: `npm run typecheck` clean, `eslint` on both changed files clean.

## Docs/ADR impact
None. Purely a read-side resource-leak fix in the LLM streaming client — no DB/schema/API-contract changes and no change to system structure (compose/domains/ESLint boundaries/migrations/auth/sync/RAG/license/content-pipeline). ADR-021 invariants are preserved: the per-provider circuit breaker still wraps only the initial dispatch, and streaming still bypasses `enqueue()`. CLAUDE.md rule 6 does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)