### PR TITLE
fix(pages): reset edit state when :id route param changes (#872)

### DIFF
--- a/frontend/src/features/pages/PageViewPage.test.tsx
+++ b/frontend/src/features/pages/PageViewPage.test.tsx
@@ -968,6 +968,101 @@ describe('PageViewPage', () => {
         expect.objectContaining({ title: 'Engineering Handbook' }),
       );
     });
+
+    // #872 follow-up — the confirmation dialogs (Discard changes? / Move to
+    // trash?) are rendered outside the `editing` branch, so the edit-state
+    // reset alone left them open across a route change. A dialog left open
+    // then acted against page B's draftKey/id (deleting page B's draft or
+    // trashing page B), e.g. after the user hit Cancel then browser-Back.
+    it('dismisses an open discard-confirmation dialog when the :id param changes', async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const router = createMemoryRouter(
+        [{ path: '/pages/:id', element: <PageViewPage /> }],
+        { initialEntries: ['/pages/page-1'] },
+      );
+
+      currentMockPage = mockPage; // page A
+      render(
+        <QueryClientProvider client={queryClient}>
+          <LazyMotion features={domAnimation}>
+            <RouterProvider router={router} />
+          </LazyMotion>
+        </QueryClientProvider>,
+      );
+
+      // Enter edit mode on page A and dirty it so Cancel opens the discard
+      // confirmation (instead of exiting straight to view mode).
+      fireEvent.click(screen.getByText('Edit'));
+      fireEvent.change(screen.getByLabelText('Article editor'), {
+        target: { value: '<p>rewritten page A</p>' },
+      });
+      fireEvent.click(screen.getByText('Cancel'));
+      expect(await screen.findByText('Discard changes?')).toBeInTheDocument();
+
+      // Navigate to page B while the discard dialog is still open.
+      currentMockPage = {
+        ...mockPage,
+        id: 'page-2',
+        title: 'Runbook',
+        bodyHtml: '<p>B</p>',
+        version: 3,
+      };
+      await act(async () => {
+        await router.navigate('/pages/page-2');
+      });
+
+      // The dialog must be dismissed on navigation — otherwise its Discard
+      // action would run against page B's draftKey (clearing page B's draft).
+      // No dialog means the confirm control is gone, so it cannot act on B.
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      expect(screen.queryByText('Discard changes?')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('confirm-dialog-confirm')).not.toBeInTheDocument();
+    });
+
+    it('dismisses an open move-to-trash dialog when the :id param changes', async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const router = createMemoryRouter(
+        [{ path: '/pages/:id', element: <PageViewPage /> }],
+        { initialEntries: ['/pages/page-1'] },
+      );
+
+      currentMockPage = mockPage; // page A
+      render(
+        <QueryClientProvider client={queryClient}>
+          <LazyMotion features={domAnimation}>
+            <RouterProvider router={router} />
+          </LazyMotion>
+        </QueryClientProvider>,
+      );
+
+      const deleteShortcut = capturedShortcuts.find((s) => s.key === 'Alt+Shift+D');
+      expect(deleteShortcut).toBeDefined();
+      act(() => {
+        deleteShortcut!.action();
+      });
+      expect(await screen.findByText('Move page to trash?')).toBeInTheDocument();
+
+      currentMockPage = {
+        ...mockPage,
+        id: 'page-2',
+        title: 'Runbook',
+        bodyHtml: '<p>B</p>',
+        version: 3,
+      };
+      await act(async () => {
+        await router.navigate('/pages/page-2');
+      });
+
+      // Left open, confirming would trash page B (mutateAsync(id) with the
+      // new id). It must be dismissed on navigation instead.
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      expect(screen.queryByText('Move page to trash?')).not.toBeInTheDocument();
+      expect(mockDeleteMutateAsync).not.toHaveBeenCalled();
+    });
   });
 
 });

--- a/frontend/src/features/pages/PageViewPage.test.tsx
+++ b/frontend/src/features/pages/PageViewPage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { PageViewPage } from './PageViewPage';
@@ -903,6 +903,70 @@ describe('PageViewPage', () => {
       });
       expect(screen.queryByText('Discard changes?')).not.toBeInTheDocument();
       expect(screen.getByText('Edit')).toBeInTheDocument();
+    });
+  });
+
+  // #872 — The /pages/:id route is not keyed, so React Router keeps a single
+  // PageViewPage instance mounted across :id changes. Edit-mode state
+  // (editing/editTitle/editHtml) is component-local and was never reset on
+  // id change, so navigating mid-edit left page A's title+body loaded while
+  // viewing page B — and saving then overwrote page B with page A's content.
+  describe('edit-mode reset on route param change (#872)', () => {
+    it('resets edit state when the :id param changes mid-edit', async () => {
+      // A data router keeps the same PageViewPage instance mounted across
+      // param changes (matching production where App.tsx renders one
+      // un-keyed <Route path="/pages/:id">). router.navigate() drives the
+      // real useParams(), bypassing this file's mocked useNavigate.
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const router = createMemoryRouter(
+        [{ path: '/pages/:id', element: <PageViewPage /> }],
+        { initialEntries: ['/pages/page-1'] },
+      );
+
+      currentMockPage = mockPage; // page A: "Engineering Handbook", version 7
+      render(
+        <QueryClientProvider client={queryClient}>
+          <LazyMotion features={domAnimation}>
+            <RouterProvider router={router} />
+          </LazyMotion>
+        </QueryClientProvider>,
+      );
+
+      // Enter edit mode on page A — editor mounts with A's title/body.
+      fireEvent.click(screen.getByText('Edit'));
+      expect(screen.getByLabelText('Article editor')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Engineering Handbook')).toBeInTheDocument();
+
+      // Navigate to page B while still in edit mode. The instance stays
+      // mounted; only the :id param + page data change.
+      currentMockPage = {
+        ...mockPage,
+        id: 'page-2',
+        title: 'Runbook',
+        bodyHtml: '<p>B</p>',
+        version: 3,
+      };
+      await act(async () => {
+        await router.navigate('/pages/page-2');
+      });
+
+      // Edit mode must have exited — no stale editor holding page A's body.
+      expect(screen.queryByLabelText('Article editor')).not.toBeInTheDocument();
+      expect(screen.getByText('Edit')).toBeInTheDocument();
+
+      // Corruption guard: a Ctrl+S after navigation must not push page A's
+      // title onto page B. Pre-fix, editing stayed true and Save fired
+      // { id: 'page-2', title: 'Engineering Handbook', version: 3 }.
+      const saveShortcut = capturedShortcuts.find((s) => s.key === 'Ctrl+S');
+      expect(saveShortcut).toBeDefined();
+      await act(async () => {
+        saveShortcut!.action();
+      });
+      expect(mockUpdatePage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Engineering Handbook' }),
+      );
     });
   });
 

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -207,15 +207,21 @@ export function PageViewPage() {
   // and the react-query page object update. Without this reset, navigating
   // to page B mid-edit leaves page A's editing/editTitle/editHtml loaded,
   // so a subsequent Save (or Ctrl+S) would overwrite page B with page A's
-  // title + body. Draft state is intentionally NOT cleared here: the
-  // per-page localStorage draft is keyed by id and its restore-on-edit
-  // feature must survive navigation.
+  // title + body. Any open confirmation dialog is dismissed too: the
+  // Discard/Trash dialogs live outside the `editing` branch, and a dialog
+  // left open across navigation (e.g. Cancel then browser-Back) would run
+  // its confirm action against page B's draftKey/id — clearing page B's
+  // draft or trashing page B. Draft state is intentionally NOT cleared
+  // here: the per-page localStorage draft is keyed by id and its
+  // restore-on-edit feature must survive navigation.
   useEffect(() => {
     setEditing(false);
     setEditHtml('');
     setEditTitle('');
     setPendingDraft(null);
     setEditorInstance(null);
+    setConfirmDiscardOpen(false);
+    setConfirmTrashOpen(false);
   }, [id]);
 
   useLayoutEffect(() => {

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -201,6 +201,23 @@ export function PageViewPage() {
     };
   }, []);
 
+  // Reset edit-mode state whenever the :id route param changes (#872). The
+  // /pages/:id route is not keyed, so React Router keeps this single
+  // PageViewPage instance mounted across id changes — only useParams().id
+  // and the react-query page object update. Without this reset, navigating
+  // to page B mid-edit leaves page A's editing/editTitle/editHtml loaded,
+  // so a subsequent Save (or Ctrl+S) would overwrite page B with page A's
+  // title + body. Draft state is intentionally NOT cleared here: the
+  // per-page localStorage draft is keyed by id and its restore-on-edit
+  // feature must survive navigation.
+  useEffect(() => {
+    setEditing(false);
+    setEditHtml('');
+    setEditTitle('');
+    setPendingDraft(null);
+    setEditorInstance(null);
+  }, [id]);
+
   useLayoutEffect(() => {
     scrollArticleToTop();
   }, [id]);


### PR DESCRIPTION
Fixes #872

## Summary
Navigating between pages while in edit mode could silently overwrite one page with another page's title and body. This adds an `id`-driven reset of edit-mode state to `PageViewPage`.

## Root cause
The `/pages/:id` route in `App.tsx` is not keyed, and the intervening `PageTransition` is a pure pass-through, so React Router keeps a single `PageViewPage` instance mounted across `:id` changes — only `useParams().id` and the react-query `page` object update. Edit-mode state (`editing` / `editTitle` / `editHtml` / `pendingDraft` / `editorInstance`) is component-local and had no effect that reset it on `id` change.

Entering edit mode on page A and then clicking page B in the always-visible sidebar tree left A's title+body loaded while the breadcrumb showed B. A subsequent Save or Ctrl+S then called `updateMutation.mutateAsync({ id: B, title: A, bodyHtml: A, version: B })` — B's version means no 409 conflict — silently replacing page B's content with page A's (and pushing to Confluence for synced pages). Even without saving, the editor's autosave wrote A's content under B's `page-B` draft key.

## Fix
Added `useEffect(() => { setEditing(false); setEditHtml(''); setEditTitle(''); setPendingDraft(null); setEditorInstance(null); }, [id])` alongside the other `id`-driven effects. The per-page localStorage draft (keyed by `id`) is intentionally left untouched so the legitimate restore-on-edit feature keeps working per page. This is the minimal, convention-aligned fix (mirrors how `discardAndExit` and conflict handling already leave edit mode); keying the subtree by `id` was rejected as heavier (remounts the editor, disturbs scroll/presence effect ordering).

## Tests
`frontend/src/features/pages/PageViewPage.test.tsx` gains `edit-mode reset on route param change (#872)`. It renders via `createMemoryRouter` so the `PageViewPage` instance stays mounted across `router.navigate()` (matching production's un-keyed route), enters edit mode on page A, navigates to page B, then asserts the editor unmounts, the Edit button returns, and a post-navigation Ctrl+S never fires Save with page A's title.

- Fails before the fix (stale editor persists; Ctrl+S corrupts page B).
- Passes after. Full file: 44/44 tests pass. `npm run typecheck` clean; `eslint` on the changed files clean.

## Docs / ADR impact
None. This is a localized frontend edit-state fix; it does not touch compose, domains, ESLint boundaries, migrations, auth/sync/RAG/license, or the content pipeline, so no `docs/architecture/*.md` diagram applies (CLAUDE.md rule 6 does not trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)