### PR TITLE
fix(notifications): make notification panel keyboard-reachable (#879)

### DIFF
--- a/frontend/src/shared/components/layout/NotificationBell.test.tsx
+++ b/frontend/src/shared/components/layout/NotificationBell.test.tsx
@@ -63,6 +63,15 @@ function renderBell() {
   );
 }
 
+// Opens the notification panel. Fires both pointerDown and click so it works
+// regardless of the underlying Radix primitive (a menu opens on pointerDown, a
+// popover opens on click) — the switch from DropdownMenu to Popover is the fix.
+function openPanel() {
+  const trigger = screen.getByTestId('notification-bell');
+  fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' });
+  fireEvent.click(trigger);
+}
+
 describe('NotificationBell', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
@@ -94,8 +103,7 @@ describe('NotificationBell', () => {
 
   it('opens dropdown on pointer interaction', async () => {
     renderBell();
-    const trigger = screen.getByTestId('notification-bell');
-    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' });
+    openPanel();
     await vi.waitFor(() => {
       expect(screen.getByText('Notifications')).toBeInTheDocument();
     });
@@ -104,5 +112,50 @@ describe('NotificationBell', () => {
   it('has correct aria-label', () => {
     renderBell();
     expect(screen.getByTestId('notification-bell')).toHaveAttribute('aria-label', 'Notifications');
+  });
+
+  // Regression for #879: the panel must not be a WAI-ARIA menu. Radix
+  // DropdownMenu.Content (role="menu") restricts keyboard focus to registered
+  // DropdownMenu.Items via a roving-focus collection and preventDefaults Tab,
+  // so the plain-button notification items and "Mark all as read" control were
+  // unreachable by keyboard (WCAG 2.1.1 failure). A Popover imposes no such
+  // trap: every inner button is an ordinary, focusable control.
+  it('exposes notification actions as keyboard-reachable buttons, not a role="menu" trap', async () => {
+    renderBell();
+    openPanel();
+
+    // Panel content renders once the notifications query resolves.
+    const firstItem = await screen.findByTestId('notification-item-n-1');
+
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+    expect(document.querySelector('[role="menuitem"]')).toBeNull();
+
+    // Each action control is an ordinary focusable button.
+    firstItem.focus();
+    expect(document.activeElement).toBe(firstItem);
+
+    const markAll = screen.getByTestId('mark-all-read');
+    markAll.focus();
+    expect(document.activeElement).toBe(markAll);
+
+    const settings = screen.getByTestId('notification-settings');
+    settings.focus();
+    expect(document.activeElement).toBe(settings);
+  });
+
+  it('navigates and dismisses the panel when a notification is clicked', async () => {
+    renderBell();
+    openPanel();
+
+    const item = await screen.findByTestId('notification-item-n-1');
+    fireEvent.click(item);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/pages/p-1');
+
+    // Unlike DropdownMenu.Items, plain buttons inside a Popover do not
+    // auto-dismiss, so the component must close the panel explicitly.
+    await vi.waitFor(() => {
+      expect(screen.queryByText('Notifications')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/shared/components/layout/NotificationBell.tsx
+++ b/frontend/src/shared/components/layout/NotificationBell.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import * as Popover from '@radix-ui/react-popover';
 import { Bell, Settings } from 'lucide-react';
 import { apiFetch } from '../../lib/api';
 import { NotificationDropdown, type Notification } from './NotificationDropdown';
@@ -66,6 +66,14 @@ function useMarkAllRead() {
 
 export function NotificationBell() {
   const navigate = useNavigate();
+  // The panel is a Radix Popover (not a DropdownMenu): its rich, scrollable,
+  // multi-action content is a popover, not a WAI-ARIA command menu. A menu would
+  // trap keyboard focus to registered Items (roving focus + Tab preventDefault),
+  // leaving the plain-button notifications and "Mark all as read" unreachable by
+  // keyboard (#879, WCAG 2.1.1). A Popover keeps every inner button focusable,
+  // but plain buttons no longer auto-dismiss, so we control open state and close
+  // it explicitly on the actions that used to be menu Items.
+  const [open, setOpen] = useState(false);
   const { data: notifications } = useNotifications();
   const markRead = useMarkNotificationRead();
   const markAllRead = useMarkAllRead();
@@ -83,6 +91,7 @@ export function NotificationBell() {
       if (notification.link) {
         navigate(notification.link);
       }
+      setOpen(false);
     },
     [markRead, navigate],
   );
@@ -92,8 +101,8 @@ export function NotificationBell() {
   }, [markAllRead]);
 
   return (
-    <DropdownMenu.Root>
-      <DropdownMenu.Trigger asChild>
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
         <button
           className="relative flex items-center justify-center rounded-md p-1.5 text-muted-foreground hover:bg-foreground/5 hover:text-foreground transition-colors outline-none"
           aria-label="Notifications"
@@ -112,10 +121,10 @@ export function NotificationBell() {
             </span>
           )}
         </button>
-      </DropdownMenu.Trigger>
+      </Popover.Trigger>
 
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content
+      <Popover.Portal>
+        <Popover.Content
           align="end"
           sideOffset={8}
           className="z-50 w-[360px] rounded-xl border border-border/50 bg-card/90 shadow-2xl backdrop-blur-xl"
@@ -123,16 +132,17 @@ export function NotificationBell() {
           {/* Title bar */}
           <div className="flex items-center justify-between border-b border-border/30 px-3 py-2.5">
             <span className="text-sm font-semibold">Notifications</span>
-            <DropdownMenu.Item asChild>
-              <button
-                onClick={() => navigate('/settings')}
-                className="rounded-md p-1 text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground transition-colors"
-                aria-label="Notification settings"
-                data-testid="notification-settings"
-              >
-                <Settings size={14} />
-              </button>
-            </DropdownMenu.Item>
+            <button
+              onClick={() => {
+                navigate('/settings');
+                setOpen(false);
+              }}
+              className="rounded-md p-1 text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground transition-colors"
+              aria-label="Notification settings"
+              data-testid="notification-settings"
+            >
+              <Settings size={14} />
+            </button>
           </div>
 
           {/* Content */}
@@ -141,8 +151,8 @@ export function NotificationBell() {
             onClickNotification={handleClickNotification}
             onMarkAllRead={handleMarkAllRead}
           />
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
-    </DropdownMenu.Root>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }


### PR DESCRIPTION
Fixes #879

## Summary
The notification bell rendered its panel inside a Radix `DropdownMenu.Content` (WAI-ARIA `role="menu"`). This swaps that primitive for a Radix `Popover`, so every control inside the panel — each notification, "Mark all as read", and the settings gear — is an ordinary focusable, Tab-reachable button. Placement (`align="end"`, `sideOffset={8}`, existing `className`) is preserved, so there is no visual change. `NotificationDropdown` stays a Radix-agnostic presentational component and is untouched.

## Root cause
Radix menus expose keyboard focus only to registered `DropdownMenu.Item`s via a roving-focus collection, and preventDefault `Tab` inside the menu content. The only registered Item was the settings gear; the notification buttons and the "Mark all as read" button are plain buttons. A keyboard user who opened the bell could therefore reach only the settings gear and could neither open a notification nor mark all as read without a pointer — a WCAG 2.1.1 (Keyboard) failure.

Because plain buttons in a Popover do not auto-dismiss the way `DropdownMenu.Item`s do, the panel's open state is now controlled and closed explicitly on notification click and on the settings action, preserving prior dismissal behavior.

## Tests
`frontend/src/shared/components/layout/NotificationBell.test.tsx`:
- The opened panel is **not** a `role="menu"` / `role="menuitem"` trap, and the notification item, "Mark all as read", and settings controls are focusable buttons.
- Clicking a notification navigates to its link **and** dismisses the panel.

Both new tests **fail on the old DropdownMenu code** (`role="menu"` present; panel does not dismiss on a plain-button click) and **pass after** the Popover swap. The existing `NotificationDropdown` standalone tests (9) and the rest of the bell suite remain green. Typecheck and ESLint are clean on the changed files.

## Docs / ADR impact
None. Per CLAUDE.md rule 6 this is a self-contained frontend UX change to a single widget (no compose/domains/ESLint-boundary/migration/auth/sync/RAG/license/content-pipeline impact), so no `docs/architecture/*` update is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)