### PR TITLE
fix(auth): route useSessionInit refresh through single-flight helper (#884)

### DIFF
--- a/docs/architecture/07-flow-auth.md
+++ b/docs/architecture/07-flow-auth.md
@@ -48,7 +48,7 @@ sequenceDiagram
 ### Client-side token refresh
 
 The SPA keeps the access token in memory (rehydrated from `localStorage` on
-reload) and refreshes it three ways, all funneling through the single-flight
+reload) and refreshes it four ways, all funneling through the single-flight
 `refreshAccessTokenOnce()` so concurrent requests trigger exactly one
 `POST /api/auth/refresh`:
 
@@ -59,6 +59,13 @@ reload) and refreshes it three ways, all funneling through the single-flight
   to a guaranteed 401 (the "401 storm").
 - **Reactive** — a `401` response still triggers a refresh + retry as the
   fallback for server-side revocation / clock skew.
+- **Session init (#884)** — `useSessionInit` fires once on app load when the
+  user looks authenticated but has no in-memory token (e.g. `localStorage`
+  migrated from an older key). It must go through the single-flight helper too:
+  in that state every mounted query also 401s and refreshes, so an independent
+  refresh here would race the deduped path — the loser presents an
+  already-rotated (revoked) JTI, tripping token-family reuse detection and
+  logging the user out despite a valid session.
 
 ### Registration quirks
 

--- a/frontend/src/shared/hooks/useSessionInit.test.ts
+++ b/frontend/src/shared/hooks/useSessionInit.test.ts
@@ -6,10 +6,17 @@ const mockClearAuth = vi.fn();
 let storeState: Record<string, unknown> = {};
 
 vi.mock('../../stores/auth-store', () => ({
-  useAuthStore: (selector: (s: Record<string, unknown>) => unknown) => selector(storeState),
+  useAuthStore: Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) => selector(storeState),
+    {
+      // refreshAccessTokenOnce (via useSessionInit) reads the store imperatively.
+      getState: () => storeState,
+    },
+  ),
 }));
 
 const { useSessionInit } = await import('./useSessionInit');
+const { refreshAccessTokenOnce } = await import('../lib/api');
 
 describe('useSessionInit', () => {
   beforeEach(() => {
@@ -114,5 +121,59 @@ describe('useSessionInit', () => {
     renderHook(() => useSessionInit());
 
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  // Regression for #884: the hook must route its refresh through the shared
+  // refreshAccessTokenOnce() single-flight helper, so that a refresh already
+  // in flight (e.g. apiFetch's reactive 401 refresh for a mounted query) is
+  // reused rather than duplicated. A duplicate /auth/refresh presents an
+  // already-rotated (revoked) JTI, tripping the backend's token-family reuse
+  // detection and forcibly logging the user out.
+  it('joins the in-flight refresh instead of firing a duplicate /auth/refresh', async () => {
+    storeState = {
+      isAuthenticated: true,
+      accessToken: null,
+      setAuth: mockSetAuth,
+      clearAuth: mockClearAuth,
+    };
+
+    let refreshCallCount = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async (input: string | URL | Request) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url === '/api/auth/refresh') {
+          refreshCallCount++;
+          // Hold the refresh open so both callers overlap in flight.
+          await new Promise((r) => setTimeout(r, 10));
+          return new Response(
+            JSON.stringify({
+              accessToken: 'new-token',
+              user: { id: '1', username: 'test', role: 'user' },
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response(JSON.stringify({ ok: true }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    );
+
+    // A competing refresh (as apiFetch would kick off on a 401) is already in
+    // flight when the hook mounts.
+    void refreshAccessTokenOnce();
+    renderHook(() => useSessionInit());
+
+    await waitFor(() => {
+      expect(mockSetAuth).toHaveBeenCalledWith('new-token', {
+        id: '1',
+        username: 'test',
+        role: 'user',
+      });
+    });
+
+    // Both paths shared one refresh — not two racing rotations.
+    expect(refreshCallCount).toBe(1);
   });
 });

--- a/frontend/src/shared/hooks/useSessionInit.ts
+++ b/frontend/src/shared/hooks/useSessionInit.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useAuthStore } from '../../stores/auth-store';
-
-const API_BASE = '/api';
+import { refreshAccessTokenOnce } from '../lib/api';
 
 /**
  * On app load, if the user appears authenticated (from persisted localStorage)
@@ -10,6 +9,17 @@ const API_BASE = '/api';
  * refresh fails (expired session, revoked token, etc.), clear auth so the user
  * is redirected to login immediately instead of seeing broken API errors.
  *
+ * The refresh is routed through the shared refreshAccessTokenOnce() helper so it
+ * joins the same single-flight promise as apiFetch's reactive 401 refresh. In
+ * this exact state (authenticated, no in-memory token) every mounted query also
+ * 401s and triggers refreshAccessTokenOnce(); firing an independent /auth/refresh
+ * here would race that deduped path, and the loser would present an
+ * already-rotated (revoked) refresh JTI — tripping the backend's token-family
+ * reuse detection and forcibly logging the user out despite a valid session.
+ *
+ * On success refreshAccessTokenOnce persists the new token+user via the store
+ * (see api.ts), so no explicit setAuth is needed here.
+ *
  * Note: The access token IS persisted in localStorage for cross-tab session
  * sharing (see auth-store). Short token expiry and refresh token rotation
  * mitigate the localStorage exposure risk.
@@ -17,7 +27,6 @@ const API_BASE = '/api';
 export function useSessionInit() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const accessToken = useAuthStore((s) => s.accessToken);
-  const setAuth = useAuthStore((s) => s.setAuth);
   const clearAuth = useAuthStore((s) => s.clearAuth);
   const attempted = useRef(false);
 
@@ -26,20 +35,8 @@ export function useSessionInit() {
     attempted.current = true;
 
     (async () => {
-      try {
-        const res = await fetch(`${API_BASE}/auth/refresh`, {
-          method: 'POST',
-          credentials: 'include',
-        });
-        if (!res.ok) {
-          clearAuth();
-          return;
-        }
-        const data = await res.json();
-        setAuth(data.accessToken, data.user);
-      } catch {
-        clearAuth();
-      }
+      const token = await refreshAccessTokenOnce();
+      if (!token) clearAuth();
     })();
-  }, [isAuthenticated, accessToken, setAuth, clearAuth]);
+  }, [isAuthenticated, accessToken, clearAuth]);
 }


### PR DESCRIPTION
Fixes #884

## Summary
`useSessionInit` fired its own raw `fetch('/api/auth/refresh', …)` instead of the shared `refreshAccessTokenOnce()` single-flight helper. This PR routes it through the helper so all refresh paths await one in-flight promise. Behavior is otherwise unchanged: on success the helper persists the new token+user via the store; on failure the hook clears auth exactly as before.

## Root cause
The hook runs precisely when `isAuthenticated === true && accessToken === null` (e.g. `localStorage` migrated from an older key that didn't persist the access token). In that state every mounted query also 401s and calls `refreshAccessTokenOnce()`, so the hook's independent refresh raced the deduped path. Both requests carried the same httpOnly refresh cookie (same JTI). The winner rotated and revoked the old JTI (`backend/src/routes/foundation/auth.ts:233`); the loser then presented that now-revoked JTI, which the backend treats as reuse and responds by revoking the entire token family (`backend/src/core/plugins/auth.ts:158-162`) — forcibly logging out a user with a valid session, with no way to silently re-authenticate.

The helper's own comment (`frontend/src/shared/lib/api.ts:30-36`) documents this exact hazard; `useSessionInit` was the sole caller bypassing it.

## Fix
- `frontend/src/shared/hooks/useSessionInit.ts` — `await refreshAccessTokenOnce()`; `clearAuth()` on a null return. Removed the now-unused `setAuth` selector and local `API_BASE` constant.

## Tests
- `frontend/src/shared/hooks/useSessionInit.test.ts` — added a regression test that starts a competing `refreshAccessTokenOnce()` and mounts the hook while it is in flight, asserting `/auth/refresh` is hit **exactly once**. Fails before the fix (2 calls → `expected 2 to be 1`), passes after (1 call). The auth-store mock now exposes `getState` so the delegated imperative store read used by the helper works. Existing tests still pass (6/6), and `api.test.ts` is unaffected (9/9).
- Gates: `npm run typecheck` clean, `eslint` clean on changed files.

## Docs / ADR impact
Updated `docs/architecture/07-flow-auth.md` (CLAUDE.md rule 6 — auth flow) to list the session-init refresh as a fourth path funneling through the single-flight `refreshAccessTokenOnce()`, matching the invariant the doc already asserts. No ADR or contract change; no backend change (the reuse-detection behavior is correct and intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)