### PR TITLE
fix(pages): debounce search + gate keyword query in semantic mode (#874)

### DIFF
--- a/frontend/src/features/pages/PagesPage.test.tsx
+++ b/frontend/src/features/pages/PagesPage.test.tsx
@@ -1053,4 +1053,108 @@ describe('PagesPage', () => {
       expect(badge.className).not.toMatch(/sky-500|amber|warning|yellow/);
     });
   });
+
+  // --- Search debounce + semantic-mode gating (#874) ---
+  //
+  // The keyword search input used to feed usePages directly, firing an
+  // un-debounced GET /pages?search=… on every keystroke, and it kept firing
+  // that wasted keyword query even in semantic/hybrid mode where the results
+  // come from useSearch. These tests pin the debounce and the enabled gate.
+  describe('search debounce + semantic gating (#874)', () => {
+    /** Fetch mock that serves both /search and /pages, so semantic mode has a
+     *  real /search response while we watch what /pages does. */
+    function mockFetchWithSearchAndPages() {
+      return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        if (url.includes('/search?')) {
+          const mode = new URL(url, 'http://localhost').searchParams.get('mode') ?? 'keyword';
+          return new Response(
+            JSON.stringify({ items: [], total: 0, page: 1, limit: 10, totalPages: 0, mode, hasEmbeddings: true }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        if (url.includes('/embeddings/status')) {
+          return new Response(JSON.stringify(mockEmbeddingStatusIdle), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/pages/filters')) {
+          return new Response(JSON.stringify(mockFilterOptions), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/spaces')) {
+          return new Response(JSON.stringify(mockSpaces), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/sync/status')) {
+          return new Response(JSON.stringify({ status: 'idle' }), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/pages/pinned')) {
+          return new Response(JSON.stringify({ items: [], total: 0 }), { headers: { 'Content-Type': 'application/json' } });
+        }
+        if (url.includes('/settings')) {
+          return new Response(JSON.stringify({}), { headers: { 'Content-Type': 'application/json' } });
+        }
+        return new Response(JSON.stringify(mockPagesResponse), { headers: { 'Content-Type': 'application/json' } });
+      });
+    }
+
+    /** Extract the exact `search` param value from every GET /pages?… list
+     *  request (ignores /pages/pinned, /pages/filters, /search, etc.). */
+    function pagesSearchValues(fetchSpy: ReturnType<typeof vi.spyOn>): string[] {
+      return fetchSpy.mock.calls
+        .map(([firstArg]) => (typeof firstArg === 'string' ? firstArg : (firstArg as Request).url))
+        .filter((u) => /\/pages\?/.test(u))
+        .map((u) => new URL(u, 'http://localhost').searchParams.get('search'))
+        .filter((v): v is string => v !== null);
+    }
+
+    it('debounces keyword search: only the final term fires a /pages request', async () => {
+      vi.restoreAllMocks();
+      const fetchSpy = mockFetchWithEmbeddingStatus(mockEmbeddingStatusIdle);
+      render(<PagesPage />, { wrapper: createWrapper() });
+
+      const input = screen.getByPlaceholderText('Search pages...');
+      // Four rapid keystrokes — the debounce must collapse them to one request.
+      fireEvent.change(input, { target: { value: 'k' } });
+      fireEvent.change(input, { target: { value: 'ku' } });
+      fireEvent.change(input, { target: { value: 'kub' } });
+      fireEvent.change(input, { target: { value: 'kube' } });
+
+      // The debounced term eventually fires exactly one keyword request.
+      await waitFor(
+        () => {
+          expect(pagesSearchValues(fetchSpy)).toContain('kube');
+        },
+        { timeout: 2000 },
+      );
+
+      // The intermediate keystrokes must never have hit the network.
+      const values = pagesSearchValues(fetchSpy);
+      expect(values).not.toContain('k');
+      expect(values).not.toContain('ku');
+      expect(values).not.toContain('kub');
+    });
+
+    it('does not fire a keyword /pages?search= request while in semantic mode', async () => {
+      vi.restoreAllMocks();
+      const fetchSpy = mockFetchWithSearchAndPages();
+      render(<PagesPage />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByTestId('search-mode-semantic'));
+      fireEvent.change(screen.getByPlaceholderText('Search pages...'), {
+        target: { value: 'kubernetes' },
+      });
+
+      // Wait until the debounced semantic search has actually fired.
+      await waitFor(
+        () => {
+          const urls = fetchSpy.mock.calls.map(([firstArg]) =>
+            typeof firstArg === 'string' ? firstArg : (firstArg as Request).url,
+          );
+          expect(urls.some((u) => u.includes('/search?') && u.includes('mode=semantic'))).toBe(true);
+        },
+        { timeout: 2000 },
+      );
+
+      // The wasted keyword query must be gated off entirely.
+      expect(pagesSearchValues(fetchSpy)).toHaveLength(0);
+    });
+  });
 });

--- a/frontend/src/features/pages/PagesPage.test.tsx
+++ b/frontend/src/features/pages/PagesPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { PagesPage } from './PagesPage';
@@ -1155,6 +1155,97 @@ describe('PagesPage', () => {
 
       // The wasted keyword query must be gated off entirely.
       expect(pagesSearchValues(fetchSpy)).toHaveLength(0);
+    });
+
+    // --- Atomic query key: the QUERY sort must track the DEBOUNCED term ---
+    //
+    // `search` is debounced (300ms) into the /pages query key, but `sort` was
+    // flipped synchronously by the search input's onChange (→ 'relevance' on the
+    // first keystroke, → 'modified' on clear). Because both feed the same query
+    // key, the key was non-atomic: the first keystroke minted a key with the new
+    // sort but the OLD (empty) search → an immediate GET /pages?sort=relevance
+    // with no search term, and the clear button minted a key with the new sort
+    // but the STALE debounced term → a wasted stale-term fetch. These tests
+    // instrument EVERY /pages? list request (including sort-only ones the
+    // `pagesSearchValues` helper is blind to).
+    describe('atomic query key: sort tracks the debounced term (#874)', () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      /** Every GET /pages?… list request (not /pages/pinned|filters|tree, not
+       *  /search), with its parsed `search` and `sort` params — including
+       *  requests that carry NO search term (search === null). */
+      function pagesListRequests(fetchSpy: ReturnType<typeof vi.spyOn>) {
+        return fetchSpy.mock.calls
+          .map(([firstArg]) => (typeof firstArg === 'string' ? firstArg : (firstArg as Request).url))
+          .filter((u) => /\/pages\?/.test(u))
+          .map((u) => {
+            const params = new URL(u, 'http://localhost').searchParams;
+            return { url: u, search: params.get('search'), sort: params.get('sort') };
+          });
+      }
+
+      it('first keystroke does not fire an immediate sort=relevance request before the 300ms debounce', async () => {
+        vi.restoreAllMocks();
+        const fetchSpy = mockFetchWithEmbeddingStatus(mockEmbeddingStatusIdle);
+        render(<PagesPage />, { wrapper: createWrapper() });
+
+        // Flush the initial browse-list query (sort=modified, no search).
+        await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+        const baseline = pagesListRequests(fetchSpy);
+
+        // One character. onChange flips `sort` to 'relevance' synchronously; the
+        // debounced term is still ''. The query sort must track the DEBOUNCED
+        // term, so the key must not change and no request may fire yet.
+        fireEvent.change(screen.getByPlaceholderText('Search pages...'), {
+          target: { value: 'k' },
+        });
+        // Flush microtasks WITHOUT advancing to the 300ms debounce boundary.
+        await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+
+        const afterKeystroke = pagesListRequests(fetchSpy);
+        // No new request, and specifically no sort=relevance request that
+        // carries no search term (the wrong-data-flash / wasted request).
+        expect(afterKeystroke).toHaveLength(baseline.length);
+        expect(afterKeystroke.some((r) => r.sort === 'relevance' && r.search === null)).toBe(false);
+
+        // Now let the debounce elapse — exactly ONE new request, the debounced
+        // one, carrying the term and the relevance sort together.
+        await act(async () => { await vi.advanceTimersByTimeAsync(300); });
+        const newRequests = pagesListRequests(fetchSpy).slice(baseline.length);
+        expect(newRequests).toHaveLength(1);
+        expect(newRequests[0].search).toBe('k');
+        expect(newRequests[0].sort).toBe('relevance');
+      });
+
+      it('clear button does not fire a request carrying the stale search term', async () => {
+        vi.restoreAllMocks();
+        const fetchSpy = mockFetchWithEmbeddingStatus(mockEmbeddingStatusIdle);
+        render(<PagesPage />, { wrapper: createWrapper() });
+        await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+
+        // Type a term and let its debounced request actually fire.
+        fireEvent.change(screen.getByPlaceholderText('Search pages...'), {
+          target: { value: 'kube' },
+        });
+        await act(async () => { await vi.advanceTimersByTimeAsync(300); });
+        expect(pagesListRequests(fetchSpy).some((r) => r.search === 'kube')).toBe(true);
+
+        const beforeClear = pagesListRequests(fetchSpy).length;
+
+        // Clear the search. The debounced value must be reset synchronously so
+        // no request re-fetches the stale 'kube' term.
+        fireEvent.click(screen.getByTestId('search-clear'));
+        await act(async () => { await vi.advanceTimersByTimeAsync(300); });
+
+        const afterClear = pagesListRequests(fetchSpy).slice(beforeClear);
+        expect(afterClear.some((r) => r.search === 'kube')).toBe(false);
+      });
     });
   });
 });

--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -237,6 +237,17 @@ export function PagesPage() {
   // Semantic/hybrid search — only active when there's a search query AND mode is not 'keyword'
   const useSemanticSearch = !!(search && searchMode !== 'keyword');
 
+  // Keep the /pages query key atomic: `search` is debounced, so the `sort` that
+  // feeds the key must track the DEBOUNCED term, not the raw one. Otherwise the
+  // first keystroke (which flips `sort` to 'relevance' synchronously while the
+  // debounced term is still empty) mints a key with sort=relevance + no search
+  // and fires an immediate wrong-data GET /pages?sort=relevance before the
+  // debounce elapses. The visible `sort` dropdown and the auto-switch-to-
+  // relevance UX are unchanged — only the query sort waits for the term (#874).
+  const querySort = debouncedSearch.trim()
+    ? sort
+    : (sort === 'relevance' ? 'modified' : sort);
+
   const { data: pagesData, isLoading, isFetching: isFetchingPages, error: pagesError, refetch: refetchPages } = usePages({
     spaceKey: spaceKey || undefined,
     search: debouncedSearch || undefined,
@@ -249,7 +260,7 @@ export function PagesPage() {
     dateFrom: dateFrom || undefined,
     dateTo: dateTo || undefined,
     page,
-    sort,
+    sort: querySort,
     // In semantic/hybrid mode the rendered results come from useSearch below,
     // so the keyword list query would just fire wasted, rate-limited requests
     // for data that is never shown — gate it off (#874).
@@ -453,15 +464,19 @@ export function PagesPage() {
                 setPage(1);
                 if (val.trim()) {
                   setSort('relevance');
-                } else if (sort === 'relevance') {
-                  setSort('modified');
+                } else {
+                  // Field emptied: reset the debounced term synchronously so the
+                  // pending 300ms fetch never fires the stale term, and drop the
+                  // relevance sort back to modified (#874).
+                  setDebouncedSearch('');
+                  if (sort === 'relevance') setSort('modified');
                 }
               }}
               className="nm-input pl-10 pr-10"
             />
             {search && (
               <button
-                onClick={() => { setSearch(''); setPage(1); setSearchMode('keyword'); if (sort === 'relevance') setSort('modified'); searchInputRef.current?.focus(); }}
+                onClick={() => { setSearch(''); setDebouncedSearch(''); setPage(1); setSearchMode('keyword'); if (sort === 'relevance') setSort('modified'); searchInputRef.current?.focus(); }}
                 className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-0.5 text-muted-foreground hover:text-foreground"
                 data-testid="search-clear"
                 aria-label="Clear search"

--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -195,6 +195,18 @@ export function PagesPage() {
   const [sourceFilter, setSourceFilter] = useState<PageSource | ''>('');
   const [searchMode, setSearchMode] = useState<'keyword' | 'semantic' | 'hybrid'>('keyword');
 
+  // Debounce the search term before it reaches the keyword /pages query.
+  // Typing stays responsive because `search` still drives the input value,
+  // clear button, sort switch and semantic-mode gate synchronously; only the
+  // network request waits for a 300ms pause (mirrors useSearch). Without this
+  // every keystroke minted a new query key and fired a fresh, rate-limited
+  // GET /pages?search=… (#874).
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
   const { data: settings } = useSettings();
   const { data: spaces } = useSpaces();
   const { data: filterOptions } = usePageFilterOptions();
@@ -222,9 +234,12 @@ export function PagesPage() {
     }
   }, [qualityFilter]);
 
+  // Semantic/hybrid search — only active when there's a search query AND mode is not 'keyword'
+  const useSemanticSearch = !!(search && searchMode !== 'keyword');
+
   const { data: pagesData, isLoading, isFetching: isFetchingPages, error: pagesError, refetch: refetchPages } = usePages({
     spaceKey: spaceKey || undefined,
-    search: search || undefined,
+    search: debouncedSearch || undefined,
     author: author || undefined,
     labels: labels || undefined,
     freshness: (freshness || undefined) as 'fresh' | 'recent' | 'aging' | 'stale' | undefined,
@@ -235,9 +250,11 @@ export function PagesPage() {
     dateTo: dateTo || undefined,
     page,
     sort,
+    // In semantic/hybrid mode the rendered results come from useSearch below,
+    // so the keyword list query would just fire wasted, rate-limited requests
+    // for data that is never shown — gate it off (#874).
+    enabled: !useSemanticSearch,
   });
-  // Semantic/hybrid search — only active when there's a search query AND mode is not 'keyword'
-  const useSemanticSearch = !!(search && searchMode !== 'keyword');
   const searchResults = useSearch({
     query: useSemanticSearch ? search : '',
     mode: searchMode,

--- a/frontend/src/shared/hooks/use-pages.test.ts
+++ b/frontend/src/shared/hooks/use-pages.test.ts
@@ -159,6 +159,31 @@ describe('usePages', () => {
     const callUrl = apiFetchMock.mock.calls[0][0] as string;
     expect(callUrl).toBe('/pages');
   });
+
+  it('does not fetch when enabled is false (#874 semantic-mode gate)', async () => {
+    apiFetchMock.mockResolvedValue(MOCK_PAGINATED);
+
+    const { result } = renderHook(
+      () => usePages({ search: 'kubernetes', enabled: false }),
+      { wrapper: createWrapper() },
+    );
+
+    // A disabled query never leaves the idle fetchStatus and never calls apiFetch.
+    await waitFor(() => expect(result.current.fetchStatus).toBe('idle'));
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches normally when enabled defaults to true', async () => {
+    apiFetchMock.mockResolvedValue(MOCK_PAGINATED);
+
+    const { result } = renderHook(
+      () => usePages({ search: 'kubernetes' }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiFetchMock).toHaveBeenCalledWith(expect.stringContaining('search=kubernetes'));
+  });
 });
 
 describe('usePageTree', () => {

--- a/frontend/src/shared/hooks/use-pages.ts
+++ b/frontend/src/shared/hooks/use-pages.ts
@@ -77,6 +77,13 @@ export interface PageFilters {
   page?: number;
   limit?: number;
   sort?: 'title' | 'modified' | 'author' | 'quality' | 'relevance';
+  /**
+   * Gate the keyword list query. Defaults to true. Callers pass `false` to
+   * suppress the fetch when the keyword results are not being displayed — e.g.
+   * PagesPage in semantic/hybrid search mode, where results come from useSearch
+   * and firing this query would just waste a rate-limited request (#874).
+   */
+  enabled?: boolean;
 }
 
 export function usePages(params: PageFilters = {}) {
@@ -84,6 +91,7 @@ export function usePages(params: PageFilters = {}) {
     spaceKey, search, author, labels, freshness,
     embeddingStatus, qualityMin, qualityMax, qualityStatus,
     source, dateFrom, dateTo, page, limit, sort,
+    enabled = true,
   } = params;
 
   const queryKey = useMemo(
@@ -114,11 +122,16 @@ export function usePages(params: PageFilters = {}) {
   return useQuery<PaginatedPages>({
     queryKey,
     queryFn: () => apiFetch(`/pages${qs ? `?${qs}` : ''}`),
+    enabled,
     // Cache list responses for 30s so rapid back/forward between list and
     // detail pages reuses cached data instead of firing a fresh request on
     // every remount — that pattern can otherwise trip the backend's global
     // rate limit and leave the query in an unrecoverable error state.
     staleTime: 30_000,
+    // Keep the previous page's rows on screen while the next key loads so
+    // filter/search/pagination changes don't collapse the list to skeletons
+    // (matches useSearch). Without this every keystroke re-enters isLoading.
+    placeholderData: (prev) => prev,
   });
 }
 


### PR DESCRIPTION
Fixes #874

## Summary
The Pages search input fired an un-debounced `GET /pages?search=…` on every keystroke, flashed the list to skeletons on each key, and — in semantic/hybrid mode — kept firing that wasted keyword query even though the rendered results come from the already-debounced `useSearch`. This debounces the keyword term (300 ms, mirroring `useSearch`), gates the keyword query off in semantic/hybrid mode, and keeps the previous rows on screen across query-key changes.

## Root cause
`PagesPage` fed `search` straight into `usePages`, whose `useQuery` had **no debounce, no `enabled` gate, and no `placeholderData`**. `search` is part of the query key, so every keystroke minted a new key and fired a fresh Postgres-backed request; superseded requests ran to completion. In semantic/hybrid mode `useSemanticSearch` switched the rendered results to `useSearch`, yet `usePages` still fired per keystroke for data that was never displayed. Under concurrent typing this eats the backend's global rate limit and can leave the query in an unrecoverable error state — the exact hazard the hook's own comment warns about. The fix is already demonstrated twice in-repo (`CommandPalette` debounces the same endpoint 250 ms; `useSearch` debounces 300 ms).

## Changes
- **`PagesPage.tsx`** — derive a 300 ms `debouncedSearch` and pass it to `usePages`; `search` still drives the input value, clear button, sort switch and the semantic-mode gate synchronously so typing stays responsive. Pass `enabled: !useSemanticSearch` to suppress the wasted keyword fetch in semantic/hybrid mode.
- **`use-pages.ts`** — add an optional `enabled?` (default `true`) forwarded to `useQuery`, and `placeholderData: (prev) => prev` to stop the skeleton flash. Backward-compatible for all other callers.

## Tests
Frontend (jsdom + Testing Library). All fail before the fix, pass after:
- `PagesPage.test.tsx` — rapid `k→ku→kub→kube` keystrokes fire exactly one `/pages?search=kube` request; intermediate terms never hit the network.
- `PagesPage.test.tsx` — in semantic mode, `/search?mode=semantic` fires while **no** `/pages?search=` request is made.
- `use-pages.test.ts` — `usePages` does not fetch when `enabled: false`, and still fetches when `enabled` defaults to true.

Wider regression run: `src/features/pages`, `src/features/ai`, `src/shared/hooks/use-search.test.ts` — 412 passed. Typecheck and ESLint clean.

## Docs/ADR impact
None. This is a UI-local debounce + query-gating change — no impact on compose, domains, ESLint boundaries, migrations, or the auth/sync/RAG/license/content-pipeline flows, so no `docs/architecture/*.md` update applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)