### PR TITLE
fix(a11y): make sidebar & outline tree rows keyboard-operable (#880)

### DIFF
--- a/frontend/src/shared/components/article/ArticleRightPane.test.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.test.tsx
@@ -418,6 +418,39 @@ describe('ArticleRightPane', () => {
     });
   });
 
+  // #880 (code-review follow-up): outline rows carry role="treeitem" but had no
+  // role="tree" ancestor and nested-children wrappers lacked role="group", so
+  // every treeitem was orphaned (axe-critical aria-required-parent). The outline
+  // list is now a role="tree" and each expanded heading's sub-headings live in a
+  // role="group".
+  describe('outline ARIA tree semantics (#880)', () => {
+    it('exposes the outline list as a labelled ARIA tree', () => {
+      useArticleViewStore.setState({
+        headings: [{ id: 'intro', text: 'Introduction', level: 1 }],
+      });
+      render(<ArticleRightPane />, { wrapper: createWrapper() });
+      const tree = screen.getByRole('tree');
+      expect(tree).toBeInTheDocument();
+      expect(tree.getAttribute('aria-label')).toBeTruthy();
+    });
+
+    it('wraps nested sub-headings in role="group" so nested treeitems have a valid parent', () => {
+      // A level-2 heading nests under the preceding level-1 heading; outline
+      // branches are expanded by default (collapsedIds is empty).
+      useArticleViewStore.setState({
+        headings: [
+          { id: 'intro', text: 'Introduction', level: 1 },
+          { id: 'usage', text: 'Usage', level: 2 },
+        ],
+      });
+      render(<ArticleRightPane />, { wrapper: createWrapper() });
+      expect(screen.getByText('Usage')).toBeInTheDocument();
+      const group = document.querySelector('[role="group"]');
+      expect(group).not.toBeNull();
+      expect(group!.querySelector('[role="treeitem"]')).not.toBeNull();
+    });
+  });
+
   it('renders version and space key in the footer', () => {
     render(<ArticleRightPane />, { wrapper: createWrapper() });
 

--- a/frontend/src/shared/components/article/ArticleRightPane.test.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.test.tsx
@@ -366,6 +366,58 @@ describe('ArticleRightPane', () => {
     expect(screen.getByText('No headings on this page.')).toBeInTheDocument();
   });
 
+  // #880: outline rows were clickable <div>s with focus-visible classes but no
+  // tabIndex/role/onKeyDown, so keyboard-only and screen-reader users could not
+  // reach any heading. Each row is now a focusable role="treeitem" that
+  // activates the jump-to-heading on Enter/Space (WCAG 2.1.1).
+  describe('outline keyboard navigation (#880)', () => {
+    it('exposes each outline row as a focusable treeitem (role + tabIndex 0)', () => {
+      useArticleViewStore.setState({
+        headings: [{ id: 'intro', text: 'Introduction', level: 1 }],
+      });
+      render(<ArticleRightPane />, { wrapper: createWrapper() });
+      const row = screen.getByText('Introduction').closest('[role="treeitem"]');
+      expect(row).not.toBeNull();
+      expect(row!.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('activates the heading on Enter (scrolls the container and marks the row active)', () => {
+      useArticleViewStore.setState({
+        headings: [{ id: 'intro', text: 'Introduction', level: 1 }],
+      });
+
+      // handleNavigate resolves the scroll container + heading target from the
+      // live DOM, so seed both and spy on the scroll it performs.
+      const scrollRoot = document.createElement('div');
+      scrollRoot.setAttribute('data-scroll-container', '');
+      const scrollToSpy = vi.fn();
+      scrollRoot.scrollTo = scrollToSpy as unknown as typeof scrollRoot.scrollTo;
+      const target = document.createElement('h1');
+      target.id = 'intro';
+      scrollRoot.appendChild(target);
+      document.body.appendChild(scrollRoot);
+
+      render(<ArticleRightPane />, { wrapper: createWrapper() });
+      const row = screen.getByText('Introduction').closest('[role="treeitem"]')!;
+      fireEvent.keyDown(row, { key: 'Enter' });
+
+      expect(scrollToSpy).toHaveBeenCalled();
+      // setActiveId(headingId) ran → the row gets the active treatment.
+      const activeRow = screen.getByText('Introduction').closest('[role="treeitem"]')!;
+      expect(activeRow.className).toContain('nm-pill-active');
+    });
+
+    it('prevents the default page-scroll on Space', () => {
+      useArticleViewStore.setState({
+        headings: [{ id: 'intro', text: 'Introduction', level: 1 }],
+      });
+      render(<ArticleRightPane />, { wrapper: createWrapper() });
+      const row = screen.getByText('Introduction').closest('[role="treeitem"]')!;
+      const notPrevented = fireEvent.keyDown(row, { key: ' ' });
+      expect(notPrevented).toBe(false);
+    });
+  });
+
   it('renders version and space key in the footer', () => {
     render(<ArticleRightPane />, { wrapper: createWrapper() });
 

--- a/frontend/src/shared/components/article/ArticleRightPane.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.tsx
@@ -122,6 +122,12 @@ const OutlineNodeItem = memo(function OutlineNodeItem({
   return (
     <div>
       <div
+        // #880: make the outline row a real keyboard-operable widget.
+        // role="treeitem" (not "button") because the collapse chevron is a
+        // nested <button>. Enter/Space jump to the heading.
+        role="treeitem"
+        tabIndex={0}
+        aria-expanded={hasChildren ? isOpen : undefined}
         className={cn(
           'group flex items-center gap-1.5 rounded-[10px] h-9 pr-2 text-sm cursor-pointer transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background',
           isActive
@@ -130,6 +136,15 @@ const OutlineNodeItem = memo(function OutlineNodeItem({
         )}
         style={{ paddingLeft: `${level * 16 + 8}px` }}
         onClick={() => onNavigate(heading.id)}
+        onKeyDown={(e) => {
+          // Ignore keydown bubbling up from the nested chevron button so the
+          // row doesn't double-activate when the chevron is focused.
+          if (e.target !== e.currentTarget) return;
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault(); // Space would otherwise scroll the page
+            onNavigate(heading.id);
+          }
+        }}
       >
         {hasChildren ? (
           <button

--- a/frontend/src/shared/components/article/ArticleRightPane.tsx
+++ b/frontend/src/shared/components/article/ArticleRightPane.tsx
@@ -169,7 +169,9 @@ const OutlineNodeItem = memo(function OutlineNodeItem({
       </div>
 
       {hasChildren && isOpen && (
-        <div>
+        // #880: role="group" gives the nested treeitem rows a valid ARIA
+        // required-parent (a treeitem must be owned by a tree or group).
+        <div role="group">
           {children.map((child) => (
             <OutlineNodeItem
               key={child.heading.id}
@@ -945,7 +947,11 @@ export function ArticleRightPane() {
             No headings on this page.
           </div>
         ) : (
-          <div className="space-y-0.5">
+          // #880: role="tree" + label give the role="treeitem" outline rows a
+          // valid required-parent context and expose real tree semantics to
+          // screen readers. Full roving-tabindex/arrow-key nav remains a tracked
+          // follow-up (epic #856).
+          <div className="space-y-0.5" role="tree" aria-label="Article outline">
             {tree.map((node) => (
               <OutlineNodeItem
                 key={node.heading.id}

--- a/frontend/src/shared/components/layout/DndLocalSpaceTree.test.tsx
+++ b/frontend/src/shared/components/layout/DndLocalSpaceTree.test.tsx
@@ -202,4 +202,26 @@ describe('DndLocalSpaceTree', () => {
       expect(leaf.getAttribute('aria-expanded')).toBeNull();
     });
   });
+
+  // #880 (code-review follow-up): rows carry role="treeitem" but had no
+  // role="tree" ancestor and nested-children wrappers lacked role="group", so
+  // every treeitem was orphaned (axe-critical aria-required-parent). The row
+  // list is now a role="tree" and each expanded node's children live in a
+  // role="group".
+  describe('ARIA tree semantics (#880)', () => {
+    it('exposes the row list as a labelled ARIA tree', () => {
+      renderTree();
+      const tree = screen.getByRole('tree');
+      expect(tree).toBeInTheDocument();
+      expect(tree.getAttribute('aria-label')).toBeTruthy();
+    });
+
+    it('wraps an expanded node\'s children in role="group" so nested treeitems have a valid parent', () => {
+      renderTree({ expandedIds: new Set(['p2']) });
+      expect(screen.getByText('Child of Two')).toBeInTheDocument();
+      const group = document.querySelector('[role="group"]');
+      expect(group).not.toBeNull();
+      expect(group!.querySelector('[role="treeitem"]')).not.toBeNull();
+    });
+  });
 });

--- a/frontend/src/shared/components/layout/DndLocalSpaceTree.test.tsx
+++ b/frontend/src/shared/components/layout/DndLocalSpaceTree.test.tsx
@@ -167,4 +167,39 @@ describe('DndLocalSpaceTree', () => {
       expect(span.className).not.toContain('font-medium');
     }
   });
+
+  // #880: local-space tree rows were clickable <div>s with no keyboard access —
+  // reorder AND navigation were mouse-only. Each row is now a focusable
+  // role="treeitem" that navigates on Enter/Space (WCAG 2.1.1).
+  describe('keyboard navigation (#880)', () => {
+    it('exposes each row as a focusable treeitem (role + tabIndex 0)', () => {
+      renderTree();
+      const row = screen.getByText('Page One').closest('[role="treeitem"]');
+      expect(row).not.toBeNull();
+      expect(row!.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('navigates on Enter', () => {
+      renderTree();
+      const row = screen.getByText('Page One').closest('[role="treeitem"]')!;
+      fireEvent.keyDown(row, { key: 'Enter' });
+      expect(mockNavigate).toHaveBeenCalledWith('/pages/p1');
+    });
+
+    it('navigates on Space and prevents the default page-scroll', () => {
+      renderTree();
+      const row = screen.getByText('Page One').closest('[role="treeitem"]')!;
+      const notPrevented = fireEvent.keyDown(row, { key: ' ' });
+      expect(notPrevented).toBe(false);
+      expect(mockNavigate).toHaveBeenCalledWith('/pages/p1');
+    });
+
+    it('exposes aria-expanded on an expandable row and omits it on a leaf', () => {
+      renderTree();
+      const expandable = screen.getByText('Page Two').closest('[role="treeitem"]')!;
+      expect(expandable.getAttribute('aria-expanded')).toBe('false');
+      const leaf = screen.getByText('Page One').closest('[role="treeitem"]')!;
+      expect(leaf.getAttribute('aria-expanded')).toBeNull();
+    });
+  });
 });

--- a/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
+++ b/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
@@ -73,6 +73,12 @@ const DndSortableTreeNode = memo(function DndSortableTreeNode({
         // scroll it into view on reload (its ancestors are auto-expanded first).
         data-active={isActive ? 'true' : undefined}
         data-page-id={node.page.id}
+        // #880: make the row a real keyboard-operable widget. role="treeitem"
+        // (not "button") because the chevron is a nested <button> — a button
+        // role here would nest interactive controls. Enter/Space navigate.
+        role="treeitem"
+        tabIndex={0}
+        aria-expanded={hasChildren ? isExpanded : undefined}
         className={cn(
           'group flex items-center gap-1.5 rounded-[10px] h-9 pr-2 text-sm cursor-pointer transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background',
           isActive
@@ -81,6 +87,15 @@ const DndSortableTreeNode = memo(function DndSortableTreeNode({
         )}
         style={{ paddingLeft: `${level * 16 + 10}px` }}
         onClick={handleNavigate}
+        onKeyDown={(e) => {
+          // Ignore keydown bubbling up from the nested chevron button so the
+          // row doesn't double-activate when the chevron is focused.
+          if (e.target !== e.currentTarget) return;
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault(); // Space would otherwise scroll the page
+            handleNavigate();
+          }
+        }}
       >
         <span className="shrink-0 opacity-0 group-hover:opacity-50 cursor-grab active:cursor-grabbing transition-opacity" aria-label="Drag to reorder">
           <GripVertical size={12} />

--- a/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
+++ b/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
@@ -121,7 +121,9 @@ const DndSortableTreeNode = memo(function DndSortableTreeNode({
       </div>
 
       {hasChildren && isExpanded && (
-        <div className="relative">
+        // #880: role="group" gives the nested treeitem rows a valid ARIA
+        // required-parent (a treeitem must be owned by a tree or group).
+        <div className="relative" role="group">
           {/* Indent guide line -- click to collapse parent */}
           <button
             type="button"
@@ -181,7 +183,11 @@ export default function DndLocalSpaceTree({
 
   return (
     <DragDropProvider onDragEnd={handleDragEnd}>
-      <div className="space-y-0.5">
+      {/* #880: role="tree" + label give the role="treeitem" rows a valid
+          required-parent context and expose real tree semantics to screen
+          readers. Keyboard reorder + full roving-tabindex/arrow-key nav remain
+          a tracked follow-up (epic #856). */}
+      <div className="space-y-0.5" role="tree" aria-label="Pages">
         {tree.map((node, idx) => (
           <DndSortableTreeNode
             key={node.page.id}

--- a/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
@@ -497,6 +497,62 @@ describe('SidebarTreeView', () => {
   });
 });
 
+// #880: tree rows were clickable <div>s with focus-visible classes but no
+// tabIndex/role/onKeyDown, so keyboard-only and screen-reader users could not
+// focus or activate any page title — a WCAG 2.1.1 (Keyboard) failure on the
+// app's primary navigation. Each row is now a focusable role="treeitem" that
+// activates navigation on Enter/Space.
+describe('SidebarTreeView keyboard navigation (#880)', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockTreeData = { ...defaultTreeData };
+    useUiStore.setState({
+      treeSidebarCollapsed: false,
+      treeSidebarSpaceKey: undefined,
+    });
+  });
+
+  it('exposes each row as a focusable treeitem (role + tabIndex 0)', () => {
+    render(<SidebarTreeView />, { wrapper: createWrapper() });
+    const row = screen.getByText('API Reference').closest('[role="treeitem"]');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('navigates on Enter', () => {
+    render(<SidebarTreeView />, { wrapper: createWrapper() });
+    const row = screen.getByText('API Reference').closest('[role="treeitem"]')!;
+    fireEvent.keyDown(row, { key: 'Enter' });
+    expect(mockNavigate).toHaveBeenCalledWith('/pages/root-2');
+  });
+
+  it('navigates on Space and prevents the default page-scroll', () => {
+    render(<SidebarTreeView />, { wrapper: createWrapper() });
+    const row = screen.getByText('API Reference').closest('[role="treeitem"]')!;
+    // fireEvent returns false when the handler called preventDefault().
+    const notPrevented = fireEvent.keyDown(row, { key: ' ' });
+    expect(notPrevented).toBe(false);
+    expect(mockNavigate).toHaveBeenCalledWith('/pages/root-2');
+  });
+
+  it('exposes aria-expanded on an expandable row and omits it on a leaf', () => {
+    render(<SidebarTreeView />, { wrapper: createWrapper() });
+    const expandable = screen.getByText('Getting Started').closest('[role="treeitem"]')!;
+    expect(expandable.getAttribute('aria-expanded')).toBe('false');
+    const leaf = screen.getByText('API Reference').closest('[role="treeitem"]')!;
+    expect(leaf.getAttribute('aria-expanded')).toBeNull();
+  });
+
+  it('ignores keydown bubbling up from the nested chevron button (no double-activation)', () => {
+    render(<SidebarTreeView />, { wrapper: createWrapper() });
+    const chevron = screen.getAllByLabelText('Expand')[0]!;
+    // Enter dispatched on the chevron bubbles to the row; the target guard must
+    // stop the row handler from also navigating.
+    fireEvent.keyDown(chevron, { key: 'Enter' });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
 // #707: on reload the tree mounts scrolled to the top; the active page's path
 // is auto-expanded but the row is out of view. The scroll container should
 // scroll the active node into view — unless it is already visible (so manual

--- a/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
@@ -553,6 +553,42 @@ describe('SidebarTreeView keyboard navigation (#880)', () => {
   });
 });
 
+// #880 (code-review follow-up): the rows carry role="treeitem" but had no
+// ancestor role="tree" and nested-children wrappers had no role="group", so
+// every treeitem was orphaned — an axe-critical aria-required-parent violation
+// that breaks screen-reader tree semantics. The row list is now a role="tree"
+// and each expanded node's children live in a role="group".
+describe('SidebarTreeView ARIA tree semantics (#880)', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockTreeData = { ...defaultTreeData };
+    useUiStore.setState({
+      treeSidebarCollapsed: false,
+      treeSidebarSpaceKey: undefined,
+    });
+  });
+
+  it('exposes the row list as a labelled ARIA tree (valid required-parent for treeitems)', () => {
+    render(<SidebarTreeView />, { wrapper: createWrapper() });
+    const tree = screen.getByRole('tree');
+    expect(tree).toBeInTheDocument();
+    expect(tree.getAttribute('aria-label')).toBeTruthy();
+  });
+
+  it('wraps an expanded node\'s children in role="group" so nested treeitems have a valid parent', () => {
+    // OPS has no homepage, so the full tree renders and "Getting Started" keeps
+    // its children (Installation/Configuration) as a nested, expandable branch.
+    useUiStore.setState({ treeSidebarCollapsed: false, treeSidebarSpaceKey: 'OPS' });
+    render(<SidebarTreeView />, { wrapper: createWrapper() });
+    fireEvent.click(screen.getByLabelText('Expand'));
+    expect(screen.getByText('Installation')).toBeInTheDocument();
+    const group = document.querySelector('[role="group"]');
+    expect(group).not.toBeNull();
+    // The nested treeitem lives inside the group.
+    expect(group!.querySelector('[role="treeitem"]')).not.toBeNull();
+  });
+});
+
 // #707: on reload the tree mounts scrolled to the top; the active page's path
 // is auto-expanded but the row is out of view. The scroll container should
 // scroll the active node into view — unless it is already visible (so manual

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -143,6 +143,12 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
         // scroll it into view on reload (its ancestors are auto-expanded first).
         data-active={isActive ? 'true' : undefined}
         data-page-id={node.page.id}
+        // #880: make the row a real keyboard-operable widget. role="treeitem"
+        // (not "button") because the chevron is a nested <button> — a button
+        // role here would nest interactive controls. Enter/Space navigate.
+        role="treeitem"
+        tabIndex={0}
+        aria-expanded={hasChildren ? isExpanded : undefined}
         className={cn(
           'group flex items-center gap-1.5 rounded-[10px] h-9 pr-2 text-sm cursor-pointer transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background',
           isActive
@@ -151,6 +157,15 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
         )}
         style={{ paddingLeft: `${level * 16 + 10}px` }}
         onClick={handleNavigate}
+        onKeyDown={(e) => {
+          // Ignore keydown bubbling up from the nested chevron button so the
+          // row doesn't double-activate when the chevron is focused.
+          if (e.target !== e.currentTarget) return;
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault(); // Space would otherwise scroll the page
+            handleNavigate();
+          }
+        }}
       >
         {hasChildren ? (
           <button

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -188,7 +188,9 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
       </div>
 
       {hasChildren && isExpanded && (
-        <div className="relative">
+        // #880: role="group" gives the nested treeitem rows a valid ARIA
+        // required-parent (a treeitem must be owned by a tree or group).
+        <div className="relative" role="group">
           {/* Indent guide line -- click to collapse parent */}
           <button
             type="button"
@@ -761,7 +763,11 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
             />
           </Suspense>
         ) : (
-          <div className="space-y-0.5">
+          // #880: role="tree" + label give the role="treeitem" rows a valid
+          // required-parent context and expose real tree semantics to screen
+          // readers. Keyboard reorder + full roving-tabindex/arrow-key nav
+          // remain a tracked follow-up (epic #856).
+          <div className="space-y-0.5" role="tree" aria-label="Pages">
             {tree.map((node) => (
               <SidebarTreeNode
                 key={node.page.id}


### PR DESCRIPTION
Fixes #880

## Summary
The sidebar page tree, the local-space (drag-and-drop) tree, and the article outline all rendered each row as a clickable `<div onClick>` that carried `focus-visible:` ring classes but had no `tabIndex`, `role`, or `onKeyDown`. Such a `<div>` is not in the tab order and can never be focused, so those ring classes were dead code and Enter/Space could never activate navigation. This change turns each row into a real keyboard-operable `role="treeitem"` widget.

## Root cause
A `<div>` with no `tabIndex` is unfocusable, so keyboard-only and screen-reader users could Tab only to the occasional expand chevron (which merely toggles expansion) and then out of the tree. There was no way to focus or activate any page title, reorder a local-space page, or reach any outline heading — a WCAG 2.1.1 (Keyboard) failure on the app's primary navigation surface. The three affected surfaces:
- `SidebarTreeView.tsx` — `SidebarTreeNode` row
- `DndLocalSpaceTree.tsx` — `DndSortableTreeNode` row
- `ArticleRightPane.tsx` — `OutlineNodeItem` row

## Fix
On each of the three row `<div>`s: add `role="treeitem"`, `tabIndex={0}`, `aria-expanded` (only when the row has children), and an Enter/Space `onKeyDown` handler that reuses the existing navigate handler. `role="treeitem"` is chosen over `role="button"` because the expand/collapse chevron is a real nested `<button>`; a button role on the row would nest interactive controls. The handler guards `e.target !== e.currentTarget` so a keydown bubbling up from the focused chevron does not double-activate the row, and calls `e.preventDefault()` on Space so it navigates instead of scrolling the page. Purely additive attributes plus a keydown handler — no change to click, mouse, or scroll behavior.

## Tests
Added a keyboard-navigation suite to each of the three sibling test files (jsdom + `@testing-library/react`):
- role `treeitem` + `tabIndex` 0 on rows
- navigation on Enter
- navigation + `preventDefault` on Space
- `aria-expanded` present on expandable rows, absent on leaves
- (sidebar) a chevron keydown does not double-navigate (target guard)

All new assertions fail before the fix (no `role="treeitem"` row exists) and pass after. Full run of the three affected test files: 132 passed. `npm run typecheck` clean; ESLint on all changed files clean.

## Docs / ADR impact
None. This is a non-structural a11y fix to existing ADR-010 UI surfaces — no change to system structure, design tokens, routing, data, or backend. CLAUDE.md rule 6 does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)