### PR TITLE
fix(mcp-docs): pin fetch_url connection to vetted IPs (SSRF DNS-rebinding) (#969)

### DIFF
--- a/mcp-docs/package-lock.json
+++ b/mcp-docs/package-lock.json
@@ -14,6 +14,7 @@
         "pino": "^10.3.1",
         "redis": "^5.11.0",
         "turndown": "^7.2.0",
+        "undici": "^7.25.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {

--- a/mcp-docs/package.json
+++ b/mcp-docs/package.json
@@ -18,6 +18,7 @@
     "pino": "^10.3.1",
     "redis": "^5.11.0",
     "turndown": "^7.2.0",
+    "undici": "^7.25.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/mcp-docs/src/security/ssrf-guard.test.ts
+++ b/mcp-docs/src/security/ssrf-guard.test.ts
@@ -115,8 +115,20 @@ describe('validateUrlWithDns — DNS-resolving guard', () => {
 
   it('allows a public hostname that resolves to a public address', async () => {
     lookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
-    const parsed = await validateUrlWithDns('https://docs.example.com/api');
-    expect(parsed.hostname).toBe('docs.example.com');
+    const { url } = await validateUrlWithDns('https://docs.example.com/api');
+    expect(url.hostname).toBe('docs.example.com');
+  });
+
+  it('returns the vetted resolved addresses so the caller can pin the connection', async () => {
+    lookupMock.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '2606:2800:220:1:248:1893:25c8:1946', family: 6 },
+    ] as never);
+    const { addresses } = await validateUrlWithDns('https://docs.example.com/api');
+    expect(addresses).toEqual([
+      { address: '93.184.216.34', family: 4 },
+      { address: '2606:2800:220:1:248:1893:25c8:1946', family: 6 },
+    ]);
   });
 
   it('still enforces the sync checks before resolving (literal private IP)', async () => {
@@ -125,9 +137,11 @@ describe('validateUrlWithDns — DNS-resolving guard', () => {
     expect(lookupMock).not.toHaveBeenCalled();
   });
 
-  it('does not block when DNS resolution fails (handled by the HTTP client later)', async () => {
+  it('rejects (fails closed) when DNS resolution fails — an unresolvable name must not fall through unvalidated', async () => {
+    // Failing open here reopened the SSRF hole: the guard resolved nothing but
+    // the fetch layer resolved (and connected to) whatever the name pointed at,
+    // so a rebinding domain that errored on the first lookup slipped past.
     lookupMock.mockRejectedValue(Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' }));
-    const parsed = await validateUrlWithDns('https://does-not-resolve.example.com');
-    expect(parsed.hostname).toBe('does-not-resolve.example.com');
+    await expect(validateUrlWithDns('https://does-not-resolve.example.com')).rejects.toThrow(SsrfError);
   });
 });

--- a/mcp-docs/src/security/ssrf-guard.ts
+++ b/mcp-docs/src/security/ssrf-guard.ts
@@ -5,6 +5,7 @@
  */
 
 import { lookup } from 'node:dns/promises';
+import type { LookupAddress } from 'node:dns';
 
 const BLOCKED_IPV4_PATTERNS = [
   /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,
@@ -77,25 +78,33 @@ export function validateUrl(urlString: string): URL {
  * cloud metadata, 127.0.0.1, a Docker-internal service, or a DNS-rebinding
  * domain) — the literal-string checks in validateUrl() never see that IP.
  *
- * NOTE: a TOCTOU gap remains between this lookup and the TCP connect; callers
- * that follow redirects must re-validate each hop (fetch-url.ts uses
- * redirect: 'manual' and rejects 3xx, so the connect target is fixed here).
+ * Returns the parsed URL alongside the *vetted* resolved addresses. Callers
+ * MUST pin the outbound connection to these addresses (see fetch-url.ts'
+ * undici Agent) — otherwise the HTTP client performs its own second DNS
+ * resolution at connect time and a rebinding domain can swap the answer for an
+ * internal IP in the gap between this guard and the connect (CVE-class TOCTOU
+ * / DNS-rebinding bypass). Redirects must also be re-validated per hop
+ * (fetch-url.ts uses redirect: 'manual' and rejects 3xx).
  *
- * @throws SsrfError if the URL is malformed, non-HTTP(S), or any resolved
- *   address is private/internal.
+ * @throws SsrfError if the URL is malformed, non-HTTP(S), fails to resolve, or
+ *   any resolved address is private/internal.
  */
-export async function validateUrlWithDns(urlString: string): Promise<URL> {
+export async function validateUrlWithDns(
+  urlString: string,
+): Promise<{ url: URL; addresses: LookupAddress[] }> {
   // All sync syntax/protocol/literal-IP/hostname checks first.
   const parsed = validateUrl(urlString);
 
   // Resolve A + AAAA records and reject if ANY resolved address is private.
-  let addresses: Array<{ address: string }>;
+  let addresses: LookupAddress[];
   try {
     addresses = await lookup(parsed.hostname, { all: true });
   } catch {
-    // DNS failures (ENOTFOUND, etc.) are surfaced by the HTTP client later;
-    // a name that does not resolve cannot reach an internal address here.
-    return parsed;
+    // Fail CLOSED. Previously we returned the parsed URL here, but the fetch
+    // layer then resolved the name itself — so an unresolvable-at-guard-time
+    // (or rebinding) domain slipped past unvalidated. If we can't vet the
+    // target address, we refuse to connect.
+    throw new SsrfError(`SSRF blocked: DNS resolution failed for '${parsed.hostname}'`);
   }
 
   for (const { address } of addresses) {
@@ -106,7 +115,7 @@ export async function validateUrlWithDns(urlString: string): Promise<URL> {
     }
   }
 
-  return parsed;
+  return { url: parsed, addresses };
 }
 
 function isBlockedIpv4(hostname: string): boolean {

--- a/mcp-docs/src/tools/fetch-url.test.ts
+++ b/mcp-docs/src/tools/fetch-url.test.ts
@@ -302,3 +302,41 @@ describe('fetchUrl — streaming reader (chunked, no Content-Length)', () => {
     await expect(fetchUrl(TEST_URL, null, {})).rejects.toThrow(/Response body is not readable/);
   });
 });
+
+describe('fetchUrl — DNS-rebinding defence (connection pinned to the vetted address)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let auditSpy: ReturnType<typeof vi.spyOn>;
+  let getCachedDocSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.mocked(lookup).mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+    auditSpy = vi.spyOn(auditLogger, 'logOutboundRequest').mockImplementation(() => {});
+    getCachedDocSpy = vi.spyOn(DocsCache.prototype, 'getCachedDoc').mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('pins the connection: fetch receives a dispatcher (undici Agent) so the guard and the connect resolve to the same IP', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response('<html><title>OK</title><body><main>hi</main></body></html>', {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    );
+
+    await fetchUrl(TEST_URL, null, {});
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, requestInit] = fetchSpy.mock.calls[0]!;
+    // Without a dispatcher, undici does its own second DNS resolution at connect
+    // time — the rebinding window between guard and fetch. A pinned Agent closes it.
+    expect(requestInit).toBeDefined();
+    expect((requestInit as { dispatcher?: unknown }).dispatcher).toBeDefined();
+    expect(
+      typeof (requestInit as { dispatcher?: { dispatch?: unknown } }).dispatcher?.dispatch,
+    ).toBe('function');
+  });
+});

--- a/mcp-docs/src/tools/fetch-url.ts
+++ b/mcp-docs/src/tools/fetch-url.ts
@@ -3,8 +3,10 @@
  * GET-only outbound requests — no POST/PUT (data leakage prevention).
  */
 
+import type { LookupAddress } from 'node:dns';
 import { JSDOM } from 'jsdom';
 import TurndownService from 'turndown';
+import { Agent } from 'undici';
 import type { RedisClientType } from 'redis';
 import { validateUrlWithDns } from '../security/ssrf-guard.js';
 import { getDomainConfig, isDomainAllowed } from '../security/domain-filter.js';
@@ -37,6 +39,29 @@ export interface FetchUrlResult {
   truncated: boolean;
 }
 
+/**
+ * Build an undici Agent that pins the outbound connection to the exact
+ * addresses already vetted by validateUrlWithDns(). undici performs no second
+ * DNS lookup at connect time, so a DNS-rebinding domain cannot swap in an
+ * internal IP in the window between the guard and the TCP connect. The Host
+ * header and TLS SNI keep the original hostname, so virtual hosting and cert
+ * validation still work.
+ */
+function createPinnedAgent(addresses: LookupAddress[]): Agent {
+  return new Agent({
+    connect: {
+      lookup(_hostname, options, callback) {
+        if (options.all) {
+          callback(null, addresses);
+        } else {
+          const [first] = addresses;
+          callback(null, first.address, first.family);
+        }
+      },
+    },
+  });
+}
+
 export async function fetchUrl(
   url: string,
   redis: RedisClientType | null,
@@ -49,7 +74,7 @@ export async function fetchUrl(
   // hostname whose A/AAAA record points at an internal address — not just
   // literal private-IP URLs. Redirects are blocked below (redirect: 'manual'),
   // so the validated host is also the host actually connected to.
-  const parsed = await validateUrlWithDns(url);
+  const { url: parsed, addresses } = await validateUrlWithDns(url);
 
   // 2. Check domain filter
   const domainConfig = await getDomainConfig(redis);
@@ -79,82 +104,94 @@ export async function fetchUrl(
     };
   }
 
-  // 4. Fetch — GET only, no redirects (SSRF + data leakage prevention)
-  const response = await fetch(url, {
-    method: 'GET',
-    redirect: 'manual',
-    headers: {
-      'User-Agent': 'Compendiq-MCP-Docs/1.0',
-      'Accept': 'text/html,application/xhtml+xml,text/plain,application/json',
-    },
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-  });
+  // 4. Fetch — GET only, no redirects (SSRF + data leakage prevention).
+  // Pin the connection to the addresses validateUrlWithDns() already vetted so
+  // undici performs no second DNS lookup — this closes the DNS-rebinding gap
+  // between the guard and the TCP connect.
+  const dispatcher = createPinnedAgent(addresses);
+  let response: Response;
+  let body: string;
+  try {
+    response = await fetch(url, {
+      method: 'GET',
+      redirect: 'manual',
+      dispatcher,
+      headers: {
+        'User-Agent': 'Compendiq-MCP-Docs/1.0',
+        'Accept': 'text/html,application/xhtml+xml,text/plain,application/json',
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    } as RequestInit & { dispatcher: Agent });
 
-  // Block redirects — an allowed domain could redirect to an internal IP
-  if (response.status >= 300 && response.status < 400) {
-    const location = response.headers.get('location') ?? 'unknown';
-    logOutboundRequest({
-      tool: 'fetch_url', url, userId: options.userId, cached: false,
-      statusCode: response.status, timestamp: new Date().toISOString(),
-    });
-    throw new Error(`Redirect to '${location}' blocked — redirects are not followed for security`);
-  }
-
-  if (!response.ok) {
-    logOutboundRequest({
-      tool: 'fetch_url', url, userId: options.userId, cached: false,
-      statusCode: response.status, timestamp: new Date().toISOString(),
-    });
-    throw new Error(`Fetch failed: ${response.status} ${response.statusText}`);
-  }
-
-  const contentType = response.headers.get('content-type') ?? '';
-
-  // Bound in-memory body size: a hostile or misconfigured allowed-domain server
-  // could otherwise exhaust the heap. Check the declared Content-Length first,
-  // then verify the actual byte count once the body has been read.
-  const contentLengthHeader = response.headers.get('content-length');
-  if (contentLengthHeader) {
-    const declaredLength = Number(contentLengthHeader);
-    if (Number.isFinite(declaredLength) && declaredLength > MAX_RESPONSE_BYTES) {
+    // Block redirects — an allowed domain could redirect to an internal IP
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location') ?? 'unknown';
       logOutboundRequest({
         tool: 'fetch_url', url, userId: options.userId, cached: false,
         statusCode: response.status, timestamp: new Date().toISOString(),
       });
-      throw new Error(`Response too large: ${declaredLength} bytes exceeds ${MAX_RESPONSE_BYTES}`);
+      throw new Error(`Redirect to '${location}' blocked — redirects are not followed for security`);
     }
-  }
 
-  // Stream the body and abort the moment we cross the cap. This bounds peak
-  // per-request memory to roughly MAX_RESPONSE_BYTES + one chunk, even when
-  // the server omits Content-Length or lies about it (Transfer-Encoding:
-  // chunked). reader.cancel() signals upstream to stop sending.
-  if (!response.body) {
-    throw new Error('Response body is not readable');
-  }
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (!value) continue;
-      total += value.byteLength;
-      if (total > MAX_RESPONSE_BYTES) {
-        await reader.cancel('Response too large');
+    if (!response.ok) {
+      logOutboundRequest({
+        tool: 'fetch_url', url, userId: options.userId, cached: false,
+        statusCode: response.status, timestamp: new Date().toISOString(),
+      });
+      throw new Error(`Fetch failed: ${response.status} ${response.statusText}`);
+    }
+
+    // Bound in-memory body size: a hostile or misconfigured allowed-domain server
+    // could otherwise exhaust the heap. Check the declared Content-Length first,
+    // then verify the actual byte count once the body has been read.
+    const contentLengthHeader = response.headers.get('content-length');
+    if (contentLengthHeader) {
+      const declaredLength = Number(contentLengthHeader);
+      if (Number.isFinite(declaredLength) && declaredLength > MAX_RESPONSE_BYTES) {
         logOutboundRequest({
           tool: 'fetch_url', url, userId: options.userId, cached: false,
           statusCode: response.status, timestamp: new Date().toISOString(),
         });
-        throw new Error(`Response too large: streamed >${MAX_RESPONSE_BYTES} bytes (cap exceeded)`);
+        throw new Error(`Response too large: ${declaredLength} bytes exceeds ${MAX_RESPONSE_BYTES}`);
       }
-      chunks.push(value);
     }
+
+    // Stream the body and abort the moment we cross the cap. This bounds peak
+    // per-request memory to roughly MAX_RESPONSE_BYTES + one chunk, even when
+    // the server omits Content-Length or lies about it (Transfer-Encoding:
+    // chunked). reader.cancel() signals upstream to stop sending.
+    if (!response.body) {
+      throw new Error('Response body is not readable');
+    }
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        total += value.byteLength;
+        if (total > MAX_RESPONSE_BYTES) {
+          await reader.cancel('Response too large');
+          logOutboundRequest({
+            tool: 'fetch_url', url, userId: options.userId, cached: false,
+            statusCode: response.status, timestamp: new Date().toISOString(),
+          });
+          throw new Error(`Response too large: streamed >${MAX_RESPONSE_BYTES} bytes (cap exceeded)`);
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    body = new TextDecoder().decode(Buffer.concat(chunks));
   } finally {
-    reader.releaseLock();
+    // Release the pinned agent's socket(s); it is single-use per request.
+    await dispatcher.close();
   }
-  const body = new TextDecoder().decode(Buffer.concat(chunks));
+
+  const contentType = response.headers.get('content-type') ?? '';
 
   // 5. Convert to markdown
   let markdown: string;


### PR DESCRIPTION
Fixes #969.

## What / why
The `fetch_url` SSRF guard resolved the target hostname once, but `fetch()` then resolved it **again** at TCP-connect time — two independent DNS resolutions. A DNS-rebinding domain could hand a public IP to the guard and an internal IP (e.g. `169.254.169.254`, `127.0.0.1`, a Docker-internal service) to the connect, sailing past the check. The guard also **failed open** on lookup errors, so an unresolvable-at-guard-time name fell through to the fetch layer's own resolution unvalidated.

Fix pins the connection to the addresses the guard already vetted:
- `validateUrlWithDns()` now returns `{ url, addresses }` and throws `SsrfError` (**fails closed**) on DNS-resolution failure instead of returning the parsed URL.
- `fetchUrl()` connects through an **undici `Agent`** whose `connect.lookup` yields only the vetted addresses, so undici performs no second DNS lookup. Host header and TLS SNI keep the original hostname (virtual hosting + cert validation intact). The per-request agent is closed in a `finally`.
- `undici` added as a direct `mcp-docs` dependency (already resolvable transitively).

## Test evidence
- `mcp-docs/src/security/ssrf-guard.test.ts`: inverted the DNS-failure case to assert `rejects.toThrow(SsrfError)`, and added a case asserting the vetted `addresses` array is returned.
- `mcp-docs/src/tools/fetch-url.test.ts`: added a case asserting `fetch` receives a `dispatcher` (pinned undici Agent).
- Fails-before / passes-after: 4 targeted assertions FAILED on the pre-fix code (guard returned the URL instead of throwing; no `dispatcher` passed), all PASS after. Full mcp-docs suite: 66 passed. `tsc --noEmit` clean.
- Additional end-to-end check (local server + bogus hostname) confirmed the connect is pinned to the vetted IP while the Host header keeps the original hostname.

## Docs / diagram impact
None — internal hardening of the mcp-docs fetch tool; no compose/domain/DB/flow structural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)