### PR TITLE
fix(infra): pass GitHub Packages token via BuildKit secret (#930)

### DIFF
--- a/backend/src/docker-compose-invariants.test.ts
+++ b/backend/src/docker-compose-invariants.test.ts
@@ -34,6 +34,10 @@ const prCheckWorkflow = readFileSync(
   join(repoRoot, '.github', 'workflows', 'pr-check.yml'),
   'utf8',
 );
+const dockerfileEnterprise = readFileSync(
+  join(repoRoot, 'docker', 'Dockerfile.enterprise'),
+  'utf8',
+);
 
 /**
  * Extract a top-level service block (2-space indented key under `services:`)
@@ -266,6 +270,23 @@ describe('.env.example stays authoritative for env vars the backend reads', () =
 describe('.github/workflows/pr-check.yml runs validation for every author', () => {
   it('does not skip typecheck/lint/test/hoist checks for Dependabot PRs', () => {
     expect(prCheckWorkflow).not.toContain('dependabot[bot]');
+  });
+});
+
+describe('docker/Dockerfile.enterprise keeps the GitHub token out of image layers (issue #930)', () => {
+  it('never writes the token into a persisted .npmrc via a build-arg', () => {
+    // A build-arg written to .npmrc in its own RUN bakes the token into that
+    // layer forever — a later `rm -f .npmrc` cannot purge earlier layer history
+    // or the exported build cache. Assert no layer interpolates the token into
+    // .npmrc from an ARG.
+    expect(dockerfileEnterprise).not.toMatch(/_authToken=\$\{GITHUB_TOKEN\}/);
+    expect(dockerfileEnterprise).not.toMatch(/^\s*ARG GITHUB_TOKEN\s*$/m);
+  });
+
+  it('injects the token via a BuildKit secret mount instead', () => {
+    // BuildKit secret mounts (`--mount=type=secret`) expose the value only for
+    // the duration of that RUN and are never committed to a layer or the cache.
+    expect(dockerfileEnterprise).toMatch(/--mount=type=secret,id=github_token/);
   });
 });
 

--- a/docker/Dockerfile.enterprise
+++ b/docker/Dockerfile.enterprise
@@ -18,8 +18,12 @@
 #
 # Usage (in compendiq-enterprise CI):
 #   docker build -f docker/Dockerfile.enterprise \
-#     --build-arg GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+#     --secret id=github_token,env=GITHUB_TOKEN \
 #     -t compendiq-enterprise:latest .
+#
+# The GitHub Packages token is passed as a BuildKit secret (never a build-arg):
+# it is mounted only for the RUN steps that need it and is never written into a
+# persisted image layer or the exported build cache.
 #
 # ─────────────────────────────────────────────────────────────────────
 
@@ -30,15 +34,17 @@ RUN apk add --no-cache python3 make g++
 
 WORKDIR /app
 
-# Configure GitHub Packages registry for @compendiq scope
-ARG GITHUB_TOKEN
-RUN echo "@compendiq:registry=https://npm.pkg.github.com" > .npmrc && \
-    echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
-
 COPY package.json package-lock.json ./
 COPY backend/package.json ./backend/
 COPY packages/contracts/package.json ./packages/contracts/
-RUN --mount=type=cache,target=/root/.npm npm ci -w backend -w @compendiq/contracts
+# The GitHub Packages token is mounted as a BuildKit secret and the .npmrc that
+# carries it is created and removed inside this single RUN, so no image layer or
+# exported cache ever contains the token.
+RUN --mount=type=secret,id=github_token --mount=type=cache,target=/root/.npm \
+    sh -c 'echo "@compendiq:registry=https://npm.pkg.github.com" > .npmrc && \
+    echo "//npm.pkg.github.com/:_authToken=$(cat /run/secrets/github_token)" >> .npmrc && \
+    npm ci -w backend -w @compendiq/contracts && \
+    rm -f .npmrc'
 
 # Build contracts
 COPY packages/contracts/ ./packages/contracts/
@@ -48,9 +54,6 @@ RUN npm run build -w @compendiq/contracts
 COPY backend/tsconfig.json backend/tsconfig.build.json ./backend/
 COPY backend/src/ backend/src/
 RUN npm run build -w backend
-
-# Clean up .npmrc (contains token)
-RUN rm -f .npmrc
 
 # ── Stage 2: Obfuscate enterprise code (Layer 2) ───────────────────
 FROM node:24-alpine AS obfuscator
@@ -83,17 +86,16 @@ RUN apk add --no-cache python3 make g++
 
 WORKDIR /app
 
-ARG GITHUB_TOKEN
-RUN echo "@compendiq:registry=https://npm.pkg.github.com" > .npmrc && \
-    echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
-
 COPY package.json package-lock.json ./
 COPY backend/package.json ./backend/
 COPY packages/contracts/package.json ./packages/contracts/
-RUN --mount=type=cache,target=/root/.npm npm ci -w backend -w @compendiq/contracts --omit=dev
-
-# Clean up .npmrc
-RUN rm -f .npmrc
+# Token mounted as a BuildKit secret; .npmrc created and removed in this same RUN
+# so it never lands in a persisted layer or the exported cache.
+RUN --mount=type=secret,id=github_token --mount=type=cache,target=/root/.npm \
+    sh -c 'echo "@compendiq:registry=https://npm.pkg.github.com" > .npmrc && \
+    echo "//npm.pkg.github.com/:_authToken=$(cat /run/secrets/github_token)" >> .npmrc && \
+    npm ci -w backend -w @compendiq/contracts --omit=dev && \
+    rm -f .npmrc'
 
 # ── Stage 4: Chromium (for PDF export) ─────────────────────────────
 FROM alpine:3.23 AS chromium

--- a/docs/ENTERPRISE-ARCHITECTURE.md
+++ b/docs/ENTERPRISE-ARCHITECTURE.md
@@ -1013,31 +1013,26 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY backend/package.json ./backend/
 COPY packages/contracts/package.json ./packages/contracts/
-COPY .npmrc.enterprise ./.npmrc
 
-# Install all deps including enterprise
-ARG GITHUB_TOKEN
-RUN --mount=type=cache,target=/root/.npm \
-    GITHUB_TOKEN=${GITHUB_TOKEN} npm ci -w backend -w @compendiq/contracts && \
-    npm install @compendiq/enterprise@^1.0.0
+# Install all deps including enterprise. The GitHub Packages token is passed as a
+# BuildKit secret (never an ARG/ENV) and the .npmrc that carries it is created and
+# removed inside this single RUN, so no image layer or exported cache holds it.
+RUN --mount=type=secret,id=github_token --mount=type=cache,target=/root/.npm \
+    sh -c 'echo "@compendiq:registry=https://npm.pkg.github.com" > .npmrc && \
+    echo "//npm.pkg.github.com/:_authToken=$(cat /run/secrets/github_token)" >> .npmrc && \
+    npm ci -w backend -w @compendiq/contracts && \
+    npm install @compendiq/enterprise@^1.0.0 && \
+    rm -f .npmrc'
 
 # Continue with standard build...
 ```
 
-Alternatively, use a `docker-compose.enterprise.yml` overlay:
+Build it with the token supplied as a secret (BuildKit is required):
 
-```yaml
-# docker/docker-compose.enterprise.yml
-# Use with: docker compose -f docker-compose.yml -f docker-compose.enterprise.yml up
-services:
-  backend:
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile.enterprise
-      args:
-        GITHUB_TOKEN: ${GITHUB_TOKEN}
-    environment:
-      COMPENDIQ_LICENSE_KEY: ${COMPENDIQ_LICENSE_KEY}
+```bash
+docker build -f docker/Dockerfile.enterprise \
+  --secret id=github_token,env=GITHUB_TOKEN \
+  -t compendiq-enterprise:latest .
 ```
 
 ### 8.4 GitHub Packages Publishing (CI in private repo)


### PR DESCRIPTION
Fixes #930.

## What / Why
`docker/Dockerfile.enterprise` wrote `GITHUB_TOKEN` into `.npmrc` in a dedicated `RUN` using a `--build-arg`. That bakes the token permanently into the builder and prod-deps layers — the later `rm -f .npmrc` only removes the file in a fresh layer and cannot purge earlier layer history or the exported build cache, so the token is recoverable from the image/cache.

The fix passes the token as a BuildKit secret (`--mount=type=secret,id=github_token`) and creates + removes the `.npmrc` inside the same `npm ci` RUN, so no layer or cache ever contains the token. Removed the `ARG GITHUB_TOKEN` declarations and the standalone `.npmrc` write/cleanup RUNs; updated the usage comment to `--secret id=github_token,env=GITHUB_TOKEN`.

## Test evidence
Extended `backend/src/docker-compose-invariants.test.ts` with a `describe('...issue #930')` block asserting the Dockerfile (a) never interpolates the token into `.npmrc` from an ARG and has no standalone `ARG GITHUB_TOKEN`, and (b) uses `--mount=type=secret,id=github_token`.
- Fails on the pre-fix Dockerfile (both assertions red).
- Passes after the fix; full file: 27 passed.

## Docs / diagram impact
Updated the enterprise build snippet in `docs/ENTERPRISE-ARCHITECTURE.md` (§8.3) to the `--secret` invocation. No architecture diagram change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)