### PR TITLE
fix(frontend): honor prefers-reduced-motion for Framer Motion (#933)

### DIFF
--- a/frontend/src/App.reduced-motion.test.tsx
+++ b/frontend/src/App.reduced-motion.test.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Capture the props framer-motion's MotionConfig is rendered with. Everything
+// else stays real so <App/> mounts its normal tree (LazyMotion, m.* etc.).
+const motionConfigSpy = vi.fn();
+
+vi.mock('framer-motion', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('framer-motion')>();
+  return {
+    ...actual,
+    MotionConfig: (props: { reducedMotion?: string; children?: ReactNode }) => {
+      motionConfigSpy(props);
+      return (
+        <div data-testid="motion-config" data-reduced-motion={props.reducedMotion}>
+          {props.children}
+        </div>
+      );
+    },
+  };
+});
+
+import { useAuthStore } from './stores/auth-store';
+import { App } from './App';
+
+describe('App – Framer Motion reduced-motion (#933)', () => {
+  afterEach(() => {
+    useAuthStore.getState().clearAuth();
+    vi.clearAllMocks();
+  });
+
+  function renderApp(initialPath = '/login') {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <App />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  }
+
+  it('wraps the app tree in a MotionConfig that honors the OS reduced-motion preference', () => {
+    useAuthStore.setState({
+      accessToken: null,
+      user: null,
+      isAuthenticated: false,
+    });
+
+    renderApp('/login');
+
+    // Without MotionConfig, Framer Motion animations ignore
+    // prefers-reduced-motion. The tree must render a MotionConfig with
+    // reducedMotion="user" so m.* animations follow the OS setting.
+    const config = screen.getByTestId('motion-config');
+    expect(config).toHaveAttribute('data-reduced-motion', 'user');
+    expect(motionConfigSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ reducedMotion: 'user' }),
+    );
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense } from 'react';
 import { Routes, Route, Navigate, useSearchParams } from 'react-router-dom';
-import { LazyMotion, domAnimation } from 'framer-motion';
+import { LazyMotion, MotionConfig, domAnimation } from 'framer-motion';
 import { useAuthStore } from './stores/auth-store';
 import { useSessionInit } from './shared/hooks/useSessionInit';
 import { useClearCacheOnLogout } from './shared/hooks/useClearCacheOnLogout';
@@ -163,64 +163,66 @@ export function App() {
 
   return (
     <LazyMotion features={domAnimation}>
-      <ErrorBoundary>
-        <Suspense fallback={<PageLoadingFallback />}>
-          <Routes>
-            <Route path="/setup" element={<SetupRoute><SetupWizard /></SetupRoute>} />
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/auth/oidc/callback" element={<OidcCallbackPage />} />
-            <Route
-              path="/*"
-              element={
-                <ProtectedRoute>
-                  <AppLayout>
-                    <ErrorBoundary>
-                      <Suspense fallback={<PageLoadingFallback />}>
-                        <Routes>
-                          <Route path="/" element={<PagesPage />} />
-                          <Route
-                            path="/pages"
-                            element={<Navigate to="/" replace />}
-                          />
-                          <Route
-                            path="/pages/new"
-                            element={<NewPagePage />}
-                          />
-                          <Route
-                            path="/pages/:id"
-                            element={<PageViewPage />}
-                          />
-                          <Route path="/trash" element={<TrashPage />} />
-                          <Route path="/ai" element={<AiAssistantPage />} />
-                          <Route path="/graph" element={<GraphPage />} />
-                          <Route path="/spaces/new" element={<NewSpacePage />} />
-                          <Route path="/spaces/:key/settings" element={<SpaceSettingsPage />} />
-                          <Route path="/admin/analytics" element={<AnalyticsPage />} />
-                          <Route
-                            path="/settings/ai-reviews/:id"
-                            element={<ReviewDetailPage />}
-                          />
-                          <Route path="/settings" element={<SettingsLayout />}>
-                            <Route index element={<SettingsIndexRedirect />} />
+      <MotionConfig reducedMotion="user">
+        <ErrorBoundary>
+          <Suspense fallback={<PageLoadingFallback />}>
+            <Routes>
+              <Route path="/setup" element={<SetupRoute><SetupWizard /></SetupRoute>} />
+              <Route path="/login" element={<LoginPage />} />
+              <Route path="/auth/oidc/callback" element={<OidcCallbackPage />} />
+              <Route
+                path="/*"
+                element={
+                  <ProtectedRoute>
+                    <AppLayout>
+                      <ErrorBoundary>
+                        <Suspense fallback={<PageLoadingFallback />}>
+                          <Routes>
+                            <Route path="/" element={<PagesPage />} />
                             <Route
-                              path=":category/:item"
-                              element={<SettingsPanelRoute />}
+                              path="/pages"
+                              element={<Navigate to="/" replace />}
                             />
-                          </Route>
-                          <Route
-                            path="*"
-                            element={<Navigate to="/" replace />}
-                          />
-                        </Routes>
-                      </Suspense>
-                    </ErrorBoundary>
-                  </AppLayout>
-                </ProtectedRoute>
-              }
-            />
-          </Routes>
-        </Suspense>
-      </ErrorBoundary>
+                            <Route
+                              path="/pages/new"
+                              element={<NewPagePage />}
+                            />
+                            <Route
+                              path="/pages/:id"
+                              element={<PageViewPage />}
+                            />
+                            <Route path="/trash" element={<TrashPage />} />
+                            <Route path="/ai" element={<AiAssistantPage />} />
+                            <Route path="/graph" element={<GraphPage />} />
+                            <Route path="/spaces/new" element={<NewSpacePage />} />
+                            <Route path="/spaces/:key/settings" element={<SpaceSettingsPage />} />
+                            <Route path="/admin/analytics" element={<AnalyticsPage />} />
+                            <Route
+                              path="/settings/ai-reviews/:id"
+                              element={<ReviewDetailPage />}
+                            />
+                            <Route path="/settings" element={<SettingsLayout />}>
+                              <Route index element={<SettingsIndexRedirect />} />
+                              <Route
+                                path=":category/:item"
+                                element={<SettingsPanelRoute />}
+                              />
+                            </Route>
+                            <Route
+                              path="*"
+                              element={<Navigate to="/" replace />}
+                            />
+                          </Routes>
+                        </Suspense>
+                      </ErrorBoundary>
+                    </AppLayout>
+                  </ProtectedRoute>
+                }
+              />
+            </Routes>
+          </Suspense>
+        </ErrorBoundary>
+      </MotionConfig>
     </LazyMotion>
   );
 }


### PR DESCRIPTION
Fixes #933.

## What / Why
`prefers-reduced-motion` was honored for CSS only; Framer Motion `m.*` transform/layout/repeat animations still ran at full motion because the app tree was never wrapped in a `MotionConfig`. This wraps the tree in `<MotionConfig reducedMotion="user">` inside the existing `LazyMotion`, so every Framer Motion animation respects the OS setting. Existing manual `useReducedMotion` cases are left intact.

## Test evidence
- New test: `frontend/src/App.reduced-motion.test.tsx` — partial-mocks `framer-motion` to capture `MotionConfig` props and asserts it is rendered with `reducedMotion="user"`.
- Fails before the fix (no `MotionConfig` in the tree → `getByTestId('motion-config')` throws); passes after.
- `App.test.tsx` (11 tests) still green; `npm run typecheck -w frontend` and eslint on touched files clean.

## Docs / diagram impact
None — no change to system structure, boundaries, migrations, or documented flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)