### PR TITLE
fix(content-converter): protect atomic macros from AI-Improve flatten (#901)

### DIFF
--- a/backend/src/core/services/content-converter.media.test.ts
+++ b/backend/src/core/services/content-converter.media.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { protectMedia, restoreMedia, htmlToMarkdown, markdownToHtml } from './content-converter.js';
+import {
+  protectMedia,
+  restoreMedia,
+  htmlToMarkdown,
+  markdownToHtml,
+  confluenceToHtml,
+  htmlToConfluence,
+} from './content-converter.js';
 
 const DRAWIO = '<div class="confluence-drawio" data-diagram-name="Arch"><img src="/api/attachments/5/Arch.png" alt="d"><a class="drawio-edit-link" data-drawio="true" href="#">Edit</a></div>';
 const IMG = '<img src="/api/attachments/5/photo.png" data-confluence-image-source="attachment" data-confluence-filename="photo.png" alt="Photo">';
@@ -129,6 +136,44 @@ describe('protectMedia / restoreMedia', () => {
     const back = restoreMedia(await markdownToHtml(md), media);
     expect(back).toContain('confluence-macro-unknown');
     expect(back).toContain('data-macro-name="roadmap"');
+  });
+});
+
+describe('atomic macro placeholders survive the AI-Improve round-trip (#901)', () => {
+  // toc / children / attachments / include / jira / status / user-mention hold
+  // no LLM-editable prose. Before #901 they were NOT in MEDIA_SELECTOR, so the
+  // AI-Improve HTML→Markdown→HTML round-trip flattened them to plain text
+  // ([Table of Contents], [JIRA: PROJ-42], @alice, …) and htmlToConfluence
+  // rebuilt nothing — the macro was permanently lost on write-back.
+  const STORAGE = [
+    '<p>Intro</p>',
+    '<ac:structured-macro ac:name="toc"><ac:parameter ac:name="maxLevel">3</ac:parameter></ac:structured-macro>',
+    '<p>See <ac:structured-macro ac:name="jira"><ac:parameter ac:name="key">PROJ-42</ac:parameter></ac:structured-macro> assigned to ',
+    '<ac:link><ri:user ri:username="alice"/></ac:link>.</p>',
+  ].join('');
+
+  it('round-trips toc, jira and user-mention macros back to storage format', async () => {
+    const html = confluenceToHtml(STORAGE);
+    const { html: prot, media } = protectMedia(html);
+    const md = htmlToMarkdown(prot);
+    const rebuilt = await markdownToHtml(md);
+    const restored = restoreMedia(rebuilt, media);
+    const back = htmlToConfluence(restored);
+
+    expect(back).toContain('ac:name="toc"');
+    expect(back).toContain('PROJ-42');
+    expect(back).toContain('ri:user');
+    expect(back).toContain('ri:username="alice"');
+  });
+
+  it('protectMedia freezes the atomic placeholders as tokens', () => {
+    const html = confluenceToHtml(STORAGE);
+    const { html: prot, media } = protectMedia(html);
+    // toc div + jira span + user-mention span are all frozen.
+    expect(media).toHaveLength(3);
+    expect(prot).not.toContain('confluence-toc');
+    expect(prot).not.toContain('confluence-jira-issue');
+    expect(prot).not.toContain('confluence-user-mention');
   });
 });
 

--- a/backend/src/core/services/content-converter.ts
+++ b/backend/src/core/services/content-converter.ts
@@ -1002,6 +1002,21 @@ const MEDIA_SELECTOR = [
   // would then rebuild nothing from). Inner prose becomes non-improvable —
   // the same preserve-over-improve tradeoff already accepted for labels/drawio.
   'div.confluence-macro-unknown',
+  // #901: freeze atomic macro placeholders — toc / children / attachments /
+  // include (block) and jira / status / user-mention (inline). Like labels and
+  // unknown-macro they carry NO LLM-editable prose (only a synthetic visible
+  // label such as [Table of Contents] / [JIRA: PROJ-42] / @alice). Without the
+  // freeze, the AI-Improve HTML→Markdown→HTML round-trip flattens that label
+  // into prose and htmlToConfluence rebuilds nothing, permanently deleting the
+  // macro on write-back. The now-redundant turndown flatten rules stay as
+  // fallbacks for non-Improve flows where protectMedia is not run.
+  'div.confluence-toc',
+  'div.confluence-children-macro',
+  'div.confluence-attachments-macro',
+  'div.confluence-include-macro',
+  'span.confluence-jira-issue',
+  'span.confluence-status',
+  'span.confluence-user-mention',
 ].join(',');
 
 // #765 review follow-up: legacy section/column wrappers nested inside


### PR DESCRIPTION
Fixes #901.

## What / why
The `toc`, `children`, `attachments`, `include`, `jira`, `status`, and `user-mention` macros are converted to atomic placeholder divs/spans that carry no LLM-editable prose (only a synthetic visible label like `[Table of Contents]`, `[JIRA: PROJ-42]`, `@alice`). They were absent from `MEDIA_SELECTOR`, so the AI-Improve `HTML→Markdown→HTML` round-trip flattened those labels into prose and `htmlToConfluence` rebuilt nothing — permanently deleting the macro on write-back.

Fix: add all seven selectors to `MEDIA_SELECTOR` so `protectMedia` freezes them whole via the existing #723 opaque-token pattern (identical to `labels`/`unknown-macro`). `restoreMedia` already re-injects both block (`<p>TOKEN</p>`) and bare inline tokens, so inline mentions/jira/status re-inject in place. The now-redundant turndown flatten rules stay as fallbacks for non-Improve flows where `protectMedia` is not run. One-file, additive change.

## Test evidence
`backend/src/core/services/content-converter.media.test.ts` — new `#901` describe block runs the real Improve round-trip (`confluenceToHtml → protectMedia → htmlToMarkdown → markdownToHtml → restoreMedia → htmlToConfluence`) over storage XHTML containing a toc, a jira (`PROJ-42`), and an `ri:user` mention.
- **Fails before:** macros flatten to `[Table of Contents]`/`[JIRA: PROJ-42]`/`@alice`; `back` contains no macro tags; `protectMedia` freezes 0 nodes.
- **Passes after:** `back` contains `ac:name="toc"`, `PROJ-42`, `ri:user`/`ri:username="alice"`; `protectMedia` freezes 3 tokens.
- Full converter suite: 208 passing. Backend typecheck + eslint clean.

## Docs / diagram impact
None — no change to system structure, boundaries, or the content-pipeline flow itself (only which placeholders the existing Improve freeze covers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)