### PR TITLE
fix(embedding): don't black out RAG search during reEmbedAll (#917)

### DIFF
--- a/backend/src/domains/llm/services/embedding-service.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.test.ts
@@ -133,6 +133,7 @@ import {
   splitByWords,
   getEmbedBreakerNextRetryTime,
   enqueueReembedAll,
+  reEmbedAll,
   runReembedAllJob,
   CHUNK_HARD_LIMIT,
   DIRTY_PAGE_BATCH_SIZE,
@@ -1989,6 +1990,45 @@ describe('chunkText', () => {
       expect(mocks.releaseEmbeddingLock).toHaveBeenCalledWith('alice', FAKE_LOCK_ID);
       // Guard check was actually invoked.
       expect(mocks.redisGet).toHaveBeenCalledWith('embedding:lock:alice');
+    });
+  });
+
+  describe('reEmbedAll', () => {
+    // Issue #917 — reEmbedAll must NOT wipe the whole embedding index up front.
+    // embedPage atomically replaces each page's embeddings inside its own
+    // transaction, so re-embedding shrinks-then-grows the index page by page
+    // and RAG search never sees an empty window. A blanket
+    // `DELETE FROM page_embeddings` before the multi-hour loop would black out
+    // vector search for the entire run.
+    it('does not issue a blanket DELETE FROM page_embeddings before re-embedding', async () => {
+      // No dirty pages → processDirtyPages returns immediately after the count.
+      mocks.query.mockImplementation(async (sql: string) => {
+        if (sql.includes('admin_settings') && sql.includes('embedding_chunk_size')) {
+          return { rows: [] };
+        }
+        if (sql.includes('SELECT user_id FROM user_settings')) {
+          return { rows: [{ user_id: 'sys-1' }] };
+        }
+        if (sql.includes('COUNT(*)') && sql.includes('embedding_dirty')) {
+          return { rows: [{ count: '0' }] };
+        }
+        return { rows: [], rowCount: 0 };
+      });
+
+      await reEmbedAll();
+
+      // The whole-index DELETE (page-scoped `DELETE ... WHERE page_id` from
+      // embedPage runs on the pooled client, not this pool-level `query`).
+      const blanketDelete = mocks.query.mock.calls.find((call) =>
+        /DELETE\s+FROM\s+page_embeddings\s*$/i.test((call[0] as string).trim()),
+      );
+      expect(blanketDelete).toBeUndefined();
+
+      // It still marks every page dirty so the per-page loop re-embeds them.
+      const dirtyUpdate = mocks.query.mock.calls.find((call) =>
+        /UPDATE\s+pages\s+SET\s+embedding_dirty\s*=\s*TRUE/i.test(call[0] as string),
+      );
+      expect(dirtyUpdate).toBeDefined();
     });
   });
 });

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -1125,9 +1125,15 @@ export async function getEmbeddingStatus(userId: string): Promise<EmbeddingStatu
  * Re-embed all pages (admin action).
  */
 export async function reEmbedAll(): Promise<void> {
-  await query('DELETE FROM page_embeddings');
+  // Issue #917 — do NOT wipe the whole index up front. `embedPage` atomically
+  // replaces each page's embeddings inside its own transaction (Phase 2), so
+  // marking every page dirty and re-embedding page by page shrinks-then-grows
+  // the index incrementally and RAG vector search never sees an empty window.
+  // A blanket `DELETE FROM page_embeddings` here would black out search for the
+  // entire multi-hour run. This mirrors `runReembedAllJob`, which also relies
+  // on per-page replacement rather than an up-front delete.
   await query(`UPDATE pages SET embedding_dirty = TRUE, embedding_status = 'not_embedded', embedded_at = NULL, embedding_error = NULL`);
-  logger.info('All embeddings cleared, pages marked dirty for re-embedding');
+  logger.info('All pages marked dirty for incremental re-embedding');
 
   // Use a system user ID for provider selection (pick any active user with settings)
   const usersResult = await query<{ user_id: string }>(


### PR DESCRIPTION
Fixes #917.

## What / why
`reEmbedAll` ran `await query('DELETE FROM page_embeddings')` before kicking off the multi-hour re-embed loop, wiping the entire vector index up front. For the whole duration of the re-embed, RAG vector search returned nothing.

The delete is unnecessary: `embedPage` (Phase 2) already opens a short-lived transaction per page that `DELETE ... WHERE page_id = $1` + re-inserts atomically, so concurrent RAG queries never see an empty window for a page. Marking every page dirty and letting the per-page loop replace embeddings one at a time shrinks-then-grows the index incrementally. This is exactly what `runReembedAllJob` already does — the two admin paths are now consistent.

The line-1129 `UPDATE pages SET embedding_dirty = TRUE ...` is kept; only the blanket `DELETE FROM page_embeddings` is removed.

## Test evidence
`backend/src/domains/llm/services/embedding-service.test.ts` — new `reEmbedAll` describe block asserts no blanket `DELETE FROM page_embeddings` is issued on the pooled `query` while pages are still marked dirty.
- Before fix: FAILS (`expected [ 'DELETE FROM page_embeddings' ] to be undefined`).
- After fix: PASSES. Full file: 92/92 pass. `npm run typecheck -w backend` clean; eslint on touched files clean.

## Docs / diagram impact
None — the per-page atomic-replace RAG flow is unchanged; this only removes an unsafe up-front delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)