### PR TITLE
fix(rag): observe orphaned keyword promise on CircuitBreaker rethrow (#921)

### DIFF
--- a/backend/src/domains/llm/services/rag-service.test.ts
+++ b/backend/src/domains/llm/services/rag-service.test.ts
@@ -372,6 +372,36 @@ describe('RAG Service', () => {
       );
     });
 
+    it('should not orphan the keyword promise when re-throwing CircuitBreakerOpenError', async () => {
+      // Regression for #921: on the CircuitBreakerOpenError rethrow path the
+      // in-flight keywordSearch promise is never awaited. If its underlying DB
+      // query rejects, that rejection must still be observed — otherwise it
+      // surfaces as an unhandledRejection that can crash the process.
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on('unhandledRejection', onUnhandled);
+      try {
+        const cbError = new CircuitBreakerOpenError('LLM server temporarily unavailable');
+        mocks.mockGenerateEmbedding.mockRejectedValue(cbError);
+        mocks.mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
+
+        // keywordSearch's DB query rejects — this is the promise that gets
+        // orphaned when the CB error short-circuits the function.
+        mocks.mockQuery.mockRejectedValue(new Error('connection terminated'));
+
+        await expect(hybridSearch('user-1', 'test query')).rejects.toThrow(
+          'LLM server temporarily unavailable',
+        );
+
+        // Flush microtasks/timers so any orphaned rejection would fire.
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
+    });
+
     it('should record keyword_fallback search type when embedding fails', async () => {
       mocks.mockGenerateEmbedding.mockRejectedValue(new Error('Ollama unreachable'));
       mocks.mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);

--- a/backend/src/domains/llm/services/rag-service.ts
+++ b/backend/src/domains/llm/services/rag-service.ts
@@ -264,6 +264,11 @@ export async function hybridSearch(
   // Start keyword search outside the try block so DB errors in keyword
   // search are not silently caught as "embedding failures".
   const keywordPromise = keywordSearch(userId, question, stageLimit);
+  // Observe the promise so a rejection can never go unhandled if the embedding
+  // path short-circuits (e.g. rethrowing CircuitBreakerOpenError) before the
+  // `await keywordPromise` below runs. This no-op observer does not consume the
+  // result — the await at the end still throws/propagates in the normal path.
+  keywordPromise.catch(() => {});
 
   try {
     // Resolve the `embedding` use-case to the provider+model that generated


### PR DESCRIPTION
Fixes #921.

## What / Why
`hybridSearch` starts `keywordSearch` before the embedding `try` block so DB errors aren't misattributed to embedding failures. But on the `CircuitBreakerOpenError` rethrow path the function returns (`throw err`) without ever reaching `await keywordPromise`. If the in-flight `keywordSearch` DB query rejects, that promise is orphaned and its rejection surfaces as a process-level `unhandledRejection` — which can crash the Node process.

Fix: attach a no-op `.catch(() => {})` observer immediately after creating `keywordPromise`. This only marks the rejection as observed; it does not consume the result, so the existing `await keywordPromise` in the normal path still throws/propagates unchanged.

## Test Evidence
`backend/src/domains/llm/services/rag-service.test.ts` — new test `should not orphan the keyword promise when re-throwing CircuitBreakerOpenError`: registers a `process.on('unhandledRejection')` collector, mocks `generateEmbedding` to reject with `CircuitBreakerOpenError` and `query` to reject, asserts the CB error propagates and no unhandled rejection is collected after flushing microtasks.

- Before fix: FAIL — collector captured `Error: connection terminated` (orphaned rejection).
- After fix: PASS — all 38 tests in the file pass. Backend typecheck + eslint on touched files clean.

## Docs / Diagram Impact
None — internal error-handling fix, no change to RAG flow structure, domains, or schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)