### PR TITLE
fix(settings): clear stored PAT on confluencePat:null (#924)

### DIFF
--- a/backend/src/routes/foundation/settings.test.ts
+++ b/backend/src/routes/foundation/settings.test.ts
@@ -691,6 +691,34 @@ describe('Settings routes – GET/PUT settings (shared tables)', () => {
     expect(updateCalls[0][1]).toContain(JSON.stringify({ improve_clarity: 'Be clear!' }));
   });
 
+  it('PUT /settings clears the stored PAT when confluencePat is null (#924)', async () => {
+    // #924: confluencePat: null is a valid nullable value meaning "disconnect".
+    // The handler must issue `confluence_pat = NULL` so the PAT is actually
+    // wiped. Previously null was silently ignored — the PAT survived while
+    // invalidateUserData still nuked the user's space_role_assignments, leaving
+    // a connected PAT with no space access.
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 }); // UPDATE user_settings
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      payload: { confluencePat: null },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    // The UPDATE must set confluence_pat = NULL.
+    const nullPatUpdate = mockQuery.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('UPDATE user_settings') &&
+        (call[0] as string).includes('confluence_pat = NULL'),
+    );
+    expect(nullPatUpdate).toHaveLength(1);
+    // Must never encrypt a null PAT (no ciphertext bound into the query).
+    expect(nullPatUpdate[0][1]).not.toContain('encrypted-pat');
+  });
+
   it('PUT /settings removes old Confluence URL from SSRF allowlist when URL changes (#481)', async () => {
     // Query 1: SELECT old confluence_url
     mockQuery.mockResolvedValueOnce({

--- a/backend/src/routes/foundation/settings.ts
+++ b/backend/src/routes/foundation/settings.ts
@@ -126,9 +126,17 @@ export async function settingsRoutes(fastify: FastifyInstance) {
       }
     }
 
-    if (body.confluencePat !== undefined && body.confluencePat !== null) {
-      updates.push(`confluence_pat = $${paramIdx++}`);
-      values.push(encryptPat(body.confluencePat));
+    if (body.confluencePat !== undefined) {
+      // #924: confluencePat is nullable — null means "disconnect", so clear the
+      // stored PAT. Ignoring null left a live PAT behind while invalidateUserData
+      // still wiped the user's space_role_assignments, stranding them with a
+      // connected credential but no space access.
+      if (body.confluencePat === null) {
+        updates.push('confluence_pat = NULL');
+      } else {
+        updates.push(`confluence_pat = $${paramIdx++}`);
+        values.push(encryptPat(body.confluencePat));
+      }
     }
 
     if (body.theme !== undefined) {


### PR DESCRIPTION
Fixes #924.

## What / Why
`PUT /settings` treated a `null` `confluencePat` as a no-op: the null branch was excluded at the `confluence_pat` update, so the stored (encrypted) PAT was never cleared. Meanwhile the post-update invalidation fired unconditionally because `null !== undefined`, so `invalidateUserData` DELETEd all of the user's `space_role_assignments`. Net effect: the user's space-role assignments were wiped while a live, connected PAT remained — a connected credential with zero space access.

The contract already types `confluencePat` as `z.string().nullable().optional()`, where `null` means "disconnect". This change handles `null` explicitly with a static `confluence_pat = NULL` fragment, so null actually clears the PAT. The subsequent assignment reset is then correct behavior (credentials genuinely changed). Minimal, surgical change to the single `if` block.

## Test Evidence
- `backend/src/routes/foundation/settings.test.ts` — new case `PUT /settings clears the stored PAT when confluencePat is null (#924)`.
- Asserts the `UPDATE user_settings` call contains `confluence_pat = NULL` and never binds an encrypted-PAT ciphertext.
- Fails BEFORE the fix (`expected [] to have length 1 but got 0` — no PAT UPDATE issued); passes AFTER. Full file: 30/30 pass.

## Docs / Diagram Impact
None — behavioral fix within the existing auth/RBAC invalidation flow; no schema, boundary, or compose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)