### PR TITLE
fix(knowledge): atomic version guard on standalone page update (#926)

### DIFF
--- a/backend/src/routes/knowledge/folder-pages.test.ts
+++ b/backend/src/routes/knowledge/folder-pages.test.ts
@@ -205,8 +205,10 @@ describe('Folder pages (#414)', () => {
           page_type: 'folder',
         }],
       });
-      // UPDATE query
-      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+      // UPDATE query — #926 guards the write with `AND version = <read version>`
+      // and treats rowCount 0 as a lost update (409). The version matches here,
+      // so the title-only write lands: rowCount 1 = success.
+      mockQueryFn.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
       const response = await app.inject({
         method: 'PUT',

--- a/backend/src/routes/knowledge/page-update.test.ts
+++ b/backend/src/routes/knowledge/page-update.test.ts
@@ -195,6 +195,10 @@ describe('PUT /api/pages/:id', () => {
             }],
           });
         }
+        // A matching, guarded UPDATE affects exactly one row (#926).
+        if (sql.includes('UPDATE pages SET')) {
+          return Promise.resolve({ rows: [], rowCount: 1 });
+        }
         return Promise.resolve({ rows: [] });
       });
 
@@ -243,6 +247,10 @@ describe('PUT /api/pages/:id', () => {
               confluence_id: null, deleted_at: null, page_type: 'page',
             }],
           });
+        }
+        // A matching, guarded UPDATE affects exactly one row (#926).
+        if (sql.includes('UPDATE pages SET')) {
+          return Promise.resolve({ rows: [], rowCount: 1 });
         }
         return Promise.resolve({ rows: [] });
       });
@@ -304,6 +312,73 @@ describe('PUT /api/pages/:id', () => {
       expect(response.statusCode).toBe(200);
       expect(mockCacheInvalidateAcrossUsers).not.toHaveBeenCalled();
       expect(mockCacheInvalidate).toHaveBeenCalledWith('user-1', 'pages');
+    });
+  });
+
+  // #926 — the standalone update read the current version, computed
+  // newVersion = version + 1, then wrote with a bare `WHERE id = $1`. Two
+  // concurrent writers that both read version N both write N+1, and the
+  // slower one silently clobbers the faster one's edit (last-write-wins,
+  // no 409). The JS pre-check only rejects a client that sends a STALE
+  // body.version; it can't see a write that landed after the SELECT. The
+  // UPDATE must carry an atomic `AND version = <read version>` guard and
+  // return 409 when it matches no row.
+  describe('standalone update — atomic version guard (#926)', () => {
+    function mockStandalonePageWithUpdate(updateResult: { rows: unknown[]; rowCount: number }) {
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('SELECT id, version, space_key')) {
+          return Promise.resolve({
+            rows: [{
+              id: 7, version: 5, space_key: 'NOTES', source: 'standalone',
+              created_by_user_id: 'user-1', visibility: 'private',
+              confluence_id: null, deleted_at: null, page_type: 'page',
+            }],
+          });
+        }
+        if (sql.includes('UPDATE pages SET')) {
+          return Promise.resolve(updateResult);
+        }
+        return Promise.resolve({ rows: [] });
+      });
+    }
+
+    it('returns 409 when the UPDATE matches no row because a concurrent writer bumped the version', async () => {
+      // A concurrent writer already advanced the row from 5 to 6, so the
+      // guarded UPDATE (`AND version = 5`) matches nothing → rowCount 0.
+      mockStandalonePageWithUpdate({ rows: [], rowCount: 0 });
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/pages/7',
+        // body.version === current read version, so the JS pre-check passes
+        // and only the atomic guard can catch the lost-update race.
+        payload: { title: 'Note', bodyHtml: '<p>note</p>', version: 5 },
+      });
+
+      expect(response.statusCode).toBe(409);
+    });
+
+    it('locks the read version into the UPDATE WHERE clause as a bound parameter', async () => {
+      mockStandalonePageWithUpdate({ rows: [], rowCount: 1 });
+
+      await app.inject({
+        method: 'PUT',
+        url: '/api/pages/7',
+        payload: { title: 'Note', bodyHtml: '<p>note</p>', version: 5 },
+      });
+
+      const call = mockQuery.mock.calls.find(
+        (c) => typeof c[0] === 'string'
+          && (c[0] as string).includes('UPDATE pages SET')
+          && (c[0] as string).includes('local_modified_by'),
+      );
+      if (!call) throw new Error('no standalone UPDATE pages call');
+      const sql = call[0] as string;
+      const params = call[1] as unknown[];
+      // Guard predicate present and parameterised (never string-interpolated).
+      expect(sql).toMatch(/version\s*=\s*\$\d+/);
+      // The bound value is the version read from the SELECT (5).
+      expect(params).toContain(5);
     });
   });
 

--- a/backend/src/routes/knowledge/pages-crud-webhooks.test.ts
+++ b/backend/src/routes/knowledge/pages-crud-webhooks.test.ts
@@ -231,8 +231,10 @@ describe('pages-crud webhook emit call-sites', () => {
           confluence_id: null, deleted_at: null, page_type: 'page',
         }],
       });
-      // UPDATE
-      mockQueryFn.mockResolvedValueOnce({ rows: [] });
+      // UPDATE — #926 guards the write with `AND version = <read version>` and
+      // treats rowCount 0 as a lost update (409). The version matches here, so
+      // the row is written: rowCount 1 = success.
+      mockQueryFn.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
       const response = await app.inject({
         method: 'PUT',

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -1271,7 +1271,14 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       // index for local_modified_by based on whether the visibility
       // column is being written in the same statement.
       const userIdParamIndex = body.visibility ? 7 : 6;
-      await query(
+      // #926: guard the write with the version we just read. The JS pre-check
+      // above only rejects a client that SENDS a stale body.version; it can't
+      // see a write that landed between our SELECT and this UPDATE. Binding
+      // `AND version = <read version>` makes a concurrent writer's row (already
+      // bumped to newVersion) fail to match, so we detect the lost update via
+      // rowCount instead of silently clobbering it (last-write-wins).
+      const versionGuardIndex = body.visibility ? 8 : 7;
+      const updateResult = await query(
         `UPDATE pages SET
            title = $2, body_html = $3, body_text = $4,
            version = $5, last_modified_at = NOW(), embedding_dirty = TRUE,
@@ -1288,11 +1295,15 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
            -- touched the page last.
            local_modified_at = NOW(), local_modified_by = $${userIdParamIndex}
            ${body.visibility ? ', visibility = $6' : ''}
-         WHERE id = $1`,
+         WHERE id = $1 AND version = $${versionGuardIndex}`,
         body.visibility
-          ? [id, body.title, body.bodyHtml, bodyText, newVersion, body.visibility, userId]
-          : [id, body.title, body.bodyHtml, bodyText, newVersion, userId],
+          ? [id, body.title, body.bodyHtml, bodyText, newVersion, body.visibility, userId, existingPage.version]
+          : [id, body.title, body.bodyHtml, bodyText, newVersion, userId, existingPage.version],
       );
+
+      if ((updateResult.rowCount ?? 0) === 0) {
+        throw fastify.httpErrors.conflict('Page has been modified since you loaded it. Please refresh and try again.');
+      }
 
       // A shared page's list rows (title/snippet) and a visibility flip both
       // change what OTHER users see (#893) — their cached trees/lists would


### PR DESCRIPTION
Fixes #926.

## What / why
The standalone branch of `PUT /api/pages/:id` (`pages-crud.ts`) read the current page version, computed `newVersion = version + 1`, then wrote with a bare `WHERE id = $1`. Two concurrent writers that both read version N both write N+1, so the slower writer silently clobbers the faster one's edit (classic lost update / last-write-wins). The pre-existing JS optimistic check only rejects a client that *sends* a stale `body.version`; it cannot detect a write that landed between our SELECT and UPDATE.

The fix binds the just-read version into the statement as `AND version = $N` and inspects `rowCount`: when the guard matches no row (a concurrent writer already bumped it), the handler throws `409 Conflict` instead of overwriting. The Confluence-push branch is deliberately untouched.

## Test evidence
`backend/src/routes/knowledge/page-update.test.ts` — new `standalone update — atomic version guard (#926)` block:
- `returns 409 when the UPDATE matches no row ...` — UPDATE mock returns `rowCount: 0`.
- `locks the read version into the UPDATE WHERE clause as a bound parameter` — asserts the SQL has a parameterised `version = $N` predicate and the read version is a bound param.

Fails before the fix (handler ignored `rowCount`, returned 200) and passes after. Full file: 11 passed. Existing standalone fixtures updated to return `rowCount: 1` for a matching guarded UPDATE (reflects real DB behavior). `npm run typecheck -w backend` and ESLint on the touched files are clean.

## Docs / diagram impact
None — behavior-only fix within an existing route; no compose, domain boundary, DB schema, or documented flow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)