### PR TITLE
fix(enterprise): log EE load failures instead of swallowing them (#898)

### DIFF
--- a/backend/src/core/enterprise/loader.test.ts
+++ b/backend/src/core/enterprise/loader.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { loadEnterprisePlugin, getEnterprisePlugin, _resetForTesting } from './loader.js';
 import { noopPlugin } from './noop.js';
+import { logger } from '../utils/logger.js';
 
 vi.mock('../utils/logger.js', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -9,6 +10,7 @@ vi.mock('../utils/logger.js', () => ({
 describe('Enterprise loader', () => {
   beforeEach(() => {
     _resetForTesting();
+    vi.mocked(logger.error).mockClear();
   });
 
   describe('loadEnterprisePlugin', () => {
@@ -25,6 +27,37 @@ describe('Enterprise loader', () => {
 
       expect(first).toBe(second);
       expect(first).toBe(noopPlugin);
+    });
+
+    it('should stay silent when the package is genuinely absent (community mode)', async () => {
+      const plugin = await loadEnterprisePlugin();
+
+      expect(plugin).toBe(noopPlugin);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    describe('when @compendiq/enterprise is present but fails to load', () => {
+      afterEach(() => {
+        vi.doUnmock('@compendiq/enterprise');
+        vi.resetModules();
+      });
+
+      it('should log an error and fall back to noop instead of swallowing the failure', async () => {
+        // Simulate a broken/misconfigured EE package: the module resolves but
+        // its top-level evaluation throws (e.g. a missing transitive dep or a
+        // boot error) — NOT a genuine "package not installed" case.
+        vi.doMock('@compendiq/enterprise', () => {
+          throw new Error('top-level EE boot failure');
+        });
+
+        _resetForTesting();
+        const plugin = await loadEnterprisePlugin();
+
+        expect(plugin).toBe(noopPlugin);
+        expect(logger.error).toHaveBeenCalledTimes(1);
+        const [, message] = vi.mocked(logger.error).mock.calls[0];
+        expect(String(message)).toContain('failed to load');
+      });
     });
   });
 

--- a/backend/src/core/enterprise/loader.ts
+++ b/backend/src/core/enterprise/loader.ts
@@ -21,6 +21,10 @@ let currentLicense: LicenseInfo | null = null;
  *   it is returned and cached.
  * - If the package is not installed (normal for community edition),
  *   the noop plugin is returned silently. No error, no warning.
+ * - If the package IS present but fails to load (broken build, missing
+ *   transitive dep, top-level boot error), the failure is logged at error
+ *   level before falling back to noop — this is a real misconfiguration,
+ *   not normal community mode, and must not be swallowed.
  * - Result is cached after the first call; subsequent calls are synchronous.
  */
 export async function loadEnterprisePlugin(): Promise<EnterprisePlugin> {
@@ -42,9 +46,24 @@ export async function loadEnterprisePlugin(): Promise<EnterprisePlugin> {
       logger.warn('Enterprise package found but exports are invalid');
       cached = null;
     }
-  } catch {
-    // Package not installed — this is normal for community edition.
-    // No log output: community mode is not an error condition.
+  } catch (err) {
+    // Only genuine package-absence is silent (normal for community edition).
+    // Node reports it as ERR_MODULE_NOT_FOUND whose message quotes the
+    // missing specifier: "Cannot find package '@compendiq/enterprise' ...".
+    // A missing transitive dependency raises the same code but quotes the
+    // DEP's name instead, so the specifier check keeps this discriminating.
+    const e = err as NodeJS.ErrnoException;
+    const packageMissing =
+      e?.code === 'ERR_MODULE_NOT_FOUND' &&
+      typeof e.message === 'string' &&
+      e.message.includes("'@compendiq/enterprise'");
+
+    if (!packageMissing) {
+      logger.error(
+        { err },
+        'Enterprise package present but failed to load — falling back to community mode',
+      );
+    }
     cached = null;
   }
 


### PR DESCRIPTION
Fixes #898.

## What / Why
The enterprise loader in `backend/src/core/enterprise/loader.ts` used a bare `catch {}` that silently swallowed **every** dynamic-import failure. A genuinely absent `@compendiq/enterprise` package (normal for community edition) and a present-but-broken EE package (missing transitive dep, top-level boot error) were handled identically — real misconfigurations vanished with no log.

The fix discriminates the two failure modes: only a genuine `ERR_MODULE_NOT_FOUND` whose message quotes the `'@compendiq/enterprise'` specifier stays silent. Any other failure is logged at `error` level before falling back to noop. Community-mode behavior is otherwise unchanged.

## Test evidence
`backend/src/core/enterprise/loader.test.ts`:
- Added a silent-path guard: package absent → `logger.error` NOT called, plugin === noopPlugin.
- Added a loud-path test using `vi.doMock('@compendiq/enterprise')` with a throwing factory to simulate a broken EE package → asserts `logger.error` called once with a "failed to load" message and plugin === noopPlugin.
- Fails-before: loud-path test failed on current code (`expected called 1 times, got 0`).
- Passes-after: all 8 tests green. Backend typecheck and ESLint on touched files clean.

## Docs / diagram impact
None — behavior-preserving error-logging change, no system structure / flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)