### PR TITLE
fix(content): split embedded CDATA terminators in code blocks (#900)

### DIFF
--- a/backend/src/core/services/content-converter.test.ts
+++ b/backend/src/core/services/content-converter.test.ts
@@ -434,6 +434,20 @@ describe('content-converter', () => {
       expect(xhtml).toContain('<![CDATA[a < b && c > d]]>');
     });
 
+    it('splits embedded CDATA terminators in code block content (#900)', () => {
+      const xhtml = htmlToConfluence('<pre><code>printf("]]&gt;");</code></pre>');
+      // The literal ]]> must be split across two adjacent CDATA sections so
+      // the wrapping section is not prematurely closed.
+      expect(xhtml).toContain('<![CDATA[printf("]]]]><![CDATA[>");]]>');
+    });
+
+    it('round-trips code blocks containing ]]> (#900)', () => {
+      const html = '<pre><code>printf("]]&gt;");</code></pre>';
+      const xhtml = htmlToConfluence(html);
+      const roundTripped = confluenceToHtml(xhtml);
+      expect(roundTripped).toContain('printf("]]&gt;");');
+    });
+
     it('round-trips code blocks', () => {
       const html = confluenceToHtml(CODE_BLOCK_PAGE);
       const xhtml = htmlToConfluence(html);

--- a/backend/src/core/services/content-converter.ts
+++ b/backend/src/core/services/content-converter.ts
@@ -965,7 +965,11 @@ export function htmlToConfluence(html: string): string {
     (_, content: string) => {
       // Unescape HTML entities back to raw text for CDATA
       const raw = he.decode(content);
-      return `<ac:plain-text-body><![CDATA[${raw}]]></ac:plain-text-body>`;
+      // #900: a literal ']]>' inside the content would prematurely close the
+      // CDATA section, producing invalid XHTML. Split it across two adjacent
+      // CDATA sections (the standard escape) so the terminator survives intact.
+      const safe = raw.replace(/\]\]>/g, ']]]]><![CDATA[>');
+      return `<ac:plain-text-body><![CDATA[${safe}]]></ac:plain-text-body>`;
     },
   );
 


### PR DESCRIPTION
Fixes #900.

## What / Why
`htmlToConfluence` wrapped `<ac:plain-text-body>` content in a single CDATA section via `he.decode(content)` without handling a literal `]]>` inside the code. That sequence prematurely terminates the CDATA section, producing invalid Confluence XHTML and corrupting/losing code text on round-trip.

The fix splits any `]]>` in the decoded content across two adjacent CDATA sections using the standard escape (`]]]]><![CDATA[>`), so the terminator survives intact. `stripCdata`'s existing global regex already re-joins the adjacent sections on the way back, so no change is needed there.

## Test evidence
`backend/src/core/services/content-converter.test.ts` (two new cases in the `htmlToConfluence` describe block):
- Asserts the split escape `<![CDATA[printf("]]]]><![CDATA[>");]]>` is emitted.
- Round-trip `confluenceToHtml(htmlToConfluence(...))` recovers the literal `]]>` in the code block.

Both FAILED on `dev` (bare `]]>` broke the CDATA / round-trip) and PASS after the one-line fix. Full file: 199/199 pass. Backend typecheck and ESLint on touched files clean.

## Docs / diagram impact
None — internal content-conversion logic only; no change to compose, domains, boundaries, migrations, or documented pipeline structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)