### PR TITLE
fix(#902): ownership-checked worker lock release

### DIFF
--- a/backend/src/core/services/redis-cache.test.ts
+++ b/backend/src/core/services/redis-cache.test.ts
@@ -539,25 +539,31 @@ describe('redis-cache embedding lock', () => {
   });
 
   describe('acquireWorkerLock', () => {
-    it('returns true when lock is acquired (SET NX returns OK)', async () => {
+    it('returns a UUID token when lock is acquired (SET NX stores that token, not "1")', async () => {
       mockRedis.set.mockResolvedValue('OK');
 
-      const acquired = await acquireWorkerLock('quality-worker');
+      const token = await acquireWorkerLock('quality-worker');
 
-      expect(acquired).toBe(true);
+      // Ownership token — a UUID, never the legacy bare '1' value.
+      expect(token).toBeTypeOf('string');
+      expect(token).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
       expect(mockRedis.set).toHaveBeenCalledWith(
         'worker:lock:quality-worker',
-        '1',
+        token,
         { NX: true, EX: 300 },
       );
+      // The stored value must be the token, never the legacy sentinel '1'.
+      expect(mockRedis.set.mock.calls[0][1]).not.toBe('1');
     });
 
-    it('returns false when lock is already held', async () => {
+    it('returns null when lock is already held', async () => {
       mockRedis.set.mockResolvedValue(null);
 
-      const acquired = await acquireWorkerLock('quality-worker');
+      const token = await acquireWorkerLock('quality-worker');
 
-      expect(acquired).toBe(false);
+      expect(token).toBeNull();
     });
 
     it('uses custom TTL when provided', async () => {
@@ -569,44 +575,59 @@ describe('redis-cache embedding lock', () => {
       expect(call[2]).toEqual({ NX: true, EX: 600 });
     });
 
-    it('falls back to true when Redis is not available', async () => {
+    it('falls back to a token when Redis is not available', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       setRedisClient(null as any);
 
-      const acquired = await acquireWorkerLock('test-worker');
+      const token = await acquireWorkerLock('test-worker');
 
-      expect(acquired).toBe(true);
+      // Truthy fallback so single-node callers still proceed.
+      expect(token).toBeTypeOf('string');
+      expect(token).toBeTruthy();
     });
 
-    it('falls back to true when Redis throws', async () => {
+    it('falls back to a token when Redis throws', async () => {
       mockRedis.set.mockRejectedValue(new Error('Redis down'));
 
-      const acquired = await acquireWorkerLock('test-worker');
+      const token = await acquireWorkerLock('test-worker');
 
-      expect(acquired).toBe(true);
+      expect(token).toBeTypeOf('string');
+      expect(token).toBeTruthy();
     });
   });
 
   describe('releaseWorkerLock', () => {
-    it('deletes the lock key', async () => {
-      mockRedis.del.mockResolvedValue(1);
+    it('releases via an ownership-checked Lua script, not a bare del (plan RED)', async () => {
+      mockRedis.eval.mockResolvedValue(1);
 
-      await releaseWorkerLock('quality-worker');
+      await releaseWorkerLock('quality-worker', 'token-abc');
 
-      expect(mockRedis.del).toHaveBeenCalledWith('worker:lock:quality-worker');
+      // Must NOT unconditionally DEL — that deletes another pod's lock when the
+      // TTL lapsed and a different holder re-acquired.
+      expect(mockRedis.del).not.toHaveBeenCalled();
+      expect(mockRedis.eval).toHaveBeenCalledTimes(1);
+      const [script, opts] = mockRedis.eval.mock.calls[0];
+      expect(script).toEqual(
+        expect.stringContaining('redis.call("get", KEYS[1]) == ARGV[1]'),
+      );
+      expect((script as string).toLowerCase()).toContain('del');
+      expect(opts).toEqual({
+        keys: ['worker:lock:quality-worker'],
+        arguments: ['token-abc'],
+      });
     });
 
     it('is a no-op when Redis is not available', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       setRedisClient(null as any);
 
-      await expect(releaseWorkerLock('test-worker')).resolves.toBeUndefined();
+      await expect(releaseWorkerLock('test-worker', 'token')).resolves.toBeUndefined();
     });
 
     it('does not throw when Redis throws', async () => {
-      mockRedis.del.mockRejectedValue(new Error('Redis timeout'));
+      mockRedis.eval.mockRejectedValue(new Error('Redis timeout'));
 
-      await expect(releaseWorkerLock('test-worker')).resolves.toBeUndefined();
+      await expect(releaseWorkerLock('test-worker', 'token')).resolves.toBeUndefined();
     });
   });
 });

--- a/backend/src/core/services/redis-cache.ts
+++ b/backend/src/core/services/redis-cache.ts
@@ -315,32 +315,55 @@ export async function forceReleaseEmbeddingLock(
 // preserving single-node behaviour.
 
 /**
- * Attempt to acquire a named worker lock via Redis SET NX EX.
- * Returns true if the lock was acquired, false if another holder has it.
- * Falls back to true when Redis is not available (single-node fallback).
+ * Release Lua — only delete the worker lock if the caller still owns it (the
+ * stored value matches the token handed out at acquisition). Prevents a batch
+ * that outlives its TTL from deleting the lock a *different* pod has since
+ * re-acquired (issue #902). Mirrors RELEASE_LOCK_SCRIPT above.
+ *
+ *   KEYS[1] = worker:lock:<name>
+ *   ARGV[1] = ownership token (UUID)
  */
-export async function acquireWorkerLock(name: string, ttlSeconds = 300): Promise<boolean> {
-  if (!_redisClient) return true; // single-node fallback
+const WORKER_RELEASE_LOCK_SCRIPT = `if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end`;
+
+/**
+ * Attempt to acquire a named worker lock via Redis SET NX EX.
+ * Returns a unique ownership token if the lock was acquired, or null if another
+ * holder has it. The token must be passed to releaseWorkerLock to prove
+ * ownership so a stale holder cannot delete a lock re-acquired by another pod.
+ * Falls back to a generated token when Redis is not available (single-node
+ * fallback — callers still proceed on truthiness).
+ */
+export async function acquireWorkerLock(
+  name: string,
+  ttlSeconds = 300,
+): Promise<string | null> {
+  const token = randomUUID();
+  if (!_redisClient) return token; // single-node fallback
   try {
-    const result = await _redisClient.set(`worker:lock:${name}`, '1', {
+    const result = await _redisClient.set(`worker:lock:${name}`, token, {
       NX: true,
       EX: ttlSeconds,
     });
-    return result !== null;
+    return result !== null ? token : null;
   } catch (err) {
     logger.error({ err, name }, 'Failed to acquire worker lock');
-    return true; // degrade to local execution
+    return token; // degrade to local execution
   }
 }
 
 /**
- * Release a named worker lock.
- * Safe to call when Redis is unavailable (no-op).
+ * Release a named worker lock, but only if the caller still owns it.
+ * Uses a Lua script to compare-and-delete against the ownership token, so a
+ * process whose lock already expired (and was re-acquired elsewhere) cannot
+ * delete the new holder's lock. Safe to call when Redis is unavailable (no-op).
  */
-export async function releaseWorkerLock(name: string): Promise<void> {
+export async function releaseWorkerLock(name: string, token: string): Promise<void> {
   if (!_redisClient) return;
   try {
-    await _redisClient.del(`worker:lock:${name}`);
+    await _redisClient.eval(WORKER_RELEASE_LOCK_SCRIPT, {
+      keys: [`worker:lock:${name}`],
+      arguments: [token],
+    });
   } catch (err) {
     logger.error({ err, name }, 'Failed to release worker lock');
   }

--- a/backend/src/core/services/token-cleanup-service.ts
+++ b/backend/src/core/services/token-cleanup-service.ts
@@ -40,8 +40,8 @@ export function startTokenCleanupWorker(): void {
 
   cleanupIntervalHandle = setInterval(async () => {
     if (cleanupLock) return;
-    const acquired = await acquireWorkerLock('token-cleanup', 300);
-    if (!acquired) return;
+    const lockToken = await acquireWorkerLock('token-cleanup', 300);
+    if (!lockToken) return;
     cleanupLock = true;
 
     try {
@@ -51,7 +51,7 @@ export function startTokenCleanupWorker(): void {
       logger.error({ err }, 'Token cleanup worker error');
     } finally {
       cleanupLock = false;
-      await releaseWorkerLock('token-cleanup');
+      await releaseWorkerLock('token-cleanup', lockToken);
     }
   }, intervalHours * 60 * 60 * 1000);
 

--- a/backend/src/domains/knowledge/services/quality-worker.ts
+++ b/backend/src/domains/knowledge/services/quality-worker.ts
@@ -394,8 +394,8 @@ export function startQualityWorker(intervalMinutes?: number): void {
 
   qualityIntervalHandle = setInterval(async () => {
     if (qualityLock) return;
-    const acquired = await acquireWorkerLock('quality-worker', 600);
-    if (!acquired) return;
+    const lockToken = await acquireWorkerLock('quality-worker', 600);
+    if (!lockToken) return;
     qualityLock = true;
     isProcessing = true;
 
@@ -409,7 +409,7 @@ export function startQualityWorker(intervalMinutes?: number): void {
     } finally {
       qualityLock = false;
       isProcessing = false;
-      await releaseWorkerLock('quality-worker');
+      await releaseWorkerLock('quality-worker', lockToken);
     }
   }, intervalMs);
 
@@ -425,8 +425,8 @@ export function startQualityWorker(intervalMinutes?: number): void {
  */
 export async function triggerQualityBatch(): Promise<void> {
   if (qualityLock) return;
-  const acquired = await acquireWorkerLock('quality-worker', 600);
-  if (!acquired) return;
+  const lockToken = await acquireWorkerLock('quality-worker', 600);
+  if (!lockToken) return;
   qualityLock = true;
   isProcessing = true;
 
@@ -440,7 +440,7 @@ export async function triggerQualityBatch(): Promise<void> {
   } finally {
     qualityLock = false;
     isProcessing = false;
-    await releaseWorkerLock('quality-worker');
+    await releaseWorkerLock('quality-worker', lockToken);
   }
 }
 

--- a/backend/src/domains/knowledge/services/summary-worker.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.ts
@@ -463,8 +463,8 @@ export function startSummaryWorker(intervalMinutes?: number): void {
 
   workerIntervalHandle = setInterval(async () => {
     if (workerLock) return;
-    const acquired = await acquireWorkerLock('summary-worker', 600);
-    if (!acquired) return;
+    const lockToken = await acquireWorkerLock('summary-worker', 600);
+    if (!lockToken) return;
     workerLock = true;
     isProcessing = true;
 
@@ -478,7 +478,7 @@ export function startSummaryWorker(intervalMinutes?: number): void {
     } finally {
       workerLock = false;
       isProcessing = false;
-      await releaseWorkerLock('summary-worker');
+      await releaseWorkerLock('summary-worker', lockToken);
     }
   }, interval);
 
@@ -494,8 +494,8 @@ export function startSummaryWorker(intervalMinutes?: number): void {
  */
 export async function triggerSummaryBatch(): Promise<void> {
   if (workerLock) return;
-  const acquired = await acquireWorkerLock('summary-worker', 600);
-  if (!acquired) return;
+  const lockToken = await acquireWorkerLock('summary-worker', 600);
+  if (!lockToken) return;
   workerLock = true;
   isProcessing = true;
 
@@ -509,7 +509,7 @@ export async function triggerSummaryBatch(): Promise<void> {
   } finally {
     workerLock = false;
     isProcessing = false;
-    await releaseWorkerLock('summary-worker');
+    await releaseWorkerLock('summary-worker', lockToken);
   }
 }
 


### PR DESCRIPTION
Fixes #902.

## What / Why
`releaseWorkerLock(name)` unconditionally `DEL`'d `worker:lock:<name>`. A worker batch that runs longer than the lock's TTL (300s for token-cleanup, 600s for quality/summary) will have its lock expire and be re-acquired by another pod — then the original batch's `finally` block deletes the *new* holder's lock, allowing two pods to run the same worker concurrently.

This mirrors the existing embedding-lock ownership pattern:
- `acquireWorkerLock` generates a per-acquisition `randomUUID`, stores it as the lock value (`SET NX EX`), and returns the token (`string`) or `null` when not acquired. Single-node / Redis-error fallback returns a fresh token so callers still proceed (they already branch on truthiness).
- `releaseWorkerLock(name, token)` deletes via an ownership-checked Lua `eval` (`if redis.call("get",KEYS[1])==ARGV[1] then return redis.call("del",KEYS[1]) else return 0 end`) — identical in shape to `RELEASE_LOCK_SCRIPT`.
- The three call sites (quality-worker, summary-worker, token-cleanup-service) capture the token and pass it to release; `if (!acquired) return` stays compatible with a UUID-vs-null return.

## Test evidence
`backend/src/core/services/redis-cache.test.ts` — extended the `acquireWorkerLock` / `releaseWorkerLock` blocks. New assertions: acquire stores a UUID token (not `'1'`) and returns it/null; release invokes an ownership-checked `eval` compare-and-delete (never a bare `del`).
- **Before fix:** 5 tests fail (acquire returns boolean/stores `'1'`, release calls bare `del`).
- **After fix:** all 110 tests across redis-cache + the three worker suites pass. Backend `typecheck` clean; ESLint clean on all touched files.

## Docs / diagram impact
None — internal lock-semantics correctness fix; no compose, domain-boundary, migration, or documented flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)