### PR TITLE
fix(confluence): follow _links.next in pagination loops (#903)

### DIFF
--- a/backend/src/domains/confluence/services/confluence-client.test.ts
+++ b/backend/src/domains/confluence/services/confluence-client.test.ts
@@ -1032,6 +1032,43 @@ describe('ConfluenceClient', () => {
       expect(ids.has('200')).toBe(true);
       expect(mockRequest).toHaveBeenCalledTimes(2);
     });
+
+    it('follows _links.next even when a page is shorter than the limit (#903)', async () => {
+      // Confluence DC may clamp a page below the requested limit (permission
+      // filtering, server-side max) while still advertising more via _links.next.
+      // The listing must be driven by the presence of `next`, not by size<limit,
+      // or the remaining ids are silently truncated.
+      const client = new ConfluenceClient(baseUrl, pat);
+      const firstPage = Array.from({ length: 40 }, (_, i) => ({ id: String(i) }));
+      const secondPage = Array.from({ length: 10 }, (_, i) => ({ id: String(40 + i) }));
+      mockRequest
+        .mockResolvedValueOnce({
+          statusCode: 200,
+          body: {
+            text: async () =>
+              JSON.stringify({
+                results: firstPage,
+                start: 0,
+                limit: 200,
+                size: 40,
+                _links: { next: '/rest/api/content?spaceKey=DEV&type=page&start=40&limit=200' },
+              }),
+          },
+        } as never)
+        .mockResolvedValueOnce({
+          statusCode: 200,
+          body: {
+            text: async () =>
+              JSON.stringify({ results: secondPage, start: 40, limit: 200, size: 10 }),
+          },
+        } as never);
+
+      const ids = await client.getAllPageIds('DEV');
+
+      expect(ids.size).toBe(50);
+      expect(ids.has('49')).toBe(true);
+      expect(mockRequest).toHaveBeenCalledTimes(2);
+    });
   });
 });
 

--- a/backend/src/domains/confluence/services/confluence-client.ts
+++ b/backend/src/domains/confluence/services/confluence-client.ts
@@ -243,8 +243,12 @@ export class ConfluenceClient {
     while (true) {
       const response = await this.getSpaces(start, limit);
       spaces.push(...response.results);
-      if (response.size < limit || !response._links?.next) break;
-      start += limit;
+      // Drive pagination by the presence of `_links.next`, not `size < limit`:
+      // Confluence DC may clamp a page below the requested limit while more
+      // results remain, so `size < limit` truncated the listing (#903). Advance
+      // by the count actually returned; an empty page guards against non-progress.
+      if (!response._links?.next || response.results.length === 0) break;
+      start += response.results.length;
     }
 
     return spaces;
@@ -308,8 +312,9 @@ export class ConfluenceClient {
         });
       }
 
-      if ((response.size ?? 0) < limit || !response._links?.next) break;
-      start += limit;
+      // See getAllSpaces: follow `_links.next` rather than `size < limit` (#903).
+      if (!response._links?.next || (response.results?.length ?? 0) === 0) break;
+      start += response.results?.length ?? 0;
     }
 
     return records;
@@ -656,8 +661,9 @@ export class ConfluenceClient {
     while (true) {
       const response = await this.searchPages(cql, start, limit);
       pages.push(...response.results);
-      if (response.size < limit || !response._links?.next) break;
-      start += limit;
+      // See getAllSpaces: follow `_links.next` rather than `size < limit` (#903).
+      if (!response._links?.next || response.results.length === 0) break;
+      start += response.results.length;
     }
 
     return pages;
@@ -829,8 +835,9 @@ export class ConfluenceClient {
     while (true) {
       const response = await this.getChildPages(parentId, start, limit);
       pages.push(...response.results);
-      if (response.size < limit || !response._links?.next) break;
-      start += limit;
+      // See getAllSpaces: follow `_links.next` rather than `size < limit` (#903).
+      if (!response._links?.next || response.results.length === 0) break;
+      start += response.results.length;
     }
 
     return pages;
@@ -874,8 +881,9 @@ export class ConfluenceClient {
     while (true) {
       const response = await this.getPages(spaceKey, start, limit);
       pages.push(...response.results);
-      if (response.size < limit || !response._links?.next) break;
-      start += limit;
+      // See getAllSpaces: follow `_links.next` rather than `size < limit` (#903).
+      if (!response._links?.next || response.results.length === 0) break;
+      start += response.results.length;
     }
 
     return pages;
@@ -899,8 +907,9 @@ export class ConfluenceClient {
         `/rest/api/content?spaceKey=${encodeURIComponent(spaceKey)}&type=page&start=${start}&limit=${limit}`,
       );
       for (const { id } of response.results) ids.add(id);
-      if (response.size < limit || !response._links?.next) break;
-      start += limit;
+      // See getAllSpaces: follow `_links.next` rather than `size < limit` (#903).
+      if (!response._links?.next || response.results.length === 0) break;
+      start += response.results.length;
     }
 
     return ids;


### PR DESCRIPTION
Fixes #903.

## What / Why
Confluence DC can return a page shorter than the requested `limit` (server-side max, permission filtering) while still advertising more results via `_links.next`. The six paginating loops in `confluence-client.ts` broke on `response.size < limit`, so the very first clamped short page ended the listing and silently truncated results — affecting space listing, incremental sync (`getModifiedPages`), child/space page enumeration, audit records, and deletion reconciliation (`getAllPageIds`).

The fix drives continuation by the presence of `_links.next` (with an empty-page non-progress guard mirroring `getPageVersions`) and advances `start` by the number of results actually returned, so a clamped short page no longer skips records.

Loops fixed: `getAllSpaces`, `getAuditRecords`, `getModifiedPages`, `getAllChildPages`, `getAllPagesInSpace`, `getAllPageIds`. (`getPageAttachments` uses a separate `results.length < limit` pattern and is out of scope.)

## Test evidence
`backend/src/domains/confluence/services/confluence-client.test.ts` — new case "follows _links.next even when a page is shorter than the limit (#903)": first page of 40 ids with `size:40 < limit 200` AND `_links.next`, second page of 10 ids with no next.
- Before fix: loop broke after page 1 → 40 ids (assertion `expected 40 to be 50` failed).
- After fix: follows next link → 50 ids, `mockRequest` called twice. Full file: 109/109 pass.

## Docs / diagram impact
None — behavioral bugfix within the content-sync client; no change to system structure, boundaries, or migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)