### PR TITLE
fix(sync): exclude NULL-id rows from deletion candidates (#905)

### DIFF
--- a/backend/src/domains/confluence/services/sync-service-delete-reconcile.integration.test.ts
+++ b/backend/src/domains/confluence/services/sync-service-delete-reconcile.integration.test.ts
@@ -86,6 +86,22 @@ async function insertPage(confluenceId: string, spaceKey: string): Promise<numbe
   return res.rows[0]!.id;
 }
 
+/**
+ * Insert a standalone KB article (source 'standalone', NULL confluence_id) that
+ * still carries a `space_key`, so it is swept up by the space-scoped candidate
+ * query. Such rows have no upstream Confluence page to reconcile against (#905).
+ */
+async function insertStandaloneNullIdPage(spaceKey: string): Promise<number> {
+  const res = await query<{ id: number }>(
+    `INSERT INTO pages (confluence_id, source, space_key, title, body_text,
+                         body_storage, body_html, inherit_perms)
+     VALUES (NULL, 'standalone', $1, 'Standalone', 'text', '', '', TRUE)
+     RETURNING id`,
+    [spaceKey],
+  );
+  return res.rows[0]!.id;
+}
+
 async function getDeletedAt(confluenceId: string): Promise<Date | null> {
   const res = await query<{ deleted_at: Date | null }>(
     'SELECT deleted_at FROM pages WHERE confluence_id = $1',
@@ -278,6 +294,34 @@ describe.skipIf(!dbAvailable)('sync-service deletion reconciliation (#706)', () 
 
     expect(client.getPageCalls).toHaveLength(200);
     expect(counts.pagesDeleted).toBe(200);
+  });
+
+  it('ignores standalone rows with a NULL confluence_id — never fetches getPage(null) nor inflates the count (#905)', async () => {
+    // A standalone KB article carries a space_key but no confluence_id, so it is
+    // swept up by the space-scoped candidate query. Its NULL id can never appear
+    // in the live listing, so without the `confluence_id IS NOT NULL` guard it
+    // becomes a bogus deletion candidate: getPage(null) is issued (a real client
+    // 404s on it), which is then mistaken for "gone" and inflates the delete
+    // count — while the UPDATE (WHERE confluence_id = NULL) matches nothing.
+    await insertPage('keep-905', 'DEV'); // real live Confluence page
+    const standaloneId = await insertStandaloneNullIdPage('DEV');
+
+    const client = makeClient({
+      liveIds: ['keep-905'], // the NULL-id row can never be in the live set
+      getPageError: () => new ConfluenceError('Resource not found', 404),
+    });
+    const counts = { pagesCreated: 0, pagesUpdated: 0, pagesDeleted: 0 };
+
+    await detectDeletedPages(client as never, 'DEV', counts);
+
+    // The standalone row has no upstream — it must never be a deletion candidate.
+    expect(client.getPageCalls).toEqual([]); // no bogus getPage(null)
+    expect(counts.pagesDeleted).toBe(0); // no phantom delete counted
+    const res = await query<{ deleted_at: Date | null }>(
+      'SELECT deleted_at FROM pages WHERE id = $1',
+      [standaloneId],
+    );
+    expect(res.rows[0]!.deleted_at).toBeNull(); // row untouched
   });
 
   // ── revival cross-check (#766 review) ────────────────────────────────────

--- a/backend/src/domains/confluence/services/sync-service.ts
+++ b/backend/src/domains/confluence/services/sync-service.ts
@@ -1528,9 +1528,13 @@ async function detectDeletedPages(
     );
   }
 
-  // Local non-deleted rows for this space.
+  // Local non-deleted rows for this space. Only rows backed by a Confluence page
+  // are reconcilable — standalone KB articles carry a space_key but a NULL
+  // confluence_id and have no upstream to confirm against. Excluding them here
+  // (mirroring the guard in purgeDeletedPages) keeps a NULL id from becoming a
+  // bogus candidate that fires getPage(null) and aborts the sync (#905).
   const existingResult = await query<{ confluence_id: string }>(
-    'SELECT confluence_id FROM pages WHERE space_key = $1 AND deleted_at IS NULL',
+    'SELECT confluence_id FROM pages WHERE space_key = $1 AND deleted_at IS NULL AND confluence_id IS NOT NULL',
     [spaceKey],
   );
 


### PR DESCRIPTION
Fixes #905.

**What/why.** `detectDeletedPages` selected every local non-deleted row for a space, including standalone KB articles (source `standalone`) which carry a `space_key` but a NULL `confluence_id`. A NULL id can never appear in the live Confluence listing, so it became a bogus deletion candidate: the reconciler issued `getPage(null)`, the 404 was mistaken for "gone", and the soft-delete branch called `cleanPageAttachments('', null)` — which throws `Invalid page ID` and **aborts the entire user sync** (also inflating `counts.pagesDeleted`).

The fix adds `AND confluence_id IS NOT NULL` to the candidate SELECT, mirroring the guard already present in the sibling `purgeDeletedPages`. Standalone rows have no upstream to reconcile against and are now correctly skipped.

**Test evidence.** `backend/src/domains/confluence/services/sync-service-delete-reconcile.integration.test.ts` — new case inserts a standalone NULL-id row alongside a live page and drives `__internal.detectDeletedPages` against a stub client (real Postgres).
- Fails before the fix: `Error: Invalid page ID` thrown from `cleanPageAttachments` via the bogus `getPage(null)` path (the exact reported crash).
- Passes after: `getPage` is never called with a null id, `counts.pagesDeleted` stays 0, and the standalone row is untouched. Full suite 27/27 green.

**Docs/diagram impact.** None — a WHERE-clause guard within the existing sync reconcile flow; no structural/table/boundary change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)