### PR TITLE
fix(sync): renew worker lock TTL via heartbeat during long syncs (#906)

### DIFF
--- a/backend/src/domains/confluence/services/sync-service.test.ts
+++ b/backend/src/domains/confluence/services/sync-service.test.ts
@@ -107,7 +107,7 @@ vi.mock('../../../core/services/redis-cache.js', () => ({
 }));
 
 // Now import the module under test
-import { getSyncStatus, setSyncStatus, startSyncWorker, stopSyncWorker, syncUser } from './sync-service.js';
+import { getSyncStatus, setSyncStatus, startSyncWorker, stopSyncWorker, syncUser, runScheduledSync } from './sync-service.js';
 import { query } from '../../../core/db/postgres.js';
 import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
 import { cleanPageAttachments } from './attachment-handler.js';
@@ -315,6 +315,81 @@ describe('sync-service', () => {
       startSyncWorker(15);
 
       expect(setIntervalSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ── lock heartbeat / renewal (#906) ───────────────────────────────────────
+
+  describe('sync lock heartbeat (#906)', () => {
+    /**
+     * Drive a `runScheduledSync()` whose single user's sync is held open on a
+     * gate, then advance fake timers past the lock-renewal interval (TTL/3 =
+     * 200s) while the run is still in-flight. Before the fix nothing re-extends
+     * the lock, so its fixed 600s TTL lapses mid-run and a second worker could
+     * start concurrently. After the fix the ownership-checked renew script
+     * fires on each heartbeat and stops once the run finishes.
+     */
+    function setupOneSlowUser() {
+      mockRedisSet.mockResolvedValue('OK'); // lock acquired
+      mockRedisEval.mockResolvedValue(1);
+
+      let releaseSpaces!: () => void;
+      const spacesGate = new Promise<string[]>((resolve) => {
+        releaseSpaces = () => resolve([]);
+      });
+      // syncUser awaits getUserAccessibleSpaces right after building the client;
+      // keeping it pending holds the whole run open across the heartbeat window.
+      vi.mocked(getUserAccessibleSpaces).mockReturnValue(spacesGate);
+
+      vi.mocked(query).mockImplementation(async (sql: string) => {
+        const s = typeof sql === 'string' ? sql : '';
+        const empty = { rows: [], rowCount: 0, command: '', oid: 0, fields: [] } as QueryResult;
+        if (s.includes('SELECT DISTINCT us.user_id')) {
+          return { rows: [{ user_id: 'user-1' }], rowCount: 1, command: '', oid: 0, fields: [] } as QueryResult;
+        }
+        if (s.includes('confluence_url') && s.includes('user_settings')) {
+          return {
+            rows: [{ confluence_url: 'https://confluence.test', confluence_pat: 'encrypted-pat' }],
+            rowCount: 1, command: '', oid: 0, fields: [],
+          } as QueryResult;
+        }
+        return empty;
+      });
+
+      return { releaseSpaces: () => releaseSpaces() };
+    }
+
+    const renewCalls = () =>
+      mockRedisEval.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).includes('redis.call("expire"'),
+      );
+
+    it('renews the lock TTL while a long-running sync is in flight', async () => {
+      const { releaseSpaces } = setupOneSlowUser();
+
+      const runPromise = runScheduledSync();
+      // Let the lock be acquired and the run reach the pending spaces gate.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(renewCalls()).toHaveLength(0);
+
+      // Cross one heartbeat window (TTL/3 = 200s) with the run still pending.
+      await vi.advanceTimersByTimeAsync(200_000);
+
+      expect(renewCalls().length).toBeGreaterThanOrEqual(1);
+      expect(mockRedisEval).toHaveBeenCalledWith(
+        expect.stringContaining('redis.call("expire", KEYS[1], ARGV[2])'),
+        expect.objectContaining({
+          keys: ['sync:worker:lock'],
+          arguments: [expect.any(String), '600'],
+        }),
+      );
+
+      // Finish the run and confirm the heartbeat stops (interval cleared).
+      releaseSpaces();
+      await runPromise;
+      const afterRun = renewCalls().length;
+      await vi.advanceTimersByTimeAsync(400_000);
+      expect(renewCalls().length).toBe(afterRun);
     });
   });
 

--- a/backend/src/domains/confluence/services/sync-service.ts
+++ b/backend/src/domains/confluence/services/sync-service.ts
@@ -113,6 +113,16 @@ const RECONCILE_DEDUPE_TTL = Math.max(
 /** Lua script: only delete the lock if the caller owns it (value matches). */
 const RELEASE_LOCK_SCRIPT = `if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end`;
 
+/** Lua script: only extend the lock TTL if the caller still owns it (value matches). */
+const RENEW_LOCK_SCRIPT = `if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("expire", KEYS[1], ARGV[2]) else return 0 end`;
+
+/**
+ * Heartbeat interval (ms) at which a running sync re-extends its lock TTL.
+ * TTL/3 gives two renewal chances before expiry so a single slow/dropped
+ * heartbeat can't let the lock lapse mid-run (#906).
+ */
+const SYNC_LOCK_RENEW_INTERVAL_MS = Math.floor((SYNC_LOCK_TTL / 3) * 1000);
+
 /**
  * Attempt to acquire the sync worker lock via Redis SET NX EX.
  * Returns a unique lock id if acquired, or null if already held.
@@ -142,6 +152,27 @@ async function releaseSyncLock(lockId: string): Promise<void> {
     await redis.eval(RELEASE_LOCK_SCRIPT, { keys: [SYNC_LOCK_KEY], arguments: [lockId] });
   } catch (err) {
     logger.error({ err }, 'Failed to release sync lock');
+  }
+}
+
+/**
+ * Re-extend the sync worker lock's TTL, but only while this caller still owns
+ * it (Lua ownership check mirrors {@link releaseSyncLock}). A sync run that
+ * outlasts the fixed {@link SYNC_LOCK_TTL} would otherwise let the lock expire
+ * and a second worker start concurrently — this heartbeat keeps mutual
+ * exclusion in force for the whole run (#906). Best-effort: a Redis hiccup is
+ * logged and the run continues (the TTL is the safety net if renewals stop).
+ */
+async function renewSyncLock(lockId: string): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis) return;
+  try {
+    await redis.eval(RENEW_LOCK_SCRIPT, {
+      keys: [SYNC_LOCK_KEY],
+      arguments: [lockId, String(SYNC_LOCK_TTL)],
+    });
+  } catch (err) {
+    logger.error({ err }, 'Failed to renew sync lock');
   }
 }
 
@@ -1844,6 +1875,12 @@ export async function runScheduledSync(): Promise<number> {
   const lockId = await acquireSyncLock();
   if (!lockId) return 0;
 
+  // Keep the lock alive for the whole run so long syncs don't let the fixed
+  // TTL expire and admit a second concurrent worker (#906).
+  const heartbeat = setInterval(() => {
+    void renewSyncLock(lockId);
+  }, SYNC_LOCK_RENEW_INTERVAL_MS);
+
   try {
     const users = await query<{ user_id: string }>(
       `SELECT DISTINCT us.user_id FROM user_settings us
@@ -1866,6 +1903,7 @@ export async function runScheduledSync(): Promise<number> {
     logger.error({ err }, 'Background sync worker error');
     return 0;
   } finally {
+    clearInterval(heartbeat);
     await releaseSyncLock(lockId);
   }
 }
@@ -1881,6 +1919,12 @@ export function startSyncWorker(intervalMinutes = 15): void {
   syncIntervalHandle = setInterval(async () => {
     const lockId = await acquireSyncLock();
     if (!lockId) return; // another process holds the lock
+
+    // Keep the lock alive for the whole run so long syncs don't let the fixed
+    // TTL expire and admit a second concurrent worker (#906).
+    const heartbeat = setInterval(() => {
+      void renewSyncLock(lockId);
+    }, SYNC_LOCK_RENEW_INTERVAL_MS);
 
     try {
       // Get all users with configured connections and RBAC space assignments
@@ -1903,6 +1947,7 @@ export function startSyncWorker(intervalMinutes = 15): void {
     } catch (err) {
       logger.error({ err }, 'Background sync worker error');
     } finally {
+      clearInterval(heartbeat);
       await releaseSyncLock(lockId);
     }
   }, intervalMs);

--- a/docs/architecture/08-flow-sync.md
+++ b/docs/architecture/08-flow-sync.md
@@ -28,6 +28,7 @@ sequenceDiagram
         S-->>T: skip (another run in progress)
     else acquired
         R-->>S: OK
+        Note over S,R: Heartbeat every TTL/3 (200s): EXPIRE sync:worker:lock 600<br/>if still owned, so long runs never let the lock lapse (#906)
         S->>DB: SELECT user_settings (decrypt PAT)
         S->>CL: getSpaces(pat)
         CL->>CF: GET /rest/api/space
@@ -95,8 +96,11 @@ sequenceDiagram
 
 ## Concurrency & safety
 
-- **Redis lock (`sync:worker:lock`)** — single active sync per instance;
-  TTL acts as a dead-man's switch.
+- **Redis lock (`sync:worker:lock`)** — single active sync per instance. The
+  600s TTL acts as a dead-man's switch; while a run is in flight an
+  ownership-checked heartbeat re-`EXPIRE`s the key every TTL/3 (200s) so a sync
+  that outlasts one TTL can't lapse and admit a second concurrent worker
+  (#906). The heartbeat is cleared alongside the lock release in `finally`.
 - **Per-user PAT scope** — each sync decrypts the PAT just-in-time, uses it
   for the duration of the run, and never logs it.
 - **SSRF guard** — `confluence-client` uses the shared SSRF guard from


### PR DESCRIPTION
Fixes #906.

## What / why
The sync worker lock (`sync:worker:lock`) was acquired once via `SET NX EX` with a fixed 600s TTL and **never renewed**. Any sync run that outlasts the TTL (large spaces, slow Confluence, many users) let the lock silently expire mid-run, so a second scheduler/pod could acquire it and run concurrently — the exact mutual exclusion the lock exists to guarantee.

The fix adds an ownership-checked heartbeat that re-extends the TTL:
- `renewSyncLock(lockId)` runs a Lua `EXPIRE` guarded by the same `get == ARGV[1]` ownership check used by `releaseSyncLock` (never extends a lock we no longer own).
- Both call sites (`runScheduledSync` and the `startSyncWorker` interval callback) start a `setInterval` at `SYNC_LOCK_TTL/3` (200s) right after acquiring the lock and `clearInterval` it in the existing `finally` alongside `releaseSyncLock`. TTL/3 gives two renewal chances before expiry so a single dropped heartbeat can't cause a lapse.

Change is confined to the lock helpers plus the two call sites; best-effort (Redis hiccup is logged, the TTL remains the safety net).

## Test evidence
`backend/src/domains/confluence/services/sync-service.test.ts` — new `sync lock heartbeat (#906)` block drives `runScheduledSync()` with one user's sync held open on a gate, advances fake timers past the 200s renewal window, and asserts the ownership-checked `EXPIRE` script fires (and stops once the run finishes / interval is cleared).
- **Before fix:** fails — `expected 0 to be greater than or equal to 1` (no renew ever issued).
- **After fix:** passes; full file 22/22 green. `npm run typecheck -w backend` clean; eslint clean on touched files.

## Docs / diagram impact
Updated `docs/architecture/08-flow-sync.md` (sync sequence diagram + Concurrency & safety note) to document the TTL/3 heartbeat renewal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)