### PR TITLE
fix(knowledge): scan duplicates in a single pass (#907)

### DIFF
--- a/backend/src/domains/knowledge/services/duplicate-detector.integration.test.ts
+++ b/backend/src/domains/knowledge/services/duplicate-detector.integration.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../test-db-helper.js';
 import { query } from '../../../core/db/postgres.js';
 import pgvector from 'pgvector';
-import { findDuplicates } from './duplicate-detector.js';
+import { findDuplicates, scanAllDuplicates } from './duplicate-detector.js';
 
 // Deterministic 1024-dim vector. All fixture pages share the same vector so
 // every candidate sits at cosine distance 0 from the source — well inside the
@@ -217,5 +217,33 @@ describe.skipIf(!dbAvailable)('duplicate-detector integration — RBAC kNN filte
     expect(new Set(ids).size).toBe(ids.length); // distinct
     expect(ids).toContain(sharedId);
     expect(ids).toContain(ownPrivateId);
+  });
+
+  it('scanAllDuplicates: single pass keeps RBAC scope and reports each pair once (#907)', async () => {
+    // Three near-identical TEAMA pages → 3 unordered pairs. One SECRET page with
+    // the same vector must never surface: the self-join CTE restricts both pair
+    // members to the caller-readable set (USER_A can read TEAMA only).
+    const vec = fakeVec(31);
+    const idA = await seedPage({ confluenceId: 'dup-1', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy guide', vec });
+    const idB = await seedPage({ confluenceId: 'dup-2', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy guide copy', vec });
+    const idC = await seedPage({ confluenceId: 'dup-3', source: 'confluence', spaceKey: 'TEAMA', title: 'Deploy runbook', vec });
+    const secretId = await seedPage({ confluenceId: 'secret-1', source: 'confluence', spaceKey: 'SECRET', title: 'Secret deploy guide', vec });
+
+    const pairs = await scanAllDuplicates(USER_A);
+
+    // 3 pages → exactly 3 unordered pairs, each reported once (self-join A<B).
+    expect(pairs).toHaveLength(3);
+    const keys = pairs.map((p) => [p.page1.id, p.page2.id].sort((x, y) => x - y).join(':'));
+    expect(new Set(keys).size).toBe(3);
+    const expectedKeys = [[idA, idB], [idA, idC], [idB, idC]]
+      .map((pr) => pr.sort((x, y) => x - y).join(':'))
+      .sort();
+    expect(keys.sort()).toEqual(expectedKeys);
+
+    // The SECRET page is invisible to USER_A and must appear in no pair.
+    const allIds = pairs.flatMap((p) => [p.page1.id, p.page2.id]);
+    expect(allIds).not.toContain(secretId);
+    const allConfIds = pairs.flatMap((p) => [p.page1.confluenceId, p.page2.confluenceId]);
+    expect(allConfIds).not.toContain('secret-1');
   });
 });

--- a/backend/src/domains/knowledge/services/duplicate-detector.test.ts
+++ b/backend/src/domains/knowledge/services/duplicate-detector.test.ts
@@ -29,6 +29,7 @@ vi.mock('../../../core/db/postgres.js', () => ({
 
 vi.mock('../../../core/services/rbac-service.js', () => ({
   getUserAccessibleSpaces: (...args: unknown[]) => mocks.mockGetUserAccessibleSpaces(...args),
+  getUserAccessibleSpacesMemoized: (...args: unknown[]) => mocks.mockGetUserAccessibleSpaces(...args),
 }));
 
 vi.mock('../../../core/utils/logger.js', () => ({
@@ -275,68 +276,101 @@ describe('DuplicateDetector', () => {
       expect(scanSQL).not.toContain('cp.confluence_id = pe.confluence_id');
     });
 
-    it('should return pairs when duplicates are found', async () => {
+    it('should return pairs from the single self-join pass', async () => {
       mocks.mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
-      // Pages scan returns one page
+      // The rewritten scan issues one self-join query returning candidate pairs.
       mocks.mockQuery.mockResolvedValueOnce({
-        rows: [{ id: 10, confluence_id: 'page-a', title: 'Page A' }],
-      });
-
-      // findDuplicates for 'page-a': preliminary SELECT
-      mocks.mockQuery.mockResolvedValueOnce({
-        rows: [{ id: 10, title: 'Page A', space_key: 'DEV' }],
-      });
-      // findDuplicates: BEGIN, SET LOCAL, CTE (1 neighbor), COMMIT
-      mocks.mockClientQuery.mockResolvedValueOnce(undefined); // BEGIN
-      mocks.mockClientQuery.mockResolvedValueOnce(undefined); // SET LOCAL
-      mocks.mockClientQuery.mockResolvedValueOnce({
         rows: [
-          { id: 20, confluence_id: 'page-b', title: 'Page B', space_key: 'DEV', distance: 0.08 },
+          {
+            page1_id: 10, page1_confluence_id: 'page-a', page1_title: 'Page A',
+            page2_id: 20, page2_confluence_id: 'page-b', page2_title: 'Page B',
+            page2_space_key: 'DEV', distance: 0.08,
+          },
         ],
-      }); // CTE
-      mocks.mockClientQuery.mockResolvedValueOnce(undefined); // COMMIT
+      });
 
       const pairs = await scanAllDuplicates('user-1', { distanceThreshold: 0.15 });
 
       expect(pairs).toHaveLength(1);
       expect(pairs[0].page1.confluenceId).toBe('page-a');
+      expect(pairs[0].page1.sourceId).toBe('page-a');
       expect(pairs[0].page2.confluenceId).toBe('page-b');
+      expect(pairs[0].page2.spaceKey).toBe('DEV');
+      expect(pairs[0].page2.embeddingDistance).toBe(0.08);
+      expect(pairs[0].page2.combinedScore).toBeGreaterThan(0);
     });
 
-    it('should deduplicate A->B and B->A pairs', async () => {
+    it('restricts both pair members to the caller-readable set and binds the threshold (#733/#907)', async () => {
+      mocks.mockGetUserAccessibleSpaces.mockResolvedValue(['DEV', 'OPS']);
+      mocks.mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await scanAllDuplicates('user-1', { distanceThreshold: 0.2 });
+
+      expect(mocks.mockQuery).toHaveBeenCalledTimes(1);
+      const [sql, params] = mocks.mockQuery.mock.calls[0];
+      const scanSQL = sql as string;
+      // Same visibility scope as findDuplicates, applied inside the averaging CTE…
+      expect(scanSQL).toContain("cp.source = 'confluence' AND cp.space_key = ANY($1::text[])");
+      expect(scanSQL).toContain("cp.source = 'standalone' AND cp.visibility = 'shared'");
+      expect(scanSQL).toContain("cp.visibility = 'private' AND cp.created_by_user_id = $2");
+      // …with each unordered pair returned exactly once via the self-join.
+      expect(scanSQL).toContain('a.page_id < b.page_id');
+      // Params: [accessibleSpaces, userId, distanceThreshold]
+      expect(params).toEqual([['DEV', 'OPS'], 'user-1', 0.2]);
+    });
+
+    it('caps how many pairs a single page may appear in (maxPairsPerPage)', async () => {
       mocks.mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
-      // Pages scan returns two pages
+      // Page 10 forms a near-duplicate pair with 20, 30 and 40. With
+      // maxPairsPerPage=2 only its two strongest (closest) pairs survive.
       mocks.mockQuery.mockResolvedValueOnce({
         rows: [
-          { id: 10, confluence_id: 'page-a', title: 'Page A' },
-          { id: 20, confluence_id: 'page-b', title: 'Page B' },
+          { page1_id: 10, page1_confluence_id: 'a', page1_title: 'A', page2_id: 20, page2_confluence_id: 'b', page2_title: 'B', page2_space_key: 'DEV', distance: 0.02 },
+          { page1_id: 10, page1_confluence_id: 'a', page1_title: 'A', page2_id: 30, page2_confluence_id: 'c', page2_title: 'C', page2_space_key: 'DEV', distance: 0.03 },
+          { page1_id: 10, page1_confluence_id: 'a', page1_title: 'A', page2_id: 40, page2_confluence_id: 'd', page2_title: 'D', page2_space_key: 'DEV', distance: 0.04 },
         ],
       });
 
-      // findDuplicates for 'page-a' → finds page-b
-      mocks.mockQuery.mockResolvedValueOnce({ rows: [{ id: 10, title: 'Page A', space_key: 'DEV' }] });
-      mocks.mockClientQuery
-        .mockResolvedValueOnce(undefined) // BEGIN
-        .mockResolvedValueOnce(undefined) // SET LOCAL
-        .mockResolvedValueOnce({
-          rows: [{ id: 20, confluence_id: 'page-b', title: 'Page B', space_key: 'DEV', distance: 0.08 }],
-        }) // CTE
-        .mockResolvedValueOnce(undefined); // COMMIT
+      const pairs = await scanAllDuplicates('user-1', { distanceThreshold: 0.15, maxPairsPerPage: 2 });
 
-      // findDuplicates for 'page-b' → finds page-a (same pair, should be deduplicated)
-      mocks.mockQuery.mockResolvedValueOnce({ rows: [{ id: 20, title: 'Page B', space_key: 'DEV' }] });
-      mocks.mockClientQuery
-        .mockResolvedValueOnce(undefined) // BEGIN
-        .mockResolvedValueOnce(undefined) // SET LOCAL
-        .mockResolvedValueOnce({
-          rows: [{ id: 10, confluence_id: 'page-a', title: 'Page A', space_key: 'DEV', distance: 0.08 }],
-        }) // CTE
-        .mockResolvedValueOnce(undefined); // COMMIT
+      expect(pairs).toHaveLength(2);
+      // The two closest (highest-scoring) partners of page 10 are kept.
+      expect(pairs.map((p) => p.page2.confluenceId)).toEqual(['b', 'c']);
+    });
+
+    it('resolves accessible spaces once and scans in a single query pass (#907)', async () => {
+      // The rewritten scan issues ONE self-join query and resolves the caller's
+      // readable spaces ONCE. The old per-page loop paid an RBAC lookup plus a
+      // dedicated kNN transaction for EVERY page (O(N) round trips + O(N×M)
+      // chunk-distance evals) — this asserts those are collapsed to a single pass.
+      mocks.mockGetUserAccessibleSpaces.mockResolvedValue(['DEV']);
+      mocks.mockQuery.mockResolvedValue({
+        rows: [
+          {
+            page1_id: 10, page1_confluence_id: 'page-a', page1_title: 'Page A',
+            page2_id: 20, page2_confluence_id: 'page-b', page2_title: 'Page B',
+            page2_space_key: 'DEV', distance: 0.05,
+          },
+          {
+            page1_id: 10, page1_confluence_id: 'page-a', page1_title: 'Page A',
+            page2_id: 30, page2_confluence_id: 'page-c', page2_title: 'Page C',
+            page2_space_key: 'DEV', distance: 0.06,
+          },
+        ],
+      });
 
       const pairs = await scanAllDuplicates('user-1', { distanceThreshold: 0.15 });
 
-      // Only 1 pair (A-B), not 2 (A-B and B-A)
-      expect(pairs).toHaveLength(1);
+      // One RBAC resolution for the whole scan (was 1 + N).
+      expect(mocks.mockGetUserAccessibleSpaces).toHaveBeenCalledTimes(1);
+      // One SQL pass — no per-page preliminary SELECT, no per-page transaction.
+      expect(mocks.mockQuery).toHaveBeenCalledTimes(1);
+      expect(mocks.mockPool.connect).not.toHaveBeenCalled();
+
+      // Each unordered pair is reported once, mapped from the self-join rows.
+      expect(pairs).toHaveLength(2);
+      expect(pairs[0].page1.confluenceId).toBe('page-a');
+      expect(pairs.map((p) => p.page2.confluenceId).sort()).toEqual(['page-b', 'page-c']);
     });
   });
 });

--- a/backend/src/domains/knowledge/services/duplicate-detector.ts
+++ b/backend/src/domains/knowledge/services/duplicate-detector.ts
@@ -1,7 +1,6 @@
 import { query, getPool } from '../../../core/db/postgres.js';
-import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
+import { getUserAccessibleSpacesMemoized as getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
 import { visiblePagesPredicate } from '../../../core/services/page-visibility.js';
-import { logger } from '../../../core/utils/logger.js';
 
 const RAG_EF_SEARCH = parseInt(process.env.RAG_EF_SEARCH ?? '100', 10);
 
@@ -169,8 +168,21 @@ export async function findDuplicates(
 }
 
 /**
- * Scan all pages for a user to find duplicate clusters.
+ * Scan all pages a user can read to find duplicate clusters.
  * Returns pairs of pages that are likely duplicates.
+ *
+ * #907: this used to loop over every candidate page and call `findDuplicates`
+ * one at a time — N+1 RBAC lookups plus N separate kNN transactions, each
+ * comparing against every chunk of every neighbour (O(N×M)). Instead we now
+ * average each readable page's chunk embeddings once (`page_avgs`) and self-join
+ * those per-page averages in a single pass, so a whole scan pays one resolver
+ * hit and one SQL round trip. No `SET LOCAL hnsw.ef_search` is needed here: the
+ * self-join computes exact pairwise distances over the averages rather than
+ * probing the HNSW index.
+ *
+ * RBAC (#733): the CTE restricts both sides of every pair to what `userId` can
+ * read (accessible Confluence spaces + shared / own-private standalone pages),
+ * mirroring `findDuplicates`, so no pair can surface a page the caller can't see.
  */
 export async function scanAllDuplicates(
   userId: string,
@@ -178,58 +190,91 @@ export async function scanAllDuplicates(
     distanceThreshold?: number;
     maxPairsPerPage?: number;
   } = {},
-): Promise<Array<{ page1: DuplicateCandidate & { sourceId: string }; page2: DuplicateCandidate }>> {
+): Promise<Array<{ page1: DuplicateCandidate & { sourceId: string | null }; page2: DuplicateCandidate }>> {
   const { distanceThreshold = 0.15, maxPairsPerPage = 3 } = options;
 
-  // Get all pages with embeddings (RBAC access control)
-  const dupSpaces = await getUserAccessibleSpaces(userId);
-  const pages = await query<{ id: number; confluence_id: string; title: string }>(
-    `SELECT DISTINCT cp.id, cp.confluence_id, cp.title
-     FROM pages cp
-     JOIN page_embeddings pe ON pe.page_id = cp.id
-     WHERE cp.space_key = ANY($1::text[])
-       AND cp.deleted_at IS NULL`,
-    [dupSpaces],
+  // #907: resolve the caller's readable space set once for the whole scan.
+  const accessibleSpaces = await getUserAccessibleSpaces(userId);
+
+  // One pass: average each readable page's chunk embeddings, then self-join the
+  // averages on a.page_id < b.page_id so every unordered pair within the
+  // distance threshold is returned exactly once (no A->B / B->A dedup needed).
+  const result = await query<{
+    page1_id: number;
+    page1_confluence_id: string | null;
+    page1_title: string;
+    page2_id: number;
+    page2_confluence_id: string | null;
+    page2_title: string;
+    page2_space_key: string;
+    distance: number;
+  }>(
+    `WITH page_avgs AS (
+       SELECT cp.id AS page_id, cp.confluence_id, cp.title, cp.space_key,
+              AVG(pe.embedding) AS avg_embedding
+       FROM page_embeddings pe
+       JOIN pages cp ON pe.page_id = cp.id
+       WHERE cp.deleted_at IS NULL
+         AND ${visiblePagesPredicate(1, 2, 'cp')}
+       GROUP BY cp.id, cp.confluence_id, cp.title, cp.space_key
+     )
+     SELECT a.page_id AS page1_id, a.confluence_id AS page1_confluence_id, a.title AS page1_title,
+            b.page_id AS page2_id, b.confluence_id AS page2_confluence_id, b.title AS page2_title,
+            b.space_key AS page2_space_key,
+            (a.avg_embedding <=> b.avg_embedding) AS distance
+     FROM page_avgs a
+     JOIN page_avgs b ON a.page_id < b.page_id
+     WHERE (a.avg_embedding <=> b.avg_embedding) <= $3
+     ORDER BY distance`,
+    [accessibleSpaces, userId, distanceThreshold],
   );
 
-  const allPairs: Array<{ page1: DuplicateCandidate & { sourceId: string }; page2: DuplicateCandidate }> = [];
-  const seen = new Set<string>();
+  // Score each pair the same way findDuplicates does: 70% embedding similarity +
+  // 30% title (Jaccard) similarity. Both metrics are symmetric, so the score is
+  // independent of which member is treated as the "source" page1.
+  const scored = result.rows.map((row) => {
+    const titleSimilarity = tokenJaccardSimilarity(row.page1_title, row.page2_title);
+    const combinedScore = (1 - row.distance) * 0.7 + titleSimilarity * 0.3;
+    return { row, titleSimilarity, combinedScore };
+  });
+  // Best pairs first, so the per-page cap keeps the strongest matches.
+  scored.sort((a, b) => b.combinedScore - a.combinedScore);
 
-  for (const page of pages.rows) {
-    try {
-      const duplicates = await findDuplicates(userId, page.confluence_id, {
-        distanceThreshold,
-        limit: maxPairsPerPage,
-      });
+  // Cap how many pairs any single page may appear in (both members counted), so
+  // a large near-identical cluster can't explode into O(k²) pairs.
+  const perPageCount = new Map<number, number>();
+  const allPairs: Array<{ page1: DuplicateCandidate & { sourceId: string | null }; page2: DuplicateCandidate }> = [];
 
-      for (const dup of duplicates) {
-        // Avoid reporting A->B and B->A. Key on the stable page PKs — standalone
-        // pages have a NULL confluenceId, which would otherwise collide.
-        const pairKey = [page.id, dup.id].sort((a, b) => a - b).join(':');
-        if (seen.has(pairKey)) continue;
-        seen.add(pairKey);
+  for (const { row, titleSimilarity, combinedScore } of scored) {
+    const count1 = perPageCount.get(row.page1_id) ?? 0;
+    const count2 = perPageCount.get(row.page2_id) ?? 0;
+    if (count1 >= maxPairsPerPage || count2 >= maxPairsPerPage) continue;
+    perPageCount.set(row.page1_id, count1 + 1);
+    perPageCount.set(row.page2_id, count2 + 1);
 
-        allPairs.push({
-          page1: {
-            sourceId: page.confluence_id,
-            id: page.id,
-            confluenceId: page.confluence_id,
-            title: page.title,
-            spaceKey: '', // Will be filled from the scan
-            embeddingDistance: 0,
-            titleSimilarity: 1,
-            combinedScore: dup.combinedScore,
-          },
-          page2: dup,
-        });
-      }
-    } catch (err) {
-      logger.error({ err, confluenceId: page.confluence_id }, 'Failed to find duplicates for page');
-    }
+    allPairs.push({
+      page1: {
+        sourceId: row.page1_confluence_id,
+        id: row.page1_id,
+        confluenceId: row.page1_confluence_id,
+        title: row.page1_title,
+        spaceKey: '', // page1 is the source side; distance/title are relative to it
+        embeddingDistance: 0,
+        titleSimilarity: 1,
+        combinedScore,
+      },
+      page2: {
+        id: row.page2_id,
+        confluenceId: row.page2_confluence_id,
+        title: row.page2_title,
+        spaceKey: row.page2_space_key,
+        embeddingDistance: row.distance,
+        titleSimilarity,
+        combinedScore,
+      },
+    });
   }
 
-  // Sort by combined score descending
-  allPairs.sort((a, b) => b.page2.combinedScore - a.page2.combinedScore);
   return allPairs;
 }
 


### PR DESCRIPTION
Fixes #907.

## What / why
`scanAllDuplicates` looped over every readable page and called `findDuplicates` one at a time. For a scan of N pages that meant **N+1 RBAC resolver hits** and **N separate kNN transactions**, each comparing the source against every chunk of every neighbour (**O(N×M)** chunk-distance evals).

This replaces the loop with a single SQL pass:
- **`page_avgs` CTE** averages each readable page's chunk embeddings once, restricted (inside the CTE) to the caller's accessible spaces + shared / own-private standalone pages via `visiblePagesPredicate`, with `deleted_at IS NULL`.
- A **self-join** `page_avgs a JOIN page_avgs b ON a.page_id < b.page_id` keeps pairs whose cosine distance is within the threshold, so every unordered pair is returned exactly once — no A→B / B→A JS dedup, and no dead `SET LOCAL hnsw.ef_search` (the self-join computes exact pairwise distances, it doesn't probe the HNSW index).
- Both `findDuplicates` and `scanAllDuplicates` now use `getUserAccessibleSpacesMemoized`, so a scan pays a single resolver hit.

Title-similarity / combined-score scoring and the `maxPairsPerPage` cap are preserved in JS over the returned rows. RBAC scope is enforced in SQL, so no pair can surface a page the caller can't read.

## Test evidence
- **Anchor (unit, no DB)** — `duplicate-detector.test.ts` › "resolves accessible spaces once and scans in a single query pass (#907)". **Fails before**: `getUserAccessibleSpaces` called **3×** and `query` called **3×** for a 2-page scan (per-page loop). **Passes after**: exactly **1** RBAC lookup, **1** query, `pool.connect` never called.
- Rewrote the two scan unit tests that mocked the old per-page transaction flow; added a `maxPairsPerPage` cap test and an RBAC/threshold param-binding test. `duplicate-detector.test.ts`: 20/20 pass.
- **Parity (backend-db)** — `duplicate-detector.integration.test.ts` › "scanAllDuplicates: single pass keeps RBAC scope and reports each pair once (#907)": 3 near-identical TEAMA pages → exactly 3 unordered pairs, each once; a same-vector SECRET page never appears. 9/9 pass.
- `npm run typecheck -w backend` clean; eslint clean on touched files; `pages-duplicates` route test 15/15.

## Docs / diagram impact
None — internal query optimization within the knowledge domain: no schema/FK, ESLint-boundary, compose, or auth/sync/RAG/license/content-pipeline flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)