### PR TITLE
fix(knowledge): keyset-paginate explicit-link full scan (#908)

### DIFF
--- a/backend/src/domains/knowledge/services/link-extractor.test.ts
+++ b/backend/src/domains/knowledge/services/link-extractor.test.ts
@@ -200,6 +200,22 @@ function makeClient(opts: {
       }
       if (s.includes('SELECT id, body_html FROM pages')) {
         opts.onPageSelect?.(s, params);
+        // Incremental scan (`id = ANY` / `LIKE ANY`) is a single fetch.
+        if (s.includes('LIKE ANY') || s.includes('id = ANY')) {
+          return { rows: opts.pageRows, rowCount: opts.pageRows.length };
+        }
+        // Full-recompute keyset pagination (#908): return rows with id > $1,
+        // ascending, capped at the $2 LIMIT — then an empty batch terminates.
+        if (s.includes('id > $')) {
+          const cursor = Number(params?.[0] ?? 0);
+          const limit = Number(params?.[1] ?? opts.pageRows.length);
+          const batch = opts.pageRows
+            .filter((r) => r.id > cursor)
+            .sort((a, b) => a.id - b.id)
+            .slice(0, limit);
+          return { rows: batch, rowCount: batch.length };
+        }
+        // Legacy unpaginated full fetch (pre-fix): one result set.
         return { rows: opts.pageRows, rowCount: opts.pageRows.length };
       }
       if (s.includes('INSERT INTO page_relationships')) {
@@ -243,6 +259,50 @@ describe('runExplicitLinkProducer — Finding 2 (producer contract)', () => {
       typeof c[0] === 'string' && (c[0] as string).includes('SELECT id, title FROM pages'),
     );
     expect(titleCall).toBeDefined();
+  });
+
+  it('full-mode recompute keyset-paginates the corpus instead of one unbounded SELECT (#908)', async () => {
+    // The full scan must never buffer/parse the whole corpus in one result
+    // set. Each page-select is a bounded keyset query (`id > $` / `ORDER BY
+    // id` / `LIMIT`), the cursor advances across batches, and the resulting
+    // edge count is identical to the old single-query behavior.
+    const titleRows = [
+      { id: 1, title: 'A' },
+      { id: 2, title: 'B' },
+      { id: 3, title: 'C' },
+    ];
+    // Chain 1→2→3: two edges total (1↔2, 2↔3).
+    const pageRows = [
+      { id: 1, body_html: '<a href="/pages/2">to 2</a>' },
+      { id: 2, body_html: '<a href="/pages/3">to 3</a>' },
+      { id: 3, body_html: '<p>leaf</p>' },
+    ];
+    const selectSqls: string[] = [];
+    const selectCursors: unknown[] = [];
+    const client = makeClient({
+      titleRows,
+      pageRows,
+      onPageSelect: (sql, params) => {
+        selectSqls.push(sql);
+        selectCursors.push(params?.[0]);
+      },
+    });
+
+    const count = await runExplicitLinkProducer(client as unknown as PoolClient);
+
+    // Every full-mode page-select is a bounded keyset query.
+    expect(selectSqls.length).toBeGreaterThan(0);
+    for (const sql of selectSqls) {
+      expect(sql).toContain('id > $');
+      expect(sql).toContain('ORDER BY id');
+      expect(sql).toContain('LIMIT');
+    }
+    // Multiple keyset queries were issued and the cursor advanced past 0.
+    expect(selectSqls.length).toBeGreaterThan(1);
+    expect(selectCursors[0]).toBe(0);
+    expect(selectCursors.some((c) => Number(c) > 0)).toBe(true);
+    // Correctness preserved: edge output unchanged vs the single-query scan.
+    expect(count).toBe(2);
   });
 });
 

--- a/backend/src/domains/knowledge/services/link-extractor.ts
+++ b/backend/src/domains/knowledge/services/link-extractor.ts
@@ -39,6 +39,13 @@ import { logger } from '../../../core/utils/logger.js';
 const APP_PAGE_PATH_RE = /^\/pages\/(\d+)(?:\/|$|\?|#)/;
 const CONFLUENCE_PAGE_HASH_PREFIX = '#confluence-page:';
 
+/**
+ * Keyset page size for the full-recompute corpus scan (#908). Bounds how much
+ * `body_html` is buffered/JSDOM-parsed in memory at once; each batch's rows are
+ * released before the next fetch instead of materialising the whole corpus.
+ */
+const FULL_SCAN_BATCH_SIZE = 500;
+
 interface ExtractedLink {
   /** Internal pages.id of the link target. */
   targetPageId: number;
@@ -228,37 +235,13 @@ export async function runExplicitLinkProducer(
 
   const useIncremental = changedPageIds && changedPageIds.length > 0;
 
-  let pagesResult: { rows: { id: number; body_html: string | null }[] };
-  if (useIncremental) {
-    // Build the LIKE-pattern list for the "find referrers" pass. Anchor
-    // each pattern with `%/pages/<id>%` (catches both relative `/pages/42`
-    // and absolute `https://host/pages/42`) and `%#confluence-page:<title>%`
-    // for the Confluence-sync placeholder shape. Substring patterns are
-    // intentionally loose — any false-positive page just gets re-parsed by
-    // JSDOM and contributes 0 edges, which is correct (idempotent).
-    const idArr = Array.from(changedPageIds!);
-    const patterns: string[] = [];
-    for (const id of idArr) {
-      patterns.push(`%/pages/${id}%`);
-      const title = idToTitle.get(id);
-      if (title && title.length > 0) {
-        patterns.push(`%#confluence-page:${escapeLikePattern(title)}%`);
-      }
-    }
-    pagesResult = await client.query<{ id: number; body_html: string | null }>(
-      `SELECT id, body_html FROM pages
-       WHERE deleted_at IS NULL
-         AND (id = ANY($1::int[]) OR body_html LIKE ANY($2::text[]))`,
-      [idArr, patterns],
-    );
-  } else {
-    pagesResult = await client.query<{ id: number; body_html: string | null }>(
-      `SELECT id, body_html FROM pages WHERE deleted_at IS NULL`,
-    );
-  }
-
   let edgesWritten = 0;
-  for (const page of pagesResult.rows) {
+  let pageCount = 0;
+
+  // Parse one page's body_html and persist its (source → target) edges. Shared
+  // by both scan modes so the parse+INSERT loop stays identical regardless of
+  // how the rows are fetched.
+  const writeEdgesForPage = async (page: { id: number; body_html: string | null }) => {
     const links = extractInternalLinks(page.body_html, titleToId, internalHosts);
     for (const link of links) {
       if (link.targetPageId === page.id) continue; // self-loops are noise
@@ -276,9 +259,60 @@ export async function runExplicitLinkProducer(
       );
       edgesWritten += r.rowCount ?? 0;
     }
+  };
+
+  if (useIncremental) {
+    // Build the LIKE-pattern list for the "find referrers" pass. Anchor
+    // each pattern with `%/pages/<id>%` (catches both relative `/pages/42`
+    // and absolute `https://host/pages/42`) and `%#confluence-page:<title>%`
+    // for the Confluence-sync placeholder shape. Substring patterns are
+    // intentionally loose — any false-positive page just gets re-parsed by
+    // JSDOM and contributes 0 edges, which is correct (idempotent).
+    const idArr = Array.from(changedPageIds!);
+    const patterns: string[] = [];
+    for (const id of idArr) {
+      patterns.push(`%/pages/${id}%`);
+      const title = idToTitle.get(id);
+      if (title && title.length > 0) {
+        patterns.push(`%#confluence-page:${escapeLikePattern(title)}%`);
+      }
+    }
+    const pagesResult = await client.query<{ id: number; body_html: string | null }>(
+      `SELECT id, body_html FROM pages
+       WHERE deleted_at IS NULL
+         AND (id = ANY($1::int[]) OR body_html LIKE ANY($2::text[]))`,
+      [idArr, patterns],
+    );
+    pageCount = pagesResult.rows.length;
+    for (const page of pagesResult.rows) {
+      await writeEdgesForPage(page);
+    }
+  } else {
+    // Full recompute: keyset-paginate by id so the entire corpus's body_html is
+    // never buffered/JSDOM-parsed in a single result set (#908). Each batch is
+    // processed and released before the next fetch, bounding peak memory and
+    // letting statement/lock pressure ease between batches. Output is unchanged
+    // — the parse+INSERT is identical and stays idempotent via ON CONFLICT.
+    let lastId = 0;
+    for (;;) {
+      const batch = await client.query<{ id: number; body_html: string | null }>(
+        `SELECT id, body_html FROM pages
+         WHERE deleted_at IS NULL AND id > $1
+         ORDER BY id
+         LIMIT $2`,
+        [lastId, FULL_SCAN_BATCH_SIZE],
+      );
+      if (batch.rows.length === 0) break;
+      for (const page of batch.rows) {
+        await writeEdgesForPage(page);
+      }
+      pageCount += batch.rows.length;
+      lastId = batch.rows[batch.rows.length - 1]!.id;
+    }
   }
+
   logger.info(
-    { edgesWritten, pageCount: pagesResult.rows.length, mode: useIncremental ? 'incremental' : 'full' },
+    { edgesWritten, pageCount, mode: useIncremental ? 'incremental' : 'full' },
     'explicit_link edges produced',
   );
   return edgesWritten;


### PR DESCRIPTION
Fixes #908.

## What / why
`runExplicitLinkProducer`'s full-recompute branch issued a single unbounded `SELECT id, body_html FROM pages WHERE deleted_at IS NULL`, buffering and JSDOM-parsing the **entire** corpus's `body_html` in one result set inside the caller's `page_relationships` DELETE/recompute transaction. On large knowledge bases this is a memory and lock-duration hazard.

This replaces the single query with a keyset-paginated loop (`WHERE deleted_at IS NULL AND id > $1 ORDER BY id LIMIT $2`, batch size 500). Each batch is parsed and its rows released before the next fetch, bounding peak memory and letting statement/lock pressure ease between batches. The parse+INSERT loop is factored into a shared `writeEdgesForPage` helper used by both modes, so behavior is identical and still idempotent via `ON CONFLICT`.

## Test evidence
- `backend/src/domains/knowledge/services/link-extractor.test.ts`
- New test `full-mode recompute keyset-paginates the corpus instead of one unbounded SELECT (#908)` in the producer-contract describe. The mock `PoolClient` (`makeClient`) is made batch-aware (returns rows for `id > cursor` up to `LIMIT`, then an empty terminating batch).
- **Fails before** the fix: producer emits one unbounded select lacking `id > $` / `ORDER BY id` / `LIMIT` (`expected '…WHERE deleted_at IS NULL' to contain 'id > $'`).
- **Passes after**: every full-mode select is a bounded keyset query, multiple queries advance the cursor, and total edge count is unchanged (2 edges over 3 pages).
- Full file: 28/28 pass. `npm run typecheck -w backend` clean; eslint on both touched files clean.

## Docs / diagram impact
None — internal query-batching within an existing flow; no schema, FK, compose, ESLint-boundary, or documented-flow change. The incremental `LIKE ANY` leading-wildcard scan and holding the parse inside the DELETE transaction are left as follow-ups (the issue's side-table / compute-then-apply redesign), out of surgical scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)