### PR TITLE
fix(quality-worker): recover pages stuck in analyzing after crash/restart (#909)

### DIFF
--- a/backend/src/domains/knowledge/services/quality-worker.test.ts
+++ b/backend/src/domains/knowledge/services/quality-worker.test.ts
@@ -320,6 +320,48 @@ describe.skipIf(!dbAvailable)('Quality Worker (DB)', () => {
       expect(result.rows[0].quality_retry_count).toBe(0); // reset on success
     });
 
+    it('recovers a page stuck in analyzing after a mid-batch crash/restart (#909)', async () => {
+      // A crash/restart while analyzePageQuality was mid-flight leaves the page
+      // at quality_status='analyzing' forever: no priority query ever selects
+      // 'analyzing', so the page is orphaned. The stale-analyzing sweep at the
+      // top of processBatch must flip it back to 'pending' so it gets re-scored.
+      const longContent = 'This is a sufficiently long article body that exceeds the fifty character minimum threshold for quality analysis processing.';
+      await query(
+        `INSERT INTO pages (confluence_id, space_key, title, body_text, body_html, quality_status, quality_analyzed_at)
+         VALUES ('stuck-analyzing', $1, 'Stuck Page', $2, $3, 'analyzing', NULL)`,
+        [testSpaceKey, longContent, `<p>${longContent}</p>`],
+      );
+
+      const processed = await processBatch();
+      expect(processed).toBe(1);
+
+      const result = await query<{ quality_status: string; quality_score: number }>(
+        "SELECT quality_status, quality_score FROM pages WHERE confluence_id = 'stuck-analyzing'",
+      );
+      expect(result.rows[0].quality_status).toBe('analyzed');
+      expect(result.rows[0].quality_score).toBe(75);
+    });
+
+    it('does not reset a freshly analyzing page within the 1h guard (#909)', async () => {
+      // A page marked 'analyzing' with a recent quality_analyzed_at is presumed
+      // to be actively processing (the 1h/NULL guard hedges against a double-
+      // acquired lock). The sweep must leave it alone.
+      const longContent = 'This is a sufficiently long article body that exceeds the fifty character minimum threshold for quality analysis processing.';
+      await query(
+        `INSERT INTO pages (confluence_id, space_key, title, body_text, body_html, quality_status, quality_analyzed_at)
+         VALUES ('fresh-analyzing', $1, 'Fresh Page', $2, $3, 'analyzing', NOW())`,
+        [testSpaceKey, longContent, `<p>${longContent}</p>`],
+      );
+
+      const processed = await processBatch();
+      expect(processed).toBe(0);
+
+      const result = await query<{ quality_status: string }>(
+        "SELECT quality_status FROM pages WHERE confluence_id = 'fresh-analyzing'",
+      );
+      expect(result.rows[0].quality_status).toBe('analyzing');
+    });
+
     it('re-analyzes a retry-exhausted failed page whose content changed since analysis (#828)', async () => {
       // A page that exhausted MAX_RETRIES sits at 'failed' with retry count 3.
       // When its content later changes (last_modified_at > quality_analyzed_at)

--- a/backend/src/domains/knowledge/services/quality-worker.ts
+++ b/backend/src/domains/knowledge/services/quality-worker.ts
@@ -286,6 +286,27 @@ export async function processBatch(): Promise<number> {
     return 0;
   }
 
+  // Recover pages stuck in 'analyzing' (#909). A crash/restart while
+  // analyzePageQuality was mid-flight leaves the page at 'analyzing' forever —
+  // no priority query below ever selects that status, so the page is orphaned.
+  // The redis worker-lock guarantees one batch at a time and analyzePageQuality
+  // runs pages sequentially, so no page is legitimately 'analyzing' at batch
+  // start; the 1h / NULL-timestamp guard is a cheap hedge against a
+  // double-acquired lock reclaiming a page another worker is actively scoring.
+  const recovered = await query(
+    `UPDATE pages
+     SET quality_status = 'pending'
+     WHERE quality_status = 'analyzing'
+       AND deleted_at IS NULL
+       AND (quality_analyzed_at IS NULL OR quality_analyzed_at < NOW() - INTERVAL '1 hour')`,
+  );
+  if (recovered.rowCount && recovered.rowCount > 0) {
+    logger.warn(
+      { count: recovered.rowCount },
+      'Recovered pages stuck in quality_status=analyzing (likely a crash/restart mid-batch) — reset to pending',
+    );
+  }
+
   // Priority 1: Unscored pages (status = 'pending')
   const pendingResult = await query<{
     id: number;


### PR DESCRIPTION
Fixes #909.

## What / Why
A crash or restart while `analyzePageQuality` was mid-flight left the page at `quality_status='analyzing'` forever. None of the three priority queries in `processBatch` ever select the `'analyzing'` status, so the page was orphaned — never re-scored until an admin ran `forceQualityRescan()`.

This adds a stale-analyzing recovery sweep at the top of `processBatch` (mirroring `webhook-outbox-poller`'s `recoverStuckDispatches`) that flips such pages back to `'pending'` so Priority 1 picks them up. A `1h / NULL quality_analyzed_at` guard hedges against reclaiming a page another worker is actively scoring under a double-acquired lock. No schema migration — reuses the existing `quality_analyzed_at` column.

## Test evidence
`backend/src/domains/knowledge/services/quality-worker.test.ts`:
- `recovers a page stuck in analyzing after a mid-batch crash/restart (#909)` — FAILS before the fix (`processBatch` returns 0, page never selected), PASSES after (swept to pending, re-scored to 'analyzed').
- `does not reset a freshly analyzing page within the 1h guard (#909)` — asserts a recent `quality_analyzed_at='analyzing'` page is left untouched.

Full file: 21 passed. Backend typecheck + eslint on touched files clean.

## Docs / diagram impact
None — behavioral recovery hedge within an existing worker; no schema, domain-boundary, compose, or documented-flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)