### PR TITLE
fix(summary): recover config-skipped pages in rescanAllSummaries (#910)

### DIFF
--- a/backend/src/domains/knowledge/services/summary-worker.test.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.test.ts
@@ -176,27 +176,32 @@ describe.skipIf(!dbAvailable)('Summary Worker', () => {
   });
 
   describe('rescanAllSummaries', () => {
-    it('should reset all non-skipped pages to pending', async () => {
+    it('resets non-skipped pages and config-skips, but not content/PII skips', async () => {
+      // p3 is a content-too-short skip (non-null summary_error) → must stay skipped.
+      // p4 is a config-skip (summary_error IS NULL) → the documented no-model
+      // recovery path (#910) must reset it to pending.
       await query(
-        `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status, summary_retry_count)
-         VALUES ('p1', $1, 'Page 1', 'content one', 'summarized', 0),
-                ('p2', $1, 'Page 2', 'content two', 'failed', 3),
-                ('p3', $1, 'Page 3', 'short', 'skipped', 0)`,
+        `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status, summary_retry_count, summary_error)
+         VALUES ('p1', $1, 'Page 1', 'content one', 'summarized', 0, NULL),
+                ('p2', $1, 'Page 2', 'content two', 'failed', 3, NULL),
+                ('p3', $1, 'Page 3', 'short', 'skipped', 0, 'Content too short for summarization'),
+                ('p4', $1, 'Page 4', 'content four', 'skipped', 0, NULL)`,
         [testSpaceKey],
       );
 
       const resetCount = await rescanAllSummaries();
-      expect(resetCount).toBe(2); // p1 and p2, not p3 (skipped)
+      expect(resetCount).toBe(3); // p1, p2, p4 — not p3 (content skip)
 
       const result = await query<{ confluence_id: string; summary_status: string; summary_retry_count: number }>(
         'SELECT confluence_id, summary_status, summary_retry_count FROM pages ORDER BY confluence_id',
       );
 
-      expect(result.rows[0].summary_status).toBe('pending');
+      expect(result.rows[0].summary_status).toBe('pending'); // p1
       expect(result.rows[0].summary_retry_count).toBe(0);
-      expect(result.rows[1].summary_status).toBe('pending');
+      expect(result.rows[1].summary_status).toBe('pending'); // p2
       expect(result.rows[1].summary_retry_count).toBe(0);
-      expect(result.rows[2].summary_status).toBe('skipped'); // unchanged
+      expect(result.rows[2].summary_status).toBe('skipped'); // p3 content skip — unchanged
+      expect(result.rows[3].summary_status).toBe('pending'); // p4 config skip — recovered
     });
   });
 

--- a/backend/src/domains/knowledge/services/summary-worker.test.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.test.ts
@@ -464,6 +464,50 @@ describe.skipIf(!dbAvailable)('Summary Worker', () => {
       expect(pageResult.rows[0].summary_status).toBe('skipped');
     });
 
+    it('clears a stale summary_error when the no-model path skips a re-synced page, so rescan recovers it (#910)', async () => {
+      // A page that previously FAILED (non-null summary_error) then got
+      // re-synced to 'pending' WITHOUT clearing summary_error. When the
+      // no-model path flips it to 'skipped', it must also null the stale
+      // error — otherwise rescanAllSummaries excludes it (config-skips are
+      // identified by summary_error IS NULL) and it never recovers.
+      const { resolveUsecase } = await import(
+        '../../llm/services/llm-provider-resolver.js'
+      );
+      vi.mocked(resolveUsecase).mockResolvedValueOnce({
+        config: {
+          providerId: 'p1', id: 'p1', name: 'X',
+          baseUrl: 'http://x/v1', apiKey: null,
+          authType: 'none', verifySsl: true, defaultModel: null,
+        },
+        model: '',
+      });
+
+      await query(
+        `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status, summary_error)
+         VALUES ('stale-err', $1, 'Re-synced Page', 'Some content', 'pending', 'LLM timeout from a prior failure')`,
+        [testSpaceKey],
+      );
+
+      const result = await runSummaryBatch('');
+      expect(result.processed).toBe(0);
+
+      // (a) The no-model skip must null the stale error and mark it skipped.
+      const afterSkip = await query<{ summary_status: string; summary_error: string | null }>(
+        "SELECT summary_status, summary_error FROM pages WHERE confluence_id = 'stale-err'",
+      );
+      expect(afterSkip.rows[0].summary_status).toBe('skipped');
+      expect(afterSkip.rows[0].summary_error).toBeNull();
+
+      // (b) rescan must now re-select and re-queue it as a config-skip.
+      const resetCount = await rescanAllSummaries();
+      expect(resetCount).toBe(1);
+
+      const afterRescan = await query<{ summary_status: string }>(
+        "SELECT summary_status FROM pages WHERE confluence_id = 'stale-err'",
+      );
+      expect(afterRescan.rows[0].summary_status).toBe('pending');
+    });
+
     it('should summarize standalone pages with NULL confluence_id', async () => {
       const longContent = 'E'.repeat(200);
       const insertResult = await query<{ id: number }>(

--- a/backend/src/domains/knowledge/services/summary-worker.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.ts
@@ -522,8 +522,12 @@ export function stopSummaryWorker(): void {
 }
 
 /**
- * Reset all summary_content_hash values to trigger full re-summarization.
- * Admin-only operation.
+ * Reset summary state to trigger full re-summarization. Admin-only operation.
+ *
+ * Recovers config-skipped pages (skipped with no summary_error, i.e. the
+ * no-model path at runSummaryBatch) so this is the documented no-model
+ * recovery route (#910). Deliberate skips carrying a non-null summary_error
+ * (content-too-short, PII-blocked) stay skipped and are not reprocessed.
  */
 export async function rescanAllSummaries(): Promise<number> {
   const result = await query(
@@ -531,8 +535,8 @@ export async function rescanAllSummaries(): Promise<number> {
      SET summary_content_hash = NULL,
          summary_status = 'pending',
          summary_retry_count = 0
-     WHERE summary_status != 'skipped'
-       AND deleted_at IS NULL
+     WHERE deleted_at IS NULL
+       AND (summary_status != 'skipped' OR summary_error IS NULL)
      RETURNING confluence_id`,
   );
   return result.rowCount ?? 0;

--- a/backend/src/domains/knowledge/services/summary-worker.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.ts
@@ -403,7 +403,12 @@ export async function runSummaryBatch(
 
   if (!assignment || !effectiveModel) {
     const flipped = await query(
-      `UPDATE pages SET summary_status = 'skipped'
+      // Clear summary_error so every no-model config-skip is consistently
+      // identifiable by `summary_error IS NULL` in rescanAllSummaries (#910).
+      // A page re-synced to 'pending' after a prior failure still carries its
+      // stale summary_error; without this reset it would be excluded from
+      // recovery and never re-summarized.
+      `UPDATE pages SET summary_status = 'skipped', summary_error = NULL
        WHERE summary_status = 'pending' AND deleted_at IS NULL`,
     );
     logger.warn(


### PR DESCRIPTION
Fixes #910.

## What & why
`rescanAllSummaries()` filtered `WHERE summary_status != 'skipped'`, so it excluded every skipped page. That broke the documented no-model recovery path: when the summary worker can't resolve a model it flips pending pages to `'skipped'`, and the module docs tell admins to hit `POST /api/llm/summary-rescan` to reprocess them — but the rescan skipped exactly those rows.

Config-skips (the no-model path) leave `summary_error` NULL, whereas deliberate skips (content-too-short, PII-blocked) carry a non-null `summary_error`. The filter now becomes `WHERE deleted_at IS NULL AND (summary_status != 'skipped' OR summary_error IS NULL)`, so config-skips are recovered while content/PII skips stay skipped.

## Test evidence
`backend/src/domains/knowledge/services/summary-worker.test.ts` — extended the `rescanAllSummaries` block with a config-skip row (p4, `summary_error` NULL) and a content-skip row (p3, non-null error).
- Before fix: `resetCount` is 2 and p4 stays `skipped` → test FAILS (`expected 2 to be 3`).
- After fix: `resetCount` is 3 (p1, p2, p4), p4 → `pending`, p3 stays `skipped` → all 24 tests PASS.

Backend typecheck and ESLint on the touched files are clean.

## Docs / diagram impact
None — query-filter fix, no change to system structure, schema, or documented flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)