### PR TITLE
fix(summary-worker): re-queue pages orphaned in 'summarizing' after a crash (#911)

### DIFF
--- a/backend/src/domains/knowledge/services/summary-worker.test.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.test.ts
@@ -268,6 +268,26 @@ describe.skipIf(!dbAvailable)('Summary Worker', () => {
       expect(result.rows[0].summary_content_hash).toHaveLength(64);
     });
 
+    it('re-queues pages orphaned in summarizing after a crash (#911)', async () => {
+      // A prior batch marked this page 'summarizing' then crashed before finishing.
+      // The next batch runs under the single-worker lock, so any leftover
+      // 'summarizing' row is necessarily orphaned and must be reset + reprocessed.
+      const longContent = 'F'.repeat(200);
+      await query(
+        `INSERT INTO pages (confluence_id, space_key, title, body_text, summary_status)
+         VALUES ('orphan1', $1, 'Orphaned Page', $2, 'summarizing')`,
+        [testSpaceKey, longContent],
+      );
+
+      await runSummaryBatch('test-model');
+
+      const row = await query<{ summary_status: string; summary_text: string | null }>(
+        "SELECT summary_status, summary_text FROM pages WHERE confluence_id = 'orphan1'",
+      );
+      expect(row.rows[0].summary_status).toBe('summarized');
+      expect(row.rows[0].summary_text).toBeTruthy();
+    });
+
     it('strips model preamble/meta framing before persisting the summary (#912)', async () => {
       const { streamChat } = await import('../../llm/services/openai-compatible-client.js');
       vi.mocked(streamChat).mockImplementationOnce(() => {

--- a/backend/src/domains/knowledge/services/summary-worker.ts
+++ b/backend/src/domains/knowledge/services/summary-worker.ts
@@ -418,6 +418,17 @@ export async function runSummaryBatch(
     model: effectiveModel,
   };
 
+  // Phase 0: Re-queue pages orphaned in 'summarizing' by a crashed prior run (#911).
+  // Every batch runs under the redis + in-memory single-worker lock, so no other
+  // run can legitimately hold a row in 'summarizing' concurrently — any leftover
+  // is necessarily stale and would otherwise never be re-selected by findCandidates.
+  await query(
+    `UPDATE pages
+     SET summary_status = 'pending'
+     WHERE summary_status = 'summarizing'
+       AND deleted_at IS NULL`,
+  );
+
   // Phase 1: Detect content changes via timestamp and mark as pending.
   // Uses last_modified_at > summary_generated_at instead of recomputing
   // SHA-256 hashes for every summarized page on every batch cycle.


### PR DESCRIPTION
Fixes #911.

## What / why
Pages left in `summary_status='summarizing'` by a crashed prior batch were never re-queued: `findCandidates` only selects rows in `('pending','failed')`, and nothing resets a stale `'summarizing'` row. Such pages stayed stuck forever, showing no summary.

This adds a **Phase 0** step at the start of `runSummaryBatch` that flips any leftover `'summarizing'` row back to `'pending'`:

```sql
UPDATE pages SET summary_status = 'pending'
WHERE summary_status = 'summarizing' AND deleted_at IS NULL;
```

The batch already runs under the redis + in-memory single-worker lock, so no concurrent run can legitimately hold a row in `'summarizing'` — any leftover is necessarily orphaned from a crash. No migration needed (there is no `summary_started_at` column, and the lock invariant makes an age gate unnecessary).

## Test evidence
`backend/src/domains/knowledge/services/summary-worker.test.ts` — new test `re-queues pages orphaned in summarizing after a crash (#911)` inserts a >100-char page with `summary_status='summarizing'` and asserts it ends `summarized` with non-null `summary_text`.
- **Before fix:** fails — status stays `summarizing` (page never selected).
- **After fix:** passes; full file 25/25 green. `npm run typecheck -w backend` clean; ESLint on touched files clean.

## Docs / diagram impact
None — behavioral fix within the summary worker; no schema, boundary, compose, or documented-flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)