### PR TITLE
fix(embedding): renew embedding lock TTL for long-running re-embed jobs (#913)

### DIFF
--- a/backend/src/core/services/redis-cache.test.ts
+++ b/backend/src/core/services/redis-cache.test.ts
@@ -10,6 +10,7 @@ import {
   getRedisClient,
   acquireEmbeddingLock,
   releaseEmbeddingLock,
+  refreshEmbeddingLock,
   isEmbeddingLocked,
   listActiveEmbeddingLocks,
   forceReleaseEmbeddingLock,
@@ -199,6 +200,59 @@ describe('redis-cache embedding lock', () => {
       setRedisClient(null as any);
 
       await expect(releaseEmbeddingLock('user-1', 'some-lock-id')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('refreshEmbeddingLock', () => {
+    it('renews the TTL and reports still-mine when the stored value matches lockId (issue #913)', async () => {
+      // The refresh Lua script returns the current holder value (ARGV[1] here,
+      // because it matches); on a match it also PEXPIREs the key. The mock
+      // echoes the stored value the script would GET back.
+      mockRedis.eval.mockImplementation(
+        async (_script: string, opts: { arguments: string[] }) => opts.arguments[0],
+      );
+      const lockId = 'lock-id-abc';
+
+      const result = await refreshEmbeddingLock('user-42', lockId);
+
+      expect(result).toBe(lockId); // still mine
+      expect(mockRedis.eval).toHaveBeenCalledTimes(1);
+      const [script, opts] = mockRedis.eval.mock.calls[0];
+      // Single atomic script: ownership check gates the TTL bump.
+      expect((script as string).toLowerCase()).toContain('get');
+      expect((script as string).toLowerCase()).toContain('pexpire');
+      expect((script as string)).toEqual(expect.stringContaining('== ARGV[1]'));
+      expect(opts).toEqual({
+        keys: ['embedding:lock:user-42'],
+        // arguments = [lockId, ttlMs]. TTL is the full EMBEDDING_LOCK_TTL_MS.
+        arguments: [lockId, '3600000'],
+      });
+    });
+
+    it('reports the foreign holder value (not-mine) so callers can abort on force-release', async () => {
+      // Key was re-acquired/force-released by another process: GET returns a
+      // different value, the script does NOT PEXPIRE, and returns that value.
+      mockRedis.eval.mockResolvedValue('someone-elses-lock');
+
+      const result = await refreshEmbeddingLock('user-42', 'my-lock');
+
+      expect(result).toBe('someone-elses-lock');
+      expect(result).not.toBe('my-lock');
+    });
+
+    it('returns null when the lock key is gone (expired/force-released)', async () => {
+      mockRedis.eval.mockResolvedValue(null);
+
+      const result = await refreshEmbeddingLock('user-42', 'my-lock');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null and does not throw when Redis client is not available', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setRedisClient(null as any);
+
+      await expect(refreshEmbeddingLock('user-1', 'my-lock')).resolves.toBeNull();
     });
   });
 

--- a/backend/src/core/services/redis-cache.ts
+++ b/backend/src/core/services/redis-cache.ts
@@ -135,6 +135,46 @@ export async function releaseEmbeddingLock(userId: string, lockId: string): Prom
 }
 
 /**
+ * Refresh Lua — bump the per-user lock's TTL, but only while the caller still
+ * owns it. The GET/PEXPIRE pair runs atomically so a concurrent force-release
+ * or re-acquisition can never be masked by a stale renewal. Returns the current
+ * stored holder value (or nil) so the caller can compare against its own lockId
+ * exactly as a plain GET would — a mismatch still signals "not mine, abort".
+ *
+ *   KEYS[1] = embedding:lock:<userId>
+ *   ARGV[1] = lockId (UUID the caller believes it holds)
+ *   ARGV[2] = TTL in milliseconds (stringified)
+ */
+const REFRESH_LOCK_SCRIPT = `local cur = redis.call("get", KEYS[1]) if cur == ARGV[1] then redis.call("pexpire", KEYS[1], ARGV[2]) end return cur`;
+
+/**
+ * Renew the embedding processing lock's TTL for a long-running holder (issue
+ * #913). The lock is written with a 1-hour safety TTL by `acquireEmbeddingLock`;
+ * a re-embed-all run over a large space can legitimately exceed that, at which
+ * point the key would expire mid-run, the holder-epoch write-guard would read a
+ * missing key and silently abort, and the job would report success with only
+ * partial results. Calling this on the guard cadence keeps the TTL sliding
+ * forward while — and only while — the caller still owns the lock.
+ *
+ * Atomically PEXPIRE-bumps the TTL when the stored value matches `lockId`, and
+ * always returns the current holder value so the caller can still detect a
+ * force-release / re-acquisition (returned value differs from `lockId`) or an
+ * expiry (null). Errors are propagated so the caller's guard try/catch can
+ * decide whether to continue — matching the previous inline `redis.get` shape.
+ */
+export async function refreshEmbeddingLock(
+  userId: string,
+  lockId: string | null,
+): Promise<string | null> {
+  if (!_redisClient) return null;
+  const result = await _redisClient.eval(REFRESH_LOCK_SCRIPT, {
+    keys: [embeddingLockKey(userId)],
+    arguments: [lockId ?? '', String(EMBEDDING_LOCK_TTL_MS)],
+  });
+  return typeof result === 'string' ? result : null;
+}
+
+/**
  * Check if the embedding processing lock is held for a user.
  * Returns false if Redis is not available.
  */

--- a/backend/src/domains/llm/services/embedding-service.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.test.ts
@@ -26,6 +26,9 @@ const mocks = vi.hoisted(() => ({
   toSql: vi.fn().mockReturnValue('[0.1,0.2]'),
   acquireEmbeddingLock: vi.fn().mockResolvedValue('fake-lock-id-for-tests'),
   releaseEmbeddingLock: vi.fn().mockResolvedValue(undefined),
+  // Holder-epoch guard (issue #913) renews-if-mine every 20 pages and returns
+  // the current holder value. Default: still ours (guard does not fire).
+  refreshEmbeddingLock: vi.fn().mockResolvedValue('fake-lock-id-for-tests'),
   isEmbeddingLocked: vi.fn().mockResolvedValue(false),
   listActiveEmbeddingLocks: vi.fn().mockResolvedValue([]),
   forceReleaseEmbeddingLock: vi.fn().mockResolvedValue({ released: true, previousHolderEpoch: null }),
@@ -75,6 +78,7 @@ vi.mock('../../../core/utils/logger.js', () => ({
 vi.mock('../../../core/services/redis-cache.js', () => ({
   acquireEmbeddingLock: (...args: unknown[]) => mocks.acquireEmbeddingLock(...args),
   releaseEmbeddingLock: (...args: unknown[]) => mocks.releaseEmbeddingLock(...args),
+  refreshEmbeddingLock: (...args: unknown[]) => mocks.refreshEmbeddingLock(...args),
   isEmbeddingLocked: (...args: unknown[]) => mocks.isEmbeddingLocked(...args),
   listActiveEmbeddingLocks: (...args: unknown[]) => mocks.listActiveEmbeddingLocks(...args),
   forceReleaseEmbeddingLock: (...args: unknown[]) => mocks.forceReleaseEmbeddingLock(...args),
@@ -177,6 +181,8 @@ describe('embedding-service', () => {
       if (typeof key === 'string' && key.startsWith('embedding:lock:')) return FAKE_LOCK_ID;
       return null;
     });
+    // Holder-epoch guard renew-if-mine (issue #913): default still-ours.
+    mocks.refreshEmbeddingLock.mockResolvedValue(FAKE_LOCK_ID);
     mocks.enqueueJob.mockResolvedValue('reembed-all');
     // Default: htmlToText returns non-trivial text so embedPage proceeds
     mocks.htmlToText.mockReturnValue('Some substantial page content for embedding that is long enough');
@@ -1922,6 +1928,7 @@ describe('chunkText', () => {
       mocks.toSql.mockReturnValue('[0.1,0.2]');
       mocks.acquireEmbeddingLock.mockResolvedValue(FAKE_LOCK_ID);
       mocks.releaseEmbeddingLock.mockResolvedValue(undefined);
+      mocks.refreshEmbeddingLock.mockResolvedValue(FAKE_LOCK_ID);
       mocks.isEmbeddingLocked.mockResolvedValue(false);
       mocks.invalidateGraphCache.mockResolvedValue(undefined);
       mocks.htmlToText.mockReturnValue('Some substantial page content for embedding that is long enough');
@@ -1975,11 +1982,12 @@ describe('chunkText', () => {
       mocks.getPool.mockReturnValue({ connect: async () => mockClient });
       mockClient.query.mockResolvedValue({ rows: [], rowCount: 1 });
 
-      // Holder-epoch guard: every redisGet returns null → the VERY FIRST
-      // guard check (after page 20) detects the mismatch and aborts. We
-      // expect ≤ 20 processed because the inner loop breaks immediately on
-      // page 21 before any more embedPage calls.
-      mocks.redisGet.mockImplementation(async () => null);
+      // Holder-epoch guard (issue #913): the renew-if-mine call returns null
+      // (lock gone / force-released) → the VERY FIRST guard check (after page
+      // 20) detects the mismatch and aborts. We expect ≤ 20 processed because
+      // the inner loop breaks immediately on page 21 before any more embedPage
+      // calls.
+      mocks.refreshEmbeddingLock.mockResolvedValue(null);
 
       const { processed, errors } = await processDirtyPages('alice');
 
@@ -1987,8 +1995,8 @@ describe('chunkText', () => {
       expect(processed).toBeLessThanOrEqual(20);
       expect(errors).toBe(0);
       expect(mocks.releaseEmbeddingLock).toHaveBeenCalledWith('alice', FAKE_LOCK_ID);
-      // Guard check was actually invoked.
-      expect(mocks.redisGet).toHaveBeenCalledWith('embedding:lock:alice');
+      // Guard check was actually invoked with our lockId (renews-if-mine).
+      expect(mocks.refreshEmbeddingLock).toHaveBeenCalledWith('alice', FAKE_LOCK_ID);
     });
   });
 });

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -5,7 +5,7 @@ import { generateEmbedding } from './openai-compatible-client.js';
 import { htmlToText } from '../../../core/services/content-converter.js';
 import { logger } from '../../../core/utils/logger.js';
 import { safeIntOr } from '../../../core/utils/safe-int.js';
-import { invalidateGraphCache, acquireEmbeddingLock, releaseEmbeddingLock, isEmbeddingLocked, getRedisClient, listActiveEmbeddingLocks } from '../../../core/services/redis-cache.js';
+import { invalidateGraphCache, acquireEmbeddingLock, releaseEmbeddingLock, refreshEmbeddingLock, isEmbeddingLocked, getRedisClient, listActiveEmbeddingLocks } from '../../../core/services/redis-cache.js';
 import { getUserAccessibleSpaces } from '../../../core/services/rbac-service.js';
 import { visiblePagesPredicate } from '../../../core/services/page-visibility.js';
 import { CircuitBreakerOpenError, getProviderBreaker } from '../../../core/services/circuit-breaker.js';
@@ -569,7 +569,6 @@ export async function processDirtyPages(
     // no duplicate/destructive release happens.
     const GUARD_CHECK_EVERY = 20;
     let pagesProcessedSinceGuardCheck = 0;
-    const guardLockKey = `embedding:lock:${userId}`;
 
     for (;;) {
       if (batchAborted) break;
@@ -581,7 +580,10 @@ export async function processDirtyPages(
         const redis = getRedisClient();
         if (redis) {
           try {
-            const stillMine = await redis.get(guardLockKey);
+            // Renew-if-mine: bump the lock TTL while we still own it (issue
+            // #913) so a legitimately long run never expires mid-flight, and
+            // read back the current holder to detect force-release / re-acquire.
+            const stillMine = await refreshEmbeddingLock(userId, lockId);
             if (stillMine !== lockId) {
               logger.warn(
                 { userId, expected: lockId, actual: stillMine },
@@ -637,7 +639,10 @@ export async function processDirtyPages(
           const redis = getRedisClient();
           if (redis) {
             try {
-              const stillMine = await redis.get(guardLockKey);
+              // Renew-if-mine: bump the lock TTL while we still own it (issue
+            // #913) so a legitimately long run never expires mid-flight, and
+            // read back the current holder to detect force-release / re-acquire.
+            const stillMine = await refreshEmbeddingLock(userId, lockId);
               if (stillMine !== lockId) {
                 logger.warn(
                   { userId, expected: lockId, actual: stillMine },


### PR DESCRIPTION
Fixes #913.

## What & why
The per-user embedding processing lock (`embedding:lock:<userId>`) is written with a 1-hour safety TTL by `acquireEmbeddingLock` but was **never renewed**. A re-embed-all run over a large space that legitimately runs longer than 1h had its lock key expire mid-flight. The holder-epoch write-guard (which re-reads the lock every 20 pages via a plain `GET`) then saw the key missing, treated it as a force-release/re-acquisition, and aborted the loop — yet the job still reported `complete` with only partial results.

This adds a **renew-if-mine** TTL refresh:
- `refreshEmbeddingLock(userId, lockId)` in `redis-cache.ts` runs one atomic Lua script: `GET` the key, `PEXPIRE` it to the full `EMBEDDING_LOCK_TTL_MS` **only when the stored value still matches the caller's lockId**, and return the current holder value.
- The two holder-epoch guard sites in `processDirtyPages` now call it in place of the plain `GET`. A genuinely-running job slides its TTL forward every 20 pages instead of expiring; an actual force-release / expiry still returns a mismatch/null and aborts exactly as before (the return value is a drop-in replacement for the old `redis.get`).

Minimal, atomic, and preserves the existing force-release abort semantics.

## Test evidence
- `backend/src/core/services/redis-cache.test.ts` — new `refreshEmbeddingLock` suite: renews + reports still-mine on match (asserts single Lua eval with `get`/`pexpire`, key, and `EMBEDDING_LOCK_TTL_MS` arg), reports foreign holder / null on non-match, no-ops when Redis is unavailable. **Fails before** (`refreshEmbeddingLock is not a function`), **passes after**.
- `backend/src/domains/llm/services/embedding-service.test.ts` — holder-epoch guard suite updated to drive the guard through `refreshEmbeddingLock`; the force-release abort test still asserts a ≤20-page abort. 91/91 pass.
- Backend `tsc --noEmit` clean; eslint clean on all touched files.

## Docs / diagram impact
None — this is a bug fix within the existing embedding-lock mechanism (the 1h TTL is unchanged, merely renewed while held); no compose, boundary, migration, or flow structure changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)