### PR TITLE
fix(embedding): interlock concurrent global dirty-page scans (#914)

### DIFF
--- a/backend/src/domains/llm/services/embedding-service.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.test.ts
@@ -544,6 +544,28 @@ describe('embedding-service', () => {
       expect(mocks.query).not.toHaveBeenCalled();
     });
 
+    it('short-circuits with alreadyProcessing when another user already holds an embedding lock (#914)', async () => {
+      // Per-user lock is free and no reembed-all is running, but another user
+      // already holds their own embedding lock. Because the dirty-page scan is
+      // GLOBAL (not per-user), proceeding here would re-embed the same pages the
+      // other holder is already working through. Back off instead.
+      mocks.acquireEmbeddingLock.mockResolvedValue(FAKE_LOCK_ID);
+      mocks.isEmbeddingLocked.mockResolvedValue(false);
+      mocks.listActiveEmbeddingLocks.mockResolvedValue([
+        { userId: 'other-user', holderEpoch: 'x', ttlRemainingMs: 60000 },
+        { userId: 'sync-user', holderEpoch: 'y', ttlRemainingMs: 60000 },
+      ]);
+
+      const result = await processDirtyPages('sync-user');
+
+      expect(result).toEqual({ processed: 0, errors: 0, alreadyProcessing: true });
+      // The just-acquired per-user lock must be released again so it is not leaked.
+      expect(mocks.releaseEmbeddingLock).toHaveBeenCalledWith('sync-user', FAKE_LOCK_ID);
+      // No dirty-page scan should have run: only the lock checks happened, no
+      // chunk-settings or COUNT queries were issued.
+      expect(mocks.query).not.toHaveBeenCalled();
+    });
+
     it('does not consult the reembed-all lock when the caller already holds the lock (#823)', async () => {
       // runReembedAllJob path: lockAlreadyHeld=true and userId is the system
       // user itself — the guard must be skipped so the global run proceeds.
@@ -1923,6 +1945,7 @@ describe('chunkText', () => {
       mocks.acquireEmbeddingLock.mockResolvedValue(FAKE_LOCK_ID);
       mocks.releaseEmbeddingLock.mockResolvedValue(undefined);
       mocks.isEmbeddingLocked.mockResolvedValue(false);
+      mocks.listActiveEmbeddingLocks.mockResolvedValue([]);
       mocks.invalidateGraphCache.mockResolvedValue(undefined);
       mocks.htmlToText.mockReturnValue('Some substantial page content for embedding that is long enough');
       vi.mocked(getSharedLlmSettings).mockResolvedValue({

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -526,6 +526,27 @@ export async function processDirtyPages(
       logger.info({ userId }, 'Reembed-all in progress — skipping competing dirty-page scan');
       return { processed: 0, errors: 0, alreadyProcessing: true };
     }
+    // Issue #914 — cross-user interlock: the per-user lock only protects a
+    // single user's key, but the dirty-page scan below is GLOBAL (it selects
+    // every `embedding_dirty = TRUE` page, not just this user's). If another
+    // user already holds their own embedding lock, launching a second scan here
+    // would redundantly re-embed the same pages the other holder is already
+    // working through. After acquiring our own lock, back off if any OTHER
+    // holder exists. Mirrors runReembedAllJob's post-acquire recheck: in a
+    // simultaneous-start race both sides back off and retry on the next cycle.
+    if (userId !== REEMBED_ALL_LOCK_USER) {
+      const otherHolders = (await listActiveEmbeddingLocks()).filter(
+        (l) => l.userId !== userId && l.userId !== REEMBED_ALL_LOCK_USER,
+      );
+      if (otherHolders.length > 0) {
+        await releaseEmbeddingLock(userId, lockId);
+        logger.info(
+          { userId, otherHolders: otherHolders.map((l) => l.userId) },
+          'Another user is already embedding — skipping competing global dirty-page scan',
+        );
+        return { processed: 0, errors: 0, alreadyProcessing: true };
+      }
+    }
   }
 
   await setLastEmbeddingRunAt(new Date());


### PR DESCRIPTION
Fixes #914.

## What / Why
`processDirtyPages` acquires a **per-user** embedding lock but then runs a **global** dirty-page scan (`WHERE embedding_dirty = TRUE`, not scoped to the user). Two concurrent users could each acquire their own distinct per-user lock and then both launch the same global scan, redundantly re-embedding the same pages.

This extends the existing post-acquire interlock — which already backs off when the `__reembed_all__` system lock is held (#823) — to also consult `listActiveEmbeddingLocks()` and back off when any **other** holder exists. On backoff it releases the just-acquired lock and returns `{ processed: 0, errors: 0, alreadyProcessing: true }`.

Mirrors the #823 acquire-then-check pattern. A simultaneous-start double-backoff is acceptable: both callers retry on the next sync cycle. The `lockAlreadyHeld` (reembed-all) path is unaffected.

## Test evidence
`backend/src/domains/llm/services/embedding-service.test.ts` — new sibling test `short-circuits with alreadyProcessing when another user already holds an embedding lock (#914)`.
- **Before fix:** current code ignores `listActiveEmbeddingLocks` in this path, proceeds to the chunk-settings/COUNT scan → FAILS.
- **After fix:** backs off, releases the lock, no scan query issued → PASSES.
- Full file: 92/92 passing. Backend typecheck clean; ESLint clean on touched files.

(Also restored the `listActiveEmbeddingLocks` mock default in the `processDirtyPages holder-epoch guard` describe's `resetAllMocks` beforeEach, which now exercises the new code path.)

## Docs / diagram impact
None — internal concurrency backoff within the existing sync/embedding flow; no compose, domain-boundary, migration, or flow-structure change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)