### PR TITLE
fix(cache): graph-cache invalidation was a silent no-op (#915)

### DIFF
--- a/backend/src/core/services/redis-cache.test.ts
+++ b/backend/src/core/services/redis-cache.test.ts
@@ -8,6 +8,7 @@ vi.mock('../utils/logger.js', () => ({
 import {
   setRedisClient,
   getRedisClient,
+  invalidateGraphCache,
   acquireEmbeddingLock,
   releaseEmbeddingLock,
   isEmbeddingLocked,
@@ -608,6 +609,80 @@ describe('redis-cache embedding lock', () => {
 
       await expect(releaseWorkerLock('test-worker')).resolves.toBeUndefined();
     });
+  });
+});
+
+// ─── Issue #915 — graph-cache invalidation across all users via SCAN ──────
+describe('invalidateGraphCache (#915)', () => {
+  let mockRedis: ReturnType<typeof createMockRedisClient>;
+
+  beforeEach(() => {
+    mockRedis = createMockRedisClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setRedisClient(mockRedis as any);
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setRedisClient(null as any);
+  });
+
+  it('SCANs the cross-user graph pattern and deletes every matching key', async () => {
+    // The graph cache is written under `kb:<userId>:pages:graph:<view>:<spaceKey>`
+    // (see routes/knowledge/pages-embeddings.ts). page_relationships is shared,
+    // so invalidation must clear every user's graph cache, not just one exact key.
+    mockRedis.scan.mockResolvedValueOnce({
+      cursor: '0',
+      keys: ['kb:u1:pages:graph:standard:all', 'kb:u2:pages:graph:clustered:ENG'],
+    });
+    mockRedis.del.mockResolvedValue(2);
+
+    await invalidateGraphCache();
+
+    expect(mockRedis.scan).toHaveBeenCalledWith('0', {
+      MATCH: 'kb:*:pages:graph:*',
+      COUNT: 100,
+    });
+    expect(mockRedis.del).toHaveBeenCalledWith([
+      'kb:u1:pages:graph:standard:all',
+      'kb:u2:pages:graph:clustered:ENG',
+    ]);
+    // Must NOT delete a bare exact key that is never written.
+    expect(mockRedis.del).not.toHaveBeenCalledWith('kb:u1:pages:graph');
+  });
+
+  it('walks the cursor across multiple SCAN pages', async () => {
+    mockRedis.scan
+      .mockResolvedValueOnce({ cursor: '7', keys: ['kb:u1:pages:graph:standard:all'] })
+      .mockResolvedValueOnce({ cursor: '0', keys: ['kb:u2:pages:graph:standard:all'] });
+    mockRedis.del.mockResolvedValue(1);
+
+    await invalidateGraphCache();
+
+    expect(mockRedis.scan).toHaveBeenCalledTimes(2);
+    expect(mockRedis.del).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not call DEL when SCAN returns no keys', async () => {
+    mockRedis.scan.mockResolvedValueOnce({ cursor: '0', keys: [] });
+
+    await invalidateGraphCache();
+
+    expect(mockRedis.del).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when Redis client is not available', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setRedisClient(null as any);
+
+    await expect(invalidateGraphCache()).resolves.toBeUndefined();
+    expect(mockRedis.scan).not.toHaveBeenCalled();
+  });
+
+  it('soft-fails when SCAN throws (logs, does not raise)', async () => {
+    mockRedis.scan.mockRejectedValue(new Error('Redis down'));
+
+    await expect(invalidateGraphCache()).resolves.toBeUndefined();
   });
 });
 

--- a/backend/src/core/services/redis-cache.ts
+++ b/backend/src/core/services/redis-cache.ts
@@ -23,16 +23,35 @@ export function getRedisClient(): RedisClientType | null {
 }
 
 /**
- * Invalidate the graph cache for a specific user.
+ * Invalidate the knowledge-graph cache for every user.
+ *
+ * Graph responses are cached under `kb:<userId>:pages:graph:<view>:<spaceKey>`
+ * (see `routes/knowledge/pages-embeddings.ts`), so a single exact-key delete
+ * never matches a real entry. Because `page_relationships` is shared across
+ * users, recomputing relationships after an embedding run must clear *all*
+ * users' graph caches — hence a SCAN-delete over `kb:*:pages:graph:*` rather
+ * than a per-user key. Uses the same cursor loop as `scanAndDelete` so it is
+ * O(1) per call and never issues a blocking `KEYS`.
+ *
  * Safe to call even if Redis is not initialised (no-op).
  */
-export async function invalidateGraphCache(userId: string): Promise<void> {
+export async function invalidateGraphCache(): Promise<void> {
   if (!_redisClient) return;
   try {
-    await _redisClient.del(key(userId, 'pages', 'graph'));
-    logger.debug({ userId }, 'Invalidated graph cache');
+    let cursor = '0';
+    do {
+      const result = await _redisClient.scan(cursor, {
+        MATCH: 'kb:*:pages:graph:*',
+        COUNT: 100,
+      });
+      cursor = String(result.cursor);
+      if (result.keys.length > 0) {
+        await _redisClient.del(result.keys);
+      }
+    } while (cursor !== '0');
+    logger.debug('Invalidated graph cache for all users');
   } catch (err) {
-    logger.error({ err, userId }, 'Failed to invalidate graph cache');
+    logger.error({ err }, 'Failed to invalidate graph cache');
   }
 }
 

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -862,8 +862,10 @@ export async function processDirtyPages(
   if (totalProcessed > 0) {
     try {
       await computePageRelationships(processedPageIds);
-      // Invalidate cached graph data so the next request reflects new relationships
-      await invalidateGraphCache(userId);
+      // Invalidate cached graph data so the next request reflects new
+      // relationships. page_relationships is shared, so clear every user's
+      // graph cache — not just this run's user (#915).
+      await invalidateGraphCache();
     } catch (err) {
       logger.error({ err, userId }, 'Failed to compute page relationships after embedding');
     }


### PR DESCRIPTION
Fixes #915.

## What / why
`invalidateGraphCache` deleted the exact key `kb:<userId>:pages:graph`, which is **never written**. Graph responses are actually cached under `kb:<userId>:pages:graph:<view>:<spaceKey>` (see `routes/knowledge/pages-embeddings.ts`). It also scoped to a single user, but `page_relationships` is shared across users — so after an embedding run recomputes relationships, every other user's graph stayed stale for up to the TTL. Net effect: the post-embedding invalidation did nothing.

The fix reworks it to a SCAN-delete over `kb:*:pages:graph:*` (same cursor loop as `scanAndDelete` / `invalidateAcrossUsers`, `MATCH` + `COUNT 100`, no blocking `KEYS`) and drops the now-unused `userId` arg. The single caller in `embedding-service.ts` is updated. Redis-null and try/catch no-op guards are preserved.

## Test evidence
`backend/src/core/services/redis-cache.test.ts` — new `describe('invalidateGraphCache (#915)')`:
- Fails BEFORE the fix: current code calls `del('kb:undefined:pages:graph')` and never scans (3 tests red for that exact reason).
- Passes AFTER: asserts `scan` is called with `MATCH kb:*:pages:graph:*`, deletes the matched keys, walks multi-page cursors, no-ops when Redis is null, and soft-fails on SCAN errors.

Full file: 66 passed. `npm run typecheck -w backend` clean; eslint clean on touched files.

## Docs / diagram impact
None — localized cache-invalidation bugfix; no compose/domain/boundary/migration/flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)