### PR TITLE
fix(llm): preserve reverse similarity edges on incremental recompute (#916)

### DIFF
--- a/backend/src/domains/llm/services/embedding-service.integration.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.integration.test.ts
@@ -6,6 +6,7 @@ import {
   isDbAvailable,
 } from '../../../test-db-helper.js';
 import { query } from '../../../core/db/postgres.js';
+import { computePageRelationships } from './embedding-service.js';
 import pgvector from 'pgvector';
 
 // Deterministic 1024-dim vector for fixtures
@@ -84,5 +85,94 @@ describe.skipIf(!dbAvailable)('page_embeddings (page_id, chunk_index) uniqueness
       'SELECT COUNT(*)::text AS count FROM page_embeddings',
     );
     expect(rows[0]!.count).toBe('2');
+  });
+});
+
+// Regression for #916: embedding_similarity edges are DIRECTED (page_id_1 is
+// the source, page_id_2 the KNN neighbour). The incremental recompute deleted
+// every edge touching a changed page on EITHER side, but only re-inserted the
+// changed page's own outbound edges. Any reverse edge Y→X owned by an unchanged
+// page Y was therefore dropped and never rebuilt. The fix scopes the
+// embedding_similarity delete to the source side (page_id_1) only.
+describe.skipIf(!dbAvailable)('computePageRelationships — directed similarity edges (#916)', () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  }, 30_000);
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+  beforeEach(async () => {
+    await truncateAllTables();
+  });
+
+  // Unit vector on the (x, y) plane at `angleDeg`, padded to 1024 dims.
+  // Cosine similarity between two such vectors is cos(angle difference), so
+  // the angular layout below fully controls the KNN graph.
+  function unitVec(angleDeg: number): number[] {
+    const rad = (angleDeg * Math.PI) / 180;
+    const v = new Array(1024).fill(0);
+    v[0] = Math.cos(rad);
+    v[1] = Math.sin(rad);
+    return v;
+  }
+
+  async function seedPageWithEmbedding(title: string, angleDeg: number): Promise<number> {
+    const page = await query<{ id: number }>(
+      `INSERT INTO pages (confluence_id, source, space_key, title, body_text, body_storage, body_html)
+       VALUES (gen_random_uuid()::text, 'confluence', 'DEV', $1, 'body', '', '')
+       RETURNING id`,
+      [title],
+    );
+    const pageId = page.rows[0]!.id;
+    await query(
+      `INSERT INTO page_embeddings (page_id, chunk_index, chunk_text, embedding, metadata)
+       VALUES ($1, 0, $2, $3, $4::jsonb)`,
+      [
+        pageId,
+        'chunk',
+        pgvector.toSql(unitVec(angleDeg)),
+        JSON.stringify({ page_title: title, section_title: title, space_key: 'DEV' }),
+      ],
+    );
+    return pageId;
+  }
+
+  async function similarityEdge(from: number, to: number): Promise<boolean> {
+    const { rows } = await query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM page_relationships
+       WHERE relationship_type = 'embedding_similarity'
+         AND page_id_1 = $1 AND page_id_2 = $2`,
+      [from, to],
+    );
+    return rows[0]!.count !== '0';
+  }
+
+  it('keeps an unchanged page\'s reverse edge (Y→X) after re-embedding X', async () => {
+    // Cluster c1..c5 sits within 5° of X; Y sits 10° away from X. With TOP_K=5:
+    //   X's 5 nearest are c1..c5 → X→Y is NOT created (asymmetric KNN).
+    //   Y's 5 nearest are X + c5..c2 → Y→X IS created.
+    const c1 = await seedPageWithEmbedding('C1', -5);
+    const c2 = await seedPageWithEmbedding('C2', -4);
+    const c3 = await seedPageWithEmbedding('C3', -3);
+    const c4 = await seedPageWithEmbedding('C4', -2);
+    const c5 = await seedPageWithEmbedding('C5', -1);
+    const x = await seedPageWithEmbedding('X', 0);
+    const y = await seedPageWithEmbedding('Y', 10);
+    void c1;
+    void c2;
+    void c3;
+    void c4;
+    void c5;
+
+    // Full recompute establishes the asymmetric graph.
+    await computePageRelationships();
+    expect(await similarityEdge(y, x)).toBe(true); // Y→X exists
+    expect(await similarityEdge(x, y)).toBe(false); // X→Y does not
+
+    // Simulate X being re-embedded: incremental recompute scoped to [X].
+    await computePageRelationships([x]);
+
+    // Y is unchanged, so its outbound Y→X edge must survive.
+    expect(await similarityEdge(y, x)).toBe(true);
   });
 });

--- a/backend/src/domains/llm/services/embedding-service.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.test.ts
@@ -458,15 +458,20 @@ describe('embedding-service', () => {
     });
 
     it('should delete only affected rows when changedPageIds is provided (incremental)', async () => {
-      // 7 query slots: BEGIN, SET LOCAL, DELETE, similarity INSERT, label INSERT,
+      // 8 query slots: BEGIN, SET LOCAL, DELETE (directed similarity edges),
+      // DELETE (symmetric edges), similarity INSERT, label INSERT,
       // parent_child INSERT (#362), COMMIT. Each must be explicitly mocked so the
       // assertions below pin the bind params for the new edge type instead of
       // relying on the beforeEach catch-all (which would silently absorb a missing
       // slot and let a regression slip through).
+      // #916: the incremental delete is split — directed embedding_similarity
+      // edges are pruned source-side only (page_id_1 = ANY), while symmetric
+      // edge types are deleted on both sides — so there are now TWO DELETE slots.
       mockClient.query
         .mockResolvedValueOnce({ rows: [] })                                                          // BEGIN
         .mockResolvedValueOnce({ rows: [] })                                                          // SET LOCAL statement_timeout
-        .mockResolvedValueOnce({ rows: [], rowCount: 2 })                                             // DELETE WHERE page_id_1 = ANY($1) OR page_id_2 = ANY($1)
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 })                                             // DELETE directed embedding_similarity WHERE page_id_1 = ANY($1)
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 })                                             // DELETE symmetric edges WHERE page_id_1 = ANY($1) OR page_id_2 = ANY($1)
         .mockResolvedValueOnce({ rows: [{ page_id_1: 1, page_id_2: 2, score: 0.9 }], rowCount: 1 })   // similarity INSERT
         .mockResolvedValueOnce({ rows: [], rowCount: 0 })                                             // label INSERT
         .mockResolvedValueOnce({ rows: [], rowCount: 0 })                                             // parent_child INSERT (#362)
@@ -477,30 +482,43 @@ describe('embedding-service', () => {
       expect(totalEdges).toBe(1);
       // Sanity: pin the slot count so a future producer that adds another query
       // can't quietly shift the assertions below to the wrong call index.
-      expect(mockClient.query).toHaveBeenCalledTimes(7);
+      expect(mockClient.query).toHaveBeenCalledTimes(8);
 
-      // DELETE should contain ANY($1)
-      const deleteCall = mockClient.query.mock.calls[2][0] as string;
-      expect(deleteCall).toContain('ANY($1)');
+      // #916: directed similarity edges are pruned SOURCE-SIDE ONLY. This delete
+      // must target relationship_type = 'embedding_similarity' and match only
+      // page_id_1 = ANY($1) — never page_id_2 — so reverse edges Y→X owned by an
+      // unchanged page Y survive.
+      const directedDeleteCall = mockClient.query.mock.calls[2][0] as string;
+      expect(directedDeleteCall).toContain("relationship_type = 'embedding_similarity'");
+      expect(directedDeleteCall).toContain('page_id_1 = ANY($1)');
+      expect(directedDeleteCall).not.toContain('page_id_2');
       expect(mockClient.query.mock.calls[2][1]).toEqual([[1, 3]]);
 
+      // #916: all symmetric edge types are deleted on BOTH sides and must
+      // explicitly exclude the directed embedding_similarity type.
+      const symmetricDeleteCall = mockClient.query.mock.calls[3][0] as string;
+      expect(symmetricDeleteCall).toContain("relationship_type <> 'embedding_similarity'");
+      expect(symmetricDeleteCall).toContain('page_id_1 = ANY($1)');
+      expect(symmetricDeleteCall).toContain('page_id_2 = ANY($1)');
+      expect(mockClient.query.mock.calls[3][1]).toEqual([[1, 3]]);
+
       // similarity query $3 should be changedPageIds
-      const similarityCall = mockClient.query.mock.calls[3];
+      const similarityCall = mockClient.query.mock.calls[4];
       expect(similarityCall[1][2]).toEqual([1, 3]);
 
       // label query $1 should be changedPageIds
-      const labelCall = mockClient.query.mock.calls[4];
+      const labelCall = mockClient.query.mock.calls[5];
       expect(labelCall[1][0]).toEqual([1, 3]);
 
       // parent_child query (#362) $1 should be changedPageIds — pins the
       // incremental contract for the new edge type.
-      const parentChildCall = mockClient.query.mock.calls[5];
+      const parentChildCall = mockClient.query.mock.calls[6];
       expect(parentChildCall[0]).toContain("'parent_child'");
       expect(parentChildCall[1][0]).toEqual([1, 3]);
 
       // COMMIT must be the final call (would silently fall through to the
       // beforeEach catch-all if the slot count above were wrong).
-      expect(mockClient.query.mock.calls[6][0]).toBe('COMMIT');
+      expect(mockClient.query.mock.calls[7][0]).toBe('COMMIT');
     });
   });
 

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -907,8 +907,23 @@ export async function computePageRelationships(changedPageIds?: number[]): Promi
 
     // Delete only affected relationships when changedPageIds provided, otherwise full recompute
     if (changedPageIds && changedPageIds.length > 0) {
+      // #916: embedding_similarity edges are DIRECTED — page_id_1 is the source
+      // (a re-embedded page), page_id_2 its KNN neighbour. Only the source-side
+      // edges are re-inserted below (LATERAL join keyed on a.page_id), so a
+      // both-sides delete would drop reverse edges Y→X owned by an unchanged
+      // page Y and never rebuild them. Scope this delete to the source side.
       await client.query(
-        'DELETE FROM page_relationships WHERE page_id_1 = ANY($1) OR page_id_2 = ANY($1)',
+        `DELETE FROM page_relationships
+         WHERE relationship_type = 'embedding_similarity' AND page_id_1 = ANY($1)`,
+        [changedPageIds],
+      );
+      // All other edge types (label_overlap, parent_child, explicit_link) are
+      // symmetric and stored canonically (lower id first), and are fully
+      // recomputed for any pair touching a changed page — so delete both sides.
+      await client.query(
+        `DELETE FROM page_relationships
+         WHERE relationship_type <> 'embedding_similarity'
+           AND (page_id_1 = ANY($1) OR page_id_2 = ANY($1))`,
         [changedPageIds],
       );
     } else {


### PR DESCRIPTION
Fixes #916.

## What / Why
`embedding_similarity` edges in `page_relationships` are **directed**: `page_id_1` is the source (a re-embedded page) and `page_id_2` its KNN neighbour. The incremental path of `computePageRelationships(changedPageIds)` deleted every similarity edge touching a changed page on **either** side (`page_id_1 = ANY OR page_id_2 = ANY`), but the re-insert only produces **source-side** edges (the LATERAL join is keyed on `a.page_id = ANY(changed)`). So a reverse edge `Y→X`, owned by an unchanged page `Y`, was deleted and never rebuilt — silently eroding the knowledge graph on every incremental re-embed.

The fix splits the incremental delete by relationship type:
- `embedding_similarity` → delete source-side only (`page_id_1 = ANY`), matching what the re-insert rebuilds.
- All symmetric types (`label_overlap`, `parent_child`, `explicit_link`, stored canonically lower-id-first and fully recomputed for any affected pair) → keep the both-sides delete.

## Test evidence
`backend/src/domains/llm/services/embedding-service.integration.test.ts` (real Postgres + pgvector). Seeds a 5-page cluster near X plus a page Y 10° away, giving asymmetric KNN (TOP_K=5): X→Y is not created, Y→X is. After a full recompute the test asserts Y→X exists, then runs `computePageRelationships([X])` and asserts Y→X survives.
- **Before fix:** `expected false to be true` — Y→X dropped by the both-sides delete.
- **After fix:** passes (4/4 in file).

## Docs / diagram impact
None — query-logic fix inside the embedding service; no schema, boundary, or flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)