### PR TITLE
fix(embedding): terminal status on short-page short-circuit (#918)

### DIFF
--- a/backend/src/domains/llm/services/embedding-service.integration.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.integration.test.ts
@@ -6,6 +6,7 @@ import {
   isDbAvailable,
 } from '../../../test-db-helper.js';
 import { query } from '../../../core/db/postgres.js';
+import { embedPage } from './embedding-service.js';
 import pgvector from 'pgvector';
 
 // Deterministic 1024-dim vector for fixtures
@@ -84,5 +85,48 @@ describe.skipIf(!dbAvailable)('page_embeddings (page_id, chunk_index) uniqueness
       'SELECT COUNT(*)::text AS count FROM page_embeddings',
     );
     expect(rows[0]!.count).toBe('2');
+  });
+});
+
+// Regression for #918: the empty/short-page short-circuit in embedPage cleared
+// embedding_dirty but never moved embedding_status off the transient 'embedding'
+// value set when the batch was marked. That left short pages stuck showing
+// "embedding" forever. The branch must land on the terminal 'not_embedded'.
+describe.skipIf(!dbAvailable)('embedPage short-page short-circuit — issue #918', () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  }, 30_000);
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+  beforeEach(async () => {
+    await truncateAllTables();
+  });
+
+  async function seedShortPage(): Promise<number> {
+    const page = await query<{ id: number }>(
+      `INSERT INTO pages (confluence_id, source, space_key, title, body_text, body_storage, body_html,
+                          embedding_status, embedding_dirty)
+       VALUES (gen_random_uuid()::text, 'confluence', 'DEV', 'Short', 'hi', '', '<p>hi</p>',
+               'embedding', TRUE)
+       RETURNING id`,
+    );
+    return page.rows[0]!.id;
+  }
+
+  it('clears embedding_dirty and lands on terminal not_embedded status', async () => {
+    const pageId = await seedShortPage();
+
+    // '<p>hi</p>' has <20 chars of text, so embedPage short-circuits before any
+    // LLM call — no provider mock needed.
+    const written = await embedPage('user-1', pageId, 'Short', 'DEV', '<p>hi</p>');
+    expect(written).toBe(0);
+
+    const { rows } = await query<{ embedding_status: string; embedding_dirty: boolean }>(
+      'SELECT embedding_status, embedding_dirty FROM pages WHERE id = $1',
+      [pageId],
+    );
+    expect(rows[0]!.embedding_dirty).toBe(false);
+    expect(rows[0]!.embedding_status).toBe('not_embedded');
   });
 });

--- a/backend/src/domains/llm/services/embedding-service.test.ts
+++ b/backend/src/domains/llm/services/embedding-service.test.ts
@@ -1258,10 +1258,12 @@ describe('embedPage', () => {
     const result = await embedPage('user-1', 101, 'Short Page', 'DEV', '<p>tiny</p>');
 
     expect(result).toBe(0);
-    // Should have called UPDATE to clear embedding_dirty (using pages.id, not confluence_id)
+    // Should have called UPDATE to clear embedding_dirty AND set the terminal
+    // 'not_embedded' status (clearing any error) so short pages don't stay stuck
+    // showing the transient 'embedding' status (using pages.id, not confluence_id).
     expect(mocks.query).toHaveBeenCalledTimes(1);
     expect(mocks.query).toHaveBeenCalledWith(
-      'UPDATE pages SET embedding_dirty = FALSE WHERE id = $1',
+      `UPDATE pages SET embedding_dirty = FALSE, embedding_status = 'not_embedded', embedding_error = NULL WHERE id = $1`,
       [101],
     );
   });
@@ -1273,9 +1275,10 @@ describe('embedPage', () => {
     const result = await embedPage('user-1', 102, 'Empty Page', 'DEV', '<p></p>');
 
     expect(result).toBe(0);
+    // Same terminal-status write as the too-short case for empty text.
     expect(mocks.query).toHaveBeenCalledTimes(1);
     expect(mocks.query).toHaveBeenCalledWith(
-      'UPDATE pages SET embedding_dirty = FALSE WHERE id = $1',
+      `UPDATE pages SET embedding_dirty = FALSE, embedding_status = 'not_embedded', embedding_error = NULL WHERE id = $1`,
       [102],
     );
   });

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -308,7 +308,7 @@ export async function embedPage(
   if (!plainText || plainText.length < 20) {
     logger.debug({ pageId, pageTitle }, 'Skipping empty/short page for embedding');
     await query(
-      'UPDATE pages SET embedding_dirty = FALSE WHERE id = $1',
+      `UPDATE pages SET embedding_dirty = FALSE, embedding_status = 'not_embedded', embedding_error = NULL WHERE id = $1`,
       [pageId],
     );
     return 0;


### PR DESCRIPTION
Fixes #918.

## What / Why
`embedPage` short-circuits for empty/short pages (plain text < 20 chars). That branch cleared `embedding_dirty` but never moved `embedding_status` off the transient `'embedding'` value that `markPagesForEmbedding` sets before the batch runs. Result: short pages were stuck displaying "embedding" indefinitely.

The fix extends the existing UPDATE to also set the already-used terminal enum value `not_embedded` and clear `embedding_error`, mirroring the `embedded`/`failed` terminal branches which set both status and dirty together. No migration, contract, or frontend change — `not_embedded` is already a valid status value used elsewhere in this file.

```
UPDATE pages SET embedding_dirty = FALSE, embedding_status = 'not_embedded', embedding_error = NULL WHERE id = $1
```

## Test Evidence
`backend/src/domains/llm/services/embedding-service.integration.test.ts` (real Postgres, `describe.skipIf(!dbAvailable)`): seeds a page with `<p>hi</p>` in the post-batch-mark state (`embedding_status='embedding'`, `embedding_dirty=TRUE`), calls `embedPage` (short-circuits, no LLM mock needed), and asserts the terminal state.

- BEFORE fix: `expected 'embedding' to be 'not_embedded'` → FAIL
- AFTER fix: 4 passed

## Docs / Diagram Impact
None — no structural change; reuses an existing status enum value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)