### PR TITLE
fix(embeddings): materialize per-page avg embedding for indexed kNN (#919)

### DIFF
--- a/backend/src/core/db/migrations/082_pages_page_avg_embedding.sql
+++ b/backend/src/core/db/migrations/082_pages_page_avg_embedding.sql
@@ -1,0 +1,65 @@
+-- Migration 082: Materialize per-page average embeddings for indexed kNN.
+--
+-- Issue #919: computePageRelationships computed AVG(embedding) over the ENTIRE
+-- page_embeddings table and then ran an exact, index-less pairwise
+-- nearest-neighbour scan on EVERY incremental embedding run. As the corpus
+-- grew this blew past the 120s statement_timeout. This migration stores each
+-- page's average embedding on the pages row and adds an HNSW index so kNN is
+-- served from the index and scoped to the changed pages instead.
+--
+-- The new column mirrors page_embeddings.embedding's CURRENT type and dimension
+-- (a prior dimension change via enqueueReembedAll may have altered it — see
+-- embedding-service.ts) so `AVG(embedding)` always assigns cleanly. The HNSW
+-- opclass and parameters mirror migration 011/048 (m=16, ef_construction=200)
+-- and honour pgvector's per-type dimension limits (vector <= 2000,
+-- halfvec <= 4000; larger falls back to a sequential scan, no index).
+
+DO $$
+DECLARE
+  base_type text;   -- 'vector' | 'halfvec'
+  dims      int;    -- pgvector stores the dimension directly in atttypmod
+  emb_type  text;   -- e.g. 'vector(1024)'
+  opclass   text;
+BEGIN
+  SELECT t.typname, a.atttypmod, format_type(a.atttypid, a.atttypmod)
+    INTO base_type, dims, emb_type
+    FROM pg_attribute a
+    JOIN pg_type t ON t.oid = a.atttypid
+   WHERE a.attrelid = 'page_embeddings'::regclass
+     AND a.attname = 'embedding'
+     AND NOT a.attisdropped;
+
+  -- Add the column with the same type as the embedding column (idempotent).
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_name = 'pages' AND column_name = 'page_avg_embedding'
+  ) THEN
+    EXECUTE format('ALTER TABLE pages ADD COLUMN page_avg_embedding %s', emb_type);
+
+    -- One-time backfill so existing deployments keep their similarity graph
+    -- immediately, before any re-embed. This is the single full-table AVG the
+    -- runtime path no longer has to pay per embedding run.
+    EXECUTE '
+      UPDATE pages p
+         SET page_avg_embedding = sub.avg
+        FROM (SELECT page_id, AVG(embedding) AS avg
+                FROM page_embeddings
+               GROUP BY page_id) sub
+       WHERE p.id = sub.page_id';
+  END IF;
+
+  -- HNSW index for index-served kNN, within pgvector's per-type dim limits.
+  opclass := CASE WHEN base_type = 'halfvec' THEN 'halfvec_cosine_ops' ELSE 'vector_cosine_ops' END;
+
+  IF NOT EXISTS (
+       SELECT 1 FROM pg_indexes WHERE indexname = 'idx_pages_page_avg_embedding_hnsw'
+     ) AND (
+       (base_type = 'vector'  AND dims <= 2000) OR
+       (base_type = 'halfvec' AND dims <= 4000)
+     ) THEN
+    EXECUTE format(
+      'CREATE INDEX idx_pages_page_avg_embedding_hnsw ON pages USING hnsw (page_avg_embedding %s) WITH (m = 16, ef_construction = 200)',
+      opclass
+    );
+  END IF;
+END $$;

--- a/backend/src/core/db/migrations/083_pages_page_avg_embedding.sql
+++ b/backend/src/core/db/migrations/083_pages_page_avg_embedding.sql
@@ -1,4 +1,4 @@
--- Migration 082: Materialize per-page average embeddings for indexed kNN.
+-- Migration 083: Materialize per-page average embeddings for indexed kNN.
 --
 -- Issue #919: computePageRelationships computed AVG(embedding) over the ENTIRE
 -- page_embeddings table and then ran an exact, index-less pairwise

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -415,8 +415,13 @@ export async function embedPage(
       );
     }
 
+    // Materialize this page's average embedding for indexed kNN (#919). The
+    // subquery sees the rows just inserted above (same transaction) and is a
+    // single-page AVG — cheap — so the relationship computation no longer has
+    // to AVG the whole page_embeddings table on every run.
     await client.query(
-      `UPDATE pages SET embedding_dirty = FALSE, embedding_status = 'embedded', embedded_at = NOW(), embedding_error = NULL
+      `UPDATE pages SET embedding_dirty = FALSE, embedding_status = 'embedded', embedded_at = NOW(), embedding_error = NULL,
+              page_avg_embedding = (SELECT AVG(embedding) FROM page_embeddings WHERE page_id = $1)
        WHERE id = $1`,
       [pageId],
     );
@@ -916,32 +921,37 @@ export async function computePageRelationships(changedPageIds?: number[]): Promi
     }
 
     // Compute embedding similarity edges using pgvector <=> operator.
-    // We compute average embedding per page, then find top-K nearest neighbors.
-    // When changedPageIds is provided, only use those pages as sources in the LATERAL join.
+    // The per-page average embedding is materialized on pages.page_avg_embedding
+    // (migration 082) and served from an HNSW index, so each source page runs a
+    // bounded top-K index probe instead of the old whole-table AVG + exact
+    // pairwise scan that timed out at scale (#919). When changedPageIds is
+    // provided only those pages are sources, so an incremental sync costs
+    // O(changed) index probes.
     const useIncremental = changedPageIds && changedPageIds.length > 0;
     const similarityResult = await client.query<{ page_id_1: number; page_id_2: number; score: number }>(
-      `WITH page_avg AS (
-         SELECT pe.page_id, AVG(pe.embedding) AS avg_embedding
-         FROM page_embeddings pe
-         JOIN pages p ON pe.page_id = p.id
+      `WITH sources AS (
+         SELECT p.id AS page_id, p.page_avg_embedding AS avg_embedding
+         FROM pages p
          WHERE p.deleted_at IS NULL
-         GROUP BY pe.page_id
+           AND p.page_avg_embedding IS NOT NULL
+           AND ($3::int[] IS NULL OR p.id = ANY($3))
        ),
        neighbors AS (
          SELECT
-           a.page_id AS page_id_1,
-           b.page_id AS page_id_2,
-           (1 - (a.avg_embedding <=> b.avg_embedding)) AS score
-         FROM page_avg a
+           s.page_id AS page_id_1,
+           b.id AS page_id_2,
+           (1 - (s.avg_embedding <=> b.page_avg_embedding)) AS score
+         FROM sources s
          CROSS JOIN LATERAL (
-           SELECT page_id, avg_embedding
-           FROM page_avg b
-           WHERE b.page_id != a.page_id
-           ORDER BY a.avg_embedding <=> b.avg_embedding
+           SELECT p2.id, p2.page_avg_embedding
+           FROM pages p2
+           WHERE p2.deleted_at IS NULL
+             AND p2.page_avg_embedding IS NOT NULL
+             AND p2.id != s.page_id
+           ORDER BY s.avg_embedding <=> p2.page_avg_embedding
            LIMIT $1
          ) b
-         WHERE (1 - (a.avg_embedding <=> b.avg_embedding)) >= $2
-           AND ($3::int[] IS NULL OR a.page_id = ANY($3))
+         WHERE (1 - (s.avg_embedding <=> b.page_avg_embedding)) >= $2
        )
        INSERT INTO page_relationships (page_id_1, page_id_2, relationship_type, score)
        SELECT page_id_1, page_id_2, 'embedding_similarity', score
@@ -1171,17 +1181,24 @@ export async function enqueueReembedAll(
     // HNSW on plain vector; falling back to halfvec or seq-scan keeps them usable.
     let columnType: string;
     let indexSql: string | null;
+    // pages.page_avg_embedding (#919) must stay the same type/dimension as
+    // page_embeddings.embedding so embedPage's `AVG(embedding)` assigns cleanly,
+    // and its HNSW index uses the matching opclass.
+    let avgIndexSql: string | null;
     // HNSW tuning parameters match migration 011 and 048 (m=16, ef_construction=200).
     const HNSW_PARAMS = `WITH (m = 16, ef_construction = 200)`;
     if (n <= 2000) {
       columnType = `vector(${n})`;
       indexSql = `CREATE INDEX idx_page_embeddings_hnsw ON page_embeddings USING hnsw (embedding vector_cosine_ops) ${HNSW_PARAMS}`;
+      avgIndexSql = `CREATE INDEX idx_pages_page_avg_embedding_hnsw ON pages USING hnsw (page_avg_embedding vector_cosine_ops) ${HNSW_PARAMS}`;
     } else if (n <= 4000) {
       columnType = `halfvec(${n})`;
       indexSql = `CREATE INDEX idx_page_embeddings_hnsw ON page_embeddings USING hnsw (embedding halfvec_cosine_ops) ${HNSW_PARAMS}`;
+      avgIndexSql = `CREATE INDEX idx_pages_page_avg_embedding_hnsw ON pages USING hnsw (page_avg_embedding halfvec_cosine_ops) ${HNSW_PARAMS}`;
     } else {
       columnType = `vector(${n})`;
       indexSql = null;
+      avgIndexSql = null;
     }
     const client = await getPool().connect();
     try {
@@ -1194,8 +1211,15 @@ export async function enqueueReembedAll(
       // and the opclass only accepts vector, or (b) the new dim is >2000.
       // Dropping the index first disentangles the ALTER from the rebuild.
       await client.query(`DROP INDEX IF EXISTS idx_page_embeddings_hnsw`);
+      await client.query(`DROP INDEX IF EXISTS idx_pages_page_avg_embedding_hnsw`);
       await client.query(
         `ALTER TABLE page_embeddings ALTER COLUMN embedding TYPE ${columnType}`,
+      );
+      // Keep pages.page_avg_embedding in lockstep with the new dimension (#919).
+      // page_embeddings was just truncated and every page is re-embedded below,
+      // so discard the now stale/wrong-dimension averages with USING NULL.
+      await client.query(
+        `ALTER TABLE pages ALTER COLUMN page_avg_embedding TYPE ${columnType} USING NULL`,
       );
       await client.query(
         `INSERT INTO admin_settings (setting_key, setting_value, updated_at)
@@ -1206,6 +1230,7 @@ export async function enqueueReembedAll(
       );
       if (indexSql) {
         await client.query(indexSql);
+        if (avgIndexSql) await client.query(avgIndexSql);
       } else {
         logger.warn(
           { dimensions: n },

--- a/backend/src/domains/llm/services/embedding-service.ts
+++ b/backend/src/domains/llm/services/embedding-service.ts
@@ -922,7 +922,7 @@ export async function computePageRelationships(changedPageIds?: number[]): Promi
 
     // Compute embedding similarity edges using pgvector <=> operator.
     // The per-page average embedding is materialized on pages.page_avg_embedding
-    // (migration 082) and served from an HNSW index, so each source page runs a
+    // (migration 083) and served from an HNSW index, so each source page runs a
     // bounded top-K index probe instead of the old whole-table AVG + exact
     // pairwise scan that timed out at scale (#919). When changedPageIds is
     // provided only those pages are sources, so an incremental sync costs

--- a/backend/src/domains/llm/services/page-avg-embedding.integration.test.ts
+++ b/backend/src/domains/llm/services/page-avg-embedding.integration.test.ts
@@ -5,7 +5,7 @@
  * run an exact (index-less) pairwise nearest-neighbour scan on every embedding
  * run, hitting the 120s statement timeout as the corpus grew. The fix
  * materializes each page's average embedding on `pages.page_avg_embedding`
- * (migration 082) and serves kNN from an HNSW index.
+ * (migration 083) and serves kNN from an HNSW index.
  *
  * These tests exercise the real SQL that the pure-vi.fn unit tests in
  * embedding-service.test.ts cannot observe:

--- a/backend/src/domains/llm/services/page-avg-embedding.integration.test.ts
+++ b/backend/src/domains/llm/services/page-avg-embedding.integration.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Integration test for issue #919 — real Postgres + pgvector.
+ *
+ * computePageRelationships used to AVG the ENTIRE page_embeddings table and
+ * run an exact (index-less) pairwise nearest-neighbour scan on every embedding
+ * run, hitting the 120s statement timeout as the corpus grew. The fix
+ * materializes each page's average embedding on `pages.page_avg_embedding`
+ * (migration 082) and serves kNN from an HNSW index.
+ *
+ * These tests exercise the real SQL that the pure-vi.fn unit tests in
+ * embedding-service.test.ts cannot observe:
+ *   1. embedPage materializes pages.page_avg_embedding as the elementwise
+ *      average of the page's chunk vectors.
+ *   2. computePageRelationships([changedId]) derives embedding_similarity
+ *      edges from the materialized averages (near neighbour linked, orthogonal
+ *      page not), so no full-table AVG is needed.
+ *
+ * Only the external embedding provider is mocked; Postgres, chunking and every
+ * DB transaction run for real. Skipped when the test PG instance is offline.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Captures the vectors the mocked provider hands back so the test can compute
+// the expected elementwise average independent of chunkText's internals.
+const cap = vi.hoisted(() => ({ vectors: [] as number[][], counter: 0 }));
+
+// Mock ONLY the external embedding provider — no real LLM call. Each chunk gets
+// a distinct deterministic 1024-dim vector so averaging is genuinely exercised.
+vi.mock('./openai-compatible-client.js', async () => {
+  const actual = await vi.importActual<typeof import('./openai-compatible-client.js')>(
+    './openai-compatible-client.js',
+  );
+  return {
+    ...actual,
+    generateEmbedding: vi.fn(async (_cfg: unknown, _model: string, texts: string[] | string) => {
+      const arr = Array.isArray(texts) ? texts : [texts];
+      return arr.map(() => {
+        const seed = ++cap.counter;
+        const v = Array.from({ length: 1024 }, (_, i) => Math.sin((i + 1) * seed) * 0.01);
+        cap.vectors.push(v);
+        return v;
+      });
+    }),
+  };
+});
+
+// Provider resolver: skip the real DB lookup — the client mock ignores config.
+vi.mock('./llm-provider-resolver.js', async () => {
+  const actual = await vi.importActual<typeof import('./llm-provider-resolver.js')>(
+    './llm-provider-resolver.js',
+  );
+  return {
+    ...actual,
+    resolveUsecase: vi.fn(async () => ({
+      config: {
+        providerId: 'test-provider',
+        id: 'test-provider',
+        name: 'Test',
+        baseUrl: 'http://localhost:0/v1',
+        apiKey: null,
+        authType: 'none' as const,
+        verifySsl: false,
+        defaultModel: 'bge-m3',
+      },
+      model: 'bge-m3',
+    })),
+  };
+});
+
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../../test-db-helper.js';
+import { query } from '../../../core/db/postgres.js';
+import { embedPage, computePageRelationships } from './embedding-service.js';
+import pgvector from 'pgvector';
+
+const dbAvailable = await isDbAvailable();
+
+/** Insert a bare page row and return its integer id. */
+async function seedPage(title = 'Page'): Promise<number> {
+  const res = await query<{ id: number }>(
+    `INSERT INTO pages (confluence_id, source, space_key, title, body_text, body_storage, body_html)
+     VALUES (gen_random_uuid()::text, 'confluence', 'DEV', $1, 'body', '', '')
+     RETURNING id`,
+    [title],
+  );
+  return res.rows[0]!.id;
+}
+
+/** Read pages.page_avg_embedding back as a plain number[] (NULL -> null). */
+async function readAvg(pageId: number): Promise<number[] | null> {
+  const res = await query<{ v: string | null }>(
+    'SELECT page_avg_embedding::text AS v FROM pages WHERE id = $1',
+    [pageId],
+  );
+  const raw = res.rows[0]!.v;
+  return raw ? (JSON.parse(raw) as number[]) : null;
+}
+
+describe.skipIf(!dbAvailable)('page_avg_embedding materialization + indexed kNN — issue #919', () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  }, 30_000);
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+  beforeEach(async () => {
+    await truncateAllTables();
+    cap.vectors = [];
+    cap.counter = 0;
+  });
+
+  it('embedPage stores the elementwise average of the page chunk vectors', async () => {
+    const pageId = await seedPage('Averaged Page');
+
+    // Body large enough to produce several chunks (each ~1500 chars target).
+    const para = '<p>' + 'Compendiq knowledge base content sentence. '.repeat(60) + '</p>';
+    const bodyHtml = para.repeat(6);
+
+    const chunks = await embedPage('test-user', pageId, 'Averaged Page', 'DEV', bodyHtml);
+
+    // Sanity: the provider was asked to embed >1 chunk so averaging matters.
+    expect(chunks).toBeGreaterThan(1);
+    expect(cap.vectors.length).toBe(chunks);
+
+    const embeddedCount = await query<{ c: string }>(
+      'SELECT COUNT(*)::text AS c FROM page_embeddings WHERE page_id = $1',
+      [pageId],
+    );
+    expect(embeddedCount.rows[0]!.c).toBe(String(chunks));
+
+    // Expected elementwise mean of the captured chunk vectors.
+    const dims = 1024;
+    const expected = new Array(dims).fill(0);
+    for (const v of cap.vectors) {
+      for (let i = 0; i < dims; i++) expected[i] += v[i]!;
+    }
+    for (let i = 0; i < dims; i++) expected[i] /= cap.vectors.length;
+
+    const stored = await readAvg(pageId);
+    expect(stored).not.toBeNull();
+    expect(stored!.length).toBe(dims);
+    // float32 storage vs float64 mean — compare a spread of components.
+    for (const i of [0, 1, 5, 42, 511, 1023]) {
+      expect(stored![i]).toBeCloseTo(expected[i], 4);
+    }
+  });
+
+  it('computePageRelationships([changed]) links the near page via materialized averages, not the orthogonal one', async () => {
+    const near = await seedPage('Near');       // A — close to changed
+    const far = await seedPage('Orthogonal');  // B — orthogonal to changed
+    const changed = await seedPage('Changed');  // C — the freshly re-embedded page
+
+    const unit = (fill: (i: number) => number): string =>
+      pgvector.toSql(Array.from({ length: 1024 }, (_, i) => fill(i)));
+
+    // A ~ [1,0,0,...]; C ~ [1,0.02,0,...] (cosine ~1 with A); B ~ [0,1,0,...] (orthogonal).
+    await query('UPDATE pages SET page_avg_embedding = $1 WHERE id = $2', [unit((i) => (i === 0 ? 1 : 0)), near]);
+    await query('UPDATE pages SET page_avg_embedding = $1 WHERE id = $2', [unit((i) => (i === 1 ? 1 : 0)), far]);
+    await query('UPDATE pages SET page_avg_embedding = $1 WHERE id = $2', [unit((i) => (i === 0 ? 1 : i === 1 ? 0.02 : 0)), changed]);
+
+    const edges = await computePageRelationships([changed]);
+    expect(edges).toBeGreaterThanOrEqual(1);
+
+    const sim = await query<{ page_id_1: number; page_id_2: number; score: number }>(
+      `SELECT page_id_1, page_id_2, score FROM page_relationships
+       WHERE relationship_type = 'embedding_similarity'
+       ORDER BY page_id_2`,
+    );
+
+    // Exactly one similarity edge: the changed page -> its near neighbour.
+    expect(sim.rows.length).toBe(1);
+    expect(sim.rows[0]!.page_id_1).toBe(changed);
+    expect(sim.rows[0]!.page_id_2).toBe(near);
+    expect(sim.rows[0]!.score).toBeGreaterThan(0.4);
+
+    // The orthogonal page must NOT be linked to the changed page.
+    const toFar = sim.rows.find((r) => r.page_id_2 === far);
+    expect(toFar).toBeUndefined();
+  });
+});

--- a/backend/src/routes/llm/llm-embedding-reembed.test.ts
+++ b/backend/src/routes/llm/llm-embedding-reembed.test.ts
@@ -66,6 +66,22 @@ beforeEach(async () => {
        USING hnsw (embedding vector_cosine_ops)
        WITH (m = 16, ef_construction = 200)`,
   );
+  // Issue #919: enqueueReembedAll now keeps pages.page_avg_embedding in lockstep
+  // with page_embeddings.embedding on a dimension change. The dimension-change
+  // tests below therefore leave page_avg_embedding at the last dimension they set
+  // (e.g. vector(4096), no index) — a leak that breaks later test files sharing
+  // this Postgres (the #919 integration suites embed 1024-dim vectors). Restore
+  // it here too, mirroring the page_embeddings reset (table is empty post-truncate
+  // so USING NULL avoids any cross-dimension cast).
+  await query(`DROP INDEX IF EXISTS idx_pages_page_avg_embedding_hnsw`);
+  await query(
+    `ALTER TABLE pages ALTER COLUMN page_avg_embedding TYPE vector(1024) USING NULL`,
+  );
+  await query(
+    `CREATE INDEX idx_pages_page_avg_embedding_hnsw ON pages
+       USING hnsw (page_avg_embedding vector_cosine_ops)
+       WITH (m = 16, ef_construction = 200)`,
+  );
   await query(
     `INSERT INTO admin_settings (setting_key, setting_value, updated_at)
      VALUES ('embedding_dimensions', '1024', NOW())

--- a/docs/architecture/06-data-model.md
+++ b/docs/architecture/06-data-model.md
@@ -72,6 +72,7 @@ erDiagram
         text visibility "private | shared"
         uuid created_by_user_id FK
         bool embedding_dirty
+        vector page_avg_embedding "materialized avg of chunk vectors, HNSW-indexed (#919)"
         timestamptz local_modified_at "non-null => local edit since last_synced (#305)"
         uuid local_modified_by FK "who last edited locally (#305)"
         text_array expected_image_files "cached asset filenames; NULL => recompute (#887)"
@@ -269,6 +270,15 @@ erDiagram
   larger models (e.g. `qwen3-embedding:8b` at 4096) fall to the seq-scan tier.
   Query-time `ef_search` is set per request. Source of truth:
   `backend/src/domains/llm/services/embedding-service.ts` (`enqueueReembedAll`).
+- **Materialized page averages (#919).** `pages.page_avg_embedding` stores each
+  page's average chunk vector, written by `embedPage` inside the same
+  transaction as the chunk inserts, with its own HNSW index
+  (`idx_pages_page_avg_embedding_hnsw`, same type/opclass/params as
+  `page_embeddings.embedding`; kept in lockstep by `enqueueReembedAll`). The
+  knowledge-graph relationship builder (`computePageRelationships`) serves
+  top-K nearest-neighbour edges from this index scoped to the changed pages,
+  instead of AVG-ing the whole `page_embeddings` table and doing an index-less
+  pairwise scan on every embedding run.
 - **Encryption at rest.** `user_settings.confluence_pat` is stored as a
   ciphertext blob (AES-256-GCM, key from `PAT_ENCRYPTION_KEY`). Never
   log or expose it to the frontend. The AES key is derived via HKDF-SHA256


### PR DESCRIPTION
Fixes #919.

## What / why

`computePageRelationships` computed `AVG(embedding)` over the **entire**
`page_embeddings` table and then ran an exact, index-less pairwise
nearest-neighbour scan on **every** incremental embedding run. As the corpus
grew this blew past the `SET LOCAL statement_timeout = 120000` and the graph
recompute started failing.

The fix materializes each page's average embedding and serves kNN from an index:

- **Migration `082_pages_page_avg_embedding.sql`** adds `pages.page_avg_embedding`
  and an HNSW index (`m=16, ef_construction=200`, mirroring migrations 011/048).
  The column and index are **dimension-aware** — they match
  `page_embeddings.embedding`'s current type/opclass (so a prior dimension change
  can't break the `AVG` assignment). Existing rows are backfilled once at deploy
  so the similarity graph keeps working before any re-embed.
- **`embedPage`** folds the single-page `AVG(embedding)` into its existing success
  `UPDATE` (same transaction as the chunk inserts, no extra round trip).
- **`computePageRelationships`** drops the whole-table `page_avg` CTE and instead
  runs an index-served top-K LATERAL over `pages.page_avg_embedding`, scoped to
  the changed pages — so an incremental sync costs O(changed) index probes
  instead of a full-table AVG + exact pairwise scan. Same param order / edge
  semantics as before.
- **`enqueueReembedAll`** keeps `page_avg_embedding` (and its index) in lockstep
  when the admin changes embedding dimensions.

## Test evidence

New backend-db integration test
`backend/src/domains/llm/services/page-avg-embedding.integration.test.ts`
(real Postgres + pgvector; only the LLM provider is mocked):

1. `embedPage` stores the elementwise average of the page's chunk vectors.
2. `computePageRelationships([changed])` links the near page (cosine ~1) and not
   the orthogonal one, derived from the materialized averages.

- **Fails before** the fix: `column "page_avg_embedding" does not exist`.
- **Passes after**: both tests green; migration 082 applies cleanly.

Regression-checked: `embedding-service.test.ts` (unit), the two existing
embedding integration suites, `llm-embedding-reembed.test.ts` (dimension change),
`migrations.test.ts`, `rag-service.integration.test.ts`, `pages-graph.test.ts` —
all pass. Backend `tsc --noEmit` and ESLint on touched files are clean.

## Docs / diagram impact

Updated `docs/architecture/06-data-model.md`: added `pages.page_avg_embedding`
to the ERD and a note describing the materialized-average index and its use by
the relationship builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)