### PR TITLE
fix(llm): abort in-flight request on queue timeout (#920)

### DIFF
--- a/backend/src/domains/llm/services/llm-queue.test.ts
+++ b/backend/src/domains/llm/services/llm-queue.test.ts
@@ -211,6 +211,29 @@ describe('llm-queue', () => {
       expect(getMetrics().maxQueueDepth).toBe(50);
     });
 
+    // Regression for #920 — on a queue timeout, the abandoned in-flight
+    // request must be ABORTED (not merely forgotten). Pre-fix, `enqueue`
+    // called `fn()` with no argument and rejected with LlmTimeoutError while
+    // the underlying fetch kept running — leaking the undici connection slot
+    // and hiding the failure from the per-provider circuit breaker. Post-fix,
+    // `enqueue` threads an AbortSignal into `fn(signal)` and aborts it before
+    // rejecting, so the fetch tears down and the breaker records a failure.
+    it('aborts the in-flight fn and rejects with LlmTimeoutError on timeout', async () => {
+      process.env.LLM_STREAM_TIMEOUT_MS = '50';
+      vi.resetModules();
+      const { enqueue } = await import('./llm-queue.js');
+
+      let capturedSignal: AbortSignal | undefined;
+      const pending = enqueue((signal) => new Promise<never>((_, reject) => {
+        capturedSignal = signal;
+        signal.addEventListener('abort', () => reject(new Error('fetch aborted')));
+      }));
+
+      await expect(pending).rejects.toMatchObject({ name: 'LlmTimeoutError' });
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+
     it('LLM_CONCURRENCY=1 limits actual concurrent execution', async () => {
       process.env.LLM_CONCURRENCY = '1';
       vi.resetModules();

--- a/backend/src/domains/llm/services/llm-queue.ts
+++ b/backend/src/domains/llm/services/llm-queue.ts
@@ -122,23 +122,38 @@ class LlmTimeoutError extends Error {
   }
 }
 
-export async function enqueue<T>(fn: () => Promise<T>): Promise<T> {
+export async function enqueue<T>(fn: (signal: AbortSignal) => Promise<T>): Promise<T> {
   if (_limiter.pendingCount >= _maxQueueDepth) {
     _totalRejected++;
     throw new QueueFullError(_limiter.pendingCount, _maxQueueDepth);
   }
 
   return _limiter(async () => {
+    // #920: thread an AbortController into `fn` so a timeout can tear down the
+    // in-flight upstream request instead of abandoning it. Aborting fixes two
+    // defects at once: undici stops the connection (no leaked concurrency slot)
+    // AND the wrapped `breaker.execute` rejects with the AbortError, so the
+    // per-provider circuit breaker records a failure on timeout rather than a
+    // slow success.
+    const controller = new AbortController();
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
         _totalTimedOut++;
+        // Reject the race with LlmTimeoutError FIRST, then abort. Ordering
+        // matters: `controller.abort()` can settle `fn` synchronously (an
+        // abort listener that rejects inline), which would otherwise win the
+        // race and surface the transport's AbortError to the caller instead
+        // of our LlmTimeoutError. Rejecting first pins the caller-visible
+        // error; the subsequent abort still tears down the in-flight request
+        // and feeds the AbortError to the wrapped breaker.
         reject(new LlmTimeoutError(_timeoutMs));
+        controller.abort();
       }, _timeoutMs);
     });
 
     try {
-      const result = await Promise.race([fn(), timeoutPromise]);
+      const result = await Promise.race([fn(controller.signal), timeoutPromise]);
       _totalProcessed++;
       return result;
     } catch (err) {

--- a/backend/src/domains/llm/services/openai-compatible-client.ts
+++ b/backend/src/domains/llm/services/openai-compatible-client.ts
@@ -154,10 +154,10 @@ export interface StreamChatOptions {
 export async function listModels(cfg: ProviderConfig): Promise<LlmModel[]> {
   return withSpan(
     'llm.list_models',
-    () => enqueue(() =>
+    () => enqueue((signal) =>
       getProviderBreaker(cfg.providerId).execute(async () => {
         const res = await undiciFetch(`${cfg.baseUrl}/models`, {
-          headers: headers(cfg), dispatcher: dispatcherFor(cfg),
+          headers: headers(cfg), dispatcher: dispatcherFor(cfg), signal,
         });
         if (!res.ok) throw new Error(`listModels HTTP ${res.status}`);
         const body = await res.json() as { data?: Array<{ id: string }> };
@@ -186,13 +186,14 @@ export async function chat(
   // disabled (withSpan passes straight through).
   return withSpan(
     'llm.chat',
-    () => enqueue(() =>
+    () => enqueue((signal) =>
       getProviderBreaker(cfg.providerId).execute(async () => {
         const res = await undiciFetch(`${cfg.baseUrl}/chat/completions`, {
           method: 'POST',
           headers: headers(cfg),
           body: JSON.stringify({ model, messages, stream: false, ...thinkingExtras(cfg.baseUrl, model, opts?.thinking) }),
           dispatcher: dispatcherFor(cfg),
+          signal,
         });
         if (!res.ok) throw new Error(`chat HTTP ${res.status}`);
         const body = await res.json() as { choices: Array<{ message: { content: string } }> };
@@ -273,13 +274,14 @@ export async function generateEmbedding(
   const input = Array.isArray(text) ? text : [text];
   return withSpan(
     'llm.embeddings',
-    () => enqueue(() =>
+    () => enqueue((signal) =>
       getProviderBreaker(cfg.providerId).execute(async () => {
         const res = await undiciFetch(`${cfg.baseUrl}/embeddings`, {
           method: 'POST',
           headers: headers(cfg),
           body: JSON.stringify({ model, input }),
           dispatcher: dispatcherFor(cfg),
+          signal,
         });
         if (!res.ok) {
           // Include the response body so callers (embedding-service's


### PR DESCRIPTION
Fixes #920.

## What & why
The LLM queue's per-request timeout rejected the caller with `LlmTimeoutError` but left the underlying request running. Two defects resulted:
- **Concurrency leak** — the abandoned undici fetch kept its connection slot open, so a timed-out request never freed queue capacity.
- **Breaker blindness** — the per-provider circuit breaker never saw the timeout; the eventual slow completion was recorded as a *success*, so a chronically slow/hung provider never tripped the breaker.

The fix threads an `AbortController` through `enqueue(fn(signal))`. On timeout we reject the race with `LlmTimeoutError` **first** (pinning the caller-visible error regardless of whether the transport rejects sync or async on abort), then `controller.abort()`. The three non-streaming client calls (`listModels`, `chat`, `generateEmbedding`) pass that signal to `undiciFetch`, so a timeout tears down the upstream request and the wrapped `breaker.execute` rejects with the `AbortError` — recording a failure. Streaming already had its own abort path and is unchanged. `enqueue`'s widened signature is backward compatible (a zero-arg `fn` remains assignable).

## Test evidence
`backend/src/domains/llm/services/llm-queue.test.ts` — new test *"aborts the in-flight fn and rejects with LlmTimeoutError on timeout"* sets `LLM_STREAM_TIMEOUT_MS=50`, enqueues a fn that captures its signal, and asserts the reject is `LlmTimeoutError` and `signal.aborted === true`.
- Before fix: FAILS — `fn()` called with no arg, `signal` is undefined (`TypeError` on `signal.addEventListener`).
- After fix: PASSES. Full `llm-queue` suite (20) and `openai-compatible-client` suite (66) green; backend typecheck + eslint clean.

## Docs / diagram impact
None — internal timeout/abort behavior only; no compose, domain/ESLint boundary, migration, or auth/sync/RAG/license/content-pipeline flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)