### PR TITLE
fix(rbac): round-trip custom role description (#935)

### DIFF
--- a/backend/src/core/db/migrations/082_roles_description.sql
+++ b/backend/src/core/db/migrations/082_roles_description.sql
@@ -1,0 +1,9 @@
+-- Migration 082: add description column to roles (#935)
+--
+-- Custom roles carry a human-readable description entered in the role editor.
+-- Without a persisted column the editor could not round-trip the value: it
+-- showed an empty Description on edit and saving overwrote the stored text
+-- with ''. The column is nullable and harmless in CE (system roles leave it
+-- NULL); the enterprise advanced-RBAC create/update routes write it.
+
+ALTER TABLE roles ADD COLUMN description TEXT;

--- a/backend/src/core/db/migrations/085_roles_description.sql
+++ b/backend/src/core/db/migrations/085_roles_description.sql
@@ -1,4 +1,4 @@
--- Migration 082: add description column to roles (#935)
+-- Migration 085: add description column to roles (#935)
 --
 -- Custom roles carry a human-readable description entered in the role editor.
 -- Without a persisted column the editor could not round-trip the value: it

--- a/backend/src/routes/foundation/rbac.test.ts
+++ b/backend/src/routes/foundation/rbac.test.ts
@@ -190,8 +190,8 @@ describe('RBAC routes', () => {
     it('should return all roles', async () => {
       (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
         rows: [
-          { id: 1, name: 'system_admin', display_name: 'System Administrator', is_system: true, permissions: ['read', 'admin'], created_at: '2026-01-01T00:00:00Z' },
-          { id: 2, name: 'viewer', display_name: 'Viewer', is_system: true, permissions: ['read'], created_at: '2026-01-01T00:00:00Z' },
+          { id: 1, name: 'system_admin', display_name: 'System Administrator', is_system: true, permissions: ['read', 'admin'], created_at: '2026-01-01T00:00:00Z', description: null },
+          { id: 2, name: 'viewer', display_name: 'Viewer', is_system: true, permissions: ['read'], created_at: '2026-01-01T00:00:00Z', description: null },
         ],
       });
 
@@ -210,7 +210,44 @@ describe('RBAC routes', () => {
         isSystem: true,
         permissions: ['read', 'admin'],
         createdAt: '2026-01-01T00:00:00Z',
+        description: null,
       });
+    });
+
+    // #935: the editor round-trips the description, so GET /api/roles must
+    // surface it. Previously the response mapping dropped the column, so
+    // opening a custom role for editing showed an empty Description and
+    // saving overwrote the stored value with ''.
+    it('should include the description for custom roles', async () => {
+      (mockQuery as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        rows: [
+          { id: 6, name: 'kb_editor', display_name: 'KB Editor', is_system: false, permissions: ['read', 'edit'], created_at: '2026-01-01T00:00:00Z', description: 'Can edit KB pages' },
+        ],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/roles',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body[0]).toEqual({
+        id: 6,
+        name: 'kb_editor',
+        displayName: 'KB Editor',
+        isSystem: false,
+        permissions: ['read', 'edit'],
+        createdAt: '2026-01-01T00:00:00Z',
+        description: 'Can edit KB pages',
+      });
+
+      // The SELECT must actually read the description column.
+      const rolesCall = (mockQuery as ReturnType<typeof vi.fn>).mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('FROM roles'),
+      );
+      expect(rolesCall).toBeDefined();
+      expect(rolesCall![0]).toContain('description');
     });
   });
 

--- a/backend/src/routes/foundation/rbac.ts
+++ b/backend/src/routes/foundation/rbac.ts
@@ -153,7 +153,8 @@ export async function rbacRoutes(fastify: FastifyInstance) {
         is_system: boolean;
         permissions: string[];
         created_at: string;
-      }>('SELECT id, name, display_name, is_system, permissions, created_at FROM roles ORDER BY id');
+        description: string | null;
+      }>('SELECT id, name, display_name, is_system, permissions, created_at, description FROM roles ORDER BY id');
 
       return result.rows.map((r) => ({
         id: r.id,
@@ -162,6 +163,7 @@ export async function rbacRoutes(fastify: FastifyInstance) {
         isSystem: r.is_system,
         permissions: r.permissions,
         createdAt: r.created_at,
+        description: r.description,
       }));
     });
 

--- a/docs/architecture/06-data-model.md
+++ b/docs/architecture/06-data-model.md
@@ -176,6 +176,7 @@ erDiagram
         bigint id PK
         text name
         jsonb permissions
+        text description
     }
 
     groups {

--- a/frontend/src/features/admin/RbacPage.tsx
+++ b/frontend/src/features/admin/RbacPage.tsx
@@ -23,6 +23,7 @@ interface Role {
   isSystem: boolean;
   permissions: string[];
   createdAt: string;
+  description?: string | null;
 }
 
 interface Group {
@@ -203,7 +204,7 @@ function RolesTab() {
   const handleEdit = (role: Role) => {
     setEditRole({
       ...role,
-      description: (role as Role & { description?: string }).description ?? '',
+      description: role.description ?? '',
       updatedAt: (role as Role & { updatedAt?: string }).updatedAt ?? role.createdAt,
     });
     setEditorOpen(true);


### PR DESCRIPTION
Fixes #935.

## What / why
Editing a custom role showed an empty **Description** and saving overwrote the stored value with `''`. The role editor already reads and writes a `description`, but the backend never persisted or returned it:
- the `roles` table had no `description` column, and
- `GET /api/roles` neither selected nor mapped it.

## Changes
- **Migration 082** (`082_roles_description.sql`): add nullable `description TEXT` to `roles`. Harmless in CE (system roles leave it NULL); EE advanced-RBAC create/update routes write it.
- **`rbac.ts`** `GET /api/roles`: add `description` to the row type, the `SELECT`, and the mapped response.
- **`RbacPage.tsx`**: add `description?: string | null` to the `Role` interface and drop the ad-hoc `(role as Role & { description?: string })` cast (`?? ''` kept). `CustomRoleEditor` already consumes `editRole.description`, so no editor change.

## Test evidence
`backend/src/routes/foundation/rbac.test.ts` — extended the `GET /api/roles` block with a custom-role case asserting the mapped response includes `description` and that the SELECT reads the column.
- **Before fix:** fails — response mapping omits `description` (toEqual mismatch, SELECT lacks the column).
- **After fix:** passes. Full file 33/33 green; migrations suite 27/27 green; backend + frontend typecheck clean; ESLint clean on touched files.

## Docs / diagram impact
Added `text description` to the `roles` entity in `docs/architecture/06-data-model.md` (DB column addition per repo rule 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)