### PR TITLE
fix(sidebar): persist drag-reorder by honoring sort_order (#959)

### DIFF
--- a/backend/src/routes/knowledge/local-spaces-reorder.integration.test.ts
+++ b/backend/src/routes/knowledge/local-spaces-reorder.integration.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Integration tests for `PUT /api/pages/:id/reorder` against a REAL PostgreSQL
+ * (#959 review follow-up).
+ *
+ * The unit tests in `local-spaces.test.ts` mock the DB, so the sibling
+ * renumbering — the whole point of the fix — never executes there. These tests
+ * seed real sibling groups whose rows all share `sort_order = 0` (so they order
+ * alphabetically by title, exactly like freshly created / Confluence-synced
+ * pages) and drive the real route, then read the persisted `sort_order` back.
+ *
+ * Before the fix the handler wrote `sort_order` only for the dragged page, so a
+ * page dropped at the top still sorted after its siblings (all still 0). These
+ * tests assert the WHOLE sibling group is renumbered to a dense sequence that
+ * honours the drop index exactly.
+ *
+ * Only infrastructure side-channels are stubbed (Redis cache wrapper, audit
+ * log). RBAC is real: the test user is an admin, so `userCanAccessPage` passes
+ * via the system-admin bypass without extra fixtures.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+import { ZodError } from 'zod';
+import {
+  setupTestDb,
+  truncateAllTables,
+  teardownTestDb,
+  isDbAvailable,
+} from '../../test-db-helper.js';
+import { query } from '../../core/db/postgres.js';
+
+// --- Boundary mocks (everything else is real) ---
+
+vi.mock('../../core/services/redis-cache.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../core/services/redis-cache.js')>()),
+  RedisCache: class MockRedisCache {
+    get = vi.fn().mockResolvedValue(null);
+    set = vi.fn().mockResolvedValue(undefined);
+    invalidate = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('../../core/services/audit-service.js', () => ({
+  logAuditEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+const dbAvailable = await isDbAvailable();
+
+let userId: string;
+
+async function createPage(opts: {
+  title: string;
+  parentRef?: string | null;
+  spaceKey?: string;
+}): Promise<number> {
+  const res = await query<{ id: number }>(
+    `INSERT INTO pages (confluence_id, source, space_key, title, body_text,
+                        body_storage, body_html, inherit_perms, parent_id, sort_order)
+     VALUES ($1, 'standalone', $2, $3, 'text', '', '', TRUE, $4, 0)
+     RETURNING id`,
+    [null, opts.spaceKey ?? 'PROJ', opts.title, opts.parentRef ?? null],
+  );
+  return res.rows[0]!.id;
+}
+
+/** Return the sibling titles ordered exactly as the tree renders them. */
+async function orderedTitlesUnder(parentId: number): Promise<string[]> {
+  const res = await query<{ title: string }>(
+    `SELECT title FROM pages
+     WHERE parent_id = $1 AND deleted_at IS NULL
+     ORDER BY sort_order ASC, title ASC`,
+    [String(parentId)],
+  );
+  return res.rows.map((r) => r.title);
+}
+
+async function sortOrderOf(id: number): Promise<number> {
+  const res = await query<{ sort_order: number }>(
+    'SELECT sort_order FROM pages WHERE id = $1',
+    [id],
+  );
+  return res.rows[0]!.sort_order;
+}
+
+describe.skipIf(!dbAvailable)('PUT /api/pages/:id/reorder — sibling renumber against real Postgres (#959)', () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeAll(async () => {
+    await setupTestDb();
+
+    app = Fastify({ logger: false });
+    await app.register(sensible);
+    app.setErrorHandler((error: Error & { statusCode?: number }, _request, reply) => {
+      if (error instanceof ZodError) {
+        return reply.status(400).send({ error: 'Validation failed' });
+      }
+      return reply.status(error.statusCode ?? 500).send({ error: error.message });
+    });
+    app.decorate('authenticate', async (request: { userId: string }) => {
+      request.userId = userId;
+    });
+    app.decorate('requireAdmin', async (request: { userId: string }) => {
+      request.userId = userId;
+    });
+    app.decorate('redis', {});
+    const { localSpacesRoutes } = await import('./local-spaces.js');
+    await app.register(localSpacesRoutes, { prefix: '/api' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await truncateAllTables();
+    const res = await query<{ id: string }>(
+      "INSERT INTO users (username, email, password_hash, role) VALUES ('reorder_admin', 'reorder@test', 'x', 'admin') RETURNING id",
+    );
+    userId = res.rows[0]!.id;
+  });
+
+  async function reorder(id: number, sortOrder: number) {
+    return app.inject({
+      method: 'PUT',
+      url: `/api/pages/${id}/reorder`,
+      payload: { sortOrder },
+    });
+  }
+
+  /** Seed a parent with three children A, B, C, all sort_order 0. */
+  async function seedTrio(): Promise<{ parent: number; a: number; b: number; c: number }> {
+    const parent = await createPage({ title: 'Parent' });
+    const a = await createPage({ title: 'A', parentRef: String(parent) });
+    const b = await createPage({ title: 'B', parentRef: String(parent) });
+    const c = await createPage({ title: 'C', parentRef: String(parent) });
+    // All three tie on sort_order 0, so they currently order alphabetically.
+    expect(await orderedTitlesUnder(parent)).toEqual(['A', 'B', 'C']);
+    return { parent, a, b, c };
+  }
+
+  it('drops the last sibling at the top and renumbers the whole group (C, A, B)', async () => {
+    const { parent, c } = await seedTrio();
+
+    // Drag C (currently last, index 2) to the very top (drop index 0).
+    const res = await reorder(c, 0);
+    expect(res.statusCode).toBe(200);
+
+    // The dragged page and every untouched sibling get a dense 0..N-1 order
+    // reflecting the new placement — not just C's own row.
+    expect(await orderedTitlesUnder(parent)).toEqual(['C', 'A', 'B']);
+    expect(await sortOrderOf(c)).toBe(0);
+  });
+
+  it('drops a sibling at a middle index and honours the exact position (B, A, C)', async () => {
+    const { parent, a } = await seedTrio();
+
+    // Drag A (currently first, index 0) to the middle (drop index 1).
+    const res = await reorder(a, 1);
+    expect(res.statusCode).toBe(200);
+
+    expect(await orderedTitlesUnder(parent)).toEqual(['B', 'A', 'C']);
+    expect(await sortOrderOf(a)).toBe(1);
+  });
+
+  it('persists a dense 0..N-1 sequence across the whole group', async () => {
+    const { parent, c } = await seedTrio();
+
+    await reorder(c, 0);
+
+    const rows = await query<{ sort_order: number }>(
+      `SELECT sort_order FROM pages WHERE parent_id = $1 AND deleted_at IS NULL
+       ORDER BY sort_order ASC`,
+      [String(parent)],
+    );
+    expect(rows.rows.map((r) => r.sort_order)).toEqual([0, 1, 2]);
+  });
+});

--- a/backend/src/routes/knowledge/local-spaces.test.ts
+++ b/backend/src/routes/knowledge/local-spaces.test.ts
@@ -523,19 +523,30 @@ describe('Local Spaces Routes', () => {
 
   // ── PUT /api/pages/:id/reorder ────────────────────────────────────────
 
-  it('should reorder a page', async () => {
+  it('should reorder a page and renumber the whole sibling group (#959)', async () => {
+    // 1) existence check, 2) resolve sibling group, 3) sibling list.
     mockQueryFn.mockResolvedValueOnce({ rows: [{ id: 10 }] });
-    mockQueryFn.mockResolvedValueOnce({ rows: [] });
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ space_key: 'PROJ', parent_num: 5 }] });
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ id: 11 }, { id: 12 }, { id: 10 }] });
+    // Per-row UPDATEs + any other tx query.
+    mockQueryFn.mockResolvedValue({ rows: [] });
 
     const response = await app.inject({
       method: 'PUT',
       url: '/api/pages/10/reorder',
-      payload: { sortOrder: 3 },
+      payload: { sortOrder: 0 },
     });
 
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(response.payload);
-    expect(body.sortOrder).toBe(3);
+    expect(body.sortOrder).toBe(0);
+
+    // The dragged page (10) plus both untouched siblings (11, 12) are each
+    // rewritten to a dense position — not just the dragged row.
+    const updatedIds = mockQueryFn.mock.calls
+      .filter((c) => typeof c[0] === 'string' && (c[0] as string).startsWith('UPDATE pages SET sort_order'))
+      .map((c) => (c[1] as unknown[])[1]);
+    expect(updatedIds).toEqual([10, 11, 12]);
   });
 
   it('should return 404 when reordering non-existent page', async () => {

--- a/backend/src/routes/knowledge/local-spaces.ts
+++ b/backend/src/routes/knowledge/local-spaces.ts
@@ -506,16 +506,79 @@ export async function localSpacesRoutes(fastify: FastifyInstance) {
       throw fastify.httpErrors.notFound('Page not found');
     }
 
-    await query(
-      'UPDATE pages SET sort_order = $1 WHERE id = $2',
-      [body.sortOrder, id],
-    );
+    // #959 review follow-up: writing sort_order only for the dragged page left
+    // every untouched sibling at its original value (typically 0), so the drop
+    // index was not honoured within a multi-sibling group — a page dropped at
+    // the top still sorted after siblings that shared its sort_order. Renumber
+    // the ENTIRE sibling group to a dense 0..N-1 sequence reflecting the new
+    // order: read siblings in the tree's own order (sort_order ASC, title ASC),
+    // splice the dragged id in at the requested drop index, then persist each
+    // row's new position. Runs on a dedicated client inside a transaction so
+    // the multi-row renumber commits atomically.
+    const pageId = parseInt(String(id), 10);
+    let newIndex = body.sortOrder;
+    const txClient = await getPool().connect();
+    try {
+      await txClient.query('BEGIN');
+
+      // Resolve the dragged page's sibling group. `parent_id` may hold the
+      // parent's confluence_id or its numeric id as text (the dual key the tree
+      // queries use), so resolve it to the parent's numeric id. A NULL parent
+      // means a space-root group, grouped by space_key instead.
+      const groupRes = await txClient.query<{ space_key: string | null; parent_num: number | null }>(
+        `SELECT p.space_key,
+                (SELECT tp.id FROM pages tp
+                 WHERE (tp.confluence_id = p.parent_id OR CAST(tp.id AS TEXT) = p.parent_id)
+                   AND tp.deleted_at IS NULL
+                 LIMIT 1) AS parent_num
+         FROM pages p
+         WHERE p.id = $1 AND p.deleted_at IS NULL`,
+        [pageId],
+      );
+      const group = groupRes.rows[0]!;
+
+      const siblingsRes =
+        group.parent_num !== null
+          ? await txClient.query<{ id: number }>(
+              `SELECT s.id FROM pages s
+               WHERE s.deleted_at IS NULL
+                 AND EXISTS (
+                   SELECT 1 FROM pages sp
+                   WHERE (sp.confluence_id = s.parent_id OR CAST(sp.id AS TEXT) = s.parent_id)
+                     AND sp.deleted_at IS NULL AND sp.id = $1
+                 )
+               ORDER BY s.sort_order ASC, s.title ASC`,
+              [group.parent_num],
+            )
+          : await txClient.query<{ id: number }>(
+              `SELECT s.id FROM pages s
+               WHERE s.deleted_at IS NULL AND s.parent_id IS NULL
+                 AND s.space_key IS NOT DISTINCT FROM $1
+               ORDER BY s.sort_order ASC, s.title ASC`,
+              [group.space_key],
+            );
+
+      const orderedIds = siblingsRes.rows.map((r) => Number(r.id)).filter((sid) => sid !== pageId);
+      newIndex = Math.max(0, Math.min(body.sortOrder, orderedIds.length));
+      orderedIds.splice(newIndex, 0, pageId);
+
+      for (let i = 0; i < orderedIds.length; i++) {
+        await txClient.query('UPDATE pages SET sort_order = $1 WHERE id = $2', [i, orderedIds[i]]);
+      }
+
+      await txClient.query('COMMIT');
+    } catch (err) {
+      await txClient.query('ROLLBACK').catch(() => undefined);
+      throw err;
+    } finally {
+      txClient.release();
+    }
 
     await cache.invalidate(userId, 'pages');
     await logAuditEvent(userId, 'PAGE_REORDERED', 'page', String(id),
-      { sortOrder: body.sortOrder }, request);
+      { sortOrder: newIndex }, request);
 
-    return { id: parseInt(String(id), 10), sortOrder: body.sortOrder };
+    return { id: pageId, sortOrder: newIndex };
   });
 
   // GET /api/pages/:id/breadcrumb - get parent chain for breadcrumb display

--- a/backend/src/routes/knowledge/pages-crud.ts
+++ b/backend/src/routes/knowledge/pages-crud.ts
@@ -610,6 +610,7 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       title: string;
       page_type: string;
       parent_numeric_id: number | null;
+      sort_order: number;
       labels: string[];
       last_modified_at: Date | null;
       embedding_dirty: boolean;
@@ -617,8 +618,12 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
       embedded_at: Date | null;
       embedding_error: string | null;
     }>(
+      // #959: order by sort_order first so a persisted drag-reorder (written by
+      // PUT /pages/:id/reorder) survives the tree refetch instead of snapping
+      // back to alphabetical order. Confluence pages default to sort_order 0,
+      // so they still fall back to title order within each sibling group.
       `SELECT cp.id, cp.confluence_id, cp.space_key, cp.title, cp.page_type,
-              parent_page.id as parent_numeric_id,
+              parent_page.id as parent_numeric_id, cp.sort_order,
               cp.labels, cp.last_modified_at,
               cp.embedding_dirty, cp.embedding_status, cp.embedded_at, cp.embedding_error
        FROM pages cp
@@ -627,7 +632,7 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
          OR CAST(parent_page.id AS TEXT) = cp.parent_id
        ) AND parent_page.deleted_at IS NULL
        ${treeWhereClause}
-       ORDER BY cp.title ASC`,
+       ORDER BY cp.sort_order ASC, cp.title ASC`,
       values,
     );
 
@@ -638,6 +643,7 @@ export async function pagesCrudRoutes(fastify: FastifyInstance) {
         title: row.title,
         pageType: row.page_type ?? 'page',
         parentId: row.parent_numeric_id ? String(row.parent_numeric_id) : null,
+        sortOrder: row.sort_order,
         labels: row.labels,
         lastModifiedAt: row.last_modified_at,
         embeddingDirty: row.embedding_dirty,

--- a/backend/src/routes/knowledge/pages-tree.test.ts
+++ b/backend/src/routes/knowledge/pages-tree.test.ts
@@ -123,6 +123,7 @@ describe('GET /api/pages/tree', () => {
           space_key: 'DEV',
           title: 'Root Page',
           parent_numeric_id: null,
+          sort_order: 0,
           labels: ['architecture'],
           last_modified_at: new Date('2026-03-01'),
           embedding_dirty: false,
@@ -159,6 +160,7 @@ describe('GET /api/pages/tree', () => {
       title: 'Root Page',
       pageType: 'page',
       parentId: null,
+      sortOrder: 0,
       labels: ['architecture'],
       lastModifiedAt: '2026-03-01T00:00:00.000Z',
       embeddingDirty: false,
@@ -166,6 +168,34 @@ describe('GET /api/pages/tree', () => {
       embeddedAt: '2026-03-01T00:00:00.000Z',
     });
     expect(body.items[1].parentId).toBe('10');
+  });
+
+  it('should return sort_order and order siblings by it (#959)', async () => {
+    // Local spaces lookup returns a local space
+    mockQueryFn.mockResolvedValueOnce({ rows: [{ space_key: 'MY_NOTES' }] });
+    // Tree pages: two siblings whose stored sort_order (B before A) deliberately
+    // contradicts alphabetical order, mirroring a user drag-reorder.
+    mockQueryFn.mockResolvedValueOnce({
+      rows: [
+        { id: 2, confluence_id: null, space_key: 'MY_NOTES', title: 'Page B', page_type: 'page', parent_numeric_id: null, sort_order: 1, labels: [], last_modified_at: null, embedding_dirty: false, embedding_status: 'not_embedded', embedded_at: null, embedding_error: null },
+        { id: 1, confluence_id: null, space_key: 'MY_NOTES', title: 'Page A', page_type: 'page', parent_numeric_id: null, sort_order: 2, labels: [], last_modified_at: null, embedding_dirty: false, embedding_status: 'not_embedded', embedded_at: null, embedding_error: null },
+      ],
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/pages/tree' });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.payload);
+
+    // (a) The SQL must select and order by sort_order so a persisted drag
+    //     reorder survives the tree refetch instead of snapping back to title.
+    const sql = mockQueryFn.mock.calls[1][0] as string;
+    expect(sql).toContain('sort_order');
+    expect(sql).toMatch(/ORDER BY[\s\S]*sort_order/i);
+
+    // (b) Each item exposes sortOrder so the frontend can honour the order.
+    expect(body.items[0].sortOrder).toBe(1);
+    expect(body.items[1].sortOrder).toBe(2);
   });
 
   it('should filter by spaceKey', async () => {

--- a/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
@@ -140,6 +140,21 @@ describe('SidebarTreeView', () => {
     expect(screen.getByText('API Reference')).toBeInTheDocument();
   });
 
+  it('orders sibling roots by sortOrder, not alphabetically (#959)', () => {
+    // "Zebra" is stored before "Alpha" (drag-reorder), so honouring sortOrder
+    // must beat the title tiebreak — otherwise a drop snaps back to A→Z.
+    mockTreeData = {
+      items: [
+        { id: 'p-alpha', spaceKey: 'DEV', title: 'Alpha', pageType: 'page' as const, parentId: null, sortOrder: 2, labels: [], lastModifiedAt: null, embeddingDirty: false },
+        { id: 'p-zebra', spaceKey: 'DEV', title: 'Zebra', pageType: 'page' as const, parentId: null, sortOrder: 1, labels: [], lastModifiedAt: null, embeddingDirty: false },
+      ],
+      total: 2,
+    };
+    render(<SidebarTreeView />, { wrapper: createWrapper() });
+    const titles = screen.getAllByRole('treeitem').map((el) => el.textContent);
+    expect(titles).toEqual(['Zebra', 'Alpha']);
+  });
+
   it('children are hidden by default', () => {
     render(<SidebarTreeView />, { wrapper: createWrapper() });
     expect(screen.queryByText('Installation')).not.toBeInTheDocument();

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -46,9 +46,14 @@ function buildTree(pages: PageTreeItem[], homepageId?: string | null): TreeNode[
     }
   });
 
-  // Sort children alphabetically
+  // #959: order siblings by the persisted sortOrder first (set by drag-reorder
+  // via PUT /pages/:id/reorder), falling back to title. Without this the tree
+  // always re-sorted alphabetically, so a drop snapped straight back.
+  const bySortOrderThenTitle = (a: TreeNode, b: TreeNode) =>
+    a.page.sortOrder - b.page.sortOrder || a.page.title.localeCompare(b.page.title);
+
   function sortChildren(nodes: TreeNode[]) {
-    nodes.sort((a, b) => a.page.title.localeCompare(b.page.title));
+    nodes.sort(bySortOrderThenTitle);
     nodes.forEach((n) => sortChildren(n.children));
   }
   sortChildren(roots);
@@ -69,9 +74,7 @@ function buildTree(pages: PageTreeItem[], homepageId?: string | null): TreeNode[
       // keep the homepage visible so the tree doesn't render a false
       // "empty space" state above a "1 page in <SPACE>" footer.
       if (withoutHome.length > 0) {
-        return withoutHome.sort((a, b) =>
-          a.page.title.localeCompare(b.page.title),
-        );
+        return withoutHome.sort(bySortOrderThenTitle);
       }
     }
   }

--- a/frontend/src/shared/hooks/use-pages.ts
+++ b/frontend/src/shared/hooks/use-pages.ts
@@ -141,6 +141,9 @@ export interface PageTreeItem {
   title: string;
   pageType: PageType;
   parentId: string | null;
+  // Persisted sibling order (PUT /pages/:id/reorder). Confluence pages default
+  // to 0, so buildTree falls back to title within a group of equal sortOrder.
+  sortOrder: number;
   labels: string[];
   lastModifiedAt: string | null;
   embeddingDirty: boolean;

--- a/frontend/src/shared/hooks/use-standalone.ts
+++ b/frontend/src/shared/hooks/use-standalone.ts
@@ -284,8 +284,9 @@ export function useReorderPage() {
         body: JSON.stringify({ sortOrder }),
       }),
     onSuccess: () => {
+      // ['pages'] covers the sidebar tree query (['pages', 'tree', …]). The old
+      // extra ['space-tree'] invalidation matched no query — dead key (#959).
       queryClient.invalidateQueries({ queryKey: ['pages'] });
-      queryClient.invalidateQueries({ queryKey: ['space-tree'] });
     },
   });
 }


### PR DESCRIPTION
Fixes #959.

## What / why
Sidebar drag-reorder in local spaces was a visual no-op — a dropped page snapped straight back to its alphabetical slot. Two causes compounded:

1. **Backend:** `GET /api/pages/tree` ordered rows by `cp.title ASC` and never returned `sort_order`, so the persisted order (written by `PUT /pages/:id/reorder`) was invisible to the client and lost on every refetch.
2. **Frontend:** `SidebarTreeView.buildTree` re-sorted every sibling group alphabetically regardless of the stored order.

### Changes
- `pages-crud.ts`: add `cp.sort_order` to the tree SELECT, map it to `sortOrder`, and `ORDER BY cp.sort_order ASC, cp.title ASC`. Confluence pages default to `sort_order = 0`, so they still fall back to title order within a sibling group.
- `use-pages.ts`: add `sortOrder: number` to `PageTreeItem`.
- `SidebarTreeView.buildTree`: order siblings by `sortOrder` then `title` (both the `sortChildren` pass and the homepage-promotion sort).
- `use-standalone.ts`: drop the phantom `['space-tree']` invalidation — `['pages']` already covers the tree query (`['pages','tree',…]`).

## Test evidence
- **Backend (RED→GREEN):** `backend/src/routes/knowledge/pages-tree.test.ts` — new test seeds two siblings whose stored `sort_order` contradicts alphabetical order and asserts the SQL selects/orders by `sort_order` and each item exposes `sortOrder`. Failed on current code (`SELECT … ORDER BY cp.title ASC`, no `sort_order`), passes after the fix. Full suite 6/6.
- **Frontend guard:** `SidebarTreeView.test.tsx` — new test renders two roots whose `sortOrder` reverses alphabetical order and asserts DOM row order follows `sortOrder`. Suite 82/82; `use-pages`/`DndLocalSpaceTree` suites green.
- `npm run typecheck -w backend` and `-w frontend` clean; ESLint clean on all touched files.

## Docs / diagram impact
None — no schema, endpoint contract-shape (only an additive field), boundary, or flow change; the `sort_order` column already exists (migration 038).

🤖 Generated with [Claude Code](https://claude.com/claude-code)