### PR TITLE
fix(infra): give backend a 60s stop_grace_period so graceful shutdown completes (#931)

### DIFF
--- a/backend/src/docker-compose-invariants.test.ts
+++ b/backend/src/docker-compose-invariants.test.ts
@@ -155,6 +155,18 @@ describe('docker/docker-compose.yml security invariants', () => {
     expect(redis).toContain('--maxmemory-policy noeviction');
     expect(composeProd).not.toContain('allkeys-lru');
   });
+
+  it('gives the backend a stop_grace_period long enough for graceful shutdown (issue #931)', () => {
+    // Docker defaults stop_grace_period to 10s and SIGKILLs the container after
+    // it, which aborts the in-process graceful-shutdown timer
+    // (DEFAULT_SHUTDOWN_TIMEOUT_MS = 50s in core/utils/graceful-shutdown.ts).
+    // The grace period must exceed that timeout so the handler force-exits
+    // itself before Docker resorts to SIGKILL. ADR-024 mandates 60s.
+    const backend = extractServiceBlock(composeProd, 'backend');
+    const match = backend.match(/^\s+stop_grace_period:\s*(\d+)s\b/m);
+    expect(match, 'backend service must declare stop_grace_period').not.toBeNull();
+    expect(Number(match![1])).toBeGreaterThanOrEqual(60);
+  });
 });
 
 describe('docker/docker-compose.dev.yml security invariants', () => {
@@ -190,6 +202,17 @@ describe('scripts/install.sh invariants', () => {
 
   it('points the backend at the mcp-docs sidecar', () => {
     expect(installSh).toContain('MCP_DOCS_URL:');
+  });
+
+  it('gives the installed backend a stop_grace_period for graceful shutdown (issue #931)', () => {
+    // The installer-generated compose must match docker/docker-compose.yml so
+    // installed deployments also survive the 50s graceful-shutdown drain
+    // instead of being SIGKILLed at Docker's 10s default.
+    const compose = extractInstallerCompose(installSh);
+    const backend = extractServiceBlock(compose, 'backend');
+    const match = backend.match(/^\s+stop_grace_period:\s*(\d+)s\b/m);
+    expect(match, 'installer backend service must declare stop_grace_period').not.toBeNull();
+    expect(Number(match![1])).toBeGreaterThanOrEqual(60);
   });
 
   it('attaches mcp-docs and searxng to a non-internal network so they can reach the internet', () => {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -61,6 +61,11 @@ services:
       redis:
         condition: service_healthy
     restart: unless-stopped
+    # SIGTERM → drain BullMQ workers + HTTP → close DB pools before SIGKILL.
+    # Must exceed the in-process SHUTDOWN_TIMEOUT_MS (default 50s) so the
+    # handler force-exits itself first; 60s leaves Docker a 10s margin.
+    # See ADR-024 (Graceful-shutdown order) and issue #931.
+    stop_grace_period: 60s
     volumes:
       - attachments:/app/data
       - "${HOST_CA_BUNDLE_PATH:-/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem}:${CONTAINER_CA_BUNDLE_PATH:-/etc/ssl/certs/ca-certificates.crt}:ro"

--- a/docs/ARCHITECTURE-DECISIONS.md
+++ b/docs/ARCHITECTURE-DECISIONS.md
@@ -1250,7 +1250,7 @@ If the at-most-once trade-off becomes user-visible (e.g. a customer reports cach
 
 **Graceful-shutdown order:**
 
-Bound to a 60s `stop_grace_period` (set in `docker/docker-compose.ee.yml`) with the BullMQ stall detector (`stalledInterval` default 30s) as the safety net for jobs that don't complete. The step order is declared in `backend/src/index.ts` and executed by `createShutdownHandler()` (`backend/src/core/utils/graceful-shutdown.ts`, added for issue #745):
+Bound to a 60s `stop_grace_period` (set on the `backend` service in `docker/docker-compose.yml`, the `scripts/install.sh` installer compose, and `docker/docker-compose.ee.yml` — issue #931) with the BullMQ stall detector (`stalledInterval` default 30s) as the safety net for jobs that don't complete. The step order is declared in `backend/src/index.ts` and executed by `createShutdownHandler()` (`backend/src/core/utils/graceful-shutdown.ts`, added for issue #745):
 
 ```
 SIGTERM

--- a/docs/architecture/05-deployment.md
+++ b/docs/architecture/05-deployment.md
@@ -157,8 +157,9 @@ flowchart LR
 
 2. **`stop_grace_period: 60s` on the `backend` service** so SIGTERM has
    time to drain HTTP handlers + finish active BullMQ jobs before
-   SIGKILL. Set in `docker/docker-compose.ee.yml` for EE; CE operators
-   running multi-replica should set it on their compose. See ADR-024 →
+   SIGKILL. Shipped in `docker/docker-compose.yml`, the installer compose
+   (`scripts/install.sh`), and `docker/docker-compose.ee.yml`, so both CE
+   and EE deployments get it out of the box. See ADR-024 →
    Graceful-shutdown order.
 
 3. **Redis must be reachable from every replica** with low latency

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -288,6 +288,9 @@ services:
       redis:
         condition: service_healthy
     restart: unless-stopped
+    # SIGTERM → drain BullMQ workers + HTTP → close DB pools before SIGKILL.
+    # Must exceed SHUTDOWN_TIMEOUT_MS (default 50s); see ADR-024 / issue #931.
+    stop_grace_period: 60s
     volumes:
       - attachments-data:/app/data
     healthcheck:


### PR DESCRIPTION
Fixes #931.

## What / why

Docker defaults `stop_grace_period` to **10s** and SIGKILLs the `backend` container after it. The in-process graceful-shutdown handler (`core/utils/graceful-shutdown.ts`) has a hard deadline `SHUTDOWN_TIMEOUT_MS` that defaults to **50s**, so on every `docker compose stop`/`down`/restart the container was killed ~40s before the drain could finish — aborting in-flight BullMQ jobs (sync/embedding/quality/summary) and open LLM SSE streams mid-answer.

Add `stop_grace_period: 60s` to the `backend` service in:
- `docker/docker-compose.yml`
- the `scripts/install.sh` installer compose heredoc

60s = 50s drain budget + 10s SIGKILL margin, matching `docker-compose.ee.yml` and ADR-024 (Graceful-shutdown order).

## Test evidence

Extended `backend/src/docker-compose-invariants.test.ts` with two assertions: the prod compose and the installer compose `backend` blocks must declare `stop_grace_period >= 60s` (>= the 50s in-process timeout so the handler force-exits before Docker's SIGKILL).

- Fails before: `expected null not to be null` (no `stop_grace_period` anywhere) — 2 failing.
- Passes after: `27 passed`.

Run: `cd backend && REDIS_URL=… npx vitest run src/docker-compose-invariants.test.ts`

## Docs / diagram impact

Structural infra change: updated ADR-024 and `docs/architecture/05-deployment.md` to note CE (compose + installer) now ships the 60s grace period out of the box, not just EE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)