### PR TITLE
Harden mcp-docs production Dockerfile (#966, #967, #968)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -94,6 +94,7 @@ services:
       context: ..
       dockerfile: mcp-docs/Dockerfile
     environment:
+      NODE_ENV: production
       PORT: "3100"
       MCP_DOCS_HOST: "0.0.0.0"
       REDIS_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD is required - set a strong password, e.g. openssl rand -hex 24}@redis:6379

--- a/mcp-docs/Dockerfile
+++ b/mcp-docs/Dockerfile
@@ -6,12 +6,23 @@ COPY mcp-docs/tsconfig.json mcp-docs/tsconfig.build.json ./
 COPY mcp-docs/src/ src/
 RUN npx tsc -p tsconfig.build.json
 
+# Production dependencies only — no typescript/tsx/vitest/pino-pretty in runtime.
+FROM node:22-alpine AS prod-deps
+WORKDIR /build
+COPY mcp-docs/package.json mcp-docs/package-lock.json* ./
+RUN npm ci --ignore-scripts --omit=dev
+
 FROM node:22-alpine
 WORKDIR /app
+# dumb-init as PID 1 reaps zombies and forwards SIGTERM to node for clean shutdown.
+RUN apk add --no-cache dumb-init
 RUN addgroup -g 1001 -S appgroup && adduser -u 1001 -S appuser -G appgroup
+# NODE_ENV=production also stops logger.ts from loading the pruned pino-pretty transport.
+ENV NODE_ENV=production
 COPY --from=builder /build/package.json ./
-COPY --from=builder /build/node_modules ./node_modules
+COPY --from=prod-deps /build/node_modules ./node_modules
 COPY --from=builder /build/dist ./dist
 USER appuser
 EXPOSE 3100
+ENTRYPOINT ["dumb-init", "--"]
 CMD ["node", "dist/index.js"]

--- a/mcp-docs/src/Dockerfile.test.ts
+++ b/mcp-docs/src/Dockerfile.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Production Dockerfile hardening invariants for the mcp-docs sidecar
+ * (issues #966, #967, #968).
+ *
+ * The mcp-docs image is a long-running service reached via HTTP by the backend.
+ * These assertions mirror the hardening already applied to backend/Dockerfile:
+ *
+ *  #966 dumb-init as PID 1 — a bare `node` PID 1 does not reap zombies and
+ *       ignores SIGTERM without an explicit handler, so `docker stop` waits the
+ *       full grace period and then SIGKILLs. `ENTRYPOINT ["dumb-init", "--"]`
+ *       forwards signals for a clean shutdown.
+ *  #967 prune dev dependencies — the runtime stage must not ship typescript,
+ *       tsx, vitest, etc. Install a dedicated prod-deps stage with
+ *       `npm ci --omit=dev` and copy node_modules from it, not from the builder.
+ *  #968 NODE_ENV=production — logger.ts loads the `pino-pretty` transport unless
+ *       NODE_ENV === 'production'. With dev deps pruned (#967) that module is
+ *       gone, so the runtime stage MUST set NODE_ENV=production or the process
+ *       crashes on boot.
+ */
+
+const mcpDocsRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = join(mcpDocsRoot, '..');
+
+const dockerfile = readFileSync(join(mcpDocsRoot, 'Dockerfile'), 'utf8');
+const composeProd = readFileSync(join(repoRoot, 'docker', 'docker-compose.yml'), 'utf8');
+const installSh = readFileSync(join(repoRoot, 'scripts', 'install.sh'), 'utf8');
+
+/** Extract the mcp-docs service block from a compose document (2-space indent). */
+function mcpDocsServiceBlock(composeText: string): string {
+  const lines = composeText.split('\n');
+  const start = lines.findIndex((line) => line === '  mcp-docs:');
+  expect(start, 'mcp-docs service not found').toBeGreaterThanOrEqual(0);
+  const block: string[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^ {0,2}\S/.test(lines[i])) break;
+    block.push(lines[i]);
+  }
+  return block.join('\n');
+}
+
+describe('mcp-docs Dockerfile — #966 dumb-init PID 1', () => {
+  it('installs dumb-init in the runtime image', () => {
+    expect(dockerfile).toMatch(/apk add [^\n]*dumb-init/);
+  });
+
+  it('uses dumb-init as the entrypoint so SIGTERM is forwarded to node', () => {
+    expect(dockerfile).toMatch(/ENTRYPOINT \["dumb-init", "--"\]/);
+  });
+});
+
+describe('mcp-docs Dockerfile — #967 prune dev dependencies', () => {
+  it('has a production-only dependency install (npm ci --omit=dev)', () => {
+    expect(dockerfile).toMatch(/npm ci[^\n]*--omit=dev/);
+  });
+
+  it('copies node_modules from the prod-deps stage, not the builder', () => {
+    expect(dockerfile).toMatch(/COPY --from=prod-deps [^\n]*node_modules/);
+    expect(dockerfile).not.toMatch(/COPY --from=builder [^\n]*node_modules/);
+  });
+});
+
+describe('mcp-docs Dockerfile — #968 NODE_ENV=production', () => {
+  it('sets NODE_ENV=production in the runtime stage', () => {
+    expect(dockerfile).toMatch(/ENV NODE_ENV=production/);
+  });
+});
+
+describe('mcp-docs compose defense-in-depth — #968 NODE_ENV=production', () => {
+  it('sets NODE_ENV: production in docker/docker-compose.yml', () => {
+    expect(mcpDocsServiceBlock(composeProd)).toMatch(/NODE_ENV:\s*production/);
+  });
+
+  it('sets NODE_ENV: production in scripts/install.sh', () => {
+    expect(mcpDocsServiceBlock(installSh)).toMatch(/NODE_ENV:\s*production/);
+  });
+});

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -344,6 +344,7 @@ services:
   mcp-docs:
     image: ghcr.io/compendiq/compendiq-ce-mcp-docs:__VERSION__
     environment:
+      NODE_ENV: production
       PORT: "3100"
       MCP_DOCS_HOST: "0.0.0.0"
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379


### PR DESCRIPTION
Fixes #966, #967, #968.

## What / Why
The mcp-docs sidecar's production Dockerfile lagged the backend/enterprise runtime hardening. This brings it in line:

- **#966 — dumb-init as PID 1.** The image ended with `CMD ["node", "dist/index.js"]` and no init, so `node` ran as PID 1: it does not reap zombies and drops SIGTERM without an explicit handler, making `docker stop` wait the full grace period then SIGKILL. Now `RUN apk add --no-cache dumb-init` + `ENTRYPOINT ["dumb-init", "--"]` forward signals for a clean shutdown.
- **#967 — prune dev dependencies.** The runtime stage COPY'd the builder's full `node_modules` (typescript, tsx, vitest, pino-pretty, @types). Added a dedicated `prod-deps` stage (`npm ci --ignore-scripts --omit=dev`) and copy `node_modules` from it instead of the builder.
- **#968 — NODE_ENV=production.** `logger.ts` only skips the `pino-pretty` transport when `NODE_ENV === 'production'`; with dev deps pruned (#967) that module is gone, so the runtime must set it or the process crashes on boot. Added `ENV NODE_ENV=production` to the runtime stage, plus `NODE_ENV: production` to the mcp-docs `environment:` blocks in `docker/docker-compose.yml` and `scripts/install.sh` as defense-in-depth.

## Test evidence
New `mcp-docs/src/Dockerfile.test.ts` (Vitest, pure file-read — no Postgres/Redis) asserts all three invariants plus the compose/installer NODE_ENV. Fails-before / passes-after on current dev:
- Before fix: 7/7 fail (no dumb-init, no `--omit=dev`, node_modules from builder, no NODE_ENV).
- After fix: 7/7 pass. Backend `docker-compose-invariants.test.ts` still green (25/25); `tsc --noEmit` clean.

## Docs / diagram impact
None — this is container-internal runtime hardening; the mcp-docs service, port, image name, and network membership in `docs/architecture/02-container.md` / `05-deployment.md` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)