### PR TITLE
fix(installer): drop phantom LLM env defaults from compose (#970)

### DIFF
--- a/backend/src/docker-compose-invariants.test.ts
+++ b/backend/src/docker-compose-invariants.test.ts
@@ -212,6 +212,36 @@ describe('scripts/install.sh invariants', () => {
     }
   });
 
+  it('does not revive the removed LLM_PROVIDER two-slot toggle (issue #970)', () => {
+    // ADR-021 replaced the legacy `LLM_PROVIDER` switch wholesale with the
+    // llm_providers table. Seeding it from the installer resurrects dead config.
+    expect(installSh).not.toMatch(/LLM_PROVIDER:/);
+  });
+
+  it('does not default OPENAI_BASE_URL to a real endpoint (issue #970)', () => {
+    // A non-empty OPENAI_BASE_URL default makes the fresh-install bootstrap OR
+    // condition true, seeding a phantom keyless OpenAI provider even when the
+    // operator only wants Ollama. Only a pure pass-through (empty default) is
+    // acceptable so the row is seeded solely when the user opts in.
+    const compose = extractInstallerCompose(installSh);
+    const backend = extractServiceBlock(compose, 'backend');
+    const usages = interpolationsOf(backend, 'OPENAI_BASE_URL');
+    expect(usages.length).toBeGreaterThan(0);
+    for (const modifier of usages) {
+      // Empty pass-through only: `:-` (or bare) — never a baked-in URL default.
+      expect(modifier).toMatch(/^:?-?$/);
+    }
+    expect(backend).not.toContain('api.openai.com');
+  });
+
+  it('does not seed the deprecated EMBEDDING_MODEL env default (issue #970)', () => {
+    // EMBEDDING_MODEL is a deprecated bootstrap fallback; baking bge-m3 into the
+    // installer keeps env-driven LLM config alive instead of the providers table.
+    const compose = extractInstallerCompose(installSh);
+    const backend = extractServiceBlock(compose, 'backend');
+    expect(backend).not.toMatch(/EMBEDDING_MODEL:/);
+  });
+
   it('keeps postgres and redis on an internal network (no host egress for the data tier)', () => {
     // The egress fix must not accidentally expose the data tier: postgres/redis
     // must still sit on an `internal: true` network per CLAUDE.md infra rules.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -261,10 +261,8 @@ services:
       JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
       PAT_ENCRYPTION_KEY: ${PAT_ENCRYPTION_KEY:?PAT_ENCRYPTION_KEY is required}
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
-      LLM_PROVIDER: ${LLM_PROVIDER:-ollama}
-      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1}
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-bge-m3}
       LLM_BEARER_TOKEN: ${LLM_BEARER_TOKEN:-}
       LLM_AUTH_TYPE: ${LLM_AUTH_TYPE:-bearer}
       LLM_VERIFY_SSL: ${LLM_VERIFY_SSL:-true}


### PR DESCRIPTION
Fixes #970.

## What / Why
The installer's `write_compose` heredoc (`scripts/install.sh`) baked three env defaults that seed dead or phantom LLM config on a fresh install:

- **`LLM_PROVIDER: ${LLM_PROVIDER:-ollama}`** — the legacy two-slot toggle removed wholesale by ADR-021 (`llm_providers` table). CLAUDE.md marks it do-not-revive. Deleted.
- **`OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1}`** — a non-empty default makes the fresh-install bootstrap OR condition true, seeding a **phantom keyless OpenAI provider** even for operators who only run Ollama. Changed to an empty pass-through (`${OPENAI_BASE_URL:-}`) so the row is seeded only when the user opts in.
- **`EMBEDDING_MODEL: ${EMBEDDING_MODEL:-bge-m3}`** — a deprecated bootstrap fallback; no longer seeded from the installer.

`OLLAMA_BASE_URL` keeps its keyless local default — that is the intended seeded provider. `OPENAI_API_KEY` was already an empty pass-through.

## Test evidence
Extended the existing `scripts/install.sh invariants` suite in `backend/src/docker-compose-invariants.test.ts` (pure fs-read, no DB) with three assertions: no `LLM_PROVIDER:`, `OPENAI_BASE_URL` has only an empty/pass-through default (and no `api.openai.com`), and no `EMBEDDING_MODEL:` in the backend block.

- **Fails before:** 3 failed | 25 passed on the pre-fix `install.sh`.
- **Passes after:** 28 passed.
- Run: `cd backend && npx vitest run src/docker-compose-invariants.test.ts`

Backend typecheck passes; ESLint clean on the changed test file.

## Docs / diagram impact
None — only deprecated bootstrap-fallback defaults are removed from the installer-generated compose; backend read behavior and `.env.example` are unchanged, and no architecture diagram, migration, or auth/sync/RAG flow is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)