### PR TITLE
fix(contracts): make LLM request `model` optional (#929)

### DIFF
--- a/backend/src/routes/llm/analyze-quality.test.ts
+++ b/backend/src/routes/llm/analyze-quality.test.ts
@@ -134,14 +134,26 @@ describe('POST /api/llm/analyze-quality', () => {
     expect(response.statusCode).toBeGreaterThanOrEqual(400);
   });
 
-  it('should reject request when model is missing', async () => {
+  it('should accept a request without model and resolve it server-side (#929)', async () => {
+    // #929: `model` is optional in the contract — the route resolves it per
+    // use-case via resolveUsecase() and ignores any body value (ADR-021).
+    async function* mockGenerator() {
+      yield { content: '## Overall Quality Score: 75/100', done: true };
+    }
+    mockStreamChatClient.mockReturnValue(mockGenerator());
+
     const response = await app.inject({
       method: 'POST',
       url: '/api/llm/analyze-quality',
       payload: { content: '<p>Some article text</p>' },
     });
 
-    expect(response.statusCode).toBeGreaterThanOrEqual(400);
+    // Not rejected for a missing model — the stream path runs instead.
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toBe('text/event-stream');
+    // The server-resolved model ('m'), not the absent body value, is used.
+    const [, model] = mockStreamChatClient.mock.calls[0] as [unknown, string];
+    expect(model).toBe('m');
   });
 
   it('should return 400 when content exceeds max length', async () => {

--- a/backend/src/routes/llm/generate-diagram.test.ts
+++ b/backend/src/routes/llm/generate-diagram.test.ts
@@ -129,14 +129,26 @@ describe('POST /api/llm/generate-diagram', () => {
     expect(response.statusCode).toBeGreaterThanOrEqual(400);
   });
 
-  it('should reject request when model is missing', async () => {
+  it('should accept a request without model and resolve it server-side (#929)', async () => {
+    // #929: `model` is optional in the contract — the route resolves it per
+    // use-case via resolveUsecase() and ignores any body value (ADR-021).
+    async function* mockGenerator() {
+      yield { content: 'graph TD\n  A --> B', done: true };
+    }
+    mockStreamChat.mockReturnValue(mockGenerator());
+
     const response = await app.inject({
       method: 'POST',
       url: '/api/llm/generate-diagram',
       payload: { content: '<p>Some article text</p>' },
     });
 
-    expect(response.statusCode).toBeGreaterThanOrEqual(400);
+    // Not rejected for a missing model — the stream path runs instead.
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toBe('text/event-stream');
+    // The server-resolved model ('m'), not the absent body value, is used.
+    const [, model] = mockStreamChat.mock.calls[0] as [unknown, string];
+    expect(model).toBe('m');
   });
 
   it('should return 400 when content exceeds max length', async () => {

--- a/backend/src/routes/llm/llm-ask.test.ts
+++ b/backend/src/routes/llm/llm-ask.test.ts
@@ -221,14 +221,25 @@ describe('POST /api/llm/ask', () => {
     expect(response.statusCode).toBeGreaterThanOrEqual(400);
   });
 
-  it('should return 400 when model is missing', async () => {
+  it('should accept a request without model and resolve it server-side (#929)', async () => {
+    // #929: `model` is optional in the contract — the route resolves it per
+    // use-case via resolveUsecase() and ignores any body value (ADR-021).
+    mockHybridSearch.mockResolvedValue([]);
+    mockBuildRagContext.mockReturnValue('No relevant context found in the knowledge base.');
+    mockStreamChatClient.mockReturnValue(singleChunkGenerator('The deployment uses CI/CD.'));
+
     const response = await app.inject({
       method: 'POST',
       url: '/api/llm/ask',
       payload: { question: 'What is the deployment process?' },
     });
 
-    expect(response.statusCode).toBeGreaterThanOrEqual(400);
+    // Not rejected for a missing model — the stream path runs instead.
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toBe('text/event-stream');
+    // The server-resolved model ('m'), not the absent body value, is used.
+    const [, model] = mockStreamChatClient.mock.calls[0] as [unknown, string];
+    expect(model).toBe('m');
   });
 
   it('should return 400 when question exceeds maximum length', async () => {

--- a/backend/src/routes/llm/llm-summarize.test.ts
+++ b/backend/src/routes/llm/llm-summarize.test.ts
@@ -197,14 +197,22 @@ describe('POST /api/llm/summarize - functionality', () => {
     expect(response.statusCode).toBeGreaterThanOrEqual(400);
   });
 
-  it('should return 400 when model is missing', async () => {
+  it('should accept a request without model and resolve it server-side (#929)', async () => {
+    // #929: `model` is optional in the contract — the route resolves it per
+    // use-case via resolveUsecase() and ignores any body value (ADR-021).
     const response = await app.inject({
       method: 'POST',
       url: '/api/llm/summarize',
       payload: { content: 'Some text to summarize' },
     });
 
-    expect(response.statusCode).toBeGreaterThanOrEqual(400);
+    // Not rejected for a missing model — the stream path runs instead.
+    expect(response.statusCode).toBeLessThan(400);
+    expect(mockStreamSSE).toHaveBeenCalledOnce();
+    expect(mockStreamChatClient).toHaveBeenCalledOnce();
+    // The server-resolved model ('m'), not the absent body value, is used.
+    const [, model] = mockStreamChatClient.mock.calls[0] as [unknown, string];
+    expect(model).toBe('m');
   });
 
   it('should return 400 when content exceeds MAX_INPUT_LENGTH', async () => {

--- a/packages/contracts/src/llm.test.ts
+++ b/packages/contracts/src/llm.test.ts
@@ -4,6 +4,14 @@ import {
   LlmProviderInputSchema,
   UsecaseAssignmentsSchema,
 } from './llm.js';
+import {
+  AskRequestSchema,
+  ImproveRequestSchema,
+  GenerateRequestSchema,
+  SummarizeRequestSchema,
+  GenerateDiagramRequestSchema,
+  AnalyzeQualityRequestSchema,
+} from './schemas/llm.js';
 
 describe('LlmUsecaseSchema', () => {
   it('accepts embedding as a valid use case', () => {
@@ -33,6 +41,38 @@ describe('LlmProviderInputSchema', () => {
     expect(() =>
       LlmProviderInputSchema.parse({ name: 'x', baseUrl: 'ftp://x', authType: 'none', verifySsl: true }),
     ).toThrow();
+  });
+});
+
+// #929: the six streaming LLM routes resolve the model server-side per
+// ADR-021 (resolveUsecase) and ignore any `model` in the request body. The
+// contract must therefore NOT require it — omitting `model` is valid.
+describe('streaming request schemas treat model as optional (#929)', () => {
+  it('AskRequestSchema parses without model', () => {
+    const parsed = AskRequestSchema.parse({ question: 'hi' });
+    expect(parsed.question).toBe('hi');
+    expect(parsed.model).toBeUndefined();
+  });
+  it('ImproveRequestSchema parses without model', () => {
+    expect(() =>
+      ImproveRequestSchema.parse({ content: 'text', type: 'grammar' }),
+    ).not.toThrow();
+  });
+  it('GenerateRequestSchema parses without model', () => {
+    expect(() => GenerateRequestSchema.parse({ prompt: 'draft a runbook' })).not.toThrow();
+  });
+  it('SummarizeRequestSchema parses without model', () => {
+    expect(() => SummarizeRequestSchema.parse({ content: 'text' })).not.toThrow();
+  });
+  it('GenerateDiagramRequestSchema parses without model', () => {
+    expect(() => GenerateDiagramRequestSchema.parse({ content: 'text' })).not.toThrow();
+  });
+  it('AnalyzeQualityRequestSchema parses without model', () => {
+    expect(() => AnalyzeQualityRequestSchema.parse({ content: 'text' })).not.toThrow();
+  });
+  it('still accepts a model when provided (back-compat)', () => {
+    const parsed = AskRequestSchema.parse({ question: 'hi', model: 'llama3' });
+    expect(parsed.model).toBe('llama3');
   });
 });
 

--- a/packages/contracts/src/schemas/llm.ts
+++ b/packages/contracts/src/schemas/llm.ts
@@ -11,7 +11,7 @@ export const ImprovementTypeSchema = z.enum([
 export const ImproveRequestSchema = z.object({
   content: z.string().min(1),
   type: ImprovementTypeSchema,
-  model: z.string().min(1),
+  model: z.string().min(1).optional(), // #929: optional — resolved server-side per ADR-021, body value ignored
   pageId: z.string().optional(),
   includeSubPages: z.boolean().optional(),
   instruction: z.string().max(10000).optional(),
@@ -23,7 +23,7 @@ export const ImproveRequestSchema = z.object({
 export const GenerateRequestSchema = z.object({
   prompt: z.string().min(1),
   template: z.enum(['runbook', 'howto', 'architecture', 'troubleshooting']).optional(),
-  model: z.string().min(1),
+  model: z.string().min(1).optional(), // #929: optional — resolved server-side per ADR-021, body value ignored
   spaceKey: z.string().optional(),
   parentId: z.string().optional(),
   pdfText: z.string().max(200_000).optional(),
@@ -41,7 +41,7 @@ export const ExtractPdfResponseSchema = z.object({
 
 export const SummarizeRequestSchema = z.object({
   content: z.string().min(1),
-  model: z.string().min(1),
+  model: z.string().min(1).optional(), // #929: optional — resolved server-side per ADR-021, body value ignored
   length: z.enum(['short', 'medium', 'detailed']).default('medium'),
   pageId: z.string().optional(),
   includeSubPages: z.boolean().optional(),
@@ -52,7 +52,7 @@ export const SummarizeRequestSchema = z.object({
 
 export const AskRequestSchema = z.object({
   question: z.string().min(1),
-  model: z.string().min(1),
+  model: z.string().min(1).optional(), // #929: optional — resolved server-side per ADR-021, body value ignored
   conversationId: z.string().uuid().optional(),
   pageId: z.string().optional(),
   includeSubPages: z.boolean().optional(),
@@ -64,7 +64,7 @@ export const AskRequestSchema = z.object({
 
 export const GenerateDiagramRequestSchema = z.object({
   content: z.string().min(1),
-  model: z.string().min(1),
+  model: z.string().min(1).optional(), // #929: optional — resolved server-side per ADR-021, body value ignored
   diagramType: z.enum(['flowchart', 'sequence', 'state', 'mindmap']).default('flowchart'),
   pageId: z.string().optional(),
   thinking: z.boolean().optional(),
@@ -72,7 +72,7 @@ export const GenerateDiagramRequestSchema = z.object({
 
 export const AnalyzeQualityRequestSchema = z.object({
   content: z.string().min(1),
-  model: z.string().min(1),
+  model: z.string().min(1).optional(), // #929: optional — resolved server-side per ADR-021, body value ignored
   pageId: z.string().optional(),
   includeSubPages: z.boolean().optional(),
   thinking: z.boolean().optional(),


### PR DESCRIPTION
Fixes #929.

## What / Why
All six streaming LLM routes (`ask`, `improve`, `generate`, `summarize`, `diagram`, `analyze-quality`) resolve the concrete provider+model server-side via `resolveUsecase()` per ADR-021 and **ignore** any `model` sent in the request body (`llm-ask.ts` destructures it only into a `bodyModel` debug log; the actual call uses `resolvedModel`). Yet every request contract required `model: z.string().min(1)`, advertising a field with no effect.

This makes `model` optional (still `.min(1)` when present) across `Ask/Improve/Generate/Summarize/GenerateDiagram/AnalyzeQuality` so the contract stops lying and matches the deliberate ADR-021 server-side resolution. Payloads that still include a model parse unchanged — fully backward compatible.

## Test evidence
`packages/contracts/src/llm.test.ts` — new suite "streaming request schemas treat model as optional (#929)": asserts each of the six schemas `.parse(...)` succeeds with `model` omitted, plus a back-compat case that a supplied model is preserved.
- Fails before: 6 tests throw `ZodError` ("expected string, received undefined").
- Passes after: 13/13 in the file, 89/89 full contracts suite.
- Regression checks: backend `llm-ask.test.ts` 15/15 (incl. the resolved-model assertion) and frontend AI tests 68/68 still pass.

## Docs / diagram impact
None — pure request-contract widening; no compose/boundary/migration or auth/sync/RAG/license/content-pipeline flow change. Aligns with existing ADR-021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)