### PR TITLE
fix(rbac): surface failed group/member/role mutations via toast (#934)

### DIFF
--- a/frontend/src/features/admin/RbacPage.test.tsx
+++ b/frontend/src/features/admin/RbacPage.test.tsx
@@ -3,8 +3,14 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { LazyMotion, domAnimation } from 'framer-motion';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { RbacPage } from './RbacPage';
 import { useAuthStore } from '../../stores/auth-store';
+
+// ── Mock sonner toast ──────────────────────────────────────────────────────────
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
 
 // ── Mock useEnterprise ─────────────────────────────────────────────────────────
 let mockHasFeature: (feature: string) => boolean = (_feature) => false;
@@ -339,5 +345,45 @@ describe('RbacPage', () => {
     });
     // The modal title and button both contain "Create Custom Role", verify the modal is open via testid
     expect(screen.getByTestId('role-name-input')).toBeInTheDocument();
+  });
+
+  // ── Mutation error surfacing (issue #934) ───────────────────────────────────
+
+  it('surfaces a toast error when creating a group fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as Request).url;
+      const method = init?.method ?? 'GET';
+      if (url.includes('/groups') && method === 'POST') {
+        return new Response(JSON.stringify({ message: 'Group name already exists' }), {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/groups')) {
+        return new Response(JSON.stringify(mockGroups), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify([]), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    render(<RbacPage />, { wrapper: createWrapper() });
+    fireEvent.click(screen.getByTestId('rbac-tab-groups'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-group-btn')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('create-group-btn'));
+
+    fireEvent.change(screen.getByTestId('group-name-input'), {
+      target: { value: 'Engineering' },
+    });
+    fireEvent.click(screen.getByTestId('submit-group'));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Group name already exists');
+    });
   });
 });

--- a/frontend/src/features/admin/RbacPage.tsx
+++ b/frontend/src/features/admin/RbacPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { m } from 'framer-motion';
+import { toast } from 'sonner';
 import {
   Shield, Users, FolderOpen, Plus, Trash2,
   UserPlus, Loader2, Lock, ShieldCheck, Pencil,
@@ -95,6 +96,7 @@ function useCreateGroup() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'groups'] });
     },
+    onError: (err: Error) => toast.error(err.message),
   });
 }
 
@@ -106,6 +108,7 @@ function useDeleteGroup() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'groups'] });
     },
+    onError: (err: Error) => toast.error(err.message),
   });
 }
 
@@ -121,6 +124,7 @@ function useAddGroupMember() {
       queryClient.invalidateQueries({ queryKey: ['admin', 'groups'] });
       queryClient.invalidateQueries({ queryKey: ['admin', 'group-members', variables.groupId] });
     },
+    onError: (err: Error) => toast.error(err.message),
   });
 }
 
@@ -135,6 +139,7 @@ function useRemoveGroupMember() {
       queryClient.invalidateQueries({ queryKey: ['admin', 'groups'] });
       queryClient.invalidateQueries({ queryKey: ['admin', 'group-members', variables.groupId] });
     },
+    onError: (err: Error) => toast.error(err.message),
   });
 }
 
@@ -158,6 +163,7 @@ function useAssignSpaceRole() {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'space-roles', variables.spaceKey] });
     },
+    onError: (err: Error) => toast.error(err.message),
   });
 }
 
@@ -171,6 +177,7 @@ function useRemoveSpaceRole() {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'space-roles', variables.spaceKey] });
     },
+    onError: (err: Error) => toast.error(err.message),
   });
 }
 


### PR DESCRIPTION
Fixes #934.

## What / Why
All six RBAC mutations in `RbacPage.tsx` (create/delete group, add/remove group member, assign/remove space role) discarded their rejected promise. A failed operation — duplicate group name (409), permission denied (403), stale assignment (404) — produced no user feedback: the form silently did nothing and the operator assumed success.

Each `useMutation` now has a hook-level `onError: (err) => toast.error(err.message)`, mirroring the existing pattern in `UsersAdminPage.tsx`. `apiFetch` already throws `ApiError` carrying the backend's `message`, so the toast shows the real reason. Per-call-site `onSuccess` options do not override the hook-level `onError`, so every call site is covered by the one handler.

## Test evidence
- `frontend/src/features/admin/RbacPage.test.tsx` — added `vi.mock('sonner', ...)` and a test that stubs `POST /groups` to return 409 `{ message: 'Group name already exists' }`, submits the create-group form, and asserts `toast.error` is called with that message.
- Fails before the fix (assertion times out — `toast.error` never called); passes after. Full file: 16/16 pass. Typecheck and ESLint clean.

## Docs / diagram impact
None — UI-only error-handling change; no system structure, boundaries, migrations, or auth/sync/RAG/license/content-pipeline flows affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)