### PR TITLE
fix(webhooks): remove nonexistent "Complete rotation" copy (#936)

### DIFF
--- a/frontend/src/features/admin/WebhooksTab.test.tsx
+++ b/frontend/src/features/admin/WebhooksTab.test.tsx
@@ -346,6 +346,10 @@ describe('WebhooksTab', () => {
 
     await waitFor(() => screen.getByTestId('webhook-rotate-dialog'));
 
+    // The dialog must not advertise a "Complete rotation" action — no such
+    // control/endpoint exists; the overlap ends automatically (issue #936).
+    expect(screen.queryByText(/Complete rotation/i)).toBeNull();
+
     fireEvent.change(screen.getByTestId('webhook-rotate-secret-input'), {
       target: { value: 'brand-new-strong-secret-xyz' },
     });
@@ -360,6 +364,12 @@ describe('WebhooksTab', () => {
     // The `until` text is a localized Date string — assert that the ISO has been
     // parsed and rendered (year + "2026" will always appear in any locale).
     expect(screen.getByTestId('webhook-rotate-until').textContent).toMatch(/2026/);
+    // The staged-rotation copy must describe the automatic retirement, not a
+    // nonexistent "Complete rotation" button (issue #936).
+    expect(screen.queryByText(/Complete rotation/i)).toBeNull();
+    expect(
+      screen.getByTestId('webhook-rotate-result').textContent,
+    ).toMatch(/automatically/i);
     expect(toastSuccess).toHaveBeenCalledWith('Secret rotated');
   });
 

--- a/frontend/src/features/admin/WebhooksTab.tsx
+++ b/frontend/src/features/admin/WebhooksTab.tsx
@@ -885,10 +885,9 @@ function RotateSecretDialog({
         <div className="flex items-start gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-amber-100">
           <AlertTriangle size={16} className="mt-0.5 shrink-0 text-amber-400" />
           <p className="text-xs">
-            Both the current and new secret will sign deliveries until you
-            press <strong>Complete rotation</strong>, or 24 hours pass — whichever
-            comes first. Receivers must accept either signature during the
-            overlap window.
+            Both the current and new secret will sign deliveries for 24 hours,
+            then the previous secret is retired automatically. Receivers must
+            accept either signature during the overlap window.
           </p>
         </div>
 
@@ -942,8 +941,8 @@ function RotateSecretDialog({
               <strong data-testid="webhook-rotate-until">
                 {new Date(result.secondaryActiveUntil).toLocaleString()}
               </strong>
-              . Update receivers, then press Complete rotation to clear the
-              secondary slot early.
+              . Update receivers before then — the previous secret stays valid
+              until that time and is cleared automatically.
             </div>
           </div>
         )}


### PR DESCRIPTION
Fixes #936.

## What / Why
The rotate-secret dialog in `WebhooksTab.tsx` instructed users to press a **Complete rotation** button "to clear the secondary slot early" and said the overlap lasts "until you press Complete rotation." No such control or endpoint exists — the overlap window always ends automatically after 24 hours. The copy referenced a nonexistent action.

Reworded both strings (pre-submit amber warning + emerald staged-rotation result) to describe the automatic retirement. Same markup and testids retained; smallest correct change (no new endpoint/button, which would be out of scope).

## Test evidence
`frontend/src/features/admin/WebhooksTab.test.tsx` — extended the existing "rotate-secret dialog submits..." test to assert `queryByText(/Complete rotation/i)` is null (dialog open and after result) and that the result copy mentions "automatically".
- Before fix: `expected <strong>Complete rotation</strong> to be null` — FAILS.
- After fix: all 15 tests in the file pass. Frontend typecheck and ESLint on touched files clean.

## Docs / diagram impact
None — copy-only change, no system-structure, schema, or flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)