### PR TITLE
fix(ai): announce completed AI answers to screen readers (#937)

### DIFF
--- a/frontend/src/features/ai/AiAssistantPage.test.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.test.tsx
@@ -1515,6 +1515,54 @@ describe('AiAssistantPage', () => {
       expect(screen.queryByTestId('streaming-cursor')).not.toBeInTheDocument();
     });
 
+    it('announces a completed answer via a primed polite live region (#937)', async () => {
+      mockModelApis();
+
+      let releaseStream: (() => void) | undefined;
+      const gate = new Promise<void>((resolve) => { releaseStream = resolve; });
+      async function* gatedStream() {
+        yield { content: 'The answer.' };
+        await gate;
+      }
+      streamSSEMock.mockReturnValue(gatedStream());
+
+      render(<AiAssistantPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
+      });
+
+      // The answer announcer must exist EMPTY and polite before any answer, so
+      // AT watches it for content changes (mirrors the error announcer priming).
+      const announcer = screen.getByTestId('ai-answer-announcer');
+      expect(announcer).toHaveAttribute('aria-live', 'polite');
+      expect(announcer).toHaveTextContent('');
+
+      const input = screen.getByPlaceholderText('Ask a question...');
+      fireEvent.change(input, { target: { value: 'Ask me' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      // While the stream is in flight the announcer stays empty — announcing
+      // mid-stream would interrupt the visible streaming answer.
+      await waitFor(() => {
+        expect(screen.getByTestId('streaming-message')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('ai-answer-announcer')).toHaveTextContent('');
+
+      // Finish the stream — the completed answer is now announced.
+      await act(async () => {
+        releaseStream?.();
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('streaming-message')).not.toBeInTheDocument();
+      });
+      const done = screen.getByTestId('ai-answer-announcer');
+      expect(done).toHaveTextContent('Answer ready');
+      // A keyed child node is mounted so AT re-announces on each new answer.
+      expect(done.firstElementChild).not.toBeNull();
+    });
+
     it('commits partial content to the message list when the stream is aborted', async () => {
       mockModelApis();
 

--- a/frontend/src/features/ai/AiAssistantPage.tsx
+++ b/frontend/src/features/ai/AiAssistantPage.tsx
@@ -420,6 +420,23 @@ function AiAssistantInner() {
         })()}
       </div>
 
+      {/* Primed polite live region for completed answers (#937). The error
+          announcer above only speaks failures; without this, a screen-reader
+          user hears nothing when an answer finishes and the streamed text is
+          silently painted into the bubble. Gated on !isStreaming so we announce
+          the finished answer once, not mid-stream (which would interrupt the
+          visible streaming). Keyed by the completed message id so a fresh node
+          is inserted per answer — that insertion is what AT re-announces. */}
+      <div role="status" aria-live="polite" data-testid="ai-answer-announcer" className="sr-only">
+        {(() => {
+          if (isStreaming) return null;
+          const lastAnswer = [...messages].reverse().find(
+            (msg) => msg.role === 'assistant' && !msg.isError && msg.content,
+          );
+          return lastAnswer ? <span key={lastAnswer.id}>Answer ready</span> : null;
+        })()}
+      </div>
+
       {/* Messages — clean document-like surface, no heavy glass.
           flex-1 so the messages area grows to fill the column, pushing
           the sticky input bar to the bottom of the page. */}


### PR DESCRIPTION
Fixes #937.

## What / Why
The AI chat page primed a `role="alert"` live region for errors, but there was no equivalent for successful answers. When a streamed response finished, the text was painted silently into the message bubble, so screen-reader users heard nothing and had no way to know an answer was ready.

This adds a sibling primed polite live region (`role="status"` `aria-live="polite"`, `data-testid="ai-answer-announcer"`) directly below the error announcer. It:
- renders empty until an answer completes (so AT watches it for changes);
- gates on `!isStreaming` so it announces the finished answer once, not mid-stream (which would interrupt the visible streaming);
- keys the `Answer ready` child by the completed assistant message id, so a fresh node is inserted per answer and AT re-announces each new one.

Minimal, surgical change — mirrors the existing error-announcer technique, no type or API changes.

## Test evidence
`frontend/src/features/ai/AiAssistantPage.test.tsx` — new test `announces a completed answer via a primed polite live region (#937)` drives a gated ask-mode stream to completion and asserts the announcer is polite + empty before/during streaming and contains a keyed `Answer ready` node after completion.
- Fails-before: `getByTestId('ai-answer-announcer')` throws (element did not exist).
- Passes-after: element exists, empty during stream, populated on completion. Full file: 57/57 pass. Frontend typecheck + eslint clean.

## Docs/diagram impact
None — no change to system structure (compose, domains, boundaries, migrations, or auth/sync/RAG/license/content-pipeline flows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)