### PR TITLE
fix(a11y): accessible names for icon-only buttons (#939)

### DIFF
--- a/frontend/src/features/ai/modes/AskMode.test.tsx
+++ b/frontend/src/features/ai/modes/AskMode.test.tsx
@@ -312,6 +312,51 @@ describe('AskMode', () => {
     expect(callBody).not.toHaveProperty('conversationId', null);
   });
 
+  describe('icon-only button accessible names (#939)', () => {
+    beforeEach(() => {
+      apiFetchMock.mockImplementation((path: string) => {
+        if (path === '/mcp-docs/status') {
+          return Promise.resolve({ enabled: true });
+        }
+        if (path === '/settings') {
+          return Promise.resolve({ llmProvider: 'ollama', ollamaModel: 'llama3', openaiModel: null });
+        }
+        if (path.startsWith('/ollama/models')) {
+          return Promise.resolve([{ name: 'llama3' }]);
+        }
+        if (path === '/llm/conversations') {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+    });
+
+    it('exposes an accessible name on the add-URL and close buttons', async () => {
+      render(<AskModeInput />, { wrapper: createWrapper() });
+
+      const attach = await screen.findByTestId('attach-url-button');
+      fireEvent.click(attach);
+
+      expect(screen.getByRole('button', { name: 'Add URL' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Close URL input' })).toBeInTheDocument();
+    });
+
+    it('exposes an accessible name on each URL chip remove button', async () => {
+      render(<AskModeInput />, { wrapper: createWrapper() });
+
+      const attach = await screen.findByTestId('attach-url-button');
+      fireEvent.click(attach);
+
+      const urlInput = screen.getByTestId('external-url-input');
+      fireEvent.change(urlInput, { target: { value: 'https://docs.example.com/guide' } });
+      fireEvent.keyDown(urlInput, { key: 'Enter' });
+
+      expect(
+        await screen.findByRole('button', { name: 'Remove docs.example.com' }),
+      ).toBeInTheDocument();
+    });
+  });
+
   it('clears input after submission', async () => {
     apiFetchMock.mockImplementation((path: string) => {
       if (path === '/settings') {

--- a/frontend/src/features/ai/modes/AskMode.tsx
+++ b/frontend/src/features/ai/modes/AskMode.tsx
@@ -115,7 +115,11 @@ export function AskModeInput() {
             >
               <Link2 size={10} />
               {new URL(url).hostname}
-              <button onClick={() => removeUrl(url)} className="hover:text-red-400">
+              <button
+                onClick={() => removeUrl(url)}
+                aria-label={`Remove ${new URL(url).hostname}`}
+                className="hover:text-red-400"
+              >
                 <X size={10} />
               </button>
             </span>
@@ -137,12 +141,14 @@ export function AskModeInput() {
           />
           <button
             onClick={addUrl}
+            aria-label="Add URL"
             className="shrink-0 rounded-md px-2 py-1 text-xs text-primary-ink hover:bg-primary/10"
           >
             <Plus size={12} />
           </button>
           <button
             onClick={() => { setShowUrlInput(false); setUrlInput(''); }}
+            aria-label="Close URL input"
             className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
           >
             <X size={12} />

--- a/frontend/src/features/ai/modes/GenerateMode.test.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.test.tsx
@@ -287,6 +287,27 @@ describe('GenerateMode', () => {
       expect(screen.getByText('5 pages')).toBeInTheDocument();
     });
 
+    it('exposes an accessible name on the PDF remove button (#939)', async () => {
+      mockExtractPdf.mockResolvedValue({
+        text: 'PDF text',
+        totalPages: 1,
+        fileSize: 1024,
+        preview: 'PDF text',
+      });
+
+      render(<GenerateModeInput />, { wrapper: createWrapper() });
+
+      const fileInput = screen.getByTestId('pdf-file-input');
+      const pdfFile = new File(['%PDF-1.4'], 'test.pdf', { type: 'application/pdf' });
+      fireEvent.change(fileInput, { target: { files: [pdfFile] } });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('pdf-preview-card')).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('button', { name: 'Remove PDF' })).toBeInTheDocument();
+    });
+
     it('removes PDF when remove button is clicked', async () => {
       mockExtractPdf.mockResolvedValue({
         text: 'PDF text',

--- a/frontend/src/features/ai/modes/GenerateMode.tsx
+++ b/frontend/src/features/ai/modes/GenerateMode.tsx
@@ -251,6 +251,7 @@ function PdfUploadZone({
           type="button"
           onClick={onRemove}
           disabled={disabled}
+          aria-label="Remove PDF"
           className="shrink-0 rounded p-1 text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
           data-testid="pdf-remove-button"
         >

--- a/frontend/src/features/pages/NewPagePage.test.tsx
+++ b/frontend/src/features/pages/NewPagePage.test.tsx
@@ -140,6 +140,11 @@ describe('NewPagePage', () => {
     expect(screen.getByPlaceholderText('Untitled page')).toBeInTheDocument();
   });
 
+  it('exposes an accessible name on the back button (#939)', () => {
+    render(<NewPagePage />, { wrapper: createWrapper() });
+    expect(screen.getByRole('button', { name: /back to pages/i })).toBeInTheDocument();
+  });
+
   it('shows article type toggle defaulting to Local Article', () => {
     render(<NewPagePage />, { wrapper: createWrapper() });
     expect(screen.getByTestId('article-type-local')).toBeInTheDocument();

--- a/frontend/src/features/pages/NewPagePage.tsx
+++ b/frontend/src/features/pages/NewPagePage.tsx
@@ -140,7 +140,7 @@ export function NewPagePage() {
           {/* Action bar */}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <button onClick={() => navigate('/pages')} className="nm-icon-button">
+              <button onClick={() => navigate('/pages')} aria-label="Back to pages" className="nm-icon-button">
                 <ArrowLeft size={18} />
               </button>
               <h1 className="text-xl font-bold">New Page</h1>

--- a/frontend/src/features/pages/TrashPage.test.tsx
+++ b/frontend/src/features/pages/TrashPage.test.tsx
@@ -107,6 +107,12 @@ describe('TrashPage', () => {
     expect(screen.getByText(/29 days until auto-purge/)).toBeInTheDocument();
   });
 
+  it('exposes an accessible name on the back button (#939)', () => {
+    mockApi({ items: [], total: 0 });
+    render(<TrashPage />, { wrapper: createWrapper() });
+    expect(screen.getByRole('button', { name: /back to dashboard/i })).toBeInTheDocument();
+  });
+
   it('shows a restore button for each trash item', async () => {
     mockApi(mockTrashData);
     render(<TrashPage />, { wrapper: createWrapper() });

--- a/frontend/src/features/pages/TrashPage.tsx
+++ b/frontend/src/features/pages/TrashPage.tsx
@@ -29,7 +29,7 @@ export function TrashPage() {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <button onClick={() => navigate('/')} className="nm-icon-button">
+        <button onClick={() => navigate('/')} aria-label="Back to dashboard" className="nm-icon-button">
           <ArrowLeft size={18} />
         </button>
         <div>

--- a/frontend/src/features/pages/VersionHistory.test.tsx
+++ b/frontend/src/features/pages/VersionHistory.test.tsx
@@ -570,6 +570,41 @@ describe('VersionHistory', () => {
     expect(screen.queryByText('+0')).not.toBeInTheDocument();
   });
 
+  it('exposes an accessible name on the comparison close button (#939)', async () => {
+    const detail = (versionNumber: number, bodyText: string) =>
+      new Response(
+        JSON.stringify({
+          confluenceId: null,
+          versionNumber,
+          title: `Page v${versionNumber}`,
+          bodyHtml: `<p>${bodyText}</p>`,
+          bodyText,
+          isCurrent: versionNumber === 3,
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (/\/versions\/3$/.test(url)) return Promise.resolve(detail(3, 'The happy cat'));
+      if (/\/versions\/2$/.test(url)) return Promise.resolve(detail(2, 'The cat'));
+      return Promise.resolve(mockVersionsResponse());
+    });
+
+    render(
+      <VersionHistory pageId="page-1" model="qwen3.5" />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(screen.getByText('History'));
+    await waitFor(() => expect(screen.getByText('v3')).toBeInTheDocument());
+
+    fireEvent.click(screen.getAllByTitle('Compare with previous version')[0]!);
+    await screen.findByTestId('unified-diff');
+
+    expect(screen.getByRole('button', { name: 'Close comparison' })).toBeInTheDocument();
+  });
+
   it('closes dialog via close button', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(

--- a/frontend/src/features/pages/VersionHistory.tsx
+++ b/frontend/src/features/pages/VersionHistory.tsx
@@ -533,6 +533,7 @@ function CompareView({
         </h4>
         <button
           onClick={onClose}
+          aria-label="Close comparison"
           className="rounded p-1 text-muted-foreground hover:bg-foreground/5"
         >
           <X size={12} />

--- a/frontend/src/features/settings/LabelManager.test.tsx
+++ b/frontend/src/features/settings/LabelManager.test.tsx
@@ -80,6 +80,19 @@ describe('LabelManager', () => {
     expect(screen.getByTestId('rename-input')).toHaveValue('architecture');
   });
 
+  it('exposes accessible names on the rename confirm/cancel buttons (#939)', async () => {
+    render(<LabelManager />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rename-architecture')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('rename-architecture'));
+
+    expect(screen.getByRole('button', { name: 'Confirm rename' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel rename' })).toBeInTheDocument();
+  });
+
   it('shows delete confirmation when delete button is clicked', async () => {
     render(<LabelManager />, { wrapper: createWrapper() });
 

--- a/frontend/src/features/settings/LabelManager.tsx
+++ b/frontend/src/features/settings/LabelManager.tsx
@@ -185,6 +185,7 @@ export function LabelManager() {
                   <button
                     onClick={handleRename}
                     disabled={renameLabel.isPending || !editValue.trim() || editValue === editingLabel}
+                    aria-label="Confirm rename"
                     className="rounded p-1 text-success hover:bg-success/10 disabled:opacity-50"
                     data-testid="rename-confirm-btn"
                   >
@@ -192,6 +193,7 @@ export function LabelManager() {
                   </button>
                   <button
                     onClick={() => setEditingLabel(null)}
+                    aria-label="Cancel rename"
                     className="rounded p-1 text-muted-foreground hover:bg-foreground/5"
                   >
                     <X size={14} />


### PR DESCRIPTION
Fixes #939.

## What & why
Several icon-only buttons rendered with an **empty accessible name**, so screen readers announced them as an unlabeled "button" with no way to tell them apart. This adds a descriptive `aria-label` to each. Attribute-only — no logic or markup-structure change.

Buttons labeled:
- `AskMode.tsx` — URL chip remove (`Remove <hostname>`), add-URL (`Add URL`), close URL input (`Close URL input`)
- `GenerateMode.tsx` — PDF remove (`Remove PDF`)
- `NewPagePage.tsx` — back (`Back to pages`)
- `TrashPage.tsx` — back (`Back to dashboard`)
- `LabelManager.tsx` — rename confirm (`Confirm rename`) / cancel (`Cancel rename`)
- `VersionHistory.tsx` — comparison close (`Close comparison`)

## Test evidence
Extended the existing jsdom suites with `getByRole('button', { name })` queries:
- `AskMode.test.tsx`, `GenerateMode.test.tsx`, `NewPagePage.test.tsx`, `TrashPage.test.tsx`, `VersionHistory.test.tsx`, `LabelManager.test.tsx`

Each new name-based query **failed before** the fix ("Unable to find an accessible element with the role button and name …") and **passes after**. Full run: 112 passed across the 6 files. `npm run typecheck -w frontend` and ESLint on the touched files are clean.

## Docs/diagram impact
None — attribute-only accessibility fix; no system-structure change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)