### PR TITLE
fix(graph): theme-aware node label colors (#941)

### DIFF
--- a/frontend/src/features/graph/GraphPage.test.tsx
+++ b/frontend/src/features/graph/GraphPage.test.tsx
@@ -459,6 +459,84 @@ describe('GraphPage', () => {
     expect(fillTextCalls.some((t: string) => t.includes('Getting Started'))).toBe(true);
   });
 
+  // ---------- #941: node labels must be theme-aware, not hardcoded white ----------
+
+  // Helper: render the full graph, grab the nodeCanvasObject callback, invoke
+  // it against a fillStyle-recording stub context and return the fillStyle
+  // values captured during the individual-node label paint.
+  async function captureLabelFillStyles(): Promise<string[]> {
+    const ForceGraph2DMock = (await import('react-force-graph-2d'))
+      .default as unknown as ReturnType<typeof vi.fn>;
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => mockGraphData,
+    } as Response);
+
+    render(<GraphPage />, { wrapper: createWrapper(['/graph?full=1']) });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-force-graph')).toBeInTheDocument();
+    });
+
+    const lastCall =
+      ForceGraph2DMock.mock.calls[ForceGraph2DMock.mock.calls.length - 1];
+    const nodeCanvasObject = lastCall[0].nodeCanvasObject;
+
+    const fillStyles: string[] = [];
+    let currentFill = '';
+    const mockCtx = {
+      beginPath: vi.fn(),
+      arc: vi.fn(),
+      fill: vi.fn(),
+      stroke: vi.fn(),
+      roundRect: vi.fn(),
+      measureText: vi.fn(() => ({ width: 10 })),
+      // Record the fillStyle in effect at each fillText call — that is the
+      // colour the label text is actually painted with.
+      fillText: vi.fn(() => fillStyles.push(currentFill)),
+      set fillStyle(v: string) { currentFill = v; },
+      get fillStyle() { return currentFill; },
+      set strokeStyle(_v: string) { /* noop */ },
+      set lineWidth(_v: number) { /* noop */ },
+      set font(_v: string) { /* noop */ },
+      set textAlign(_v: string) { /* noop */ },
+      set textBaseline(_v: string) { /* noop */ },
+      set globalAlpha(_v: number) { /* noop */ },
+    };
+
+    const testNode = { ...mockGraphData.nodes[0], x: 0, y: 0 };
+    nodeCanvasObject(testNode, mockCtx, 0.5);
+    return fillStyles;
+  }
+
+  it('paints node labels in a near-black colour on the light theme (#941)', async () => {
+    const { useThemeStore } = await import('../../stores/theme-store');
+    act(() => useThemeStore.getState().setTheme('honey-linen'));
+
+    const fillStyles = await captureLabelFillStyles();
+
+    // The label is painted after the node circle; its fillStyle must NOT be
+    // white on the light theme (invisible on the linen surface).
+    const labelFill = fillStyles[fillStyles.length - 1];
+    expect(labelFill).toBeDefined();
+    expect(labelFill).not.toMatch(/rgba?\(\s*255\s*,\s*255\s*,\s*255/);
+    expect(labelFill).toMatch(/rgba?\(\s*10\s*,\s*10\s*,\s*10/);
+
+    act(() => useThemeStore.getState().setTheme('graphite-honey'));
+  });
+
+  it('keeps node labels white on the dark theme (#941)', async () => {
+    const { useThemeStore } = await import('../../stores/theme-store');
+    act(() => useThemeStore.getState().setTheme('graphite-honey'));
+
+    const fillStyles = await captureLabelFillStyles();
+
+    const labelFill = fillStyles[fillStyles.length - 1];
+    expect(labelFill).toMatch(/rgba?\(\s*255\s*,\s*255\s*,\s*255/);
+  });
+
   it('switches to clustered view when toggle is clicked', async () => {
     // First fetch for individual view
     vi.spyOn(globalThis, 'fetch')

--- a/frontend/src/features/graph/GraphPage.tsx
+++ b/frontend/src/features/graph/GraphPage.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import { ZoomIn, ZoomOut, Maximize, RefreshCw, Info, Layers, Grid3x3, Filter, Search, X, Settings, Loader2 } from 'lucide-react';
 import { cn } from '../../shared/lib/cn';
 import { useSearch } from '../../shared/hooks/use-standalone';
+import { useIsLightTheme } from '../../shared/hooks/use-is-light-theme';
 import { useAuthStore } from '../../stores/auth-store';
 import { useGraphData, useLocalGraphData, useRefreshGraph, type LocalGraphFilters, type GraphMeta } from './graph-hooks';
 
@@ -72,6 +73,40 @@ const EDGE_COLORS: Record<string, string> = {
 };
 
 const MAX_TOOLTIP_LABELS = 5;
+
+// #941: node text/border colours must adapt to the active theme. On the light
+// (Honey Linen) theme the previously-hardcoded white label was invisible
+// against the linen surface. Text goes near-black on light, white on dark;
+// borders mirror that so the outline reads on both surfaces. The honey
+// center-node stroke stays theme-independent (it reads on both).
+interface GraphCanvasColors {
+  label: string;
+  title: string;
+  badge: string;
+  border: string;
+  borderHover: string;
+  hoverStroke: string;
+}
+
+function getCanvasColors(isLight: boolean): GraphCanvasColors {
+  return isLight
+    ? {
+        label: 'rgba(10,10,10,0.85)',
+        title: 'rgba(10,10,10,0.95)',
+        badge: 'rgba(10,10,10,0.7)',
+        border: 'rgba(10,10,10,0.4)',
+        borderHover: 'rgba(10,10,10,0.9)',
+        hoverStroke: 'rgba(10,10,10,0.8)',
+      }
+    : {
+        label: 'rgba(255,255,255,0.85)',
+        title: 'rgba(255,255,255,0.95)',
+        badge: 'rgba(255,255,255,0.7)',
+        border: 'rgba(255,255,255,0.4)',
+        borderHover: 'rgba(255,255,255,0.9)',
+        hoverStroke: 'rgba(255,255,255,0.8)',
+      };
+}
 
 // ---------- Component ----------
 
@@ -155,6 +190,11 @@ export function GraphPage() {
   const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
   const [hoveredNode, setHoveredNode] = useState<(GraphNode | ClusterNode) | null>(null);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
+
+  // #941: derive theme-aware canvas colours so node labels/borders stay
+  // legible on both the dark (Graphite Honey) and light (Honey Linen) themes.
+  const isLight = useIsLightTheme();
+  const canvasColors = useMemo(() => getCanvasColors(isLight), [isLight]);
 
   const prefersReducedMotion = useMemo(() => {
     if (typeof window === 'undefined') return false;
@@ -262,7 +302,7 @@ export function GraphPage() {
         ctx.globalAlpha = 1;
 
         // Thicker border for clusters
-        ctx.strokeStyle = isHovered ? 'rgba(255,255,255,0.9)' : 'rgba(255,255,255,0.4)';
+        ctx.strokeStyle = isHovered ? canvasColors.borderHover : canvasColors.border;
         ctx.lineWidth = (isHovered ? 2.5 : 1.5) / globalScale;
         ctx.stroke();
 
@@ -271,14 +311,14 @@ export function GraphPage() {
         ctx.font = `bold ${fontSize}px Inter, system-ui, sans-serif`;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
-        ctx.fillStyle = 'rgba(255,255,255,0.95)';
+        ctx.fillStyle = canvasColors.title;
         const truncated = node.title.length > 20 ? node.title.slice(0, 17) + '...' : node.title;
         ctx.fillText(truncated, x, y - 3 / globalScale);
 
         // Count badge
         const badgeFontSize = Math.max(9 / globalScale, 1.2);
         ctx.font = `${badgeFontSize}px Inter, system-ui, sans-serif`;
-        ctx.fillStyle = 'rgba(255,255,255,0.7)';
+        ctx.fillStyle = canvasColors.badge;
         ctx.fillText(`${node.articleCount} pages`, x, y + fontSize);
         return;
       }
@@ -295,7 +335,7 @@ export function GraphPage() {
       ctx.fill();
 
       if (isHovered || isCenter) {
-        ctx.strokeStyle = isCenter ? 'rgba(245, 158, 66, 0.9)' : 'rgba(255,255,255,0.8)';
+        ctx.strokeStyle = isCenter ? 'rgba(245, 158, 66, 0.9)' : canvasColors.hoverStroke;
         ctx.lineWidth = (isCenter ? 2 : 1.5) / globalScale;
         ctx.stroke();
       }
@@ -305,12 +345,12 @@ export function GraphPage() {
         ctx.font = `${isHovered || isCenter ? 'bold ' : ''}${fontSize}px Inter, system-ui, sans-serif`;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';
-        ctx.fillStyle = 'rgba(255,255,255,0.85)';
+        ctx.fillStyle = canvasColors.label;
         const truncated = label.length > 30 ? label.slice(0, 27) + '...' : label;
         ctx.fillText(truncated, x, y + size + 2 / globalScale);
       }
     },
-    [spaceKeys, hoveredNode, data?.centerId],
+    [spaceKeys, hoveredNode, data?.centerId, canvasColors],
   );
 
   const nodePointerAreaPaint = useCallback(


### PR DESCRIPTION
Fixes #941.

## What / Why
Graph node labels, cluster titles/badges, and hover/cluster borders in `GraphPage`'s `nodeCanvasObject` were hardcoded to white (`rgba(255,255,255,…)`). On the **Honey Linen** light theme these render invisible against the linen surface.

The fix derives canvas colours from the active theme via the existing `useIsLightTheme()` hook: near-black (`rgba(10,10,10,…)`) on light, white on dark. A small `getCanvasColors(isLight)` helper keys the five affected literals off theme; the memoized result is added to the callback's dependency array so labels repaint on theme switch. The honey center-node stroke (`rgba(245,158,66,0.9)`) is left unchanged since it reads on both themes.

## Test evidence
`frontend/src/features/graph/GraphPage.test.tsx` — two new #941 tests invoke the captured `nodeCanvasObject` against a `fillStyle`-recording stub context:
- light theme (`honey-linen`): label fill must NOT be white and must be near-black
- dark theme (`graphite-honey`): label fill stays white

Fails-before: the light-theme assertion fails on `rgba(255,255,255,0.85)`. Passes-after: all 24 GraphPage tests green. Typecheck + eslint clean on both touched files.

## Docs / diagram impact
None — pure presentational colour fix, no change to system structure, boundaries, or flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)