### PR TITLE
fix(pages): preserve article scroll position on in-place refetch (#943)

### DIFF
--- a/frontend/src/features/pages/PageViewPage.test.tsx
+++ b/frontend/src/features/pages/PageViewPage.test.tsx
@@ -1065,5 +1065,72 @@ describe('PageViewPage', () => {
     });
   });
 
+  // #943 — In-place refetches of the SAME page (tag add/remove, resync,
+  // requality, drawio save → invalidateQueries(['pages', id])) hand React a
+  // fresh page object with an unchanged id + version. The scroll-reset effect
+  // must key off navigation (id / version), not the page object identity;
+  // otherwise every background invalidation yanks the reader's scroll position
+  // back to the top of the article. A version bump (a genuinely new revision)
+  // still resets, matching navigation semantics.
+  describe('scroll position preservation on in-place refetch (#943)', () => {
+    it('does not reset scroll when the page object changes but id + version are unchanged', async () => {
+      const scrollContainer = document.createElement('div');
+      scrollContainer.setAttribute('data-scroll-container', '');
+      document.body.appendChild(scrollContainer);
+      const scrollSpy = vi.spyOn(scrollContainer, 'scrollTo');
+
+      currentMockPage = mockPage;
+      const { rerender } = render(<PageViewPage />, { wrapper: createWrapper() });
+
+      // Initial mount scrolls to top (navigation reset). Wait for it, then
+      // clear the spy so we only observe the refetch behaviour.
+      await waitFor(() => {
+        expect(scrollSpy).toHaveBeenCalledWith({ top: 0, left: 0, behavior: 'auto' });
+      });
+      scrollSpy.mockClear();
+
+      // Simulate an optimistic write / invalidation: a brand-new page object
+      // with the SAME id and version (e.g. a label was added).
+      currentMockPage = {
+        ...mockPage,
+        labels: [...mockPage.labels, 'newly-added'],
+      };
+      rerender(<PageViewPage />);
+
+      // Give any effects + double-rAF a chance to fire, then assert the scroll
+      // container was NOT reset — the reader keeps their place.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      expect(scrollSpy).not.toHaveBeenCalled();
+
+      scrollContainer.remove();
+    });
+
+    it('still resets scroll when the page version changes (a genuine new revision)', async () => {
+      const scrollContainer = document.createElement('div');
+      scrollContainer.setAttribute('data-scroll-container', '');
+      document.body.appendChild(scrollContainer);
+      const scrollSpy = vi.spyOn(scrollContainer, 'scrollTo');
+
+      currentMockPage = mockPage;
+      const { rerender } = render(<PageViewPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(scrollSpy).toHaveBeenCalledWith({ top: 0, left: 0, behavior: 'auto' });
+      });
+      scrollSpy.mockClear();
+
+      currentMockPage = { ...mockPage, version: mockPage.version + 1 };
+      rerender(<PageViewPage />);
+
+      await waitFor(() => {
+        expect(scrollSpy).toHaveBeenCalledWith({ top: 0, left: 0, behavior: 'auto' });
+      });
+
+      scrollContainer.remove();
+    });
+  });
+
 });
 

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -228,10 +228,21 @@ export function PageViewPage() {
     scrollArticleToTop();
   }, [id]);
 
+  // Reset scroll to the top only on navigation-like transitions: a new page
+  // id, or a genuine new revision (version bump). Keying off `page` object
+  // identity — as this once did — reran on every in-place refetch (label
+  // add/remove, resync, requality, drawio save all invalidate ['pages', id]
+  // and hand React a fresh object with the same version), yanking the reader
+  // back to the top mid-article (#943). The `if (!page) return` guard covers
+  // the initial loading render.
   useEffect(() => {
     if (!page) return;
     scrollArticleToTop();
-  }, [id, page?.version, page]);
+    // `page` is referenced only by the null guard; depending on its object
+    // identity is exactly the bug (#943). Navigation is captured by id +
+    // page?.version, so those are the only deps we want.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, page?.version]);
 
   const handleImageClick = useCallback((src: string, alt: string) => {
     setLightboxSrc({ alt, src });


### PR DESCRIPTION
Fixes #943.

## What / why
`PageViewPage`'s scroll-reset effect keyed off the `page` object identity (`[id, page?.version, page]`). Any in-place invalidation of `['pages', id]` — tag add/remove, resync, requality, drawio save, presence-driven refetches — hands React a fresh `page` object with an unchanged id and version, which reran `scrollArticleToTop()` and yanked the reader back to the top mid-article.

The fix drops `page` from the dependency array (`[id, page?.version]`), so the effect only fires on navigation-like transitions: a new page id, or a genuine new revision (version bump). The `if (!page) return` guard still covers the initial loading render. A separate `useLayoutEffect(..., [id])` already handled the navigation reset and is untouched.

## Test evidence
`frontend/src/features/pages/PageViewPage.test.tsx` — new `describe('scroll position preservation on in-place refetch (#943)')`:
- **does not reset scroll when the page object changes but id + version are unchanged** — fails before the fix (`scrollTo` called 1 time on the refetch rerender), passes after.
- **still resets scroll when the page version changes** — guards the intended behaviour (green before and after).

Full file: 48/48 pass. `tsc --noEmit` clean, ESLint clean on both touched files.

## Docs / diagram impact
None — pure component-local effect-dependency fix; no compose/domain/DB/auth/sync/RAG/license/content-pipeline structure changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)