### PR TITLE
fix(pages): stop pretending advanced filters apply in semantic/hybrid search (#945)

### DIFF
--- a/frontend/src/features/pages/PagesPage.test.tsx
+++ b/frontend/src/features/pages/PagesPage.test.tsx
@@ -752,6 +752,48 @@ describe('PagesPage', () => {
     expect(screen.queryByTestId('filter-pill-embeddingStatus')).not.toBeInTheDocument();
   });
 
+  // --- Advanced filters ignored in semantic/hybrid search (#945) ---
+  //
+  // The backend applies author/date/label/etc. filters only in keyword mode —
+  // semantic (vectorSearch) and hybrid (hybridSearch) ignore them entirely.
+  // The UI must stop pretending they're active: show a notice and visually
+  // mark the active-filter pills as inactive whenever semantic/hybrid search
+  // is running, so users aren't misled into thinking their filters applied.
+  describe('advanced filters honesty in semantic/hybrid search (#945)', () => {
+    it('shows an "ignored" notice and marks pills inactive when a filter is set in semantic mode', async () => {
+      render(<PagesPage />, { wrapper: createWrapper() });
+
+      // Activate an advanced filter → pill appears.
+      fireEvent.click(screen.getByTestId('advanced-filters-toggle'));
+      fireEvent.change(screen.getByTestId('filter-freshness'), { target: { value: 'stale' } });
+      expect(screen.getByTestId('filter-pill-freshness')).toBeInTheDocument();
+
+      // Keyword mode honors the filter: no notice, pills are active.
+      expect(screen.queryByTestId('filters-ignored-notice')).not.toBeInTheDocument();
+      expect(screen.getByTestId('active-filter-pills')).not.toHaveAttribute('data-inactive', 'true');
+
+      // Switch to semantic mode and enter a query — the backend now ignores
+      // the filter, so the UI must say so.
+      fireEvent.click(screen.getByTestId('search-mode-semantic'));
+      fireEvent.change(screen.getByPlaceholderText('Search pages...'), {
+        target: { value: 'kubernetes' },
+      });
+
+      const notice = await screen.findByTestId('filters-ignored-notice');
+      expect(notice).toBeInTheDocument();
+      expect(screen.getByTestId('active-filter-pills')).toHaveAttribute('data-inactive', 'true');
+    });
+
+    it('does not show the notice in semantic mode when no advanced filters are active', () => {
+      render(<PagesPage />, { wrapper: createWrapper() });
+      fireEvent.click(screen.getByTestId('search-mode-semantic'));
+      fireEvent.change(screen.getByPlaceholderText('Search pages...'), {
+        target: { value: 'kubernetes' },
+      });
+      expect(screen.queryByTestId('filters-ignored-notice')).not.toBeInTheDocument();
+    });
+  });
+
   // --- Visual divider test ---
 
   it('renders a visual divider between sort and filters toggle', () => {

--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -689,9 +689,21 @@ export function PagesPage() {
           </div>
         )}
 
-        {/* Active filter pills */}
+        {/* Active filter pills.
+            Semantic/hybrid search ignores advanced filters (the backend
+            vector/hybrid paths never receive them), so when semantic search is
+            running we visually mark the pills as inactive rather than pretend
+            they still filter the results (#945). */}
         {activeFilters.length > 0 && (
-          <div className="flex flex-wrap items-center gap-2 border-t border-border/50 pt-3" data-testid="active-filter-pills">
+          <div
+            className={cn(
+              'flex flex-wrap items-center gap-2 border-t border-border/50 pt-3',
+              useSemanticSearch && 'opacity-50',
+            )}
+            data-testid="active-filter-pills"
+            data-inactive={useSemanticSearch ? 'true' : undefined}
+            aria-disabled={useSemanticSearch || undefined}
+          >
             {activeFilters.map((f) => (
               <button
                 key={f.key}
@@ -712,6 +724,19 @@ export function PagesPage() {
               Clear all
             </button>
           </div>
+        )}
+
+        {/* Honest notice: advanced filters are keyword-only. In semantic/hybrid
+            mode the backend ignores them, so tell the user instead of silently
+            dropping them (#945). */}
+        {useSemanticSearch && activeFilterCount > 0 && (
+          <p
+            className="flex items-center gap-1.5 text-xs text-muted-foreground"
+            data-testid="filters-ignored-notice"
+          >
+            <AlertTriangle size={12} className="shrink-0 text-warning" aria-hidden="true" />
+            Advanced filters apply to keyword search only — they don't affect semantic or hybrid results.
+          </p>
         )}
       </div>
 


### PR DESCRIPTION
Fixes #945.

## What / why
The backend applies advanced filters (author, date range, labels, source, etc.) **only in keyword search**. The semantic path (`vectorSearch(userId, embedding, limit)`) and hybrid path (`hybridSearch(userId, q, limit)`) in `backend/src/routes/knowledge/search.ts` never receive those filters. But `PagesPage` kept rendering the active-filter pills as active in semantic/hybrid mode, misleading users into believing their filters had narrowed the results.

Per the finding, the fix is a UX honesty change — not a backend signature expansion (out of scope):
- When semantic/hybrid search is running **and** filters are active, render a small notice (`data-testid="filters-ignored-notice"`): "Advanced filters apply to keyword search only — they don't affect semantic or hybrid results."
- Mark the active-filter pills block as inactive: dimmed (`opacity-50`), `aria-disabled`, and `data-inactive="true"`.
- Keyword mode is completely unchanged; pills stay active and honest there.

## Test evidence
`frontend/src/features/pages/PagesPage.test.tsx` — new `describe('advanced filters honesty in semantic/hybrid search (#945)')`:
- Sets a filter, asserts no notice + pills active in keyword mode, then switches to semantic mode + query and asserts the notice appears and pills carry `data-inactive="true"`.
- Also asserts no notice shows in semantic mode when no filters are active.

Fails-before: the `filters-ignored-notice` element does not exist → `findByTestId` times out. Passes-after: 62/62 in the file pass. Frontend typecheck clean; ESLint clean on both touched files.

## Docs / diagram impact
None — pure frontend UI state change, no compose/domain/boundary/migration/auth/sync/RAG/license/content-pipeline structural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)