### PR TITLE
fix(pages): give filter/sort selects accessible names (#946)

### DIFF
--- a/frontend/src/features/pages/PagesPage.test.tsx
+++ b/frontend/src/features/pages/PagesPage.test.tsx
@@ -925,6 +925,35 @@ describe('PagesPage', () => {
     });
   });
 
+  // --- Accessibility: filter/sort controls have accessible names (#946) ---
+  //
+  // The three top-row selects (space / source / sort) had no accessible name,
+  // and the advanced-panel <label>s were not programmatically associated with
+  // their controls (no htmlFor/id). Screen readers announced these as unnamed
+  // "combobox"/"edit" fields. These tests pin the aria-label + label/for wiring.
+  describe('filter control accessible names (#946)', () => {
+    it('top-row space/source/sort selects expose an accessible name', () => {
+      render(<PagesPage />, { wrapper: createWrapper() });
+      expect(screen.getByRole('combobox', { name: /filter by space/i })).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /filter by source/i })).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /sort pages/i })).toBeInTheDocument();
+    });
+
+    it('advanced-panel labels are programmatically associated with their controls', () => {
+      render(<PagesPage />, { wrapper: createWrapper() });
+      fireEvent.click(screen.getByTestId('advanced-filters-toggle'));
+
+      // Role-name / label-text queries only match once htmlFor/id wiring exists.
+      expect(screen.getByRole('combobox', { name: /author/i })).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /labels/i })).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /freshness/i })).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /embedding/i })).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /quality/i })).toBeInTheDocument();
+      expect(screen.getByLabelText(/modified from/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/modified to/i)).toBeInTheDocument();
+    });
+  });
+
   describe('performance: virtual scrolling + memoized items (#511, #521)', () => {
     it('renders visible page list items with stable keys (by id, not index)', async () => {
       render(<PagesPage />, { wrapper: createWrapper() });

--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -513,6 +513,7 @@ export function PagesPage() {
             value={spaceKey}
             onChange={(e) => { setSpaceKey(e.target.value); setPage(1); setForcePageList(false); }}
             className="nm-select-md w-40 shrink-0"
+            aria-label="Filter by space"
           >
             <option value="">All Spaces</option>
             {spaces?.map((s) => (
@@ -525,6 +526,7 @@ export function PagesPage() {
             onChange={(e) => { setSourceFilter(e.target.value as PageSource | ''); setPage(1); }}
             className="nm-select-md w-32 shrink-0"
             data-testid="filter-source"
+            aria-label="Filter by source"
           >
             <option value="">All Sources</option>
             {PageSourceEnum.options.map((source) => (
@@ -536,6 +538,7 @@ export function PagesPage() {
             value={sort}
             onChange={(e) => setSort(e.target.value as typeof sort)}
             className="nm-select-md w-40 shrink-0"
+            aria-label="Sort pages"
           >
             <option value="modified">Last Modified</option>
             <option value="title">Title</option>
@@ -574,8 +577,9 @@ export function PagesPage() {
           <div className="grid grid-cols-2 items-end gap-3 border-t border-border/40 pt-3 sm:grid-cols-3 lg:grid-cols-4" data-testid="advanced-filters-panel">
             {/* Author filter */}
             <div className="min-w-40">
-              <label className="mb-1 block text-xs text-muted-foreground">Author</label>
+              <label htmlFor="filter-author-select" className="mb-1 block text-xs text-muted-foreground">Author</label>
               <select
+                id="filter-author-select"
                 value={author}
                 onChange={(e) => { setAuthor(e.target.value); setPage(1); }}
                 className="nm-select-md w-full"
@@ -590,8 +594,9 @@ export function PagesPage() {
 
             {/* Labels filter */}
             <div className="min-w-40">
-              <label className="mb-1 block text-xs text-muted-foreground">Labels</label>
+              <label htmlFor="filter-labels-select" className="mb-1 block text-xs text-muted-foreground">Labels</label>
               <select
+                id="filter-labels-select"
                 value={labels}
                 onChange={(e) => { setLabels(e.target.value); setPage(1); }}
                 className="nm-select-md w-full"
@@ -606,8 +611,9 @@ export function PagesPage() {
 
             {/* Freshness filter */}
             <div className="min-w-32">
-              <label className="mb-1 block text-xs text-muted-foreground">Freshness</label>
+              <label htmlFor="filter-freshness-select" className="mb-1 block text-xs text-muted-foreground">Freshness</label>
               <select
+                id="filter-freshness-select"
                 value={freshness}
                 onChange={(e) => { setFreshness(e.target.value); setPage(1); }}
                 className="nm-select-md w-full"
@@ -623,8 +629,9 @@ export function PagesPage() {
 
             {/* Embedding status filter */}
             <div className="min-w-36">
-              <label className="mb-1 block text-xs text-muted-foreground">Embedding</label>
+              <label htmlFor="filter-embedding-select" className="mb-1 block text-xs text-muted-foreground">Embedding</label>
               <select
+                id="filter-embedding-select"
                 value={embeddingStatus}
                 onChange={(e) => { setEmbeddingStatus(e.target.value); setPage(1); }}
                 className="nm-select-md w-full"
@@ -638,8 +645,9 @@ export function PagesPage() {
 
             {/* Quality score filter */}
             <div className="min-w-36">
-              <label className="mb-1 block text-xs text-muted-foreground">Quality</label>
+              <label htmlFor="filter-quality-select" className="mb-1 block text-xs text-muted-foreground">Quality</label>
               <select
+                id="filter-quality-select"
                 value={qualityFilter}
                 onChange={(e) => { setQualityFilter(e.target.value); setPage(1); }}
                 className="nm-select-md w-full"
@@ -655,8 +663,9 @@ export function PagesPage() {
 
             {/* Date range */}
             <div className="min-w-36">
-              <label className="mb-1 block text-xs text-muted-foreground">Modified From</label>
+              <label htmlFor="filter-date-from-input" className="mb-1 block text-xs text-muted-foreground">Modified From</label>
               <input
+                id="filter-date-from-input"
                 type="date"
                 value={dateFrom}
                 onChange={(e) => { setDateFrom(e.target.value); setPage(1); }}
@@ -665,8 +674,9 @@ export function PagesPage() {
               />
             </div>
             <div className="min-w-36">
-              <label className="mb-1 block text-xs text-muted-foreground">Modified To</label>
+              <label htmlFor="filter-date-to-input" className="mb-1 block text-xs text-muted-foreground">Modified To</label>
               <input
+                id="filter-date-to-input"
                 type="date"
                 value={dateTo}
                 onChange={(e) => { setDateTo(e.target.value); setPage(1); }}


### PR DESCRIPTION
Fixes #946.

## What / Why
The three top-row selects on the Pages screen (space, source, sort) had no accessible name, and the advanced-filter `<label>`s were purely visual — not programmatically associated with their controls. Screen readers announced these as unnamed `combobox`/edit fields, failing WCAG 4.1.2 / 1.3.1.

- Added `aria-label` to the space (`Filter by space`), source (`Filter by source`), and sort (`Sort pages`) selects.
- Wired each advanced-panel label to its control with matching `htmlFor`/`id`: author, labels, freshness, embedding, quality selects plus the Modified From/To date inputs.

Attributes-only change; no logic or behavior change.

## Test evidence
`frontend/src/features/pages/PagesPage.test.tsx` — new `filter control accessible names (#946)` describe block:
- asserts `getByRole('combobox', { name: /filter by space|source/i })` and `/sort pages/i` resolve;
- after opening the advanced panel, asserts author/labels/freshness/embedding/quality comboboxes resolve by accessible name and the date inputs resolve via `getByLabelText(/modified from|to/i)`.

Fails before (unnamed comboboxes / unassociated labels), passes after. Full file: 62/62 pass. `npm run typecheck -w frontend` and `eslint` on the touched files are clean.

## Docs / diagram impact
None — accessibility attributes only; no change to system structure, data flow, or the content/auth/sync/RAG/license pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)