### PR TITLE
fix(pages): accessible names for pagination chevrons (#947)

### DIFF
--- a/frontend/src/features/pages/PagesPage.test.tsx
+++ b/frontend/src/features/pages/PagesPage.test.tsx
@@ -1248,4 +1248,61 @@ describe('PagesPage', () => {
       });
     });
   });
+
+  // --- Pagination chevron accessible names (#947) ---
+  //
+  // The prev/next chevron buttons are icon-only (a bare <ChevronLeft/> or
+  // <ChevronRight/>), so without an aria-label they have no accessible name and
+  // screen-reader / keyboard users cannot tell them apart. There are two
+  // identical pairs — one for the keyword/browse list and one for the
+  // semantic/hybrid results — so both must expose names.
+  describe('pagination accessibility (#947)', () => {
+    const json = (body: unknown) =>
+      new Response(JSON.stringify(body), { headers: { 'Content-Type': 'application/json' } });
+
+    /** Mock fetch so every list/search response reports multiple pages, forcing
+     *  the pagination controls to render in either mode. */
+    function mockFetchWithMultiplePages(totalPages: number) {
+      const items = makeManyPages(3).items;
+      return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        if (url.includes('/embeddings/status')) return json(mockEmbeddingStatusIdle);
+        if (url.includes('/pages/filters')) return json(mockFilterOptions);
+        if (url.includes('/spaces')) return json(mockSpaces);
+        if (url.includes('/sync/status')) return json({ status: 'idle' });
+        if (url.includes('/pages/pinned')) return json({ items: [], total: 0 });
+        if (url.includes('/settings')) return json({});
+        if (url.includes('/search?')) {
+          const mode = new URL(url, 'http://localhost').searchParams.get('mode') ?? 'keyword';
+          return json({ items, total: items.length, page: 1, limit: 3, totalPages, mode, hasEmbeddings: true });
+        }
+        return json({ items, total: items.length, page: 1, limit: 3, totalPages });
+      });
+    }
+
+    it('keyword-mode pagination chevrons expose Previous/Next accessible names', async () => {
+      vi.restoreAllMocks();
+      mockFetchWithMultiplePages(3);
+      render(<PagesPage />, { wrapper: createWrapper() });
+
+      expect(await screen.findByRole('button', { name: /previous page/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /next page/i })).toBeInTheDocument();
+    });
+
+    it('semantic-mode pagination chevrons expose Previous/Next accessible names', async () => {
+      vi.restoreAllMocks();
+      mockFetchWithMultiplePages(3);
+      render(<PagesPage />, { wrapper: createWrapper() });
+
+      fireEvent.click(screen.getByTestId('search-mode-semantic'));
+      fireEvent.change(screen.getByPlaceholderText('Search pages...'), {
+        target: { value: 'kubernetes' },
+      });
+
+      expect(
+        await screen.findByRole('button', { name: /previous page/i }, { timeout: 2000 }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /next page/i })).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/features/pages/PagesPage.tsx
+++ b/frontend/src/features/pages/PagesPage.tsx
@@ -835,16 +835,18 @@ export function PagesPage() {
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page <= 1}
+                aria-label="Previous page"
                 className="rounded-xl border border-border/40 bg-card/50 backdrop-blur-sm p-2 disabled:opacity-30"
               >
                 <ChevronLeft size={18} />
               </button>
-              <span className="text-sm text-muted-foreground">
+              <span className="text-sm text-muted-foreground" aria-live="polite">
                 Page {page} of {searchResults.totalPages}
               </span>
               <button
                 onClick={() => setPage((p) => Math.min(searchResults.totalPages, p + 1))}
                 disabled={page >= searchResults.totalPages}
+                aria-label="Next page"
                 className="rounded-xl border border-border/40 bg-card/50 backdrop-blur-sm p-2 disabled:opacity-30"
               >
                 <ChevronRight size={18} />
@@ -929,16 +931,18 @@ export function PagesPage() {
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page <= 1}
+                aria-label="Previous page"
                 className="rounded-xl border border-border/40 bg-card/50 backdrop-blur-sm p-2 disabled:opacity-30"
               >
                 <ChevronLeft size={18} />
               </button>
-              <span className="text-sm text-muted-foreground">
+              <span className="text-sm text-muted-foreground" aria-live="polite">
                 Page {page} of {pagesData.totalPages}
               </span>
               <button
                 onClick={() => setPage((p) => Math.min(pagesData.totalPages, p + 1))}
                 disabled={page >= pagesData.totalPages}
+                aria-label="Next page"
                 className="rounded-xl border border-border/40 bg-card/50 backdrop-blur-sm p-2 disabled:opacity-30"
               >
                 <ChevronRight size={18} />


### PR DESCRIPTION
Fixes #947.

## What / Why
The prev/next pagination chevrons on the Pages screen are icon-only buttons (`<ChevronLeft/>` / `<ChevronRight/>`) with no accessible name, so screen-reader and keyboard users cannot tell them apart. There are two identical pairs — one for the keyword/browse list, one for the semantic/hybrid results.

This adds `aria-label="Previous page"` / `aria-label="Next page"` to both pairs and `aria-live="polite"` on the "Page X of N" indicators so page changes are announced. No logic change.

## Test Evidence
Extended `frontend/src/features/pages/PagesPage.test.tsx` with a `pagination accessibility (#947)` describe covering both modes via `getByRole('button', { name: /previous page|next page/i })`.

- BEFORE fix: both tests fail — the `getByRole` name queries find no matching button.
- AFTER fix: both pass. Full file: 62 passed. Frontend typecheck and ESLint on the touched files are clean.

## Docs / Diagram Impact
None — accessibility attribute change only, no system-structure impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)