### PR TITLE
fix(setup): wizard Test Connection probes real Confluence auth (#950)

### DIFF
--- a/frontend/src/features/setup/steps/ConfluenceStep.test.tsx
+++ b/frontend/src/features/setup/steps/ConfluenceStep.test.tsx
@@ -17,13 +17,23 @@ function renderStep(onNext = vi.fn(), onBack = vi.fn()) {
   return { onNext, onBack };
 }
 
+function jsonResponse(payload: unknown) {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// Route by URL/method: the wizard must probe POST /settings/test-confluence
+// (which actually authenticates against Confluence), not a local read.
 function mockOkFetch() {
-  return vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
-    new Response(JSON.stringify([]), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    }),
-  );
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const url = typeof input === 'string' ? input : (input as Request).url;
+    if (url.includes('/settings/test-confluence') && (init as RequestInit | undefined)?.method === 'POST') {
+      return jsonResponse({ success: true, message: 'Connection successful' });
+    }
+    return jsonResponse([]);
+  });
 }
 
 describe('ConfluenceStep', () => {
@@ -103,6 +113,48 @@ describe('ConfluenceStep', () => {
     // The whole payload must validate against the contract the backend parses with.
     const parsed = UpdateSettingsSchema.parse(body);
     expect(parsed.confluenceUrl).toBe('https://confluence.example.com');
+  });
+
+  it('keeps Continue disabled when the connection probe reports failure (#950)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as Request).url;
+      if (url.includes('/settings/test-confluence') && (init as RequestInit | undefined)?.method === 'POST') {
+        // The credentials are wrong: the backend probe fails even though the
+        // settings save (PUT /settings) succeeds.
+        return jsonResponse({ success: false, message: 'Connection failed' });
+      }
+      return jsonResponse([]);
+    });
+    renderStep();
+
+    fireEvent.change(screen.getByTestId('confluence-url'), {
+      target: { value: 'https://confluence.example.com' },
+    });
+    fireEvent.change(screen.getByTestId('confluence-pat'), {
+      target: { value: 'bad-pat' },
+    });
+
+    fireEvent.click(screen.getByTestId('test-confluence-btn'));
+
+    // The failure must surface and the wizard must NOT let the user proceed.
+    await waitFor(() => {
+      expect(screen.getByTestId('confluence-test-result')).toHaveTextContent(
+        'Connection failed',
+      );
+    });
+    expect(screen.getByTestId('confluence-next-btn')).toBeDisabled();
+
+    // Prove the wizard hit the real probe endpoint with the entered credentials.
+    const probeCall = fetchSpy.mock.calls.find(
+      ([reqUrl, init]) =>
+        (typeof reqUrl === 'string' ? reqUrl : (reqUrl as Request).url).includes(
+          '/settings/test-confluence',
+        ) && (init as RequestInit | undefined)?.method === 'POST',
+    );
+    expect(probeCall).toBeDefined();
+    const probeBody = JSON.parse((probeCall![1] as RequestInit).body as string);
+    expect(probeBody.url).toBe('https://confluence.example.com');
+    expect(probeBody.pat).toBe('bad-pat');
   });
 
   it('re-requires a test after the PAT is edited following a passing test', async () => {

--- a/frontend/src/features/setup/steps/ConfluenceStep.tsx
+++ b/frontend/src/features/setup/steps/ConfluenceStep.tsx
@@ -29,10 +29,20 @@ export function ConfluenceStep({ onNext, onBack }: ConfluenceStepProps) {
         }),
       });
 
-      // Test connection by fetching spaces
-      await apiFetch('/spaces');
-      setTestSuccess(true);
-      toast.success('Confluence connected successfully');
+      // Actually authenticate against Confluence with the entered credentials.
+      // A local read (GET /spaces) succeeds regardless of the PAT's validity,
+      // so any credentials would "pass" — probe the real endpoint instead (#950).
+      const result = await apiFetch<{ success: boolean; message: string }>(
+        '/settings/test-confluence',
+        { method: 'POST', body: JSON.stringify({ url: confluenceUrl, pat }) },
+      );
+      if (result.success) {
+        setTestSuccess(true);
+        toast.success('Confluence connected successfully');
+      } else {
+        setTestSuccess(false);
+        toast.error(result.message || 'Connection test failed');
+      }
     } catch (err) {
       setTestSuccess(false);
       toast.error(err instanceof Error ? err.message : 'Connection test failed');


### PR DESCRIPTION
Fixes #950.

## What / why
The setup wizard's Confluence "Test Connection" saved settings then called `GET /api/spaces` — a local DB read that returns successfully regardless of whether the entered PAT/URL actually authenticate against Confluence. Any credentials therefore "passed" and enabled Continue.

The fix probes `POST /settings/test-confluence` (which performs a real authenticated request against the Confluence instance) and gates `testSuccess`/Continue on `result.success`, showing `result.message` on failure. This mirrors the existing `ConfluenceTab.tsx` settings panel. No backend or contract change needed — `TestConfluenceSchema` and the endpoint already exist.

## Test evidence
`frontend/src/features/setup/steps/ConfluenceStep.test.tsx`
- New test `keeps Continue disabled when the connection probe reports failure (#950)`: PUT /settings succeeds but the probe returns `{ success: false }`; asserts the failure banner shows and Continue stays disabled, and that the probe was called with `{ url, pat }`.
- Fails-before (current code ignores the probe and always enables Continue) / passes-after. Existing 4 tests still pass. `mockOkFetch` now routes the probe response by URL+method.

Typecheck and ESLint on the touched files: clean.

## Docs / diagram impact
None — behavior fix within the existing setup flow; no new endpoint, schema, table, or boundary change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)