### PR TITLE
fix(a11y): reveal code-copy and draw.io controls on keyboard focus (#951)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1836,7 +1836,9 @@ h1, h2, h3, h4, h5, h6,
   z-index: 1;
 }
 
-pre:hover .code-copy-btn {
+pre:hover .code-copy-btn,
+pre:focus-within .code-copy-btn,
+.code-copy-btn:focus-visible {
   opacity: 1;
 }
 
@@ -2178,7 +2180,9 @@ pre:hover .code-copy-btn {
   backdrop-filter: blur(4px);
 }
 
-.confluence-drawio:hover .drawio-inline-edit-btn {
+.confluence-drawio:hover .drawio-inline-edit-btn,
+.confluence-drawio:focus-within .drawio-inline-edit-btn,
+.drawio-inline-edit-btn:focus-visible {
   opacity: 1;
 }
 
@@ -2285,7 +2289,8 @@ pre:hover .code-copy-btn {
   transition: opacity 0.2s ease;
 }
 
-.drawio-nodeview:hover .drawio-nodeview__overlay {
+.drawio-nodeview:hover .drawio-nodeview__overlay,
+.drawio-nodeview:focus-within .drawio-nodeview__overlay {
   opacity: 1;
 }
 

--- a/frontend/src/shared/components/article/index-css-a11y.test.ts
+++ b/frontend/src/shared/components/article/index-css-a11y.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression tests for #951 — code-copy and draw.io controls that are hidden
+ * with opacity:0 and revealed only on :hover must also be revealed on keyboard
+ * focus, otherwise keyboard users can never see them (WCAG 2.4.7 Focus Visible).
+ *
+ * jsdom cannot compute focus-visible opacity from a stylesheet, so the reliable
+ * check is that index.css declares a focus-based reveal selector for each
+ * hover-revealed control. Each reveal must set opacity back to 1.
+ */
+
+const cssPath = resolve(__dirname, '../../../index.css');
+const css = readFileSync(cssPath, 'utf-8');
+
+/** Collapse whitespace so selector assertions are insensitive to formatting. */
+const normalized = css.replace(/\s+/g, ' ');
+
+/** Return the `{ ... }` declaration body for the first rule matching `selector`. */
+function ruleBody(selector: string): string {
+  const idx = normalized.indexOf(selector);
+  expect(idx, `selector not found: ${selector}`).toBeGreaterThanOrEqual(0);
+  const open = normalized.indexOf('{', idx);
+  const close = normalized.indexOf('}', open);
+  return normalized.slice(open + 1, close);
+}
+
+describe('#951 keyboard focus reveals hover-only controls', () => {
+  it('code-copy button is revealed when the pre or the button receives focus', () => {
+    const revealsOnFocus =
+      normalized.includes('pre:focus-within .code-copy-btn') ||
+      normalized.includes('.code-copy-btn:focus-visible') ||
+      normalized.includes('.code-copy-btn:focus');
+    expect(revealsOnFocus).toBe(true);
+
+    if (normalized.includes('pre:focus-within .code-copy-btn')) {
+      expect(ruleBody('pre:focus-within .code-copy-btn')).toContain('opacity: 1');
+    }
+  });
+
+  it('inline draw.io edit button is revealed on keyboard focus', () => {
+    const revealsOnFocus =
+      normalized.includes('.confluence-drawio:focus-within .drawio-inline-edit-btn') ||
+      normalized.includes('.drawio-inline-edit-btn:focus-visible') ||
+      normalized.includes('.drawio-inline-edit-btn:focus');
+    expect(revealsOnFocus).toBe(true);
+
+    if (normalized.includes('.confluence-drawio:focus-within .drawio-inline-edit-btn')) {
+      expect(
+        ruleBody('.confluence-drawio:focus-within .drawio-inline-edit-btn'),
+      ).toContain('opacity: 1');
+    }
+  });
+
+  it('draw.io node-view overlay is revealed when the node view receives focus', () => {
+    expect(normalized).toContain(
+      '.drawio-nodeview:focus-within .drawio-nodeview__overlay',
+    );
+    expect(
+      ruleBody('.drawio-nodeview:focus-within .drawio-nodeview__overlay'),
+    ).toContain('opacity: 1');
+  });
+});


### PR DESCRIPTION
Fixes #951.

## What / why
Three interactive controls in the article view — the code-block copy button (`.code-copy-btn`), the inline draw.io edit button (`.drawio-inline-edit-btn`), and the draw.io node-view overlay (`.drawio-nodeview__overlay`) — are hidden with `opacity: 0` and revealed only by `:hover` rules. Keyboard users who tab to them saw nothing, violating WCAG 2.4.7 (Focus Visible).

Each hover reveal now has matching focus reveals set to `opacity: 1`:
- `pre:focus-within .code-copy-btn`, `.code-copy-btn:focus-visible`
- `.confluence-drawio:focus-within .drawio-inline-edit-btn`, `.drawio-inline-edit-btn:focus-visible`
- `.drawio-nodeview:focus-within .drawio-nodeview__overlay`

Pure CSS beside the existing hover rules; no component changes.

## Test evidence
`frontend/src/shared/components/article/index-css-a11y.test.ts` reads `index.css` and asserts a focus-based reveal selector (set to opacity:1) exists for each control. jsdom can't compute `:focus-visible` opacity from a stylesheet, so stylesheet-content assertion is the reliable check.
- Before fix: 3 tests FAIL (selectors absent).
- After fix: `Test Files 1 passed (1) / Tests 3 passed (3)`.
Frontend typecheck and ESLint on the touched files are clean.

## Docs / diagram impact
None — pure CSS a11y fix, no change to system structure, flows, or env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)