### PR TITLE
fix(frontend): remove nested interactive element in LocationPicker tree (#952)

### DIFF
--- a/frontend/src/shared/components/LocationPicker.test.tsx
+++ b/frontend/src/shared/components/LocationPicker.test.tsx
@@ -160,6 +160,31 @@ describe('LocationPicker', () => {
     expect(screen.getByText('Configuration')).toBeInTheDocument();
   });
 
+  it('exposes the folder expander as a keyboard-focusable native button', async () => {
+    render(
+      <LocationPicker
+        spaceKey="DEV"
+        onSelect={mockOnSelect}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    fireEvent.click(screen.getByLabelText('Select page location'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Getting Started')).toBeInTheDocument();
+    });
+
+    const expandCtl = screen.getAllByLabelText('Expand')[0];
+    // Must be a real <button> (not a nested span[role=button]) so it is
+    // Tab-focusable and Enter/Space activatable — no interactive nesting.
+    expect(expandCtl.tagName).toBe('BUTTON');
+    expect(expandCtl).toHaveAttribute('aria-expanded', 'false');
+    expect(expandCtl).not.toHaveAttribute('tabindex', '-1');
+    // The expander must not be nested inside another interactive element.
+    expect(expandCtl.closest('button')).toBe(expandCtl);
+  });
+
   it('calls onSelect with correct data when Confirm is clicked', async () => {
     render(
       <LocationPicker

--- a/frontend/src/shared/components/LocationPicker.tsx
+++ b/frontend/src/shared/components/LocationPicker.tsx
@@ -141,9 +141,7 @@ const PickerTreeNode = memo(function PickerTreeNode({
 
   return (
     <div>
-      <button
-        type="button"
-        onClick={handleSelect}
+      <div
         className={cn(
           'group flex w-full items-center gap-1.5 rounded-md py-1.5 pr-2 text-sm transition-colors',
           isSelected
@@ -153,32 +151,38 @@ const PickerTreeNode = memo(function PickerTreeNode({
         style={{ paddingLeft: `${level * 16 + 8}px` }}
       >
         {hasChildren ? (
-          <span
-            role="button"
-            tabIndex={-1}
+          <button
+            type="button"
             onClick={handleToggle}
-            className="shrink-0 rounded p-0.5 hover:bg-foreground/10"
+            aria-expanded={isExpanded}
             aria-label={isExpanded ? 'Collapse' : 'Expand'}
+            className="shrink-0 rounded p-0.5 hover:bg-foreground/10"
           >
             {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-          </span>
+          </button>
         ) : (
           <span className="w-[20px] shrink-0" />
         )}
-        {hasChildren ? (
-          isExpanded ? (
-            <FolderOpen size={15} className="shrink-0 text-action/80" />
+        <button
+          type="button"
+          onClick={handleSelect}
+          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+        >
+          {hasChildren ? (
+            isExpanded ? (
+              <FolderOpen size={15} className="shrink-0 text-action/80" />
+            ) : (
+              <Folder size={15} className="shrink-0 text-action/70" />
+            )
           ) : (
-            <Folder size={15} className="shrink-0 text-action/70" />
-          )
-        ) : (
-          <FileText size={15} className="shrink-0 text-muted-foreground/70" />
-        )}
-        <span className="truncate">{node.page.title}</span>
-        {isSelected && (
-          <Check size={14} className="ml-auto shrink-0 text-action" />
-        )}
-      </button>
+            <FileText size={15} className="shrink-0 text-muted-foreground/70" />
+          )}
+          <span className="truncate">{node.page.title}</span>
+          {isSelected && (
+            <Check size={14} className="ml-auto shrink-0 text-action" />
+          )}
+        </button>
+      </div>
 
       {hasChildren && isExpanded && (
         <div>


### PR DESCRIPTION
Fixes #952.

## What / Why
In `PickerTreeNode`, the folder chevron was a `span[role="button"][tabIndex=-1]` nested **inside** the row `<button>`. Nesting an interactive element inside another button is invalid HTML/ARIA and made folder expansion keyboard-inaccessible (the span was removed from tab order and native buttons cannot contain interactive descendants).

The row is now a plain `<div>` container holding two sibling native buttons:
1. A real `<button>` expander (with `aria-expanded` and `aria-label` Expand/Collapse) shown when the node has children.
2. The select `<button>` wrapping the icon, title, and check.

Both are Tab-focusable and Enter/Space activatable. No interactive nesting remains.

## Test evidence
`frontend/src/shared/components/LocationPicker.test.tsx` — added `exposes the folder expander as a keyboard-focusable native button`, asserting the expander is a `BUTTON`, has `aria-expanded="false"`, is not `tabindex=-1`, and is not nested inside another button.

- Fails before (current code): `expected 'SPAN' to be 'BUTTON'`.
- Passes after the fix; all 13 tests in the file pass. Existing chevron-click/select tests keep passing (aria-label + handlers preserved).

## Docs / diagram impact
None — pure frontend accessibility fix; no system-structure, schema, or flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)