### PR TITLE
fix(frontend): auth-rewrite /api/local-attachments/ images in read mode (#953)

### DIFF
--- a/frontend/src/shared/components/article/ArticleViewer.test.tsx
+++ b/frontend/src/shared/components/article/ArticleViewer.test.tsx
@@ -59,6 +59,20 @@ describe('ArticleViewer', () => {
     expect(mockFetchAuthenticatedBlob).toHaveBeenCalledWith('/api/attachments/page-1/dashboard.png');
   });
 
+  it('rewrites protected local-attachment images (standalone draw.io PNGs) to authenticated blob URLs', async () => {
+    mockFetchAuthenticatedBlob.mockResolvedValueOnce('blob:diagram');
+
+    const html = '<p><img src="/api/local-attachments/42/diagram.png" alt="Diagram" /></p>';
+    const { container } = render(<ArticleViewer content={html} />);
+
+    await waitFor(() => {
+      const img = container.querySelector('img');
+      expect(img).toHaveAttribute('src', 'blob:diagram');
+    });
+
+    expect(mockFetchAuthenticatedBlob).toHaveBeenCalledWith('/api/local-attachments/42/diagram.png');
+  });
+
   it('replaces failed image with error placeholder containing a Retry button', async () => {
     mockFetchAuthenticatedBlob.mockResolvedValueOnce(null);
 

--- a/frontend/src/shared/components/article/ArticleViewer.tsx
+++ b/frontend/src/shared/components/article/ArticleViewer.tsx
@@ -335,7 +335,9 @@ export function ArticleViewer({
     }
 
     const raf = requestAnimationFrame(() => {
-      const images = container.querySelectorAll<HTMLImageElement>('img[src^="/api/attachments/"]');
+      const images = container.querySelectorAll<HTMLImageElement>(
+        'img[src^="/api/attachments/"], img[src^="/api/local-attachments/"]',
+      );
       if (images.length === 0) return;
 
       images.forEach(async (img) => {


### PR DESCRIPTION
Fixes #953.

## What / Why
`ArticleViewer`'s authenticated-image rewrite selector only matched `img[src^="/api/attachments/"]`. Standalone draw.io PNGs are served from `/api/local-attachments/`, so in read mode those images kept their raw `src` and the browser fetched them without the auth header, producing 401s and broken images.

The selector is the only gate — the blob-rewrite path (removes src, fetches via `fetchAuthenticatedBlob`, swaps in a `blob:` URL) and the error-placeholder/Retry path already operate on whatever matches, and `fetchAuthenticatedBlob` is prefix-agnostic. Widening the selector to also match `/api/local-attachments/` is the minimal correct fix.

## Test Evidence
- `frontend/src/shared/components/article/ArticleViewer.test.tsx` — added a test mirroring the existing attachment case with `<img src="/api/local-attachments/42/diagram.png">`, asserting the img gains `src="blob:diagram"` and that `fetchAuthenticatedBlob` was called with the local-attachments URL.
- Before fix: FAILS (selector never matches; src unchanged, fetch never called).
- After fix: PASSES (full file: 38 passed). Frontend typecheck and eslint on touched files clean.

## Docs / Diagram Impact
None — pure selector widening within the existing auth-image rewrite; no change to system structure, boundaries, or documented flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)