### PR TITLE
fix(editor): stop serializing whole doc on every keystroke (#954)

### DIFF
--- a/frontend/src/features/pages/NewPagePage.test.tsx
+++ b/frontend/src/features/pages/NewPagePage.test.tsx
@@ -40,11 +40,17 @@ vi.mock('../../shared/hooks/use-spaces', () => ({
   }),
 }));
 
-const { mockSetContent, mockEditorInstance, mockUseTemplateMutateAsync, mockImportMutateAsync, templatesState } = vi.hoisted(() => {
-  const setContent = vi.fn();
+const { editorHtml, mockSetContent, mockEditorInstance, mockUseTemplateMutateAsync, mockImportMutateAsync, templatesState } = vi.hoisted(() => {
+  // Live HTML the fake editor owns. setContent (template apply) and the
+  // textarea's onChange (typing) both write here; getHTML reads it — mirroring
+  // the real Editor now that the body is read off the instance, not synced to
+  // parent state per keystroke (#954).
+  const html = { current: '' };
+  const setContent = vi.fn((content: string) => { html.current = content; });
   return {
+    editorHtml: html,
     mockSetContent: setContent,
-    mockEditorInstance: { commands: { setContent } },
+    mockEditorInstance: { commands: { setContent }, getHTML: () => html.current },
     mockUseTemplateMutateAsync: vi.fn(),
     mockImportMutateAsync: vi.fn(),
     templatesState: { items: [] as { id: number; title: string; category: string | null }[] },
@@ -70,7 +76,7 @@ vi.mock('../../shared/hooks/use-standalone', () => ({
 vi.mock('../../shared/components/article/Editor', async () => {
   const { useEffect } = await import('react');
   return {
-    Editor: ({ onChange, onEditorReady }: { content: string; onChange: (html: string) => void; placeholder: string; draftKey: string; onEditorReady?: (editor: unknown) => void }) => {
+    Editor: ({ onChange, onEditorReady }: { content: string; onChange?: (dirty: boolean) => void; placeholder: string; draftKey: string; onEditorReady?: (editor: unknown) => void }) => {
       useEffect(() => {
         onEditorReady?.(mockEditorInstance);
         return () => onEditorReady?.(null);
@@ -78,7 +84,12 @@ vi.mock('../../shared/components/article/Editor', async () => {
       return (
         <textarea
           data-testid="mock-editor"
-          onChange={(e) => onChange(e.target.value)}
+          onChange={(e) => {
+            // Typing writes the live HTML the fake instance serves via getHTML,
+            // then signals dirty (the parent no longer receives the HTML).
+            editorHtml.current = e.target.value;
+            onChange?.(true);
+          }}
         />
       );
     },
@@ -117,6 +128,7 @@ describe('NewPagePage', () => {
     mockUseTemplateMutateAsync.mockReset();
     mockImportMutateAsync.mockReset();
     templatesState.items.length = 0;
+    editorHtml.current = '';
   });
 
   it('navigates to the imported page using articles[0].id from the import envelope', async () => {

--- a/frontend/src/features/pages/NewPagePage.tsx
+++ b/frontend/src/features/pages/NewPagePage.tsx
@@ -26,6 +26,9 @@ export function NewPagePage() {
   const [title, setTitle] = useState('');
   const [spaceKey, setSpaceKey] = useState('');
   const [parentId, setParentId] = useState<string | undefined>();
+  // Seeds the editor's initial content (empty, or a template applied before
+  // the editor has mounted). The live body is read from the editor instance on
+  // create (#954) — it is not synced per keystroke.
   const [bodyHtml, setBodyHtml] = useState('');
   const [articleType, setArticleType] = useState<ArticleType>('local');
   const [visibility, setVisibility] = useState<Visibility>('private');
@@ -76,10 +79,13 @@ export function NewPagePage() {
       return;
     }
     try {
+      // Read the live HTML off the editor instance (#954). `bodyHtml` is only a
+      // fallback seed (empty, or a template applied before the editor mounted).
+      const bodyToSave = editorInstance?.getHTML() ?? bodyHtml;
       const result = await createMutation.mutateAsync({
         spaceKey: spaceKey,
         title: title.trim(),
-        bodyHtml,
+        bodyHtml: bodyToSave,
         ...(parentId ? { parentId } : {}),
         ...(selectedSpace?.source === 'local' ? { visibility } : {}),
       } as Parameters<typeof createMutation.mutateAsync>[0]);
@@ -329,8 +335,7 @@ export function NewPagePage() {
           {/* Editor body */}
           <FeatureErrorBoundary featureName="Editor">
             <Editor
-              content=""
-              onChange={setBodyHtml}
+              content={bodyHtml}
               placeholder="Start writing your page..."
               draftKey={NEW_PAGE_DRAFT_KEY}
               naked
@@ -345,14 +350,15 @@ export function NewPagePage() {
       {showTemplateGallery && (
         <TemplateGallery
           onSelect={(html) => {
-            // Push the template into the live TipTap editor — the Editor is
-            // mounted with content="" and never re-reads the prop, so state
-            // alone would stay invisible and be overwritten by the first
-            // keystroke's onUpdate. emitUpdate fires onUpdate, which keeps
-            // bodyHtml and the localStorage draft in sync.
+            // Push the template into the live TipTap editor — the Editor never
+            // re-reads the content prop after mount, so setContent is how the
+            // template becomes visible. emitUpdate fires onUpdate so the
+            // localStorage draft is written; the body is read back from the
+            // editor instance on create (#954).
             editorInstance?.commands.setContent(html, { emitUpdate: true });
-            // Fallback for the brief window before TipTap finishes mounting
-            // (immediatelyRender: false), when editorInstance is still null.
+            // Seed fallback for the brief window before TipTap finishes
+            // mounting (immediatelyRender: false), when editorInstance is still
+            // null: the Editor picks this up as its initial content.
             setBodyHtml(html);
             setShowTemplateGallery(false);
           }}

--- a/frontend/src/features/pages/PageViewPage.test.tsx
+++ b/frontend/src/features/pages/PageViewPage.test.tsx
@@ -67,25 +67,52 @@ vi.mock('../../shared/components/article/ArticleViewer', async () => {
 // Configurable draft content so tests can exercise the restore-draft dialog.
 let mockDraftContent: string | null = null;
 
-vi.mock('../../shared/components/article/Editor', () => ({
-  Editor: ({
-    content,
-    onChange,
-  }: {
-    content: string;
-    onChange: (value: string) => void;
-  }) => (
-    <textarea
-      aria-label="Article editor"
-      value={content}
-      onChange={(event) => onChange(event.target.value)}
-    />
-  ),
-  EditorToolbar: () => null,
-  TableContextToolbar: () => null,
-  getDraft: () => mockDraftContent,
-  clearDraft: vi.fn(),
-}));
+vi.mock('../../shared/components/article/Editor', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  return {
+    // Mirrors the real Editor's contract (#954): the body is owned by the
+    // editor instance (read via getHTML() on save), NOT pushed to the parent
+    // per keystroke. onChange is a cheap boolean dirty signal. The textarea is
+    // uncontrolled so typed text persists and is reflected by getHTML().
+    Editor: ({
+      content,
+      onChange,
+      onEditorReady,
+    }: {
+      content: string;
+      onChange?: (dirty: boolean) => void;
+      onEditorReady?: (editor: { getHTML: () => string } | null) => void;
+    }) => {
+      const htmlRef = React.useRef(content);
+      React.useEffect(() => {
+        // `state.doc.descendants` lets the save path's draw.io drain walk an
+        // empty doc (no diagrams) without throwing on the fake instance.
+        const instance = {
+          getHTML: () => htmlRef.current,
+          state: { doc: { descendants: () => {} } },
+        };
+        onEditorReady?.(instance as never);
+        return () => onEditorReady?.(null);
+      }, [onEditorReady]);
+      return (
+        <textarea
+          aria-label="Article editor"
+          defaultValue={content}
+          onChange={(event) => {
+            htmlRef.current = event.target.value;
+            onChange?.(true);
+          }}
+        />
+      );
+    },
+    EditorToolbar: () => null,
+    TableContextToolbar: () => null,
+    LayoutContextToolbar: () => null,
+    ColumnContextToolbar: () => null,
+    getDraft: () => mockDraftContent,
+    clearDraft: vi.fn(),
+  };
+});
 
 vi.mock('../../shared/components/feedback/FeatureErrorBoundary', () => ({
   FeatureErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,

--- a/frontend/src/features/pages/PageViewPage.tsx
+++ b/frontend/src/features/pages/PageViewPage.tsx
@@ -150,8 +150,16 @@ export function PageViewPage() {
   const [editing, setEditing] = useState(false);
   const [editorInstance, setEditorInstance] = useState<EditorType | null>(null);
 
+  // `editHtml` seeds the editor's initial content when entering edit mode
+  // (published body or a restored draft). It is NOT updated per keystroke —
+  // the live HTML is read from `editorInstance.getHTML()` on save (#954).
   const [editHtml, setEditHtml] = useState('');
   const [editTitle, setEditTitle] = useState('');
+  // Dirty flag flipped by the editor's onChange (#954). A cheap boolean avoids
+  // storing/serializing the whole document on every keystroke: after the first
+  // change setIsDirty(true) is a no-op re-render, so typing no longer re-renders
+  // this page.
+  const [isDirty, setIsDirty] = useState(false);
   const [headings, setHeadings] = useState<TocHeading[]>([]);
   const [lightboxSrc, setLightboxSrc] = useState<{ alt: string; src: string } | null>(null);
   const [drawioEditingDiagram, setDrawioEditingDiagram] = useState<string | null>(null);
@@ -218,6 +226,7 @@ export function PageViewPage() {
     setEditing(false);
     setEditHtml('');
     setEditTitle('');
+    setIsDirty(false);
     setPendingDraft(null);
     setEditorInstance(null);
     setConfirmDiscardOpen(false);
@@ -253,12 +262,16 @@ export function PageViewPage() {
       return;
     }
     setEditHtml(page.bodyHtml);
+    setIsDirty(false);
     setEditing(true);
   }, [id, page]);
 
   const handleRestoreDraft = useCallback(() => {
     if (pendingDraft === null) return;
     setEditHtml(pendingDraft);
+    // A restored draft diverges from the published page, so the editor is
+    // dirty from the outset — Cancel must guard it and Save must persist it.
+    setIsDirty(true);
     setPendingDraft(null);
     setEditing(true);
   }, [pendingDraft]);
@@ -267,20 +280,23 @@ export function PageViewPage() {
     setPendingDraft(null);
     if (!page) return;
     setEditHtml(page.bodyHtml);
+    setIsDirty(false);
     setEditing(true);
   }, [page]);
 
-  // The editor is dirty when the working title/body diverges from the
-  // persisted page. editHtml starts equal to page.bodyHtml (or the restored
-  // draft) and only changes on a genuine Editor onChange, so a pristine
-  // editor produces no false positive (#944).
+  // The editor is dirty when the title diverges from the persisted page or the
+  // body was touched. `isDirty` is set by the Editor's onChange (and seeded
+  // true when a draft is restored), so a pristine editor produces no false
+  // positive (#944). Body edits are tracked via the flag rather than a live
+  // HTML string so typing doesn't re-render the page (#954).
   const isEditorDirty = useCallback(() => {
     if (!page) return false;
-    return editTitle !== page.title || editHtml !== page.bodyHtml;
-  }, [page, editTitle, editHtml]);
+    return editTitle !== page.title || isDirty;
+  }, [page, editTitle, isDirty]);
 
   const discardAndExit = useCallback(() => {
     if (draftKey) clearDraft(draftKey);
+    setIsDirty(false);
     setEditing(false);
   }, [draftKey]);
 
@@ -315,8 +331,11 @@ export function PageViewPage() {
       for (const msg of drain.errors) {
         toast.warning(msg);
       }
-      // `editor.getHTML()` reflects the newly-committed node attributes,
-      // so pull the post-drain HTML rather than the pre-drain `editHtml`.
+      // Read the live HTML straight off the editor instance (#954) — it's the
+      // single source of truth for body content, and also reflects the
+      // newly-committed draw.io node attributes from the drain above. The
+      // `editHtml` seed is only a fallback for the (practically unreachable)
+      // case where the editor instance isn't ready.
       const bodyToSave = editorInstance?.getHTML() ?? editHtml;
 
       await updateMutation.mutateAsync({
@@ -326,6 +345,7 @@ export function PageViewPage() {
         version: page.version,
       });
       if (draftKey) clearDraft(draftKey);
+      setIsDirty(false);
       setEditing(false);
       toast.success('Page saved.');
     } catch (error) {
@@ -747,7 +767,7 @@ export function PageViewPage() {
                 experience matches the reader's line length exactly. */}
             <div className="mx-auto max-w-[1200px]">
               <FeatureErrorBoundary featureName="Editor">
-                <Editor content={editHtml} onChange={setEditHtml} draftKey={draftKey} naked onEditorReady={setEditorInstance} hideToolbar pageId={id} onSave={handleSave} vimEnabled={vimEnabled} />
+                <Editor content={editHtml} onChange={() => setIsDirty(true)} draftKey={draftKey} naked onEditorReady={setEditorInstance} hideToolbar pageId={id} onSave={handleSave} vimEnabled={vimEnabled} />
               </FeatureErrorBoundary>
             </div>
           </>

--- a/frontend/src/shared/components/article/Editor.test.tsx
+++ b/frontend/src/shared/components/article/Editor.test.tsx
@@ -67,6 +67,41 @@ describe('Editor', () => {
     mockFetchAuthenticatedBlob.mockResolvedValue(null);
   });
 
+  it('signals dirty via a boolean onChange, not a serialized HTML string (#954)', async () => {
+    // Perf invariant: the hot per-keystroke onUpdate path must NOT serialize
+    // the whole document (getHTML) and hand it to the parent. onChange fires a
+    // cheap boolean dirty flag instead, so the parent can flip an isDirty flag
+    // without re-rendering on every keystroke and without paying the O(doc)
+    // serialization cost each time.
+    const onChange = vi.fn();
+    let editor: EditorType | null = null;
+    render(
+      <Editor
+        content="<p>seed</p>"
+        editable={true}
+        draftKey="page-954"
+        onChange={onChange}
+        onEditorReady={(e) => { editor = e; }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(editor).not.toBeNull();
+    });
+
+    editor!.commands.insertContent(' x');
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    const lastArg = onChange.mock.calls.at(-1)![0];
+    // Pre-fix this was the serialized HTML string (`<p>seed x</p>`). Post-fix
+    // it is a boolean dirty signal.
+    expect(typeof lastArg).toBe('boolean');
+    expect(lastArg).toBe(true);
+  });
+
   it('sticky toolbar reads as the top of the article card (#30 overhaul)', async () => {
     // The internal toolbar must look like the visual top of the article card
     // below — same bg, rounded only on top, sticks at top:0 when scrolling.

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -236,7 +236,15 @@ const ConfluenceImage = Image.extend({
 
 interface EditorProps {
   content?: string;
-  onChange?: (html: string) => void;
+  /**
+   * Fired on every document change with a `dirty` flag (always `true`). This is
+   * intentionally a cheap boolean, NOT the serialized HTML: serializing the
+   * whole document (getHTML) on the hot per-keystroke path is O(doc) and, when
+   * the parent stored the result in React state, re-rendered the page on every
+   * keystroke (#954). Read the current HTML from the editor instance
+   * (via `onEditorReady`) only when you actually need it — e.g. on save.
+   */
+  onChange?: (dirty: boolean) => void;
   editable?: boolean;
   placeholder?: string;
   /** Key for localStorage auto-save (e.g. "page-draft-12345"). Omit to disable. */
@@ -1255,8 +1263,10 @@ function defaultVimDisplayState(): VimState {
 export function Editor({ content, onChange, editable = true, placeholder, draftKey, naked = false, onEditorReady, hideToolbar = false, pageId, onSave, vimEnabled: vimEnabledProp }: EditorProps) {
   const isLight = useIsLightTheme();
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  // Latest debounced draft awaiting write, so unmount can flush it (#877)
-  const pendingDraftRef = useRef<{ key: string; html: string } | null>(null);
+  // draftKey of a debounced draft awaiting write, so unmount can flush it
+  // (#877). We store only the key and serialize the editor lazily at flush
+  // time (#954) rather than snapshotting getHTML() on every keystroke.
+  const pendingDraftRef = useRef<string | null>(null);
   // Ref for the editor instance so async paste/drop handlers can insert images
   const editorRef = useRef<EditorType | null>(null);
   // Keep pageId in a ref so editorProps closures see the latest value
@@ -1293,15 +1303,19 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
     });
   };
 
-  const saveDraft = useCallback((html: string) => {
+  const saveDraft = useCallback(() => {
     if (!draftKey) return;
     // Fresh edits mean there IS unsaved work again — allow it to be flushed.
     suppressedFlushKeys.delete(draftKey);
-    pendingDraftRef.current = { key: draftKey, html };
+    pendingDraftRef.current = draftKey;
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
+      // Serialize lazily here (once per debounce window) instead of on every
+      // keystroke (#954). editorRef is still live — the timer only fires while
+      // mounted; the unmount path clears it and flushes separately below.
       try {
-        localStorage.setItem(`draft:${draftKey}`, html);
+        const html = editorRef.current?.getHTML();
+        if (html != null) localStorage.setItem(`draft:${draftKey}`, html);
       } catch { /* quota exceeded — ignore */ }
       pendingDraftRef.current = null;
       timerRef.current = undefined;
@@ -1314,10 +1328,13 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
   // discarded draft. Uses refs only, so [] deps are correct.
   useEffect(() => () => {
     if (timerRef.current) clearTimeout(timerRef.current);
-    const pending = pendingDraftRef.current;
-    if (pending && !suppressedFlushKeys.has(pending.key)) {
+    const pendingKey = pendingDraftRef.current;
+    if (pendingKey && !suppressedFlushKeys.has(pendingKey)) {
+      // This cleanup runs before useEditor's own teardown, so editorRef still
+      // points at a live editor we can serialize (#954).
       try {
-        localStorage.setItem(`draft:${pending.key}`, pending.html);
+        const html = editorRef.current?.getHTML();
+        if (html != null) localStorage.setItem(`draft:${pendingKey}`, html);
       } catch { /* quota exceeded — ignore */ }
     }
     pendingDraftRef.current = null;
@@ -1391,10 +1408,10 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
       ...(vimEnabled ? [VimExtension.configure({
         onStateChange: setVimDisplayState,
         onSave: () => {
-          // Flush current editor content to React state, then trigger server-side save
-          if (editorRef.current) {
-            onChange?.(editorRef.current.getHTML());
-          }
+          // Mark dirty then trigger the server-side save. The save handler
+          // reads the current HTML straight off the editor instance (#954),
+          // so there's no editor→React-state flush to do here.
+          onChange?.(true);
           onSaveRef.current?.();
         },
       })] : []),
@@ -1467,10 +1484,13 @@ export function Editor({ content, onChange, editable = true, placeholder, draftK
     content,
     editable,
     immediatelyRender: false,
-    onUpdate: ({ editor: ed }) => {
-      const html = ed.getHTML();
-      onChange?.(html);
-      saveDraft(html);
+    onUpdate: () => {
+      // Hot path: fire a cheap dirty signal and schedule the debounced draft
+      // save. Do NOT serialize getHTML() here (#954) — that runs on every
+      // keystroke and, when the parent stored it in state, re-rendered the
+      // whole page each time. The draft/save paths serialize lazily instead.
+      onChange?.(true);
+      saveDraft();
     },
   }, [vimEnabled]);
 


### PR DESCRIPTION
Fixes #954.

## What / why
TipTap's `onUpdate` called `editor.getHTML()` on **every keystroke** and passed the serialized document to the parent via `onChange`. `PageViewPage` stored that string in React state, so each keystroke re-rendered the whole page **and** paid an O(document) serialization cost — the editor felt janky on large pages.

`onChange` is now a cheap `(dirty: boolean)` signal. The live HTML is read from the editor instance (`editor.getHTML()`) only when it's actually needed:
- **on save** (`PageViewPage` / `NewPagePage` read `editorInstance.getHTML()`),
- **on the debounced draft write and the unmount flush** (serialized lazily from the still-live editor ref, so the #877 flush-on-unmount behavior is preserved).

`PageViewPage` now tracks an `isDirty` boolean instead of a live `editHtml` string (`editHtml` is kept only as the initial-content seed for the editor). `NewPagePage` reads the body off the editor instance on create. After the first keystroke `setIsDirty(true)` is a no-op state write, so typing no longer re-renders the page.

## Test evidence
- Added to `frontend/src/shared/components/article/Editor.test.tsx`: asserts the `onChange` argument is a boolean, not a serialized HTML string. **Fails before** the fix (received `'string'` — the serialized `<p>seed x</p>`), **passes after**.
- Existing #877 draft-flush tests still pass (draft serialized from the live editor ref at flush time, still contains the typed text).
- Consumer test mocks (`PageViewPage.test.tsx`, `NewPagePage.test.tsx`) updated to the new contract (editor instance exposes `getHTML()`; `onChange` is a dirty signal).
- Full frontend suite green: 2291 tests. `tsc --noEmit` clean; ESLint clean on touched files.

## Docs / diagram impact
None — this is a frontend refactor of the editor's `onChange` contract; it doesn't affect compose, domain/ESLint boundaries, DB schema, or the auth/sync/RAG/license/content-pipeline flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)