### PR TITLE
fix(a11y): expose aria-pressed on editor & page toggle buttons (#955)

### DIFF
--- a/frontend/src/features/pages/NewPagePage.test.tsx
+++ b/frontend/src/features/pages/NewPagePage.test.tsx
@@ -146,6 +146,34 @@ describe('NewPagePage', () => {
     expect(screen.getByTestId('article-type-confluence')).toBeInTheDocument();
   });
 
+  it('exposes aria-pressed on the article type toggle buttons (#955)', () => {
+    // These are toggle buttons — screen-reader users need aria-pressed to know
+    // which type is currently selected. Default is Local.
+    render(<NewPagePage />, { wrapper: createWrapper() });
+    expect(screen.getByTestId('article-type-local')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('article-type-confluence')).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(screen.getByTestId('article-type-confluence'));
+    expect(screen.getByTestId('article-type-local')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('article-type-confluence')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('exposes aria-pressed on the visibility toggle buttons (#955)', async () => {
+    render(<NewPagePage />, { wrapper: createWrapper() });
+    // Visibility picker only renders once a local space is selected.
+    fireEvent.change(screen.getByTestId('space-selector'), { target: { value: '__local__' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('visibility-picker')).toBeInTheDocument();
+    });
+    // Default visibility is Private.
+    expect(screen.getByTestId('visibility-private')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('visibility-shared')).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(screen.getByTestId('visibility-shared'));
+    expect(screen.getByTestId('visibility-private')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('visibility-shared')).toHaveAttribute('aria-pressed', 'true');
+  });
+
   it('shows space selector always visible', () => {
     render(<NewPagePage />, { wrapper: createWrapper() });
     // Space selector is always shown regardless of article type

--- a/frontend/src/features/pages/NewPagePage.tsx
+++ b/frontend/src/features/pages/NewPagePage.tsx
@@ -205,6 +205,7 @@ export function NewPagePage() {
             <div className="flex gap-1" data-testid="article-type-toggle">
               <button
                 onClick={() => setArticleType('local')}
+                aria-pressed={articleType === 'local'}
                 className={cn(
                   'flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
                   articleType === 'local'
@@ -217,6 +218,7 @@ export function NewPagePage() {
               </button>
               <button
                 onClick={() => setArticleType('confluence')}
+                aria-pressed={articleType === 'confluence'}
                 className={cn(
                   'flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
                   articleType === 'confluence'
@@ -258,6 +260,7 @@ export function NewPagePage() {
               <div className="flex gap-1" data-testid="visibility-picker">
                 <button
                   onClick={() => setVisibility('private')}
+                  aria-pressed={visibility === 'private'}
                   className={cn(
                     'flex items-center justify-center gap-1 rounded-lg px-2.5 py-1.5 text-sm transition-colors',
                     visibility === 'private'
@@ -270,6 +273,7 @@ export function NewPagePage() {
                 </button>
                 <button
                   onClick={() => setVisibility('shared')}
+                  aria-pressed={visibility === 'shared'}
                   className={cn(
                     'flex items-center justify-center gap-1 rounded-lg px-2.5 py-1.5 text-sm transition-colors',
                     visibility === 'shared'

--- a/frontend/src/shared/components/article/Editor.test.tsx
+++ b/frontend/src/shared/components/article/Editor.test.tsx
@@ -995,4 +995,24 @@ describe('EditorToolbar — header numbering toggle', () => {
     const toolbar = screen.getByRole('toolbar', { name: 'Page editor toolbar' });
     expect(toolbar).toBeInTheDocument();
   });
+
+  // ---------- #955 toolbar toggle buttons expose pressed state ----------
+
+  it('exposes aria-pressed on active and inactive toggle buttons (#955)', () => {
+    // Screen readers announce a toggle button's on/off state via aria-pressed.
+    // Without it, users can't tell whether Bold (or any formatting toggle) is
+    // currently applied. Build a mock editor whose selection is inside bold
+    // text so Bold reads active and Italic reads inactive.
+    const base = createMockEditor();
+    const editor = {
+      ...base,
+      isActive: (name: string) => name === 'bold',
+    } as unknown as EditorType;
+    render(<EditorToolbar editor={editor} />);
+
+    const boldBtn = screen.getByTitle('Bold (Ctrl+B)');
+    const italicBtn = screen.getByTitle('Italic (Ctrl+I)');
+    expect(boldBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(italicBtn).toHaveAttribute('aria-pressed', 'false');
+  });
 });

--- a/frontend/src/shared/components/article/Editor.tsx
+++ b/frontend/src/shared/components/article/Editor.tsx
@@ -273,6 +273,7 @@ function ToolbarButton({
       onClick={onClick}
       disabled={disabled}
       title={title}
+      aria-pressed={active}
       className={cn(
         'rounded p-1.5 transition-colors',
         active ? 'bg-action/20 text-action ring-1 ring-action/30' : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',


### PR DESCRIPTION
Fixes #955.

## What & why
Editor toolbar formatting toggles (Bold, Italic, Underline, headings, lists, blockquote, code block, header-numbering, vim, layout/border toggles, …) and the New Page **Type** (Local/Confluence) and **Visibility** (Private/Shared) toggle buttons exposed their on/off state visually only. Assistive tech announced them as plain buttons with no pressed state, failing WCAG 4.1.2 (Name, Role, Value).

Adds `aria-pressed` reflecting each toggle's active state:
- `ToolbarButton` in `Editor.tsx` now sets `aria-pressed={active}`, mirroring the existing `MenuButton` in `EditorBubbleMenu.tsx`. Because `active` is optional, non-toggle buttons (Insert Table, Undo, Redo, …) pass no `active`, so `aria-pressed` stays absent and they remain plain buttons.
- The four Type/Visibility buttons in `NewPagePage.tsx` set `aria-pressed` from their selection state.

Attribute-only change; no logic touched.

## Test evidence
- `frontend/src/shared/components/article/Editor.test.tsx` — new case asserts Bold reads `aria-pressed="true"` when the selection is bold and Italic reads `"false"`.
- `frontend/src/features/pages/NewPagePage.test.tsx` — new cases assert the Type and Visibility toggles expose `aria-pressed` and that it flips on click.

Both failed before the fix (`aria-pressed` was `null`) and pass after. Full `Editor.test.tsx` + `NewPagePage.test.tsx` run: 69 passed. Frontend typecheck and eslint on the touched files are clean.

## Docs/diagram impact
None — purely an accessibility attribute addition; no system structure, boundaries, migrations, or documented flows affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)