### PR TITLE
fix(a11y): command palette focus trap, focus restore & combobox semantics (#958)

### DIFF
--- a/frontend/src/shared/components/layout/CommandPalette.test.tsx
+++ b/frontend/src/shared/components/layout/CommandPalette.test.tsx
@@ -243,6 +243,91 @@ describe('CommandPalette', () => {
     unmount();
   });
 
+  it('exposes the active option to assistive tech via combobox + aria-activedescendant', async () => {
+    useCommandPaletteStore.getState().open();
+    const { unmount } = render(<CommandPalette />, { wrapper: createWrapper() });
+
+    // The search input must be an ARIA combobox that owns the results listbox.
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveAttribute('aria-controls', 'cmdk-listbox');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    // Move the highlight down twice; the input must point at the highlighted option.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    const activeId = input.getAttribute('aria-activedescendant');
+    expect(activeId).toBeTruthy();
+    const activeOption = document.getElementById(activeId!);
+    expect(activeOption).not.toBeNull();
+    expect(activeOption).toHaveAttribute('role', 'option');
+    expect(activeOption).toHaveAttribute('aria-selected', 'true');
+
+    // Exactly one option is selected, and it is the active descendant.
+    const selected = screen
+      .getAllByRole('option')
+      .filter((o) => o.getAttribute('aria-selected') === 'true');
+    expect(selected).toHaveLength(1);
+    expect(selected[0]).toBe(activeOption);
+    unmount();
+  });
+
+  it('closes on Escape when focus is on a result option, not just the input', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ items: [{ id: '1', title: 'Test Page', spaceKey: 'TST' }] }),
+    );
+
+    useCommandPaletteStore.getState().open();
+    const { unmount } = render(<CommandPalette />, { wrapper: createWrapper() });
+
+    const input = screen.getByLabelText('Search');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    const resultLabel = await screen.findByText('Test Page');
+    const resultButton = resultLabel.closest('button');
+    expect(resultButton).not.toBeNull();
+
+    // Escape while a result option holds focus must still dismiss the palette.
+    fireEvent.keyDown(resultButton!, { key: 'Escape' });
+
+    expect(useCommandPaletteStore.getState().isOpen).toBe(false);
+    unmount();
+  });
+
+  it('restores focus to the previously focused element after closing', async () => {
+    const { unmount } = render(
+      <div>
+        <button data-testid="palette-opener">Open</button>
+        <CommandPalette />
+      </div>,
+      { wrapper: createWrapper() },
+    );
+
+    const opener = screen.getByTestId('palette-opener');
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+
+    act(() => {
+      useCommandPaletteStore.getState().open();
+    });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Focus moves into the palette while it is open.
+    const input = screen.getByLabelText('Search');
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    // Closing must return focus to whatever was focused before it opened.
+    act(() => {
+      useCommandPaletteStore.getState().close();
+    });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(opener);
+    });
+    unmount();
+  });
+
   it('shows recent searches from localStorage', async () => {
     localStorage.setItem('kb-recent-searches', JSON.stringify(['previous search']));
 

--- a/frontend/src/shared/components/layout/CommandPalette.tsx
+++ b/frontend/src/shared/components/layout/CommandPalette.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { m, AnimatePresence } from 'framer-motion';
+import * as Dialog from '@radix-ui/react-dialog';
+import { m } from 'framer-motion';
 import {
   Search, FileText, Plus, Settings, Bot, RefreshCw,
   Clock, ArrowRight, Sparkles,
@@ -52,6 +53,10 @@ export function CommandPalette() {
   const close = useCommandPaletteStore((s) => s.close);
   const navigate = useNavigate();
   const inputRef = useRef<HTMLInputElement>(null);
+  // The element focused before the palette opened, so focus can be restored on
+  // close. Radix Dialog only restores to a <Dialog.Trigger>, but this palette
+  // opens programmatically (Cmd+K) with no trigger, so we track it ourselves.
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
 
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
@@ -64,17 +69,13 @@ export function CommandPalette() {
   const isAiMode = query.trimStart().toLowerCase().startsWith('/ai');
   const aiQuery = isAiMode ? query.trimStart().slice(3).trim() : '';
 
-  // Load recent searches when opened
+  // Reset transient state when opened (focus is handled by Radix onOpenAutoFocus)
   useEffect(() => {
     if (isOpen) {
       setRecentSearches(getRecentSearches());
       setQuery('');
       setResults([]);
       setSelectedIndex(0);
-      // Focus input on next tick after mount
-      requestAnimationFrame(() => {
-        inputRef.current?.focus();
-      });
     }
   }, [isOpen]);
 
@@ -186,35 +187,49 @@ export function CommandPalette() {
     }
   }, [allItems.length, close, handleSelect, selectedIndex]);
 
-  if (!isOpen) return null;
+  // aria-activedescendant/option ids share a stable index space with `allItems`
+  // (and with the selectedIndex / handleSelect indices used below).
+  const activeOptionId = allItems.length > 0 ? `cmdk-opt-${selectedIndex}` : undefined;
 
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <>
-          {/* Backdrop */}
+    <Dialog.Root open={isOpen} onOpenChange={(open) => { if (!open) close(); }}>
+      <Dialog.Portal>
+        {/* Backdrop — Radix owns focus trap/restore + Escape; keep click-to-close */}
+        <Dialog.Overlay asChild>
           <m.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
             transition={{ duration: 0.15 }}
             className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
             onClick={close}
             data-testid="command-palette-backdrop"
           />
+        </Dialog.Overlay>
 
-          {/* Palette */}
+        {/* Palette — handleKeyDown lives here so arrows/Enter/Escape work
+            regardless of which child (input or an option button) holds focus */}
+        <Dialog.Content
+          asChild
+          aria-describedby={undefined}
+          onOpenAutoFocus={(e) => {
+            e.preventDefault();
+            restoreFocusRef.current = document.activeElement as HTMLElement | null;
+            inputRef.current?.focus();
+          }}
+          onCloseAutoFocus={(e) => {
+            // Radix would focus the (nonexistent) trigger; restore the opener.
+            e.preventDefault();
+            restoreFocusRef.current?.focus();
+          }}
+          onKeyDown={handleKeyDown}
+        >
           <m.div
             initial={{ opacity: 0, scale: 0.95, y: -20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.95, y: -20 }}
             transition={{ duration: 0.15 }}
-            className="fixed inset-x-0 top-[15%] z-50 mx-auto w-full max-w-xl"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="command-palette-title"
+            className="fixed inset-x-0 top-[15%] z-50 mx-auto w-full max-w-xl outline-none"
           >
-            <span id="command-palette-title" className="sr-only">Command palette</span>
+            <Dialog.Title className="sr-only">Command palette</Dialog.Title>
             <div className={cn(
               'nm-card overflow-hidden shadow-2xl transition-shadow duration-200',
               isAiMode && 'shadow-[0_0_30px_-5px_rgba(168,85,247,0.4)] ring-1 ring-purple-500/30',
@@ -234,13 +249,17 @@ export function CommandPalette() {
                   type="text"
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
-                  onKeyDown={handleKeyDown}
                   placeholder={isAiMode ? 'Ask AI anything...' : 'Search pages or type a command...'}
                   className={cn(
                     'flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground',
                     isAiMode && 'text-purple-700 dark:text-purple-100 placeholder:text-purple-300/50',
                   )}
                   aria-label="Search"
+                  role="combobox"
+                  aria-expanded={allItems.length > 0}
+                  aria-controls="cmdk-listbox"
+                  aria-activedescendant={activeOptionId}
+                  autoComplete="off"
                 />
                 <kbd className="rounded border border-border/50 px-1.5 py-0.5 text-[10px] text-muted-foreground">
                   ESC
@@ -248,7 +267,12 @@ export function CommandPalette() {
               </div>
 
               {/* Results */}
-              <div className="max-h-80 overflow-y-auto p-2">
+              <div
+                className="max-h-80 overflow-y-auto p-2"
+                role="listbox"
+                id="cmdk-listbox"
+                aria-label="Results"
+              >
                 {/* AI mode result */}
                 {isAiMode && (
                   <div className="mb-2">
@@ -256,6 +280,9 @@ export function CommandPalette() {
                       AI Assistant
                     </p>
                     <button
+                      id="cmdk-opt-0"
+                      role="option"
+                      aria-selected={selectedIndex === 0}
                       onClick={() => handleSelect(0)}
                       onMouseEnter={() => setSelectedIndex(0)}
                       data-testid="ai-mode-ask-button"
@@ -286,6 +313,9 @@ export function CommandPalette() {
                       return (
                         <button
                           key={result.id}
+                          id={`cmdk-opt-${idx}`}
+                          role="option"
+                          aria-selected={selectedIndex === idx}
                           onClick={() => handleSelect(idx)}
                           onMouseEnter={() => setSelectedIndex(idx)}
                           className={cn(
@@ -329,6 +359,9 @@ export function CommandPalette() {
                       return (
                         <button
                           key={`recent-${i}`}
+                          id={`cmdk-opt-${idx}`}
+                          role="option"
+                          aria-selected={selectedIndex === idx}
                           onClick={() => handleSelect(idx)}
                           onMouseEnter={() => setSelectedIndex(idx)}
                           className={cn(
@@ -361,6 +394,9 @@ export function CommandPalette() {
                       return (
                         <button
                           key={action.id}
+                          id={`cmdk-opt-${baseIdx}`}
+                          role="option"
+                          aria-selected={selectedIndex === baseIdx}
                           onClick={() => handleSelect(baseIdx)}
                           onMouseEnter={() => setSelectedIndex(baseIdx)}
                           className={cn(
@@ -393,8 +429,8 @@ export function CommandPalette() {
               </div>
             </div>
           </m.div>
-        </>
-      )}
-    </AnimatePresence>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }


### PR DESCRIPTION
Fixes #958.

## What / why
The command palette declared `role="dialog"` / `aria-modal="true"` but was a bare framer-motion `div`, so the modal contract was unmet: no focus trap, no focus restore, `Escape` fired only from the search input, and arrow-key selection was purely visual (invisible to assistive tech).

- Adopts the Radix Dialog pattern already used by the sibling `KeyboardShortcutsModal` (`Root`/`Portal`/`Overlay`/`Content`, `asChild` so the framer-motion entrance animation is preserved). Radix now owns the focus trap, `Escape`, `aria-modal`, and the inert background.
- The palette opens programmatically (Cmd+K / header buttons, no `<Dialog.Trigger>`), so Radix's default trigger-based restore is a no-op and focus was lost to `<body>`. We capture the pre-open `activeElement` in `onOpenAutoFocus` and restore it in `onCloseAutoFocus`.
- `handleKeyDown` moves from the input onto `Dialog.Content`, so arrows / Enter / Escape work regardless of which child (input or an option button) holds focus.
- Combobox pattern: input gets `role="combobox"` + `aria-controls` / `aria-expanded` / `aria-activedescendant`; the results area becomes `role="listbox"` (`id="cmdk-listbox"`); every result / action / recent / AI option gets a stable `id="cmdk-opt-<idx>"` + `role="option"` + `aria-selected`. The existing visual highlight is unchanged.

## Test evidence
Extended `frontend/src/shared/components/layout/CommandPalette.test.tsx` (jsdom + Testing Library) with three tests:
- combobox + `aria-activedescendant` tracks the highlighted `role="option"` after two ArrowDowns
- `Escape` from a focused result option (not just the input) closes the palette
- focus returns to the previously-focused element after close

Fails before / passes after: on `origin/dev` all three fail (no `combobox` role; Escape on a button leaves `isOpen === true`; focus lands on `body`). After the fix the full file passes (26/26). `AppLayout.test.tsx` (renders the palette) still green; `npm run typecheck -w frontend` and `eslint` on the touched files are clean.

## Docs / diagram impact
None — component-level a11y change; no compose / domain / DB / auth / sync / RAG / license / content-pipeline structure changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)