### PR TITLE
fix(sidebar): stop memoized tree rows subscribing to location (#960)

### DIFF
--- a/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
+++ b/frontend/src/shared/components/layout/DndLocalSpaceTree.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import {
   ChevronRight,
   ChevronDown,
@@ -16,6 +16,8 @@ export interface DndLocalSpaceTreeProps {
   expandedIds: Set<string>;
   toggleExpand: (id: string) => void;
   activePageId: string | undefined;
+  // #960: passed down from the parent so rows don't subscribe to location.
+  isAiRoute: boolean;
   reorderPage: { mutate: (args: { id: string; sortOrder: number }) => void };
 }
 
@@ -25,6 +27,7 @@ interface DndSortableTreeNodeProps {
   expandedSet: Set<string>;
   toggleExpand: (id: string) => void;
   activePageId: string | undefined;
+  isAiRoute: boolean;
   sortableIndex: number;
 }
 
@@ -34,14 +37,13 @@ const DndSortableTreeNode = memo(function DndSortableTreeNode({
   expandedSet,
   toggleExpand,
   activePageId,
+  isAiRoute,
   sortableIndex,
 }: DndSortableTreeNodeProps) {
   const navigate = useNavigate();
-  const location = useLocation();
   const isExpanded = expandedSet.has(node.page.id);
   const hasChildren = node.children.length > 0;
   const isActive = node.page.id === activePageId;
-  const isAiRoute = location.pathname === '/ai';
 
   const sortable = useSortable({
     id: node.page.id,
@@ -141,6 +143,7 @@ const DndSortableTreeNode = memo(function DndSortableTreeNode({
               expandedSet={expandedSet}
               toggleExpand={toggleExpand}
               activePageId={activePageId}
+              isAiRoute={isAiRoute}
               sortableIndex={idx}
             />
           ))}
@@ -154,6 +157,7 @@ const DndSortableTreeNode = memo(function DndSortableTreeNode({
     prev.level === next.level &&
     prev.activePageId === next.activePageId &&
     prev.expandedSet === next.expandedSet &&
+    prev.isAiRoute === next.isAiRoute &&
     prev.sortableIndex === next.sortableIndex
   );
 });
@@ -163,6 +167,7 @@ export default function DndLocalSpaceTree({
   expandedIds,
   toggleExpand,
   activePageId,
+  isAiRoute,
   reorderPage,
 }: DndLocalSpaceTreeProps) {
   const handleDragEnd = useCallback(
@@ -195,6 +200,7 @@ export default function DndLocalSpaceTree({
             expandedSet={expandedIds}
             toggleExpand={toggleExpand}
             activePageId={activePageId}
+            isAiRoute={isAiRoute}
             sortableIndex={idx}
           />
         ))}

--- a/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useSearchParams } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SidebarTreeView, SidebarTreeNode } from './SidebarTreeView';
 import type { TreeNode, SidebarTreeNodeProps } from './SidebarTreeView';
@@ -24,11 +24,16 @@ vi.mock('./DndLocalSpaceTree', () => ({
 }));
 
 const mockNavigate = vi.fn();
+// #960: count how often a tree row consuming useNavigate renders. Each row
+// calls useNavigate() exactly once per render (before and after the fix), so
+// this spy is a reliable render counter — React's <Profiler> onRender proved
+// unreliable for context-driven re-renders under jsdom.
+const mockUseNavigate = vi.fn(() => mockNavigate);
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return {
     ...actual,
-    useNavigate: () => mockNavigate,
+    useNavigate: () => mockUseNavigate(),
   };
 });
 
@@ -745,6 +750,7 @@ describe('SidebarTreeNode memoization', () => {
       expandedSet,
       toggleExpand: vi.fn(),
       activePageId: 'page-1',
+      isAiRoute: false,
     };
 
     expect(component.compare(props, { ...props, toggleExpand: vi.fn() })).toBe(true);
@@ -757,8 +763,8 @@ describe('SidebarTreeNode memoization', () => {
     const node = makeNode('page-1', 'Test');
     const expandedSet = new Set<string>();
     const toggleExpand = vi.fn();
-    const prev: SidebarTreeNodeProps = { node, level: 0, expandedSet, toggleExpand, activePageId: undefined };
-    const next: SidebarTreeNodeProps = { node, level: 0, expandedSet, toggleExpand, activePageId: 'page-1' };
+    const prev: SidebarTreeNodeProps = { node, level: 0, expandedSet, toggleExpand, activePageId: undefined, isAiRoute: false };
+    const next: SidebarTreeNodeProps = { node, level: 0, expandedSet, toggleExpand, activePageId: 'page-1', isAiRoute: false };
 
     expect(component.compare(prev, next)).toBe(false);
   });
@@ -769,8 +775,21 @@ describe('SidebarTreeNode memoization', () => {
     };
     const node = makeNode('page-1', 'Test');
     const toggleExpand = vi.fn();
-    const prev: SidebarTreeNodeProps = { node, level: 0, expandedSet: new Set<string>(), toggleExpand, activePageId: undefined };
-    const next: SidebarTreeNodeProps = { node, level: 0, expandedSet: new Set<string>(), toggleExpand, activePageId: undefined };
+    const prev: SidebarTreeNodeProps = { node, level: 0, expandedSet: new Set<string>(), toggleExpand, activePageId: undefined, isAiRoute: false };
+    const next: SidebarTreeNodeProps = { node, level: 0, expandedSet: new Set<string>(), toggleExpand, activePageId: undefined, isAiRoute: false };
+
+    expect(component.compare(prev, next)).toBe(false);
+  });
+
+  it('custom comparator returns false (re-render) when isAiRoute changes (#960)', () => {
+    const component = SidebarTreeNode as unknown as {
+      compare: (prev: SidebarTreeNodeProps, next: SidebarTreeNodeProps) => boolean;
+    };
+    const node = makeNode('page-1', 'Test');
+    const expandedSet = new Set<string>();
+    const toggleExpand = vi.fn();
+    const prev: SidebarTreeNodeProps = { node, level: 0, expandedSet, toggleExpand, activePageId: undefined, isAiRoute: false };
+    const next: SidebarTreeNodeProps = { node, level: 0, expandedSet, toggleExpand, activePageId: undefined, isAiRoute: true };
 
     expect(component.compare(prev, next)).toBe(false);
   });
@@ -783,8 +802,8 @@ describe('SidebarTreeNode memoization', () => {
     const toggleExpand = vi.fn();
     const node1 = makeNode('page-1', 'Test');
     const node2 = makeNode('page-1', 'Test Changed');
-    const prev: SidebarTreeNodeProps = { node: node1, level: 0, expandedSet, toggleExpand, activePageId: undefined };
-    const next: SidebarTreeNodeProps = { node: node2, level: 0, expandedSet, toggleExpand, activePageId: undefined };
+    const prev: SidebarTreeNodeProps = { node: node1, level: 0, expandedSet, toggleExpand, activePageId: undefined, isAiRoute: false };
+    const next: SidebarTreeNodeProps = { node: node2, level: 0, expandedSet, toggleExpand, activePageId: undefined, isAiRoute: false };
 
     expect(component.compare(prev, next)).toBe(false);
   });
@@ -802,6 +821,7 @@ describe('SidebarTreeNode memoization', () => {
           expandedSet={expandedSet}
           toggleExpand={toggleExpand}
           activePageId={undefined}
+          isAiRoute={false}
         />
       </MemoryRouter>,
     );
@@ -864,6 +884,7 @@ describe('SidebarTreeNode memoization', () => {
           expandedSet={expandedSet}
           toggleExpand={toggleExpand}
           activePageId={undefined}
+          isAiRoute={false}
         />
       </MemoryRouter>,
     );
@@ -888,6 +909,7 @@ describe('SidebarTreeNode memoization', () => {
           expandedSet={expandedSet}
           toggleExpand={toggleExpand}
           activePageId={undefined}
+          isAiRoute={false}
         />
       </MemoryRouter>,
     );
@@ -910,6 +932,7 @@ describe('SidebarTreeNode memoization', () => {
           expandedSet={expandedSet}
           toggleExpand={toggleExpand}
           activePageId={undefined}
+          isAiRoute={false}
         />
       </MemoryRouter>,
     );
@@ -932,6 +955,7 @@ describe('SidebarTreeNode memoization', () => {
           expandedSet={expandedSet}
           toggleExpand={toggleExpand}
           activePageId={undefined}
+          isAiRoute={false}
         />
       </MemoryRouter>,
     );
@@ -953,6 +977,7 @@ describe('SidebarTreeNode memoization', () => {
           expandedSet={expandedSet}
           toggleExpand={toggleExpand}
           activePageId={undefined}
+          isAiRoute={false}
         />
       </MemoryRouter>,
     );
@@ -1017,6 +1042,55 @@ describe('SidebarTreeNode memoization', () => {
       useUiStore.setState({ treeSidebarSpaceKey: 'DEV' });
       render(<SidebarTreeView />, { wrapper: createWrapper() });
       expect(screen.getByText('4 pages in DEV')).toBeInTheDocument();
+    });
+  });
+
+  // #960: memoized rows used to call useLocation() internally, so every
+  // location / searchParams change re-rendered every row in the tree — the
+  // memo comparator never got a chance to bail. The /ai signal is now passed
+  // in as a stable `isAiRoute` prop derived once by the parent, so a row only
+  // re-renders when one of its actually-tracked props changes.
+  describe('does not subscribe to location (#960)', () => {
+    function UrlChanger() {
+      const [, setSearchParams] = useSearchParams();
+      return (
+        <button onClick={() => setSearchParams({ pageId: 'x' })}>change-url</button>
+      );
+    }
+
+    it('does not re-render a memoized row when the URL/searchParams change', () => {
+      mockUseNavigate.mockClear();
+      const node = makeNode('page-1', 'Stable Row');
+      const expandedSet = new Set<string>();
+      const toggleExpand = vi.fn();
+
+      render(
+        // The root consumes no location, so only location-subscribing
+        // descendants re-render when the URL changes. UrlChanger is a SIBLING
+        // of the row (never an ancestor), so a re-render of the row can only
+        // come from the row's own hook subscriptions — not from a parent.
+        <MemoryRouter initialEntries={['/pages']}>
+          <SidebarTreeNode
+            node={node}
+            level={0}
+            expandedSet={expandedSet}
+            toggleExpand={toggleExpand}
+            activePageId={undefined}
+            isAiRoute={false}
+          />
+          <UrlChanger />
+        </MemoryRouter>,
+      );
+
+      // The row rendered once on mount → useNavigate called once.
+      expect(mockUseNavigate).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByText('change-url'));
+
+      // Before the fix the row consumed useLocation and re-rendered on the URL
+      // change (useNavigate called a 2nd time). After the fix its props are
+      // stable, the memo bails, and the row does not re-render (still 1).
+      expect(mockUseNavigate).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/frontend/src/shared/components/layout/SidebarTreeView.tsx
+++ b/frontend/src/shared/components/layout/SidebarTreeView.tsx
@@ -103,6 +103,11 @@ export interface SidebarTreeNodeProps {
   expandedSet: Set<string>;
   toggleExpand: (id: string) => void;
   activePageId: string | undefined;
+  // #960: derived once by the parent from location.pathname and passed down as
+  // a stable prop. Rows must NOT call useLocation() themselves — that subscribed
+  // every memoized row to every location/searchParams change, defeating the memo
+  // comparator and re-rendering the whole tree on each navigation.
+  isAiRoute: boolean;
 }
 
 export const SidebarTreeNode = memo(function SidebarTreeNode({
@@ -111,13 +116,12 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
   expandedSet,
   toggleExpand,
   activePageId,
+  isAiRoute,
 }: SidebarTreeNodeProps) {
   const navigate = useNavigate();
-  const location = useLocation();
   const isExpanded = expandedSet.has(node.page.id);
   const hasChildren = node.children.length > 0;
   const isActive = node.page.id === activePageId;
-  const isAiRoute = location.pathname === '/ai';
 
   const handleNavigate = useCallback(() => {
     if (hasChildren) toggleExpand(node.page.id);
@@ -208,6 +212,7 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
               expandedSet={expandedSet}
               toggleExpand={toggleExpand}
               activePageId={activePageId}
+              isAiRoute={isAiRoute}
             />
           ))}
         </div>
@@ -219,7 +224,8 @@ export const SidebarTreeNode = memo(function SidebarTreeNode({
     prev.node === next.node &&
     prev.level === next.level &&
     prev.activePageId === next.activePageId &&
-    prev.expandedSet === next.expandedSet
+    prev.expandedSet === next.expandedSet &&
+    prev.isAiRoute === next.isAiRoute
   );
 });
 
@@ -294,6 +300,9 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
   const homepageId = selectedSpaceOption?.homepageId;
   const tree = useMemo(() => buildTree(pages, homepageId), [pages, homepageId]);
   const isLocalSpace = selectedSpaceOption?.source === 'local';
+  // #960: derive the /ai signal once here and thread it into every row as a
+  // stable prop so the rows themselves don't subscribe to location.
+  const isAiRoute = location.pathname === '/ai';
 
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
 
@@ -759,6 +768,7 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
               expandedIds={expandedIds}
               toggleExpand={toggleExpand}
               activePageId={activePageId}
+              isAiRoute={isAiRoute}
               reorderPage={reorderPage}
             />
           </Suspense>
@@ -775,6 +785,7 @@ export function SidebarTreeView({ onNavigate }: { onNavigate?: () => void } = {}
                 expandedSet={expandedIds}
                 toggleExpand={toggleExpand}
                 activePageId={activePageId}
+                isAiRoute={isAiRoute}
               />
             ))}
           </div>


### PR DESCRIPTION
Fixes #960.

## What / why
`SidebarTreeNode` and `DndSortableTreeNode` each called `useLocation()` internally, only to compute the `/ai` route signal. Consuming `useLocation` subscribes every memoized row to the router context, so **any** location or `searchParams` change re-rendered every row in the sidebar tree — the `React.memo` comparator never got a chance to bail because the re-render came from the hook subscription, not the parent.

The `/ai` signal is now derived once in the parent `SidebarTreeView` (which already reads `location`) and threaded down as a stable `isAiRoute` prop. Both memo comparators gained an `isAiRoute` check so a genuine `/ai` transition still re-renders. `useNavigate` is kept (it does not subscribe to location). Rows now re-render only when a tracked prop actually changes.

## Test evidence
`frontend/src/shared/components/layout/SidebarTreeView.test.tsx` — new `does not subscribe to location (#960)` test renders a single `SidebarTreeNode` with a **sibling** `UrlChanger` (not an ancestor) that writes a `searchParam`, and counts the row's renders via the shared `useNavigate` spy (called once per render). React's `<Profiler>` proved unreliable for context-driven re-renders under jsdom, so render counting via the hook is used instead.

- **Before fix:** the row consumed `useLocation`, re-rendered on the unrelated URL change → useNavigate called 2× → FAIL.
- **After fix:** props stable, memo bails, row does not re-render → useNavigate called 1× → PASS.

Also added a comparator unit test asserting `isAiRoute` changes force a re-render. Full file: 83 tests pass; frontend typecheck + eslint clean.

## Docs / diagram impact
None — pure frontend render/memoization fix; no compose, domain boundary, DB, or auth/sync/RAG/license/content-pipeline change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)