### PR TITLE
fix(a11y): visible keyboard highlight on UserMenu items (#962)

### DIFF
--- a/frontend/src/shared/components/layout/UserMenu.test.tsx
+++ b/frontend/src/shared/components/layout/UserMenu.test.tsx
@@ -223,6 +223,27 @@ describe('UserMenu', () => {
     });
   });
 
+  // Radix applies data-[highlighted] to the roving-focus menu item during
+  // keyboard navigation. With only hover:* styles and outline-none, keyboard
+  // users get no visible highlight (issue #962). Assert every menu item carries
+  // a data-[highlighted] style so the focused item is always visible.
+  it('every menu item has a data-[highlighted] style for keyboard focus visibility', async () => {
+    mockUser = { username: 'adminuser', role: 'admin' };
+    renderUserMenu();
+    const trigger = screen.getByRole('button');
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' });
+
+    await vi.waitFor(() => {
+      expect(trigger).toHaveAttribute('data-state', 'open');
+    });
+
+    const items = screen.getAllByRole('menuitem');
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      expect(item.className).toMatch(/data-\[highlighted\]:/);
+    }
+  });
+
   // Task 5 — avatar initial bubble is brand chrome (not an AI affordance), so
   // it must route to ink-action and not amber. The Playwright contrast spec in
   // Task 6 will catch the colour combo at run-time; this guards the contract

--- a/frontend/src/shared/components/layout/UserMenu.tsx
+++ b/frontend/src/shared/components/layout/UserMenu.tsx
@@ -42,7 +42,7 @@ export function UserMenu() {
           <DropdownMenu.Separator className="my-1 h-px bg-foreground/10" />
           <DropdownMenu.Item
             onSelect={() => navigate('/settings')}
-            className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-sm text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground transition-colors"
+            className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-sm text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground data-[highlighted]:bg-foreground/10 data-[highlighted]:text-foreground transition-colors"
           >
             <Settings size={14} />
             Settings
@@ -55,7 +55,7 @@ export function UserMenu() {
             // server-side on each /admin/analytics/* endpoint.
             <DropdownMenu.Item
               onSelect={() => navigate('/admin/analytics')}
-              className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-sm text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground transition-colors"
+              className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-sm text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground data-[highlighted]:bg-foreground/10 data-[highlighted]:text-foreground transition-colors"
             >
               <BarChart3 size={14} />
               Analytics
@@ -63,7 +63,7 @@ export function UserMenu() {
           )}
           <DropdownMenu.Item
             onSelect={openShortcuts}
-            className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-sm text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground transition-colors"
+            className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-sm text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground data-[highlighted]:bg-foreground/10 data-[highlighted]:text-foreground transition-colors"
           >
             <Keyboard size={14} />
             Keyboard Shortcuts
@@ -75,7 +75,7 @@ export function UserMenu() {
               e.preventDefault();
               setSingleKeyEnabled(!singleKeyEnabled);
             }}
-            className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-sm text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground transition-colors"
+            className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-sm text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground data-[highlighted]:bg-foreground/10 data-[highlighted]:text-foreground transition-colors"
           >
             <span className="flex-1">Single-key shortcuts</span>
             <Switch.Root
@@ -92,7 +92,7 @@ export function UserMenu() {
           <DropdownMenu.Separator className="my-1 h-px bg-foreground/10" />
           <DropdownMenu.Item
             onSelect={() => void logoutApi()}
-            className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-sm text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground transition-colors"
+            className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-sm text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground data-[highlighted]:bg-foreground/10 data-[highlighted]:text-foreground transition-colors"
           >
             <LogOut size={14} />
             Sign out


### PR DESCRIPTION
Fixes #962.

## What / Why
Radix `DropdownMenu.Item`s in `UserMenu` used `outline-none` together with hover-only styling (`hover:bg-foreground/5 hover:text-foreground`). Radix drives keyboard navigation via roving focus and sets `data-highlighted` on the focused item — but nothing styled that state, so keyboard users saw no highlight at all (WCAG 2.4.7 focus visibility). Fix adds `data-[highlighted]:bg-foreground/10 data-[highlighted]:text-foreground` to all five menu items, giving a visible highlight during keyboard navigation while keeping `outline-none` for pointer users.

## Test Evidence
`frontend/src/shared/components/layout/UserMenu.test.tsx` — new test opens the menu and asserts every `menuitem` carries a `data-[highlighted]:` style.
- Before fix: FAILS (`expected 'flex cursor-pointer …' to match /data-\[highlighted\]:/`).
- After fix: PASSES (16/16 in the file).

## Docs / Diagram Impact
None — Tailwind class-only change to an existing component; no structural, schema, or flow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)