### PR TITLE
chore(release): v0.6.3

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "//hoisting-note": "`p-limit` and `ipaddr.js` are ALSO declared in the root package.json `dependencies` block to force npm to hoist them to root node_modules. The runtime Docker stage only copies the root tree, so any version pinned here that ends up nested under backend/node_modules disappears at runtime. If you change the ranges below, update the root mirror in lockstep — the docker-build smoke step is the safety net but local repros are faster.",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/mcp-docs/package.json
+++ b/mcp-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq-mcp-docs",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compendiq",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compendiq",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "workspaces": [
         "backend",
         "frontend",
@@ -25,7 +25,7 @@
       }
     },
     "backend": {
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@fastify/compress": "^8.3.1",
@@ -1430,7 +1430,7 @@
       "license": "MIT"
     },
     "frontend": {
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@compendiq/contracts": "*",
         "@dnd-kit/react": "^0.3.2",
@@ -20341,7 +20341,7 @@
     },
     "packages/contracts": {
       "name": "@compendiq/contracts",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "zod": "^4.3.6"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compendiq",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "description": "Compendiq - AI-powered knowledge base management with Confluence integration and Ollama LLM backend",
   "workspaces": [

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compendiq/contracts",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump **0.6.2 → 0.6.3** across all five package.jsons (root, backend, frontend, packages/contracts, mcp-docs) + lockfile, preparing the `dev → main` release of the 2026-07-10 code & UX audit fixes (Epic #856).

**Scope:** 56 merged PRs (#1023–#1083) — security (SSRF/DNS-rebind, layer-baked token), sync & data-integrity (pagination truncation, worker-lock TTL, page-path backfill), embeddings/graph, LLM queue/circuit-breaker, infra (docker hardening), and accessibility. All bug/perf fixes — no new features, no breaking changes → SemVer **patch** (pre-1.0).

Merged `dev` verified green: backend 3448 tests, frontend 2334 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)