### PR TITLE
fix(user-menu): open and dismiss on click for pointerdown-less input

### DIFF
--- a/frontend/src/shared/components/layout/UserMenu.test.tsx
+++ b/frontend/src/shared/components/layout/UserMenu.test.tsx
@@ -97,6 +97,66 @@ describe('UserMenu', () => {
     });
   });
 
+  // Some input environments (software KVMs, remote/streamed desktop sessions,
+  // certain mouse/trackpad drivers) deliver a legacy `click` but never a
+  // `pointerdown`. Radix's trigger opens ONLY on pointerdown, so the menu was
+  // unreachable by mouse for those users even though every plain onClick button
+  // still worked. The trigger must therefore also open on a plain click.
+  it('opens the dropdown on a plain click when no pointerdown precedes it', async () => {
+    renderUserMenu();
+    const trigger = screen.getByRole('button');
+    fireEvent.click(trigger);
+    await vi.waitFor(() => {
+      expect(trigger).toHaveAttribute('data-state', 'open');
+    });
+  });
+
+  // Guard the normal-input path: when both pointerdown and the compatibility
+  // click fire for the same press, the click must NOT toggle the menu closed
+  // again (which a naive onClick-toggle would do).
+  it('stays open when pointerdown is immediately followed by a click (normal input)', async () => {
+    renderUserMenu();
+    const trigger = screen.getByRole('button');
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' });
+    fireEvent.click(trigger);
+    await vi.waitFor(() => {
+      expect(trigger).toHaveAttribute('data-state', 'open');
+    });
+    expect(trigger).toHaveAttribute('data-state', 'open');
+  });
+
+  // With the click-to-open fallback, the menu can be opened by input that never
+  // emits `pointerdown`. Radix's built-in dismiss is ALSO pointerdown-based
+  // (onPointerDownOutside), so those users can't dismiss by clicking away. The
+  // menu must therefore also close on a plain outside click (Escape already
+  // works via keydown).
+  it('closes on a plain outside click when no pointerdown fires', async () => {
+    renderUserMenu();
+    const trigger = screen.getByRole('button');
+    fireEvent.click(trigger);
+    await vi.waitFor(() => {
+      expect(trigger).toHaveAttribute('data-state', 'open');
+    });
+    fireEvent.click(document.body);
+    await vi.waitFor(() => {
+      expect(trigger).toHaveAttribute('data-state', 'closed');
+    });
+  });
+
+  // A click INSIDE the open menu must not be treated as "outside" and dismiss it
+  // prematurely — item selection handles closing on its own.
+  it('does not dismiss when the click lands inside the menu', async () => {
+    renderUserMenu();
+    const trigger = screen.getByRole('button');
+    fireEvent.click(trigger);
+    await vi.waitFor(() => {
+      expect(screen.getByText('Single-key shortcuts')).toBeInTheDocument();
+    });
+    // The single-key toggle calls preventDefault to keep the menu open.
+    fireEvent.click(screen.getByText('Single-key shortcuts'));
+    expect(trigger).toHaveAttribute('data-state', 'open');
+  });
+
   it('shows Settings item in dropdown', async () => {
     renderUserMenu();
     const trigger = screen.getByRole('button');

--- a/frontend/src/shared/components/layout/UserMenu.tsx
+++ b/frontend/src/shared/components/layout/UserMenu.tsx
@@ -1,6 +1,7 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import * as Switch from '@radix-ui/react-switch';
 import { BarChart3, Keyboard, LogOut, Settings, User } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../../stores/auth-store';
 import { useKeyboardShortcutsStore } from '../../../stores/keyboard-shortcuts-store';
@@ -15,10 +16,53 @@ export function UserMenu() {
   const singleKeyEnabled = useUiStore((s) => s.singleKeyShortcutsEnabled);
   const setSingleKeyEnabled = useUiStore((s) => s.setSingleKeyShortcutsEnabled);
 
+  // Radix opens the trigger on `pointerdown`. Some input environments (software
+  // KVMs like Synergy/Barrier, remote/streamed desktop sessions, certain
+  // mouse/trackpad drivers) deliver a legacy `click` but never a `pointerdown`,
+  // leaving the menu unreachable by mouse while every plain onClick button still
+  // works. Drive `open` ourselves so a plain click can also open it, and use a
+  // ref to skip the compatibility `click` that follows a real `pointerdown` so
+  // normal input doesn't toggle straight back closed.
+  const [open, setOpen] = useState(false);
+  const pointerHandledRef = useRef(false);
+
+  // Radix's outside-dismiss is also pointerdown-based (onPointerDownOutside), so
+  // the same pointerdown-less input that needs the click-to-open fallback can't
+  // dismiss the menu by clicking away either (Escape still works via keydown).
+  // Close on a plain outside click too. The listener runs only while open and is
+  // attached after the opening click has already propagated, so it never
+  // self-closes; clicks on the trigger (toggle) or inside the portalled menu
+  // (item selection) are ignored.
+  useEffect(() => {
+    if (!open) return;
+    const onDocumentClick = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      const trigger = document.querySelector('button[aria-haspopup="menu"]');
+      const menu = document.querySelector('[role="menu"]');
+      if (trigger?.contains(target) || menu?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('click', onDocumentClick, true);
+    return () => document.removeEventListener('click', onDocumentClick, true);
+  }, [open]);
+
   return (
-    <DropdownMenu.Root>
+    <DropdownMenu.Root open={open} onOpenChange={setOpen}>
       <DropdownMenu.Trigger asChild>
-        <button className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-foreground/5 transition-colors outline-none">
+        <button
+          onPointerDown={() => {
+            pointerHandledRef.current = true;
+          }}
+          onClick={() => {
+            if (pointerHandledRef.current) {
+              pointerHandledRef.current = false;
+              return;
+            }
+            setOpen((prev) => !prev);
+          }}
+          className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-foreground/5 transition-colors outline-none"
+        >
           <div className="flex h-7 w-7 items-center justify-center rounded-full bg-action text-xs font-medium text-action-foreground" data-testid="user-avatar-initial">
             {user?.username?.charAt(0).toUpperCase() ?? '?'}
           </div>


### PR DESCRIPTION
## Problem

The top-right user menu did not open when clicked in certain input environments. Root cause, confirmed via live instrumentation of real clicks: the affected input delivers legacy `mousedown`/`click` events but **never** `pointerdown` (with an impossible `buttons` bitmask — the signature of synthesized/relayed mouse input, e.g. software KVMs, remote/streamed desktop sessions, or certain mouse/trackpad drivers). Radix `DropdownMenu.Trigger` opens only on `pointerdown` and dismisses outside clicks only via `onPointerDownOutside`, so the menu was unreachable by mouse while every plain `onClick` control still worked. (Keyboard — Enter/Space/↓ — always worked.)

## Fix

`UserMenu.tsx` now drives its own `open` state:

- **Open on click:** an `onClick` fallback opens the menu; an `onPointerDown` ref skips the compatibility `click` that follows a real `pointerdown`, so normal input doesn't double-toggle.
- **Dismiss on outside click:** a document-level `click` listener (active only while open) closes the menu when the click lands outside the trigger and the portalled menu — the click-based equivalent of Radix's `pointerdown`-based dismiss.

Escape and keyboard navigation are unchanged. Normal pointer, touch, and automation input are unaffected.

## Tests

- New (RED → GREEN): `opens the dropdown on a plain click when no pointerdown precedes it`; `closes on a plain outside click when no pointerdown fires`
- Guards: `stays open when pointerdown is immediately followed by a click (normal input)`; `does not dismiss when the click lands inside the menu`
- UserMenu **20/20**, layout suite **217/217**, `tsc --noEmit` clean, `eslint` clean
- Verified live against the deployed build: click-only opens the menu and outside-click-only dismisses it.

## Scope / notes

Behavior-only change to one UI component — no domain/boundary/migration/auth/sync/RAG/license changes, so no `docs/architecture` diagram applies. A codebase audit found no other high-impact `pointerdown`-opening component (this was the only Radix `DropdownMenu`). One medium item (editor AI-panel outside-dismiss in `EditorBubbleMenu.tsx`) and a few low drag-based items remain from the same root cause and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
